### PR TITLE
fix(sdd): name the exit for a vanished worktree, ignore fenced checkboxes, skip container dirs, and carry the change selector

### DIFF
--- a/internal/assets/claude/commands/sdd-continue.md
+++ b/internal/assets/claude/commands/sdd-continue.md
@@ -2,7 +2,7 @@
 description: Continue the next SDD phase in the dependency chain
 ---
 
-Read `~/.claude/skills/_shared/sdd-orchestrator-workflow.md` FIRST, then treat it as the authoritative SDD workflow instructions for this command.
+Read the SDD workflow FIRST: `.claude/skills/_shared/sdd-orchestrator-workflow.md` under the workspace when a workspace-scope install wrote it there, otherwise `~/.claude/skills/_shared/sdd-orchestrator-workflow.md`. Then treat it as the authoritative SDD workflow instructions for this command.
 The Claude Code session model is controlled by Claude Code; Gentle AI only configures models for Agent tool calls to phase sub-agents.
 
 WORKFLOW:

--- a/internal/assets/claude/commands/sdd-ff.md
+++ b/internal/assets/claude/commands/sdd-ff.md
@@ -2,7 +2,7 @@
 description: Fast-forward all SDD planning phases — proposal through tasks
 ---
 
-Read `~/.claude/skills/_shared/sdd-orchestrator-workflow.md` FIRST, then treat it as the authoritative SDD workflow instructions for this command.
+Read the SDD workflow FIRST: `.claude/skills/_shared/sdd-orchestrator-workflow.md` under the workspace when a workspace-scope install wrote it there, otherwise `~/.claude/skills/_shared/sdd-orchestrator-workflow.md`. Then treat it as the authoritative SDD workflow instructions for this command.
 The Claude Code session model is controlled by Claude Code; Gentle AI only configures models for Agent tool calls to phase sub-agents.
 
 WORKFLOW:

--- a/internal/assets/claude/commands/sdd-new.md
+++ b/internal/assets/claude/commands/sdd-new.md
@@ -2,7 +2,7 @@
 description: Start a new SDD change — runs exploration then creates a proposal
 ---
 
-Read `~/.claude/skills/_shared/sdd-orchestrator-workflow.md` FIRST, then treat it as the authoritative SDD workflow instructions for this command.
+Read the SDD workflow FIRST: `.claude/skills/_shared/sdd-orchestrator-workflow.md` under the workspace when a workspace-scope install wrote it there, otherwise `~/.claude/skills/_shared/sdd-orchestrator-workflow.md`. Then treat it as the authoritative SDD workflow instructions for this command.
 The Claude Code session model is controlled by Claude Code; Gentle AI only configures models for Agent tool calls to phase sub-agents.
 
 WORKFLOW:

--- a/internal/assets/claude/sdd-orchestrator.md
+++ b/internal/assets/claude/sdd-orchestrator.md
@@ -114,6 +114,6 @@ The canonical native bounded-review contract is injected from the shared provide
 
 The detailed SDD procedure is intentionally NOT embedded in this always-on parent thread. Before handling any SDD command, meta-command, continuation, apply/verify/archive routing, or SDD/Judgment-Day phase delegation, read:
 
-`~/.claude/skills/_shared/sdd-orchestrator-workflow.md`
+`.claude/skills/_shared/sdd-orchestrator-workflow.md` under the workspace when a workspace-scope install wrote it there, otherwise `~/.claude/skills/_shared/sdd-orchestrator-workflow.md`
 
 That lazy surface contains the SDD commands, init/dispatcher guards, execution-mode gatekeeper, artifact store policy, delivery strategy, dependency graph, review workload guard, model assignments, sub-agent launch protocol, context protocol, topic keys, and recovery rules.

--- a/internal/assets/sdd_exits_wording_test.go
+++ b/internal/assets/sdd_exits_wording_test.go
@@ -1,0 +1,26 @@
+package assets
+
+import (
+	"strings"
+	"testing"
+)
+
+// #2130: a workspace-scope install writes the lazy SDD workflow under the
+// workspace's .claude, so every pointer names that location first, then home.
+func TestClaudeWorkflowPointersNameWorkspaceAndHomeLocations(t *testing.T) {
+	for _, asset := range []string{"claude/commands/sdd-new.md", "claude/commands/sdd-continue.md", "claude/commands/sdd-ff.md", "claude/sdd-orchestrator.md"} {
+		content := MustRead(asset)
+		workspace := strings.Index(content, "`.claude/skills/_shared/sdd-orchestrator-workflow.md`")
+		home := strings.Index(content, "`~/.claude/skills/_shared/sdd-orchestrator-workflow.md`")
+		if workspace < 0 || home < 0 || workspace > home {
+			t.Errorf("%s must name the workspace-scope workflow path before the home-scope one (workspace=%d home=%d)", asset, workspace, home)
+		}
+	}
+}
+
+// #2480: regenerating tasks.md must keep the existing list and numbering.
+func TestTasksSkillPreservesExistingTaskListOnRegeneration(t *testing.T) {
+	if content := MustRead("skills/sdd-tasks/SKILL.md"); !strings.Contains(content, "never rewrite") || !strings.Contains(content, "numbering") {
+		t.Fatal("skills/sdd-tasks/SKILL.md must say regeneration preserves the existing task list and numbering, never rewriting from scratch")
+	}
+}

--- a/internal/assets/skills/sdd-tasks/SKILL.md
+++ b/internal/assets/skills/sdd-tasks/SKILL.md
@@ -247,6 +247,7 @@ Return to the orchestrator:
 - Testing tasks should reference specific scenarios from the specs
 - Each task should be completable in ONE session (if a task feels too big, split it)
 - Use hierarchical numbering: 1.1, 1.2, 2.1, 2.2, etc.
+- When tasks.md already exists, regeneration MUST preserve the existing task list and numbering: append new tasks or edit tasks in place, never rewrite the file from scratch
 - NEVER include vague tasks like "implement feature" or "add tests"
 - Apply any `rules.tasks` from `openspec/config.yaml`
 - If the project uses TDD, integrate test-first tasks: RED task (write failing test) → GREEN task (make it pass) → REFACTOR task (clean up)

