### PR TITLE
fix(review): drop committed paths from an inherited untracked declaration and carry the claim text to the refuter

### DIFF
--- a/internal/cli/review_facade.go
+++ b/internal/cli/review_facade.go
@@ -1307,7 +1307,14 @@ func RunReviewRecover(args []string, stdout io.Writer) error {
 		}
 		intended = append(intended, scope.Intended...)
 	case currentChangesSuccessor && predecessorRecord.State.InitialSnapshot.Kind == reviewtransaction.TargetCurrentChanges:
-		intended = append(intended, predecessorRecord.State.InitialSnapshot.IntendedUntracked...)
+		// Issue #3759: a declared path committed since the predecessor froze
+		// is tracked now and already inside the current-changes target, so
+		// replaying it would only refuse as "already tracked".
+		remaining, inheritErr := builder.StillUntracked(context.Background(), predecessorRecord.State.InitialSnapshot.IntendedUntracked)
+		if inheritErr != nil {
+			return inheritErr
+		}
+		intended = append(intended, remaining...)
 	}
 	target := reviewtransaction.Target{Kind: reviewtransaction.TargetCurrentChanges, Projection: projection, IntendedUntracked: intended}
 	if *committedOnly {

--- a/internal/cli/review_provider_role_materialize_test.go
+++ b/internal/cli/review_provider_role_materialize_test.go
@@ -624,3 +624,23 @@ func recordHasAdmittedRole(state reviewtransaction.CompactState, role reviewtran
 	}
 	return false
 }
+
+// TestRefuterRequestCarriesTheFindingClaimText is #3482: the compiled refuter
+// batch listed each inferential finding as finding_id plus proof locations
+// only, so the refuter had no proposition to corroborate or refute and could
+// honestly return nothing but inconclusive, which escalates every lineage.
+func TestRefuterRequestCarriesTheFindingClaimText(t *testing.T) {
+	reviewEnabledHome(t)
+	t.Setenv(reviewPiHostRelayContractEnvironment, reviewPiHostRelayContract)
+	repo, _, record, handle := piRefuterReview(t)
+	handle = rctx2ReviewRepositoryContextForTest(t, repo, reviewtransaction.ReviewRepositoryContextBinding{
+		LineageID: record.State.LineageID, TargetIdentity: record.State.InitialSnapshot.Identity, Revision: record.State.CapturePhaseRevision,
+	})
+	var prompt bytes.Buffer
+	if err := RunReview(append(append([]string{"capture-refuter"}, piRefuterBinding(repo, record, handle)...), "--agent", string(model.AgentPi), "--materialize=true"), &prompt); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(prompt.String(), `"finding_id":"R3-001"`) || !strings.Contains(prompt.String(), `"claim":"candidate failure"`) {
+		t.Fatalf("refuter request omits the finding's claim text; the refuter can only return inconclusive:\n%s", prompt.String())
+	}
+}

