### PR TITLE
fix(review): keep the frozen exclude declaration on re-entry and name the runnable recover when a status-derived binding does not match

### DIFF
--- a/internal/cli/review_facade.go
+++ b/internal/cli/review_facade.go
@@ -7,6 +7,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"errors"
+	"flag"
 	"fmt"
 	"io"
 	"os"
@@ -856,9 +857,15 @@ func runReviewStatus(ctx context.Context, args []string, stdout io.Writer) error
 		}
 		result := newReviewTargetStatusResultForContract(native, *contract)
 		result.intendedUntracked = intendedScope
-		if native.Decision.FrozenReviewing {
-			// Explicit reviewing resume keeps the immutable scope that the reviewer
-			// artifacts bind, rather than asking live workspace drift to select one.
+		// Explicit reviewing resume keeps the immutable scope that the reviewer
+		// artifacts bind, rather than asking live workspace drift to select one.
+		// The same holds when the live target still equals the frozen one: an
+		// exclude declaration froze no intended path, so it is indistinguishable
+		// from an undeclared scope and STATUS used to ask for it again on every
+		// re-entry (#3120). The reviewing authority already holds that decision.
+		if native.Decision.FrozenReviewing ||
+			native.Applicability == reviewtransaction.TargetApplicabilityCurrent && native.State == reviewtransaction.StateReviewing &&
+				native.AuthorityVersion == reviewtransaction.AuthorityVersionCompact && !intendedScope.Declared {
 			intendedScope = reviewIntendedUntrackedScope{
 				Intended: append([]string{}, native.Projection.IntendedUntracked...), Declared: true,
 			}
@@ -1405,6 +1412,10 @@ func RunReviewRecover(args []string, stdout io.Writer) error {
 			return reviewUnchangedApprovedScopeRefusal(err, explicitCwd, *predecessor, *expected, *successor)
 		case reviewtransaction.RecoveryPredecessorNotInvalidated(err):
 			return reviewNotInvalidatedPredecessorRefusal(err, explicitCwd, *predecessor, *expected, *successor, predecessorRecord.State.State)
+		case errors.Is(err, reviewtransaction.ErrCompactRecoveryAuthorizationInexact) && authorizationProvided:
+			if _, derivable := reviewSelfRecoveryShapeForRecover(predecessorRecord.State.State, snapshot.Identity != predecessorRecord.State.InitialSnapshot.Identity); derivable {
+				return reviewInexactRecoveryAuthorizationRefusal(err, *predecessor, *expected, *successor, *disposition, reviewRecoverSelectorTokens(flags))
+			}
 		}
 		return err
 	}
@@ -1427,6 +1438,39 @@ func RunReviewRecover(args []string, stdout io.Writer) error {
 func reviewUnchangedRecoveryRefusal(cause error, cwd, predecessor, expected, successor, disposition string) error {
 	return fmt.Errorf("%w: the candidate is byte-identical to the escalated predecessor, so this successor would carry the exact content whose verification failed and there is nothing to re-review; change the candidate first (apply the fix that verification asked for, and stage it if you review the staged projection), then re-run: %s",
 		cause, reviewRecoverCommand(cwd, predecessor, expected, successor, disposition))
+}
+
+// reviewInexactRecoveryAuthorizationRefusal explains why a supplied
+// maintainer authorization did not bind and names what runs (#3099, #2910).
+//
+// The refusal stays exactly as strict: a binding is accepted only when it names
+// the successor target this command derived, and that target follows the
+// selectors given to this command, not the ones a status query was given. What
+// it never said is the shape a binding has, or that this recovery shape does
+// not need one: the command derives actor, reason, and binding itself, so the
+// continuation is the same invocation without the three flags. This refusal is
+// relayed verbatim into machine envelopes, so it stays path-free and the
+// continuation runs with the repository as the working directory.
+func reviewInexactRecoveryAuthorizationRefusal(cause error, predecessor, expected, successor, disposition string, selectors []string) error {
+	return fmt.Errorf("%w: an accepted binding is the LF-joined text `gentle-ai.review-recovery-authorization/v1` followed by one key=value line each for predecessor_lineage, predecessor_revision, target_identity (the successor target this command derived, echoed above), actor, and reason; a target derived by a status query with different selectors never binds here. This recovery shape derives its own binding, so omit --maintainer-authorization, --actor, and --reason and, with the repository as the working directory, re-run: %s",
+		cause, strings.Join(append([]string{reviewRecoverCommand("", predecessor, expected, successor, disposition)}, selectors...), " "))
+}
+
+// reviewRecoverSelectorTokens re-renders the target selectors this recover was
+// given, so a printed re-run derives the same successor target.
+func reviewRecoverSelectorTokens(flags *flag.FlagSet) []string {
+	tokens := []string{}
+	flags.Visit(func(value *flag.Flag) {
+		switch value.Name {
+		case "projection", "base-ref", "committed-only", "workspace-overlay", "release-scope", "untracked-scope", "expected-untracked-inventory":
+			tokens = append(tokens, "--"+value.Name+"="+value.Value.String())
+		case "intended-untracked":
+			for _, path := range *value.Value.(*reviewRepeatedPathFlag) {
+				tokens = append(tokens, "--intended-untracked="+path)
+			}
+		}
+	})
+	return tokens
 }
 
 // reviewRecoverCommand renders one literal `gentle-ai review recover`

--- a/internal/cli/review_recovery_collect_binding_test.go
+++ b/internal/cli/review_recovery_collect_binding_test.go
@@ -1,0 +1,150 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/gentleman-programming/gentle-ai/v2/internal/reviewtransaction"
+)
+
+// recoveryCollectBindingFixture is the #3099/#2910 shape: an escalated
+// lineage frozen with two selected untracked paths, a changed candidate, and a
+// negotiated STATUS that selected the exclude scope. It returns the repository,
+// the exclude selectors STATUS used, and the binding a maintainer assembles
+// from the recovery_authorization_required collect alone.
+func recoveryCollectBindingFixture(t *testing.T, lineage string) (string, []string, map[string]string, string) {
+	t.Helper()
+	repo := initReviewCLIRepo(t)
+	if err := os.WriteFile(filepath.Join(repo, "tracked.txt"), []byte("base\none\ntwo\nthree\nfour\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	for _, name := range []string{"notes-a.txt", "notes-b.txt"} {
+		writeUndeclaredWorkspaceFile(t, repo, name, "untracked but explicitly selected\n", 0o644)
+	}
+	_, digest, err := (reviewtransaction.SnapshotBuilder{Repo: repo}).IntendedUntrackedInventory(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	selected, err := (reviewtransaction.SnapshotBuilder{Repo: repo}).Build(context.Background(), reviewtransaction.Target{
+		Kind: reviewtransaction.TargetCurrentChanges, Projection: reviewtransaction.ProjectionWorkspace,
+		IntendedUntracked: []string{"notes-a.txt", "notes-b.txt"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var output bytes.Buffer
+	if err := RunReview([]string{
+		"start", "--contract", ReviewIntegrationContractV2, "--cwd", repo, "--lineage", lineage,
+		"--target", selected.Identity, "--projection", string(reviewtransaction.ProjectionWorkspace),
+		"--untracked-scope=select", "--expected-untracked-inventory=" + digest,
+		"--intended-untracked", "notes-a.txt", "--intended-untracked", "notes-b.txt",
+	}, &output); err != nil {
+		t.Fatal(negotiatedReviewStartFailure(err, output.String()))
+	}
+	started := decodeNegotiatedReviewStart(t, output.Bytes())
+	escalateReviewForRecovery(t, repo, ReviewFacadeStartResult{
+		LineageID: started.LineageID, TargetIdentity: started.RepositoryContext.TargetIdentity, SelectedLenses: started.SelectedLenses,
+	})
+	if err := os.WriteFile(filepath.Join(repo, "tracked.txt"), []byte("base\none\ntwo\nthree\nfixed\nmore\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	selectors := []string{"--untracked-scope=exclude", "--expected-untracked-inventory=" + digest}
+	output.Reset()
+	if err := RunReview(append([]string{
+		"status", "--cwd", repo, "--contract", ReviewIntegrationContractV2, "--lineage", lineage, "--next-transition",
+	}, selectors...), &output); err != nil {
+		t.Fatalf("STATUS: %v\n%s", err, output.String())
+	}
+	var status ReviewTargetStatusResult
+	decodeStrictReviewJSON(t, output.Bytes(), &status)
+	if status.NextTransition == nil || status.NextTransition.Kind != reviewNextTransitionCollect ||
+		status.NextTransition.ReasonCode != "recovery_authorization_required" ||
+		status.NextTransition.Collect == nil || len(status.NextTransition.Collect.Inputs) != 1 {
+		t.Fatalf("STATUS transition = %#v", status.NextTransition)
+	}
+	input := status.NextTransition.Collect.Inputs[0]
+	bound, err := reviewTransitionArgumentMap(input.Arguments)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return repo, selectors, bound, strings.Join([]string{
+		input.Schema,
+		"predecessor_lineage=" + bound["lineage"],
+		"predecessor_revision=" + bound["expected-revision"],
+		"target_identity=" + bound["target"],
+		"actor=maintainer",
+		"reason=corrected candidate after escalation",
+	}, "\n")
+}
+
+func recoverWithCollectBinding(repo string, bound map[string]string, successor, authorization string, selectors ...string) ([]byte, error) {
+	var output bytes.Buffer
+	err := RunReview(append([]string{
+		"recover", "--cwd", repo,
+		"--predecessor-lineage", bound["lineage"], "--expected-predecessor-revision", bound["expected-revision"],
+		"--successor-lineage", successor, "--disposition", bound["disposition"],
+		"--actor", "maintainer", "--reason", "corrected candidate after escalation", "--maintainer-authorization", authorization,
+	}, selectors...), &output)
+	return output.Bytes(), err
+}
+
+// TestRecoveryCollectBindingRunsRecoverWithTheSelectorsStatusUsed pins the
+// converging half: the binding assembled from the collect is exactly the one
+// `review recover` accepts once recover derives the same successor target.
+func TestRecoveryCollectBindingRunsRecoverWithTheSelectorsStatusUsed(t *testing.T) {
+	reviewEnabledHome(t)
+	repo, selectors, bound, authorization := recoveryCollectBindingFixture(t, "collect-binding-converges")
+	payload, err := recoverWithCollectBinding(repo, bound, "collect-bound-successor", authorization, selectors...)
+	if err != nil {
+		t.Fatalf("recover refused the binding assembled from its own collect: %v\n%s", err, payload)
+	}
+	var result ReviewRecoverResult
+	decodeStrictReviewJSON(t, payload, &result)
+	if result.LineageID != "collect-bound-successor" || result.TargetIdentity != bound["target"] || result.State != reviewtransaction.StateReviewing {
+		t.Fatalf("recover = %#v, want a reviewing successor over %s", result, bound["target"])
+	}
+}
+
+// TestRecoveryCollectBindingRefusalNamesARunnableRecover is the reported
+// half: the same binding handed to a recover that was not given the selectors
+// derives a different successor target and is refused. The refusal must name a
+// recover that runs, and running it must create the successor.
+func TestRecoveryCollectBindingRefusalNamesARunnableRecover(t *testing.T) {
+	reviewEnabledHome(t)
+	repo, _, bound, authorization := recoveryCollectBindingFixture(t, "collect-binding-refused")
+	payload, err := recoverWithCollectBinding(repo, bound, "collect-refused-successor", authorization)
+	if err == nil {
+		t.Fatalf("recover accepted a binding over a target it did not derive:\n%s", payload)
+	}
+	message := err.Error()
+	_, continuation, named := strings.Cut(message, "re-run: ")
+	if !named || !strings.HasPrefix(continuation, "gentle-ai review recover ") || !strings.Contains(message, "key=value") {
+		t.Fatalf("refusal names no runnable recover: %s", message)
+	}
+	if strings.Contains(message, repo) {
+		t.Fatalf("refusal published the repository path: %s", message)
+	}
+	previous, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chdir(repo); err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = os.Chdir(previous) }()
+	fields := strings.Fields(continuation)
+	var recovered bytes.Buffer
+	if err := RunReview(fields[2:], &recovered); err != nil {
+		t.Fatalf("printed continuation %q refused: %v\n%s", continuation, err, recovered.String())
+	}
+	var result ReviewRecoverResult
+	decodeStrictReviewJSON(t, recovered.Bytes(), &result)
+	if result.LineageID != "collect-refused-successor" || result.State != reviewtransaction.StateReviewing ||
+		result.Recovery.PredecessorLineageID != bound["lineage"] {
+		t.Fatalf("printed continuation = %#v, want a reviewing successor of %s", result, bound["lineage"])
+	}
+}

--- a/internal/cli/review_start_excluded_untracked_reentry_test.go
+++ b/internal/cli/review_start_excluded_untracked_reentry_test.go
@@ -1,0 +1,73 @@
+package cli
+
+import (
+	"bytes"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/gentleman-programming/gentle-ai/v2/internal/reviewtransaction"
+)
+
+// TestExcludedUntrackedDeclarationSurvivesReviewingReentry is the #3120 shape:
+// a lineage frozen with --untracked-scope exclude, then re-entered through the
+// three routes a consumer actually runs. None of them may ask for the untracked
+// selection again, because the frozen authority already holds that decision.
+func TestExcludedUntrackedDeclarationSurvivesReviewingReentry(t *testing.T) {
+	reviewEnabledHome(t)
+	repo := initReviewCLIRepo(t)
+	writeReviewStartCandidate(t, repo, "candidate.go", "package candidate\n\nfunc Candidate() int { return 1 }\n", 0o644)
+	writeUndeclaredWorkspaceFile(t, repo, "scratch/mockup.txt", "kept outside the candidate\n", 0o644)
+	started := runNegotiatedReviewStartExcludingUntracked(t, repo, "excluded-untracked-reentry")
+	if started.Action != "created" || started.State != reviewtransaction.StateReviewing {
+		t.Fatalf("START = %s/%s", started.Action, started.State)
+	}
+
+	previous, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chdir(repo); err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = os.Chdir(previous) }()
+
+	assertReentry := func(route string, args []string) {
+		t.Helper()
+		var output bytes.Buffer
+		if err := RunReview(args, &output); err != nil {
+			t.Fatalf("%s: %v\n%s", route, err, output.String())
+		}
+		var status ReviewTargetStatusResult
+		decodeStrictReviewJSON(t, output.Bytes(), &status)
+		if status.Authority == nil || status.Authority.LineageID != started.LineageID {
+			t.Fatalf("%s bound %#v, want lineage %s", route, status.Authority, started.LineageID)
+		}
+		if status.NextTransition == nil || status.NextTransition.ReasonCode != "reviewer_results_required" {
+			t.Fatalf("%s re-asked the frozen untracked decision: %#v", route, status.NextTransition)
+		}
+	}
+
+	continuationArgs := func(result ReviewIntegrationStartResult) []string {
+		t.Helper()
+		if result.NextTransition == nil || result.NextTransition.Execute == nil {
+			t.Fatalf("START published no status continuation: %#v", result.NextTransition)
+		}
+		fields := strings.Fields(result.NextTransition.Execute.Command)
+		if len(fields) < 3 || fields[0] != "gentle-ai" || fields[1] != "review" {
+			t.Fatalf("continuation command = %q", result.NextTransition.Execute.Command)
+		}
+		return fields[2:]
+	}
+
+	assertReentry("START-published continuation", continuationArgs(started))
+	assertReentry("exact-lineage STATUS", []string{
+		"status", "--contract", ReviewIntegrationContractV2, "--next-transition", "--lineage", started.LineageID,
+	})
+
+	replayed := runNegotiatedReviewStartExcludingUntracked(t, repo, started.LineageID)
+	if replayed.Action != "replayed" || replayed.LineageID != started.LineageID {
+		t.Fatalf("second START = %s/%s", replayed.Action, replayed.LineageID)
+	}
+	assertReentry("replayed START continuation", continuationArgs(replayed))
+}


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #3120
Closes #3099
Closes #2910

All three reproduced today on current main before this change, each with a test that drives the real CLI route. For #3099/#2910 the symptom is as reported but the mechanism differs from the issue text; see below.

---

## 🏷️ PR Type

- [x] `type:bug` — Bug fix (non-breaking change that fixes an issue)

---

## 📝 Summary

- **#3120**: after a negotiated START with `--untracked-scope=exclude`, the START-published status continuation, `status --lineage`, and the continuation of a replayed START all collected `intended_untracked_selection_required` again. STATUS adopted the frozen declaration only on the drift path (`FrozenReviewing`); on a current target an exclude declaration (`IntendedUntracked=[]`) was indistinguishable from "undeclared", so `NeedsSelection` stayed true. STATUS now adopts the frozen declaration for any current reviewing compact authority when the caller declares nothing, the same override the drift path already applied. No new refusal for replayed START: the re-ask came from STATUS, not START, in every reporter's trace.
- **#3099 / #2910**: the `recovery_authorization_required` collect emits the target STATUS derived from the caller's selectors, and `review recover` accepts a binding assembled from it only when recover is given the same selectors; without them recover derives the successor target from predecessor inheritance, refuses with the bare sentinel (no continuation, no format) and echoes a different identity. That is the reporters' loop. The refusal now states the LF `key=value` binding shape, says why a status-derived target does not bind there, and prints the `gentle-ai review recover ...` re-run with the caller's own selector flags; the test executes the printed continuation and asserts a reviewing successor. The sentinel and the `escalated_recovery_authorization_inexact` mapping are preserved via `%w`. No selector rows or authorization template were added to the collect: both would be new wire vocabulary; the refusal-side fix removes the dead end without changing envelopes.

---

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/cli/review_facade.go` | STATUS adopts the frozen declaration on any current reviewing authority; inexact status-derived recovery binding refusal names the runnable recover. |
| Tests | `TestExcludedUntrackedDeclarationSurvivesReviewingReentry` (red on main: continuation re-asked the selection), `TestRecoveryCollectBindingRefusalNamesARunnableRecover` (red on main: refusal named no runnable recover), `TestRecoveryCollectBindingRunsRecoverWithTheSelectorsStatusUsed` (green pin). |

---

## 🤖 AI Assistance

- [ ] **None** — No material AI assistance was used.
- [x] **Material assistance used** — Complete all applicable declaration fields below.

**Tool/model (if known):** Claude Code (Claude Fable 5) with triage, reproduction, and writer agents.

**Material scope:** Reproduction on current main (including probing every reachable `recovery_authorization_required` shape), tests (red first), core change.

**Verification performed:** `go test ./...` on the branch merged with origin/main, `go run ./internal/gofmtcheck`, `GOOS=windows go vet`, deadcode ratchet, `cd bench && go test ./...`, driven bench corpus (summary appended). E2E Docker left to CI.

---

## 🧪 Test Plan

**Unit Tests**
```bash
go test ./...
```

**Go Format**
```bash
go run ./internal/gofmtcheck
```

**Benchmark Validation**

Review-lifecycle change: driven corpus against a binary built from this branch. Summary line: `journeys: 61 completed, 0 unsupported, 0 failed` (binary built from this branch merged with origin/main). The journeys that pinned these reason codes (`j90`, `j94`) are retired in `retiredAtomicJourneyReplacements`; `j60`, `j75`, `j88`, `j110`, `j111` were run individually as well.

- [x] Unit tests pass (`go test ./...`)
- [x] Go format passes (`go run ./internal/gofmtcheck`)
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`) (left to CI)
- [x] Manually tested locally

---

## ✅ Contributor Checklist

- [x] PR is linked to an issue with `status:approved`
- [x] PR stays within 400 changed lines, or I have requested/obtained maintainer-applied `size:exception` with rationale documented
- [x] I have added the appropriate `type:*` label to this PR
- [x] Unit tests pass (`go test ./...`)
- [x] Go format passes (`go run ./internal/gofmtcheck`)
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`) (left to CI)
- [x] Benchmark validation completed, or this change is not applicable to the benchmark (explain why in the Test Plan).
- [x] I have updated documentation if necessary
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] I understand, reviewed, and take responsibility for the complete submission
- [x] I selected exactly one AI-assistance option and, if material assistance was used, completed all applicable declaration fields
- [x] My commits do not include `Co-Authored-By` trailers

---

## 💬 Notes for Reviewers

No new verb, flag, reason code, envelope field, contract row, or ceiling. Refusal ratchet baseline untouched. Two things deliberately left alone because they are not in the reported loop: the "escalated recovery" wording of the shared sentinel for other dispositions, and the missing `review schema` entry.

https://claude.ai/code/session_01SCnBzvpvtWpFLdbSfsJcCG



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Review recovery now provides a runnable continuation when authorization details or selectors are incomplete.
  - Review status preserves the previously selected untracked-file scope during re-entry.
  - Recovery accepts the exact selectors used during the original review transition.

- **Bug Fixes**
  - Prevented excluded untracked files from triggering repeated selection prompts when a review is resumed or replayed.
  - Improved recovery handling for inexact maintainer authorization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


**Native review:** transaction `review-71bdc2faf111d82d` closed `approved` on the first pass; acknowledgement burned (`gentle-ai.review-acknowledged/v1`).