--- a/internal/cli/sdd_attempt_removed_worktree_test.go
+++ b/internal/cli/sdd_attempt_removed_worktree_test.go
@@ -1,0 +1,38 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// #2661 at the CLI boundary: with the bound worktree gone, acquire's block and
+// the passed settle's refusal name the interrupted settle, which succeeds.
+func TestRunSDDAttemptRemovedWorktreeNamesAndAdmitsInterruptedSettle(t *testing.T) {
+	repo := initReviewCLIRepo(t)
+	linked := filepath.Join(t.TempDir(), "linked")
+	runReviewCLIGit(t, repo, "worktree", "add", "-q", "--detach", linked)
+	const change = "removed-worktree"
+	acquired, _ := runCompactSDDAttempt(t, compactAcquireArgs(linked, change, "linked-acquire", 2))
+	if err := os.RemoveAll(linked); err != nil || acquired.State != "proceed" {
+		t.Fatalf("linked acquire = %#v, remove err = %v", acquired, err)
+	}
+	runReviewCLIGit(t, repo, "worktree", "prune")
+	blocked, _ := runCompactSDDAttempt(t, compactAcquireArgs(repo, change, "main-acquire", 2))
+	refused, _ := runCompactSDDAttempt(t, compactSettleArgs(repo, change, acquired.Token, "main-settle-passed", "passed"))
+	for _, tt := range []struct {
+		label  string
+		result compactAttemptOutput
+		reason string
+	}{{"acquire", blocked, "active_attempt"}, {"passed settle", refused, "worktree_mismatch"}} {
+		if tt.result.State != "blocked" || tt.result.Reason != tt.reason {
+			t.Fatalf("%s after removal = %#v, want blocked(%s)", tt.label, tt.result, tt.reason)
+		}
+		assertExitNames(t, tt.result.Exit, "no longer exists", "--outcome interrupted", "`gentle-ai sdd-attempt settle --cwd")
+	}
+	settled, _ := runCompactSDDAttempt(t, compactSettleArgsWithEvidence(repo, change, acquired.Token, "main-settle-interrupted", "interrupted", ""))
+	status := runSDDAttemptStatus(t, []string{"status", "--cwd", repo, "--change", change})
+	if settled.State != "proceed" || status.ActiveAttempt != nil {
+		t.Fatalf("interrupted settle after removal = %#v, active = %#v; want proceed and no active attempt", settled, status.ActiveAttempt)
+	}
+}