--- a/internal/cli/review_provider_roles.go
+++ b/internal/cli/review_provider_roles.go
@@ -172,6 +172,12 @@ func reviewProviderNewRefuterRequest(ctx context.Context, repo, storeDir string,
 }
 
 func reviewProviderRefuterClaims(snapshot string, input reviewtransaction.CompactReviewInput) ([]reviewtransaction.RefuterClaim, error) {
+	claimText := map[string]string{}
+	for _, result := range input.LensResults {
+		for _, finding := range result.Findings {
+			claimText[finding.ID] = finding.Claim
+		}
+	}
 	claims := make([]reviewtransaction.RefuterClaim, 0)
 	for _, classification := range input.Classifications {
 		if classification.Class != reviewtransaction.EvidenceInferential {
@@ -179,7 +185,7 @@ func reviewProviderRefuterClaims(snapshot string, input reviewtransaction.Compac
 		}
 		switch classification.Causality {
 		case reviewtransaction.CausalIntroduced, reviewtransaction.CausalBehaviorActivated, reviewtransaction.CausalWorsened:
-			claims = append(claims, reviewtransaction.RefuterClaim{FindingID: classification.FindingID, SnapshotIdentity: snapshot, Proof: classification.Proof})
+			claims = append(claims, reviewtransaction.RefuterClaim{FindingID: classification.FindingID, SnapshotIdentity: snapshot, Proof: classification.Proof, Claim: claimText[classification.FindingID]})
 		}
 	}
 	if len(claims) == 0 {

--- a/internal/cli/review_recover_intended_untracked_test.go
+++ b/internal/cli/review_recover_intended_untracked_test.go
@@ -236,3 +236,60 @@ func TestReviewRecoverStillNeverSweepsUndeclaredUntracked(t *testing.T) {
 		}
 	}
 }
+
+// TestReviewRecoverInheritsDeclarationAfterDeclaredPathWasCommitted is #3759.
+//
+// Inheriting the predecessor's frozen declaration (#3159) replayed it
+// verbatim, so once ordinary development committed one of those paths the
+// successor build refused with "already tracked" and named one path per
+// attempt. A committed path is no longer untracked: the index carries it and
+// the current-changes target already covers it, so there is nothing left to
+// declare. Inheritance keeps only the entries that are still untracked.
+func TestReviewRecoverInheritsDeclarationAfterDeclaredPathWasCommitted(t *testing.T) {
+	reviewEnabledHome(t)
+	repo, predecessor := escalatedIntendedUntrackedRecoveryFixture(t, "recover-3759")
+
+	// Unrelated development lands one declared path between escalation and
+	// recovery; the other declared path stays untracked.
+	runReviewCLIGit(t, repo, "add", "notes-a.txt")
+	runReviewCLIGit(t, repo, "commit", "-qm", "land notes-a")
+	if err := os.WriteFile(filepath.Join(repo, "tracked.txt"), []byte("base\none\ntwo\nthree\ncorrected\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	builder := reviewtransaction.SnapshotBuilder{Repo: repo}
+	complete, err := builder.Build(context.Background(), reviewtransaction.Target{
+		Kind: reviewtransaction.TargetCurrentChanges, Projection: reviewtransaction.ProjectionWorkspace,
+		IntendedUntracked: []string{"notes-b.txt"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	authorization := reviewRecoveryAuthorization(predecessor.State.LineageID, predecessor.Revision,
+		complete.Identity, "maintainer", "recover after landing a declared path")
+
+	var output bytes.Buffer
+	if err := RunReviewRecover([]string{
+		"--cwd", repo, "--predecessor-lineage", predecessor.State.LineageID,
+		"--expected-predecessor-revision", predecessor.Revision,
+		"--successor-lineage", "recover-3759-successor", "--disposition", "escalated",
+		"--reason", "recover after landing a declared path", "--actor", "maintainer",
+		"--maintainer-authorization", authorization,
+	}, &output); err != nil {
+		t.Fatalf("recovery inheriting a declaration with one committed path was refused: %v\n%s", err, output.String())
+	}
+	store, err := reviewtransaction.CompactAuthoritativeStore(context.Background(), repo, "recover-3759-successor")
+	if err != nil {
+		t.Fatal(err)
+	}
+	successor, err := store.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := strings.Join(successor.State.InitialSnapshot.IntendedUntracked, ","); got != "notes-b.txt" {
+		t.Fatalf("successor declaration = %q, want only the still-untracked notes-b.txt", got)
+	}
+	if successor.State.InitialSnapshot.Identity != complete.Identity {
+		t.Fatalf("successor identity %s does not bind the authorized candidate %s", successor.State.InitialSnapshot.Identity, complete.Identity)
+	}
+}

--- a/internal/reviewtransaction/snapshot.go
+++ b/internal/reviewtransaction/snapshot.go
@@ -694,6 +694,33 @@ func (builder SnapshotBuilder) IntendedUntrackedInventory(ctx context.Context) (
 	return paths, intendedUntrackedInventoryDigest(paths), nil
 }
 
+// StillUntracked keeps the entries of a frozen intended-untracked declaration
+// that the index does not carry yet (issue #3759). A declared path committed
+// after the declaration froze is no longer untracked: the current-changes
+// target already covers it, so replaying it would only trip the
+// "already tracked" refusal in buildCurrentChanges.
+func (builder SnapshotBuilder) StillUntracked(ctx context.Context, declared []string) ([]string, error) {
+	remaining := []string{}
+	if len(declared) == 0 {
+		return remaining, nil
+	}
+	root, err := builder.ResolveRepositoryRoot(ctx)
+	if err != nil {
+		return nil, err
+	}
+	trackedOutput, err := runGitInventory(ctx, root, "ls-files", "--cached", "-z", "--")
+	if err != nil {
+		return nil, err
+	}
+	tracked := nulSeparatedPathSet(trackedOutput)
+	for _, path := range declared {
+		if _, isTracked := tracked[path]; !isTracked {
+			remaining = append(remaining, path)
+		}
+	}
+	return remaining, nil
+}
+
 // ValidateIntendedUntrackedSelection proves paths remain eligible in STATUS's inventory.
 func (builder SnapshotBuilder) ValidateIntendedUntrackedSelection(ctx context.Context, expectedDigest string, selected []string) ([]string, error) {
 	paths, digest, err := builder.IntendedUntrackedInventory(ctx)

--- a/internal/reviewtransaction/transaction.go
+++ b/internal/reviewtransaction/transaction.go
@@ -170,6 +170,9 @@ type RefuterClaim struct {
 	FindingID        string `json:"finding_id"`
 	SnapshotIdentity string `json:"snapshot_identity"`
 	Proof            string `json:"proof"`
+	// Claim is the finding's own assertion. Without it the refuter has no
+	// proposition to corroborate or refute (issue #3482).
+	Claim string `json:"claim,omitempty"`
 }
 
 type EvidenceRoute struct {


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #3759
Closes #3482

Both reproduced today on current main before this change, each with a test that drives the real CLI route.

---

## 🏷️ PR Type

- [x] `type:bug` — Bug fix (non-breaking change that fixes an issue)

---

## 📝 Summary

- **#3759**: `review recover` without `--untracked-scope` inherited the predecessor's frozen intended-untracked declaration verbatim, so a path committed between START and recover was declared again and refused with `intended-untracked path "notes-a.txt" is already tracked`, with no exit short of restarting the lineage. The inherit route now keeps only the declared entries the index does not carry (`SnapshotBuilder.StillUntracked`, `git ls-files --cached` from the resolved root). A committed path is already inside the tracked target, so there is nothing left to declare. The #3159 guard (still-untracked entries are never dropped) and the #2394 guard (no sweep) are unchanged; explicit `--untracked-scope select` is unchanged. The earlier draft that compared resolved bytes against the frozen tree and added a list-every-stale-path refusal was not taken: it added machinery and a new refusal for a case the successor's tracked diff already covers.
- **#3482**: the compiled refuter batch carried each finding's `finding_id`, `snapshot_identity`, and `proof`, but never the claim text being adjudicated, so inferential blockers could only return inconclusive and always escalated. `RefuterClaim` gains `claim` (`omitempty`, filled from the admitted lens finding by id). Severity is deliberately not carried: it is not part of the proposition. The key appears only inside the compiled refuter prompt payload; persisted legacy bytes are unchanged and gentle-pi has no consumer of the claims shape.

---

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/reviewtransaction/snapshot.go`, `internal/cli/review_facade.go` | Inherited declaration filtered to still-untracked entries. |
| `internal/reviewtransaction/transaction.go`, `internal/cli/review_provider_roles.go` | Refuter claims carry the finding's claim text. |
| Tests | `TestReviewRecoverInheritsDeclarationAfterDeclaredPathWasCommitted` (red on main with the reported refusal), `TestRefuterRequestCarriesTheFindingClaimText` (red on main: no `claim` in the materialized refuter prompt). |

---

## 🤖 AI Assistance

- [ ] **None** — No material AI assistance was used.
- [x] **Material assistance used** — Complete all applicable declaration fields below.

**Tool/model (if known):** Claude Code (Claude Fable 5) with triage, reproduction, and writer agents.

**Material scope:** Reproduction on current main, tests (red first), core change.

**Verification performed:** `go test ./...` on the branch merged with origin/main, `go run ./internal/gofmtcheck`, `GOOS=windows go vet`, deadcode ratchet, `cd bench && go test ./...`, driven bench corpus (summary appended). E2E Docker left to CI.

---

## 🧪 Test Plan

**Unit Tests**
```bash
go test ./...
```

**Go Format**
```bash
go run ./internal/gofmtcheck
```

**Benchmark Validation**

Review-lifecycle change: driven corpus against a binary built from this branch. Summary line: `journeys: 61 completed, 0 unsupported, 0 failed` (binary built from this branch merged with origin/main).

- [x] Unit tests pass (`go test ./...`)
- [x] Go format passes (`go run ./internal/gofmtcheck`)
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`) (left to CI)
- [x] Manually tested locally

---

## ✅ Contributor Checklist

- [x] PR is linked to an issue with `status:approved`
- [x] PR stays within 400 changed lines, or I have requested/obtained maintainer-applied `size:exception` with rationale documented
- [x] I have added the appropriate `type:*` label to this PR
- [x] Unit tests pass (`go test ./...`)
- [x] Go format passes (`go run ./internal/gofmtcheck`)
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`) (left to CI)
- [x] Benchmark validation completed, or this change is not applicable to the benchmark (explain why in the Test Plan).
- [x] I have updated documentation if necessary
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] I understand, reviewed, and take responsibility for the complete submission
- [x] I selected exactly one AI-assistance option and, if material assistance was used, completed all applicable declaration fields
- [x] My commits do not include `Co-Authored-By` trailers

---

## 💬 Notes for Reviewers

No new state, verb, flag, reason code, contract row, or ceiling. Refusal ratchet baseline untouched. The only message touched by behaviour is the one that no longer fires on inherit.

https://claude.ai/code/session_01SCnBzvpvtWpFLdbSfsJcCG



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Recovery now excludes intended-untracked paths that became tracked before recovery.
  * Recovery reports validation errors instead of proceeding with outdated paths.
  * Refuter requests now include the original claim text alongside finding details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


**Native review:** four-lens transaction `review-c146dc862ab7cb6a` closed `approved` on the first pass; acknowledgement burned (`gentle-ai.review-acknowledged/v1`).