--- a/internal/cli/sdd_task_result.go
+++ b/internal/cli/sdd_task_result.go
@@ -35,6 +35,7 @@ func runSDDTaskResult(args []string, stdin io.Reader, stdout io.Writer) error {
 	flags.SetOutput(io.Discard)
 	phase := flags.String("phase", "", "required; SDD phase that produced the result")
 	cwd := flags.String("cwd", "", "required; repository working directory for the continuation")
+	change := flags.String("change", "", "optional; SDD change name the continuation selects")
 	input := flags.String("input", "-", "result path; use - to read stdin")
 	taskModel := flags.String("task-model", "", "optional; provider/model route that produced the result")
 	latchedPhase := flags.String("latched-phase", "", "optional; phase that failed earlier in this session")
@@ -56,14 +57,14 @@ func runSDDTaskResult(args []string, stdin io.Reader, stdout io.Writer) error {
 		if *latchedPhase == "" || *latchedCode == "" {
 			return errors.New("sdd-task-result requires both --latched-phase and --latched-code, or neither; run " + sddTaskResultUsage)
 		}
-		return errors.New(sddtaskresult.DispatchLatched(*phase, *latchedPhase, *latchedCode, *cwd))
+		return errors.New(sddtaskresult.DispatchLatched(*phase, *latchedPhase, *latchedCode, *cwd, strings.TrimSpace(*change)))
 	}
 
 	output, err := readSDDTaskResult(*input, stdin)
 	if err != nil {
 		return err
 	}
-	if handoff := sddtaskresult.Handoff(sddtaskresult.Classify(output), *phase, *cwd, *taskModel); handoff != "" {
+	if handoff := sddtaskresult.Handoff(sddtaskresult.Classify(output), *phase, *cwd, strings.TrimSpace(*change), *taskModel); handoff != "" {
 		return errors.New(handoff)
 	}
 	_, err = fmt.Fprintln(stdout, `{"status":"ok"}`)

--- a/internal/sddstatus/runtime_admission.go
+++ b/internal/sddstatus/runtime_admission.go
@@ -68,7 +68,7 @@ func (store RuntimeStore) runtimeBeginAdmission(
 	ctx context.Context, status RuntimeStatus, request BeginAttemptRequest,
 ) (runtimeBeginAdmissionResult, error) {
 	if status.ActiveAttempt != nil {
-		return runtimeBeginAdmissionResult{}, ErrRuntimeAttemptActive
+		return runtimeBeginAdmissionResult{}, store.runtimeAttemptActiveRefusal(*status.ActiveAttempt)
 	}
 	// A passed objective terminates its own scope, not the change. When the
 	// request names a distinct work unit, the ordinary continuation is the

--- a/internal/sddstatus/runtime_compact.go
+++ b/internal/sddstatus/runtime_compact.go
@@ -193,7 +193,13 @@ func runtimeReadiness(in runtimeReadinessInput) (CompactAttemptResult, bool) {
 	case in.Status.DecisionRequired:
 		return compactBlocked(CompactBlockMaintainerDecision, ""), true
 	case in.Status.ActiveAttempt != nil:
-		return compactBlocked(CompactBlockActiveAttempt, activeToken), true
+		result := compactBlocked(CompactBlockActiveAttempt, activeToken)
+		// #2661: name the one settlement a vanished bound worktree admits.
+		if bound, missing := runtimeBoundWorktree(*in.Status.ActiveAttempt); missing {
+			result.Exit = runtimeMissingWorktreeExit(*in.Status.ActiveAttempt, bound, "<repo>", "<change>", activeToken)
+			result.Detail = result.Exit
+		}
+		return result, true
 	default:
 		return CompactAttemptResult{}, false
 	}

--- a/internal/sddstatus/runtime_ledger.go
+++ b/internal/sddstatus/runtime_ledger.go
@@ -875,10 +875,15 @@ func (store RuntimeStore) Finish(ctx context.Context, request FinishAttemptReque
 			return runtimeRecord{}, errors.New("interrupted attempts must omit evidence_revision; rerun `gentle-ai sdd-attempt finish` or `gentle-ai sdd-attempt settle` with --outcome interrupted and without --evidence-revision")
 		}
 		// Check the effective binding before candidate capture or line charging.
-		if active.EffectiveWorktree != "" && active.EffectiveWorktree != store.Workspace {
+		// A vanished bound worktree (#2661) admits only an interrupted settle.
+		bound, boundMissing := runtimeBoundWorktree(*active)
+		if boundMissing && request.Outcome != AttemptInterrupted {
+			return runtimeRecord{}, store.runtimeMissingWorktreeRefusal(ErrRuntimeWorktreeMismatch, *active, bound)
+		}
+		if !boundMissing && active.EffectiveWorktree != "" && active.EffectiveWorktree != store.Workspace {
 			return runtimeRecord{}, store.runtimeEffectiveWorktreeMismatchRefusal(*active)
 		}
-		if active.EffectiveWorktree == "" && active.BeginWorktree != "" && active.BeginWorktree != store.Workspace {
+		if !boundMissing && active.EffectiveWorktree == "" && active.BeginWorktree != "" && active.BeginWorktree != store.Workspace {
 			return runtimeRecord{}, store.runtimeWorktreeMismatchRefusal(active.Ordinal, active.BeginWorktree)
 		}
 		// Failed-evidence remediation is an SDD-only invariant. The immutable
@@ -909,6 +914,9 @@ func (store RuntimeStore) Finish(ctx context.Context, request FinishAttemptReque
 		// records the attempt's own product as no change at all (#3806). This
 		// resolves which selection this settlement overlays, and refuses while
 		// the caller can still act when the answer is nobody's decision yet.
+		if boundMissing {
+			return runtimeMissingWorktreeInterruptedRecord(status, *active, request)
+		}
 		intendedUntracked, declaredInventory, err := store.settlementUntrackedSelection(ctx, *active, request)
 		if err != nil {
 			return runtimeRecord{}, err
@@ -1276,6 +1284,67 @@ func (store RuntimeStore) runtimeEffectiveWorktreeMismatchRefusal(active Runtime
 		ErrRuntimeWorktreeMismatch, active.Ordinal, pathquote.Quote(active.BeginWorktree), pathquote.Quote(active.EffectiveWorktree), pathquote.Quote(store.Workspace), pathquote.Quote(active.EffectiveWorktree))
 }
 
+// runtimeBoundWorktree names the worktree an active attempt is bound to and
+// whether that path has vanished from disk (#2661): a removed and pruned
+// linked worktree made every exit that named it unrunnable. Only a not-exist
+// stat counts; any other failure keeps the ordinary binding checks.
+func runtimeBoundWorktree(active RuntimeAttempt) (string, bool) {
+	bound := active.EffectiveWorktree
+	if bound == "" {
+		bound = active.BeginWorktree
+	}
+	if bound == "" {
+		return "", false
+	}
+	_, err := os.Stat(bound)
+	return bound, errors.Is(err, os.ErrNotExist)
+}
+
+// runtimeMissingWorktreeExit is the one exit for a vanished bound worktree:
+// passed and failed need evidence measured there, so only interrupted is
+// admitted, from any worktree of the repository. cwd and change arrive
+// rendered so the compact readiness surface can pass placeholders.
+func runtimeMissingWorktreeExit(active RuntimeAttempt, bound, cwd, change, token string) string {
+	return fmt.Sprintf("attempt %d is bound to worktree %s, which no longer exists on disk, so its passed or failed evidence cannot be measured; "+
+		"settle it as interrupted from any worktree of this repository with `gentle-ai sdd-attempt settle --cwd %s --change %s --token %s "+
+		"--request-id \"<unique-request-id>\" --outcome interrupted --diagnosis \"<why-the-worktree-is-gone>\" --harness-disposition invalidated "+
+		"--cleanup-evidence \"<evidence>\" --process-evidence \"<evidence>\"`, then follow the ledger's next_action, or have a maintainer discard "+
+		"the objective with `gentle-ai sdd-attempt reset --cwd %s --change %s --expected-revision <the revision that status prints> "+
+		"--request-id \"<unique-request-id>\" --reason \"<why-the-objective-changed>\" --actor \"<actor>\"`",
+		active.Ordinal, pathquote.Quote(bound), cwd, change, token, cwd, change)
+}
+
+func (store RuntimeStore) runtimeMissingWorktreeRefusal(sentinel error, active RuntimeAttempt, bound string) error {
+	return fmt.Errorf("%w: %s", sentinel, runtimeMissingWorktreeExit(active, bound, pathquote.Quote(store.Workspace), fmt.Sprintf("%q", store.Change), "\"<acquire-token>\""))
+}
+
+// runtimeAttemptActiveRefusal is ErrRuntimeAttemptActive with the vanished
+// worktree exit composed in when that is the state the caller is actually in.
+func (store RuntimeStore) runtimeAttemptActiveRefusal(active RuntimeAttempt) error {
+	if bound, missing := runtimeBoundWorktree(active); missing {
+		return store.runtimeMissingWorktreeRefusal(ErrRuntimeAttemptActive, active, bound)
+	}
+	return ErrRuntimeAttemptActive
+}
+
+// runtimeMissingWorktreeInterruptedRecord closes an attempt whose bound
+// worktree is gone on its own begin candidate with no line charge; a later
+// begin or reset measures drift against the worktree it runs from, as before.
+func runtimeMissingWorktreeInterruptedRecord(status RuntimeStatus, active RuntimeAttempt, request FinishAttemptRequest) (runtimeRecord, error) {
+	if request.IntendedUntracked != nil {
+		return runtimeRecord{}, fmt.Errorf("%w: the bound worktree no longer exists, so no untracked inventory can be declared against it; rerun `gentle-ai sdd-attempt settle` with --outcome interrupted and without --untracked-scope", ErrRuntimeUndeclaredUntracked)
+	}
+	intended := slices.Clone(active.IntendedUntracked)
+	return runtimeRecord{Operation: runtimeOperationFinish, Finish: &runtimeFinishEvent{
+		Ordinal: active.Ordinal, FinishCandidateIdentity: active.BeginCandidateIdentity, FinishCandidateTree: active.BeginCandidateTree,
+		Outcome: AttemptInterrupted, Diagnosis: request.Diagnosis, HarnessDisposition: request.HarnessDisposition,
+		CleanupEvidence: request.CleanupEvidence, ProcessEvidence: request.ProcessEvidence,
+		RemediatesEvidenceRevision: request.RemediatesEvidenceRevision,
+		ChangedLineBudgetExceeded:  runtimeChangedLineBudgetExceeded(status, 0),
+		IntendedUntracked:          &intended,
+	}}, nil
+}
+
 // runtimeObjectiveChangeRefusal turns the changed-objective begin demand into
 // a refusal that names the continuation that actually clears it.
 //
@@ -1452,7 +1521,7 @@ func (store RuntimeStore) Reset(ctx context.Context, request ResetObjectiveReque
 	return store.mutate(ctx, request.ExpectedRevision, request.RequestID, digest, func(replay runtimeReplay) (runtimeRecord, error) {
 		status := replay.Status
 		if status.ActiveAttempt != nil {
-			return runtimeRecord{}, ErrRuntimeAttemptActive
+			return runtimeRecord{}, store.runtimeAttemptActiveRefusal(*status.ActiveAttempt)
 		}
 		if status.Objective == nil {
 			return runtimeRecord{}, ErrRuntimeNoObjective
@@ -1540,7 +1609,7 @@ func (store RuntimeStore) Rescope(ctx context.Context, request RescopeObjectiveR
 	return store.mutate(ctx, request.ExpectedRevision, request.RequestID, digest, func(replay runtimeReplay) (runtimeRecord, error) {
 		status := replay.Status
 		if status.ActiveAttempt != nil {
-			return runtimeRecord{}, ErrRuntimeAttemptActive
+			return runtimeRecord{}, store.runtimeAttemptActiveRefusal(*status.ActiveAttempt)
 		}
 		objective := status.Objective
 		if objective == nil {
@@ -3060,6 +3129,9 @@ func (store RuntimeStore) runtimeHandoffStatusExit() string {
 }
 
 func (store RuntimeStore) runtimeHandoffSourceRefusal(active RuntimeAttempt) error {
+	if bound, missing := runtimeBoundWorktree(active); missing {
+		return store.runtimeMissingWorktreeRefusal(ErrRuntimeHandoffSource, active, bound)
+	}
 	return fmt.Errorf("%w: attempt %d has effective worktree %s, but handoff ran from %s; %s",
 		ErrRuntimeHandoffSource, active.Ordinal, pathquote.Quote(active.EffectiveWorktree), pathquote.Quote(store.Workspace), store.runtimeHandoffStatusExit())
 }

--- a/internal/sddstatus/runtime_ledger_removed_worktree_test.go
+++ b/internal/sddstatus/runtime_ledger_removed_worktree_test.go
@@ -1,0 +1,83 @@
+package sddstatus
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// #2661: after the bound linked worktree is removed and pruned, every exit
+// named the vanished path. Each refusal must say the worktree is gone and name
+// the interrupted settle, which is admitted from any worktree of the repo.
+func TestRuntimeLedgerRemovedWorktreeSettlesInterruptedFromMainWorktree(t *testing.T) {
+	repo := initRuntimeLedgerRepo(t)
+	worktree := filepath.Join(t.TempDir(), "removed-worktree")
+	runRuntimeLedgerGit(t, repo, "worktree", "add", "-q", "-b", "removed-branch", worktree)
+	change := "removed-worktree"
+	linked, err := OpenRuntimeStore(context.Background(), worktree, change)
+	if err != nil {
+		t.Fatal(err)
+	}
+	began, err := linked.Begin(context.Background(), BeginAttemptRequest{
+		RequestID: "begin-linked", WorkUnit: "removed-worktree-unit",
+		EvidenceGoal: "prove the removed worktree exit", MaxAttempts: 2, MaxChangedLines: 200,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.RemoveAll(worktree); err != nil {
+		t.Fatal(err)
+	}
+	runRuntimeLedgerGit(t, repo, "worktree", "prune")
+	main, _ := OpenRuntimeStore(context.Background(), repo, change)
+	settle := func(outcome AttemptOutcome, requestID, evidence string) error {
+		_, err := main.Finish(context.Background(), FinishAttemptRequest{
+			ExpectedRevision: began.Revision, RequestID: requestID, Outcome: outcome, EvidenceRevision: evidence,
+			Diagnosis: "the bound worktree was removed", HarnessDisposition: HarnessInvalidated,
+			CleanupEvidence: "worktree directory deleted", ProcessEvidence: "no process remained",
+		})
+		return err
+	}
+	_, beginErr := main.Begin(context.Background(), BeginAttemptRequest{
+		ExpectedRevision: began.Revision, RequestID: "begin-main", WorkUnit: "another-unit",
+		EvidenceGoal: "prove the active-attempt exit", MaxAttempts: 2, MaxChangedLines: 200,
+	})
+	acquired, _ := main.Acquire(context.Background(), CompactAcquireRequest{BeginAttemptRequest: BeginAttemptRequest{
+		RequestID: "acquire-main", WorkUnit: "another-unit", EvidenceGoal: "prove the compact exit", MaxAttempts: 2, MaxChangedLines: 200,
+	}})
+	_, handoffErr := main.Handoff(context.Background(), HandoffAttemptRequest{
+		ExpectedRevision: began.Revision, RequestID: "handoff-main", DestinationWorktree: repo,
+	})
+	for _, tt := range []struct {
+		label    string
+		err      error
+		sentinel error
+	}{
+		{"passed settle", settle(AttemptPassed, "finish-passed", runtimeTestHash('9')), ErrRuntimeWorktreeMismatch},
+		{"begin", beginErr, ErrRuntimeAttemptActive},
+		{"acquire", errors.New(acquired.Exit), nil},
+		{"handoff", handoffErr, ErrRuntimeHandoffSource},
+	} {
+		if tt.sentinel != nil && !errors.Is(tt.err, tt.sentinel) {
+			t.Fatalf("%s error = %v, want %v", tt.label, tt.err, tt.sentinel)
+		}
+		for _, want := range []string{"no longer exists", "--outcome interrupted", "`gentle-ai sdd-attempt settle --cwd"} {
+			if !strings.Contains(tt.err.Error(), want) {
+				t.Fatalf("%s refusal does not name %q:\n%s", tt.label, want, tt.err.Error())
+			}
+		}
+	}
+	if acquired.State != CompactStateBlocked || acquired.Reason != CompactBlockActiveAttempt {
+		t.Fatalf("acquire = %#v, want blocked(active_attempt)", acquired)
+	}
+	if err := settle(AttemptInterrupted, "finish-interrupted", ""); err != nil {
+		t.Fatalf("interrupted settle from the main worktree: %v", err)
+	}
+	status, err := main.Status()
+	if err != nil || status.ActiveAttempt != nil || len(status.Attempts) != 1 || status.Attempts[0].Outcome != AttemptInterrupted || status.Attempts[0].ChangedLines != 0 {
+		t.Fatalf("status after interrupted settle = %#v err = %v", status, err)
+	}
+}

--- a/internal/sddstatus/status.go
+++ b/internal/sddstatus/status.go
@@ -317,12 +317,39 @@ func listActiveOpenSpecChanges(workspaceRoot string) ([]string, error) {
 
 	changes := make([]string, 0, len(entries))
 	for _, entry := range entries {
-		if entry.IsDir() && entry.Name() != "archive" {
+		if entry.IsDir() && entry.Name() != "archive" && entry.Name() != "active" &&
+			!openSpecChangeContainer(filepath.Join(workspaceRoot, "openspec", "changes", entry.Name())) {
 			changes = append(changes, entry.Name())
 		}
 	}
 	sort.Strings(changes)
 	return changes, nil
+}
+
+// openSpecChangeContainer reports whether a directory under openspec/changes
+// is a container of changes rather than a change (#2317): it holds no SDD
+// artifact itself while a subdirectory does, the legacy `active/` layout. An
+// empty scaffold keeps its historical standing as a candidate, and a marker
+// that fails to stat for any reason other than not existing counts as present.
+func openSpecChangeContainer(changeRoot string) bool {
+	holdsArtifact := func(dir string) bool {
+		for _, marker := range []string{"proposal.md", "design.md", "tasks.md", "specs", "spec.md", "verify-report.md", "state.yaml", "exploration.md"} {
+			if _, err := os.Stat(filepath.Join(dir, marker)); !errors.Is(err, os.ErrNotExist) {
+				return true
+			}
+		}
+		return false
+	}
+	entries, err := os.ReadDir(changeRoot)
+	if err != nil || holdsArtifact(changeRoot) {
+		return false
+	}
+	for _, entry := range entries {
+		if entry.IsDir() && holdsArtifact(filepath.Join(changeRoot, entry.Name())) {
+			return true
+		}
+	}
+	return false
 }
 
 // selectableOpenSpecChanges filters exploration-only directories out of the
@@ -1647,7 +1674,22 @@ func countTaskProgress(tasksPath string) (TaskProgress, error) {
 
 func countTaskProgressText(content string) TaskProgress {
 	var progress TaskProgress
+	fence := ""
 	for _, line := range strings.Split(content, "\n") {
+		// #2480: a checkbox row inside a ``` or ~~~ fence is an example. A fence
+		// closes on a same-character run at least as long as the opener, alone.
+		if run := fencedCodeRun(line); run != "" {
+			switch {
+			case fence == "":
+				fence = run
+			case run[0] == fence[0] && len(run) >= len(fence) && strings.TrimSpace(line) == run:
+				fence = ""
+			}
+			continue
+		}
+		if fence != "" {
+			continue
+		}
 		matches := taskCheckbox.FindStringSubmatch(line)
 		if len(matches) == 0 {
 			continue
@@ -1661,6 +1703,20 @@ func countTaskProgressText(content string) TaskProgress {
 	}
 	progress.AllComplete = progress.Total > 0 && progress.Pending == 0
 	return progress
+}
+
+// fencedCodeRun returns the leading run of three or more backticks or tildes
+// that opens or closes a fenced code block, or "" when the line is not a fence.
+func fencedCodeRun(line string) string {
+	trimmed := strings.TrimLeft(line, " \t")
+	if trimmed == "" || (trimmed[0] != '`' && trimmed[0] != '~') {
+		return ""
+	}
+	run := strings.TrimLeft(trimmed, string(trimmed[0]))
+	if len(trimmed)-len(run) < 3 {
+		return ""
+	}
+	return trimmed[:len(trimmed)-len(run)]
 }
 
 func artifactBlockedReasons(artifacts map[string]ArtifactState, taskProgress TaskProgress, changeName string) blockerReasons {

--- a/internal/sddstatus/status_parsing_exits_test.go
+++ b/internal/sddstatus/status_parsing_exits_test.go
@@ -1,0 +1,29 @@
+package sddstatus
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+// #2480: a checkbox row inside a fenced code block is an example, not a task.
+func TestCountTaskProgressSkipsFencedCodeBlocks(t *testing.T) {
+	progress := countTaskProgressText("- [ ] 1.1 Real task\n\n~~~text\n- [ ] example row\n~~~\n\n```markdown\n- [x] another example\n```\n")
+	if progress.Total != 1 || progress.Pending != 1 || progress.Completed != 0 {
+		t.Fatalf("progress = %#v, want exactly the one task outside the fences", progress)
+	}
+}
+
+// #2317: a legacy openspec/changes/active/ container, or any artifact-less
+// directory whose subdirectories hold changes, is not a change and must not
+// make selection ambiguous. Empty scaffolds keep their historical standing.
+func TestChangeContainersDoNotMakeSelectionAmbiguous(t *testing.T) {
+	root := t.TempDir()
+	seedReadyChange(t, root, "feat-x", "- [ ] 1.1 Work\n")
+	write(t, filepath.Join(root, "openspec", "changes", "active", "legacy-change", "proposal.md"), "# Proposal\n")
+	write(t, filepath.Join(root, "openspec", "changes", "legacy", "older-change", "tasks.md"), "- [ ] 1.1 Old\n")
+	status, err := Resolve(ResolveOptions{CWD: root})
+	if err != nil || status.ChangeName == nil || *status.ChangeName != "feat-x" || status.NextRecommended == "select-change" {
+		t.Fatalf("err = %v ChangeName = %v NextRecommended = %q, want feat-x auto-selected\nBlockedReasons: %v",
+			err, ptrValue(status.ChangeName), status.NextRecommended, status.BlockedReasons)
+	}
+}

--- a/internal/sddtaskresult/handoff.go
+++ b/internal/sddtaskresult/handoff.go
@@ -45,8 +45,14 @@ func shellQuote(value string) string {
 	return "'" + strings.ReplaceAll(value, "'", `'\''`) + "'"
 }
 
-func continuationFor(cwd string) string {
-	return "gentle-ai sdd-status --cwd " + shellQuote(cwd) + " --json"
+// continuationFor names the change when the caller knows it (#2790): with two
+// active changes the selector-less form only answers select-change.
+func continuationFor(cwd, change string) string {
+	selector := ""
+	if change != "" {
+		selector = shellQuote(change) + " "
+	}
+	return "gentle-ai sdd-status " + selector + "--cwd " + shellQuote(cwd) + " --json"
 }
 
 func encode(payload handoffPayload) string {
@@ -60,7 +66,7 @@ func encode(payload handoffPayload) string {
 
 // Handoff renders the typed terminal failure for one classified phase result.
 // An admitted result has no handoff and returns the empty string.
-func Handoff(class Class, phase, cwd, taskModel string) string {
+func Handoff(class Class, phase, cwd, change, taskModel string) string {
 	code := class.FailureCode()
 	if code == "" {
 		return ""
@@ -71,7 +77,7 @@ func Handoff(class Class, phase, cwd, taskModel string) string {
 	}
 	payload := handoffPayload{
 		SchemaName: handoffSchema, Status: "blocked", Code: code, Phase: phase,
-		Summary: summary, Continuation: continuationFor(cwd),
+		Summary: summary, Continuation: continuationFor(cwd, change),
 	}
 	if routeToken.MatchString(taskModel) {
 		payload.TaskModel = taskModel
@@ -82,12 +88,12 @@ func Handoff(class Class, phase, cwd, taskModel string) string {
 // DispatchLatched renders the refusal a later launch receives after an earlier
 // phase failed in the same session. That launch never dispatched, so it names
 // the phase it requested alongside the phase and code that actually failed.
-func DispatchLatched(requested, latchedPhase, latchedCode, cwd string) string {
+func DispatchLatched(requested, latchedPhase, latchedCode, cwd, change string) string {
 	return encode(handoffPayload{
 		SchemaName: handoffSchema, Status: "blocked", Code: "sdd_task_dispatch_latched",
 		Phase: requested, LatchedPhase: latchedPhase, LatchedCode: latchedCode,
 		Summary:      fmt.Sprintf("%s was not dispatched. Earlier in this session %s returned %s, and SDD launches stay latched afterwards so a failed phase is never silently retried and no later phase advances on top of it. No provider call, no subagent, and no artifact write happened for this launch, so it produced no new evidence about the original failure.", requested, latchedPhase, latchedCode),
-		Continuation: continuationFor(cwd),
+		Continuation: continuationFor(cwd, change),
 		Exit:         "Inspect the artifact state the original failure left, surface it to the user, and start a new session to launch SDD phases again. Relaunching in this session cannot dispatch.",
 	})
 }

--- a/internal/sddtaskresult/handoff_test.go
+++ b/internal/sddtaskresult/handoff_test.go
@@ -11,7 +11,7 @@ import (
 // its continuation exactly once.
 
 func TestHandoffCarriesThePrefixAndSchema(t *testing.T) {
-	handoff := Handoff(ClassEmpty, "sdd-apply", "/repo", "")
+	handoff := Handoff(ClassEmpty, "sdd-apply", "/repo", "", "")
 	if !strings.HasPrefix(handoff, "GENTLE_AI_SDD_FAILURE ") {
 		t.Fatalf("handoff lost its literal prefix: %q", handoff)
 	}
@@ -40,7 +40,7 @@ func TestHandoffQuotesACwdContainingASingleQuote(t *testing.T) {
 	// would compare against JSON escaping rather than the command a consumer
 	// actually runs.
 	var decoded map[string]any
-	handoff := Handoff(ClassMalformed, "sdd-verify", "/re'po", "")
+	handoff := Handoff(ClassMalformed, "sdd-verify", "/re'po", "", "")
 	if err := json.Unmarshal([]byte(strings.TrimPrefix(handoff, "GENTLE_AI_SDD_FAILURE ")), &decoded); err != nil {
 		t.Fatalf("handoff payload is not JSON: %v", err)
 	}
@@ -51,17 +51,17 @@ func TestHandoffQuotesACwdContainingASingleQuote(t *testing.T) {
 }
 
 func TestHandoffCarriesAValidatedTaskModel(t *testing.T) {
-	if handoff := Handoff(ClassEmpty, "sdd-apply", "/repo", "openai/gpt-5.6"); !strings.Contains(handoff, `"taskModel":"openai/gpt-5.6"`) {
+	if handoff := Handoff(ClassEmpty, "sdd-apply", "/repo", "", "openai/gpt-5.6"); !strings.Contains(handoff, `"taskModel":"openai/gpt-5.6"`) {
 		t.Errorf("handoff dropped a valid task model: %q", handoff)
 	}
 	// A route token that cannot be trusted is omitted, never echoed.
-	if handoff := Handoff(ClassEmpty, "sdd-apply", "/repo", "not a model/../etc"); strings.Contains(handoff, "taskModel") {
+	if handoff := Handoff(ClassEmpty, "sdd-apply", "/repo", "", "not a model/../etc"); strings.Contains(handoff, "taskModel") {
 		t.Errorf("handoff echoed an untrusted task model: %q", handoff)
 	}
 }
 
 func TestDispatchLatchedNamesBothPhases(t *testing.T) {
-	handoff := DispatchLatched("sdd-verify", "sdd-apply", "sdd_task_result_empty", "/repo")
+	handoff := DispatchLatched("sdd-verify", "sdd-apply", "sdd_task_result_empty", "/repo", "")
 	var decoded map[string]any
 	if err := json.Unmarshal([]byte(strings.TrimPrefix(handoff, "GENTLE_AI_SDD_FAILURE ")), &decoded); err != nil {
 		t.Fatalf("latched payload is not JSON: %v", err)
@@ -82,7 +82,28 @@ func TestDispatchLatchedNamesBothPhases(t *testing.T) {
 }
 
 func TestHandoffIsEmptyForAnAdmittedResult(t *testing.T) {
-	if handoff := Handoff(ClassOK, "sdd-apply", "/repo", ""); handoff != "" {
+	if handoff := Handoff(ClassOK, "sdd-apply", "/repo", "", ""); handoff != "" {
 		t.Errorf("an admitted result produced a failure handoff: %q", handoff)
+	}
+}
+
+// #2790: with two active changes, a selector-less sdd-status answers
+// select-change, so a handoff that knows the change must name it.
+func TestHandoffContinuationNamesTheChangeWhenKnown(t *testing.T) {
+	for _, tt := range []struct{ change, want string }{
+		{change: "", want: "gentle-ai sdd-status --cwd '/repo' --json"},
+		{change: "feat-x", want: "gentle-ai sdd-status 'feat-x' --cwd '/repo' --json"},
+	} {
+		var decoded map[string]any
+		handoff := Handoff(ClassEmpty, "sdd-apply", "/repo", tt.change, "")
+		if err := json.Unmarshal([]byte(strings.TrimPrefix(handoff, HandoffPrefix)), &decoded); err != nil {
+			t.Fatalf("handoff payload is not JSON: %v", err)
+		}
+		if decoded["continuation"] != tt.want {
+			t.Errorf("change %q: continuation = %#v, want %q", tt.change, decoded["continuation"], tt.want)
+		}
+		if latched := DispatchLatched("sdd-verify", "sdd-apply", "sdd_task_result_empty", "/repo", tt.change); !strings.Contains(latched, tt.want) {
+			t.Errorf("change %q: latched handoff does not carry %q: %s", tt.change, tt.want, latched)
+		}
 	}
 }

--- a/testdata/golden/combined-claude-claudemd.golden
+++ b/testdata/golden/combined-claude-claudemd.golden
@@ -239,7 +239,7 @@ Historical compatibility commands may read older artifacts manually, but they ar
 
 The detailed SDD procedure is intentionally NOT embedded in this always-on parent thread. Before handling any SDD command, meta-command, continuation, apply/verify/archive routing, or SDD/Judgment-Day phase delegation, read:
 
-`~/.claude/skills/_shared/sdd-orchestrator-workflow.md`
+`.claude/skills/_shared/sdd-orchestrator-workflow.md` under the workspace when a workspace-scope install wrote it there, otherwise `~/.claude/skills/_shared/sdd-orchestrator-workflow.md`
 
 That lazy surface contains the SDD commands, init/dispatcher guards, execution-mode gatekeeper, artifact store policy, delivery strategy, dependency graph, review workload guard, model assignments, sub-agent launch protocol, context protocol, topic keys, and recovery rules.
 <!-- /gentle-ai:sdd-orchestrator -->

--- a/testdata/golden/sdd-claude-claudemd.golden
+++ b/testdata/golden/sdd-claude-claudemd.golden
@@ -205,7 +205,7 @@ Historical compatibility commands may read older artifacts manually, but they ar
 
 The detailed SDD procedure is intentionally NOT embedded in this always-on parent thread. Before handling any SDD command, meta-command, continuation, apply/verify/archive routing, or SDD/Judgment-Day phase delegation, read:
 
-`~/.claude/skills/_shared/sdd-orchestrator-workflow.md`
+`.claude/skills/_shared/sdd-orchestrator-workflow.md` under the workspace when a workspace-scope install wrote it there, otherwise `~/.claude/skills/_shared/sdd-orchestrator-workflow.md`
 
 That lazy surface contains the SDD commands, init/dispatcher guards, execution-mode gatekeeper, artifact store policy, delivery strategy, dependency graph, review workload guard, model assignments, sub-agent launch protocol, context protocol, topic keys, and recovery rules.
 <!-- /gentle-ai:sdd-orchestrator -->

--- a/testdata/golden/sdd-claude-cmd-sdd-continue.golden
+++ b/testdata/golden/sdd-claude-cmd-sdd-continue.golden
@@ -2,7 +2,7 @@
 description: Continue the next SDD phase in the dependency chain
 ---
 
-Read `~/.claude/skills/_shared/sdd-orchestrator-workflow.md` FIRST, then treat it as the authoritative SDD workflow instructions for this command.
+Read the SDD workflow FIRST: `.claude/skills/_shared/sdd-orchestrator-workflow.md` under the workspace when a workspace-scope install wrote it there, otherwise `~/.claude/skills/_shared/sdd-orchestrator-workflow.md`. Then treat it as the authoritative SDD workflow instructions for this command.
 The Claude Code session model is controlled by Claude Code; Gentle AI only configures models for Agent tool calls to phase sub-agents.
 
 WORKFLOW:

--- a/testdata/golden/sdd-claude-cmd-sdd-ff.golden
+++ b/testdata/golden/sdd-claude-cmd-sdd-ff.golden
@@ -2,7 +2,7 @@
 description: Fast-forward all SDD planning phases — proposal through tasks
 ---
 
-Read `~/.claude/skills/_shared/sdd-orchestrator-workflow.md` FIRST, then treat it as the authoritative SDD workflow instructions for this command.
+Read the SDD workflow FIRST: `.claude/skills/_shared/sdd-orchestrator-workflow.md` under the workspace when a workspace-scope install wrote it there, otherwise `~/.claude/skills/_shared/sdd-orchestrator-workflow.md`. Then treat it as the authoritative SDD workflow instructions for this command.
 The Claude Code session model is controlled by Claude Code; Gentle AI only configures models for Agent tool calls to phase sub-agents.
 
 WORKFLOW:

--- a/testdata/golden/sdd-claude-cmd-sdd-new.golden
+++ b/testdata/golden/sdd-claude-cmd-sdd-new.golden
@@ -2,7 +2,7 @@
 description: Start a new SDD change — runs exploration then creates a proposal
 ---
 
-Read `~/.claude/skills/_shared/sdd-orchestrator-workflow.md` FIRST, then treat it as the authoritative SDD workflow instructions for this command.
+Read the SDD workflow FIRST: `.claude/skills/_shared/sdd-orchestrator-workflow.md` under the workspace when a workspace-scope install wrote it there, otherwise `~/.claude/skills/_shared/sdd-orchestrator-workflow.md`. Then treat it as the authoritative SDD workflow instructions for this command.
 The Claude Code session model is controlled by Claude Code; Gentle AI only configures models for Agent tool calls to phase sub-agents.
 
 WORKFLOW:


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #2661
Closes #2480
Closes #2317
Closes #2130
Closes #2790

Same root class: an exit that named something the caller could not use (a vanished path, a fenced example, a container directory, the wrong skills path, a selector-less continuation). All five reproduced today on current main before this change; #3105 (gate wording for planned paths) was implemented but dropped to stay under budget and will land on its own.

---

## 🏷️ PR Type

- [x] `type:bug` — Bug fix (non-breaking change that fixes an issue)

---

## 📝 Summary

- **#2661**: after `rm -rf <worktree>; git worktree prune`, the ledger's active attempt made acquire answer `active_attempt`, settle and handoff `worktree_mismatch` telling the caller to rerun with the removed `--cwd`, and reset "already has an active attempt". A bound worktree that no longer exists (`os.Stat` not-exist only) now admits exactly one settlement, `--outcome interrupted`, from any worktree of the repository (recorded on the begin candidate, zero line charge, no untracked declaration); passed and failed stay refused because their evidence cannot be measured; every refusal and the compact `active_attempt` exit name that settle and the maintainer reset.
- **#2480** (narrowed): checkbox rows inside fenced code blocks were counted as tasks; the task parser now tracks CommonMark fences. One sdd-tasks bullet: regeneration appends or edits in place, never rewrites from scratch.
- **#2317** (narrowed): a legacy `openspec/changes/active/` container was listed as a change; `active`, `archive`, and any artifact-less directory whose subdirectories hold artifacts are skipped, while empty scaffolds keep their standing (existing pins).
- **#2130** (narrowed): the Claude `sdd-*` commands and orchestrator named only `~/.claude/skills/_shared/sdd-orchestrator-workflow.md`; they now name the workspace `.claude/skills/_shared/...` first, then the home path (assets are static, no scope-aware renderer exists).
- **#2790** (narrowed): the failed-task continuation is `gentle-ai sdd-status <change> --cwd <repo> --json` when the change is known; `sdd-task-result` gains an optional `--change`; without it the bytes are unchanged. Adapters do not pass it yet.

---

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/sddstatus/runtime_ledger.go`, `runtime_compact.go`, `runtime_admission.go` | `runtimeBoundWorktree`, `runtimeMissingWorktreeExit`, interrupted-only settlement for a vanished worktree, refusals name it. |
| `internal/sddstatus/status.go` | Fenced checkbox rows ignored; container directories skipped in change discovery. |
| `internal/sddtaskresult/handoff.go`, `internal/cli/sdd_task_result.go` | `--change` threaded into the continuation. |
| `internal/assets/claude/commands/{sdd-new,sdd-continue,sdd-ff}.md`, `claude/sdd-orchestrator.md`, `skills/sdd-tasks/SKILL.md` | Wording. |
| Tests | `runtime_ledger_removed_worktree_test.go`, `sdd_attempt_removed_worktree_test.go`, `status_parsing_exits_test.go`, `sdd_exits_wording_test.go`, `handoff_test.go`; each ran first on the unmodified tree and failed on the reported shape. |
| `testdata/golden/*` (5) | Regenerated for the command wording. |

---

## 🤖 AI Assistance

- [ ] **None** — No material AI assistance was used.
- [x] **Material assistance used** — Complete all applicable declaration fields below.

**Tool/model (if known):** Claude Code (Claude Fable 5) with reproduction and writer agents.

**Material scope:** Reproduction on current main, tests (red first), production and asset change.

**Verification performed:** `go test ./...`, `go run ./internal/gofmtcheck`, `go vet` including `GOOS=windows`, driven bench corpus (summary appended). E2E Docker left to CI.

---

## 🧪 Test Plan

**Unit Tests**
```bash
go test ./...
```

**Go Format**
```bash
go run ./internal/gofmtcheck
```

**Benchmark Validation**

SDD runtime lifecycle change: driven corpus against a binary built from this branch. Summary line: `journeys: 61 completed, 0 unsupported, 0 failed`.

- [x] Unit tests pass (`go test ./...`)
- [x] Go format passes (`go run ./internal/gofmtcheck`)
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`) (left to CI)
- [x] Manually tested locally

---

## ✅ Contributor Checklist

- [x] PR is linked to an issue with `status:approved`
- [x] PR stays within 400 changed lines, or I have requested/obtained maintainer-applied `size:exception` with rationale documented
- [x] I have added the appropriate `type:*` label to this PR
- [x] Unit tests pass (`go test ./...`)
- [x] Go format passes (`go run ./internal/gofmtcheck`)
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`) (left to CI)
- [x] Benchmark validation completed, or this change is not applicable to the benchmark (explain why in the Test Plan).
- [x] I have updated documentation if necessary
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] I understand, reviewed, and take responsibility for the complete submission
- [x] I selected exactly one AI-assistance option and, if material assistance was used, completed all applicable declaration fields
- [x] My commits do not include `Co-Authored-By` trailers

---

## 💬 Notes for Reviewers

The one admission change: `Finish`/`Settle` accept `--outcome interrupted` when the attempt's bound worktree no longer exists on disk (not-exist only; any other stat failure keeps the ordinary binding checks), recording the begin candidate with zero line charge. Passed and failed are refused there. No `guard:population` or refusal-ratchet baseline change; no ceiling raised.

https://claude.ai/code/session_01SCnBzvpvtWpFLdbSfsJcCG


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - SDD task results can now continue with a specified change when multiple changes are active.
  - Added recovery guidance for attempts whose worktrees have been removed, including interrupted-settle support.

- **Bug Fixes**
  - Workflow commands now correctly find workspace-installed instructions before using user-level instructions.
  - Task regeneration preserves existing task lists and numbering.
  - Status detection no longer counts example checkboxes or legacy container folders as active tasks or changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


**Native review:** four-lens transaction `review-3115cd5c75e6d04f` closed `approved`; acknowledgement burned (`gentle-ai.review-acknowledged/v1`). The reliability lens needed a third capture: the first two reviewer payloads were refused at admission (reviewer JSON missing its final closing brace; preserved under `.git/gentle-ai/rejected-results/`), STATUS reoffered the same slot each time.
