### PR TITLE
fix(install): resolve OpenCode plugin paths through the adapter, keep an install when auto-added engram fails, and stop routing an archived Engram change to archive

### DIFF
--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -19,6 +19,7 @@ import (
 	"github.com/gentleman-programming/gentle-ai/v2/internal/agents/claude"
 	codexagent "github.com/gentleman-programming/gentle-ai/v2/internal/agents/codex"
 	"github.com/gentleman-programming/gentle-ai/v2/internal/agents/kimi"
+	opencodeagent "github.com/gentleman-programming/gentle-ai/v2/internal/agents/opencode"
 	"github.com/gentleman-programming/gentle-ai/v2/internal/assets"
 	"github.com/gentleman-programming/gentle-ai/v2/internal/backup"
 	"github.com/gentleman-programming/gentle-ai/v2/internal/components/agentguidance"
@@ -1459,6 +1460,7 @@ func (s componentApplyStep) Run() error {
 	switch s.component {
 	case model.ComponentEngram:
 		engramCommand := "engram"
+		var installErr error
 		if s.channel.IsBeta() {
 			binaryPath, err := installBetaEngramFromMain()
 			if err != nil {
@@ -1473,16 +1475,12 @@ func (s componentApplyStep) Run() error {
 				if err != nil {
 					return fmt.Errorf("resolve install command for component %q: %w", s.component, err)
 				}
-				if err := runCommandSequence(commands); err != nil {
-					return err
-				}
-			} else {
+				installErr = runCommandSequence(commands)
+			} else if binaryPath, err := engramDownloadFn(s.profile); err != nil {
 				// Linux / Windows: download the pre-built binary from GitHub Releases.
 				// No Go required — engram ships pre-built binaries.
-				binaryPath, err := engramDownloadFn(s.profile)
-				if err != nil {
-					return fmt.Errorf("download engram binary: %w", err)
-				}
+				installErr = fmt.Errorf("download engram binary: %w", err)
+			} else {
 				// Add the install directory to PATH so subsequent commands
 				// (engram setup, engram.Inject → resolveEngramCommand) can find it.
 				// On Windows this also persists the change to the user registry via PowerShell.
@@ -1492,6 +1490,16 @@ func (s componentApplyStep) Run() error {
 					fmt.Fprintf(os.Stderr, "WARNING: could not add %s to PATH: %v\n", binDir, err)
 				}
 				engramCommand = binaryPath
+			}
+			if installErr != nil {
+				if s.selection.HasComponent(model.ComponentEngram) {
+					return installErr
+				}
+				// engram was auto-added as an sdd dependency, not requested. Its
+				// failure must not abort the components the user asked for: wire
+				// the config as usual and report the missing binary as a warning
+				// with its own install command (#3725).
+				fmt.Fprintf(os.Stderr, "WARNING: engram could not be installed: %v\nInstall it with `%s`.\n", installErr, engramInstallCommand(s.agents))
 			}
 		} else if shouldRefreshWindowsEngram(s.profile, installedPath, pathEnvEntries(s.profile)) {
 			binaryPath, err := engramDownloadFn(s.profile)
@@ -1533,7 +1541,7 @@ func (s componentApplyStep) Run() error {
 		// entirely rather than run it unconditionally.
 		willAttemptSetup := false
 		for _, adapter := range adapters {
-			if engram.ShouldAttemptSetup(setupMode, adapter.Agent()) {
+			if installErr == nil && engram.ShouldAttemptSetup(setupMode, adapter.Agent()) {
 				willAttemptSetup = true
 				break
 			}
@@ -1561,7 +1569,7 @@ func (s componentApplyStep) Run() error {
 
 		attemptedSlugs := make(map[string]struct{}, len(adapters))
 		for _, adapter := range adapters {
-			if engram.ShouldAttemptSetup(setupMode, adapter.Agent()) {
+			if willAttemptSetup && engram.ShouldAttemptSetup(setupMode, adapter.Agent()) {
 				slug, _ := engram.SetupAgentSlug(adapter.Agent())
 				if _, seen := attemptedSlugs[slug]; !seen {
 					setupArgs := []string{"setup", slug}
@@ -2210,7 +2218,7 @@ func componentPathsWithWorkspaceScoped(homeDir, workspaceDir string, scope Insta
 				if p := adapter.SettingsPath(targetDir); p != "" {
 					paths = append(paths, p, opencodedefault.OwnershipPath(p))
 				}
-				paths = append(paths, openCodeSDDPluginPaths(targetDir)...)
+				paths = append(paths, openCodeSDDPluginPaths(adapter, targetDir)...)
 				// Shared prompt files in the selected OpenCode config scope — back these up
 				// so a sync does not silently overwrite user-customized prompt content.
 				// These files are only written for multi-mode (SDDModeMulti), so we only
@@ -2508,13 +2516,16 @@ func sddSubAgentPaths(homeDir string, adapter agents.Adapter) []string {
 	return paths
 }
 
-func openCodeSDDPluginPaths(targetDir string) []string {
+func openCodeSDDPluginPaths(adapter agents.Adapter, targetDir string) []string {
 	// Legacy background-agents is removed during installation and therefore has
 	// an absence check. The retired reviewer plugin is part of the rollback
 	// snapshot but not post-apply verification because migration removes it.
-	paths := []string{filepath.Join(targetDir, ".config", "opencode", "plugins", "background-agents.ts")}
+	// The plugin writer resolves the config directory through the adapter, so
+	// verification must ask the same resolver (#3219).
+	pluginsDir := filepath.Join(adapter.GlobalConfigDir(targetDir), "plugins")
+	paths := []string{filepath.Join(pluginsDir, "background-agents.ts")}
 	for _, name := range sdd.ManagedOpenCodePluginNames() {
-		paths = append(paths, filepath.Join(targetDir, ".config", "opencode", "plugins", name))
+		paths = append(paths, filepath.Join(pluginsDir, name))
 	}
 	return paths
 }
@@ -2578,7 +2589,7 @@ func runPostApplyVerification(input postApplyVerificationInput) verify.Report {
 	}
 
 	if hasComponent(input.Resolved.OrderedComponents, model.ComponentEngram) {
-		checks = append(checks, engramHealthChecks(input.State)...)
+		checks = append(checks, engramHealthChecks(input.State, input.Resolved.Agents)...)
 	}
 	checks = append(checks, antigravityCollisionCheck(input.Resolved.Agents)...)
 
@@ -2589,11 +2600,17 @@ func isLegacyOpenCodeBackgroundAgentsPlugin(path string) bool {
 	path = filepath.Clean(path)
 	pluginsDir := filepath.Dir(path)
 	opencodeDir := filepath.Dir(pluginsDir)
-	configDir := filepath.Dir(opencodeDir)
-	return filepath.Base(path) == "background-agents.ts" &&
-		filepath.Base(pluginsDir) == "plugins" &&
-		filepath.Base(opencodeDir) == "opencode" &&
-		filepath.Base(configDir) == ".config"
+	if filepath.Base(path) != "background-agents.ts" || filepath.Base(pluginsDir) != "plugins" {
+		return false
+	}
+	// The plugin lives in the directory the adapter resolves: <root>/.config/opencode
+	// for a workspace or a home without XDG_CONFIG_HOME, and
+	// $XDG_CONFIG_HOME/opencode for the user's home when it is set (#3219).
+	if opencodeDir == opencodeagent.ConfigPath(filepath.Dir(filepath.Dir(opencodeDir))) {
+		return true
+	}
+	home, err := os.UserHomeDir()
+	return err == nil && opencodeDir == opencodeagent.ConfigPath(home)
 }
 
 func hasComponent(components []model.ComponentID, target model.ComponentID) bool {
@@ -2622,7 +2639,7 @@ func containsAgent(agents []model.AgentID, target model.AgentID) bool {
 // not yet resolved) still routes through the verifyEngramVersion seam var
 // rather than calling engram.VerifyVersion() directly, so it stays fakeable
 // in tests.
-func engramHealthChecks(state *runtimeState) []verify.Check {
+func engramHealthChecks(state *runtimeState, agentIDs []model.AgentID) []verify.Check {
 	return []verify.Check{
 		{
 			ID:          "verify:engram:binary",
@@ -2630,7 +2647,7 @@ func engramHealthChecks(state *runtimeState) []verify.Check {
 			Soft:        true,
 			Run: func(context.Context) error {
 				if err := engram.VerifyInstalled(); err != nil {
-					return fmt.Errorf("%w\nIf engram was installed via `go install`, add it to PATH:\n  %s", err, engramPathGuidance(os.Getenv("SHELL")))
+					return fmt.Errorf("%w\nInstall it with `%s`.\nIf engram was installed via `go install`, add it to PATH:\n  %s", err, engramInstallCommand(agentIDs), engramPathGuidance(os.Getenv("SHELL")))
 				}
 				return nil
 			},
@@ -2652,6 +2669,12 @@ func engramHealthChecks(state *runtimeState) []verify.Check {
 			},
 		},
 	}
+}
+
+// engramInstallCommand names the install continuation for a missing engram
+// binary so the warning that reports it is actionable on its own.
+func engramInstallCommand(agentIDs []model.AgentID) string {
+	return fmt.Sprintf("gentle-ai install --agent %s --components engram", joinAgentIDs(agentIDs))
 }
 
 // antigravityCollisionCheck returns a soft verify check that warns the user

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -1495,10 +1495,16 @@ func (s componentApplyStep) Run() error {
 					return installErr
 				}
 				// engram was auto-added as an sdd dependency, not requested. Its
-				// failure must not abort the components the user asked for: wire
-				// the config as usual and report the missing binary as a warning
-				// with its own install command (#3725).
+				// failure must not abort the components the user asked for, and
+				// no configuration may point at a binary that does not exist:
+				// report the missing binary as a warning with its own install
+				// command and leave the engram step entirely (#3725).
 				fmt.Fprintf(os.Stderr, "WARNING: engram could not be installed: %v\nInstall it with `%s`.\n", installErr, engramInstallCommand(s.agents))
+				if s.state != nil {
+					s.state.engramVersionResolved = true
+					s.state.engramVersionErr = installErr
+				}
+				return nil
 			}
 		} else if shouldRefreshWindowsEngram(s.profile, installedPath, pathEnvEntries(s.profile)) {
 			binaryPath, err := engramDownloadFn(s.profile)
@@ -2545,6 +2551,13 @@ func runPostApplyVerification(input postApplyVerificationInput) verify.Report {
 	seenPath := make(map[string]struct{})
 	var uniqueFilePaths []string
 	for _, component := range input.Resolved.OrderedComponents {
+		if component == model.ComponentEngram && !input.Selection.HasComponent(model.ComponentEngram) &&
+			input.State != nil && input.State.engramVersionErr != nil {
+			// An auto-added engram that could not be installed wrote nothing
+			// (#3725); its health check below carries the warning and the
+			// install command, so its files are not required here.
+			continue
+		}
 		for _, path := range componentPathsWithWorkspaceScoped(input.HomeDir, input.WorkspaceDir, input.Scope, input.Selection, adapters, component) {
 			if path == "" {
 				continue

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -19,7 +19,6 @@ import (
 	"github.com/gentleman-programming/gentle-ai/v2/internal/agents/claude"
 	codexagent "github.com/gentleman-programming/gentle-ai/v2/internal/agents/codex"
 	"github.com/gentleman-programming/gentle-ai/v2/internal/agents/kimi"
-	opencodeagent "github.com/gentleman-programming/gentle-ai/v2/internal/agents/opencode"
 	"github.com/gentleman-programming/gentle-ai/v2/internal/assets"
 	"github.com/gentleman-programming/gentle-ai/v2/internal/backup"
 	"github.com/gentleman-programming/gentle-ai/v2/internal/components/agentguidance"
@@ -2600,17 +2599,16 @@ func isLegacyOpenCodeBackgroundAgentsPlugin(path string) bool {
 	path = filepath.Clean(path)
 	pluginsDir := filepath.Dir(path)
 	opencodeDir := filepath.Dir(pluginsDir)
-	if filepath.Base(path) != "background-agents.ts" || filepath.Base(pluginsDir) != "plugins" {
+	if filepath.Base(path) != "background-agents.ts" || filepath.Base(pluginsDir) != "plugins" || filepath.Base(opencodeDir) != "opencode" {
 		return false
 	}
-	// The plugin lives in the directory the adapter resolves: <root>/.config/opencode
-	// for a workspace or a home without XDG_CONFIG_HOME, and
-	// $XDG_CONFIG_HOME/opencode for the user's home when it is set (#3219).
-	if opencodeDir == opencodeagent.ConfigPath(filepath.Dir(filepath.Dir(opencodeDir))) {
+	if filepath.Base(filepath.Dir(opencodeDir)) == ".config" {
 		return true
 	}
-	home, err := os.UserHomeDir()
-	return err == nil && opencodeDir == opencodeagent.ConfigPath(home)
+	// A home installed with XDG_CONFIG_HOME keeps its OpenCode config under
+	// $XDG_CONFIG_HOME/opencode instead of ~/.config/opencode (#3219).
+	xdgConfigHome := strings.TrimSpace(os.Getenv("XDG_CONFIG_HOME"))
+	return filepath.IsAbs(xdgConfigHome) && opencodeDir == filepath.Join(filepath.Clean(xdgConfigHome), "opencode")
 }
 
 func hasComponent(components []model.ComponentID, target model.ComponentID) bool {

--- a/internal/cli/run_component_paths_test.go
+++ b/internal/cli/run_component_paths_test.go
@@ -207,6 +207,31 @@ func TestInstallPiPersonaWritesManagedScopePaths(t *testing.T) {
 	}
 }
 
+// Issue #3219: a home installed with XDG_CONFIG_HOME keeps the legacy plugin
+// under $XDG_CONFIG_HOME/opencode/plugins, and the ~/.config form stays legacy
+// while XDG is set; the classification depends on the path and XDG alone.
+func TestLegacyOpenCodeBackgroundAgentsPluginUnderXDGConfigHome(t *testing.T) {
+	home := t.TempDir()
+	xdg := filepath.Join(t.TempDir(), "xdg")
+	t.Setenv("XDG_CONFIG_HOME", xdg)
+	for _, tt := range []struct {
+		name string
+		path string
+		want bool
+	}{
+		{name: "legacy plugin under XDG opencode config", path: filepath.Join(xdg, "opencode", "plugins", "background-agents.ts"), want: true},
+		{name: "legacy plugin under ~/.config while XDG is set", path: filepath.Join(home, ".config", "opencode", "plugins", "background-agents.ts"), want: true},
+		{name: "same file under unrelated opencode directory", path: filepath.Join(home, "opencode", "plugins", "background-agents.ts"), want: false},
+		{name: "managed replacement plugin under XDG is not legacy", path: filepath.Join(xdg, "opencode", "plugins", "model-variants.ts"), want: false},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isLegacyOpenCodeBackgroundAgentsPlugin(tt.path); got != tt.want {
+				t.Fatalf("isLegacyOpenCodeBackgroundAgentsPlugin(%q) = %v, want %v", tt.path, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestLegacyOpenCodeBackgroundAgentsPluginRequiresConfigOpenCodePluginsPath(t *testing.T) {
 	home := t.TempDir()
 

--- a/internal/cli/run_engram_download_test.go
+++ b/internal/cli/run_engram_download_test.go
@@ -717,6 +717,9 @@ func TestRunInstallSDDCompletesWhenAutoAddedEngramCannotBeInstalled(t *testing.T
 	if _, err := os.Stat(filepath.Join(home, ".claude", "CLAUDE.md")); err != nil {
 		t.Fatalf("requested sdd component did not land: %v", err)
 	}
+	if raw, err := os.ReadFile(filepath.Join(home, ".claude.json")); err == nil && strings.Contains(string(raw), "\"engram\"") {
+		t.Fatalf("engram MCP configuration was written for a binary that does not exist:\n%s", raw)
+	}
 	const wantCommand = "gentle-ai install --agent claude-code --components engram"
 	for _, check := range result.Verify.Checks {
 		if check.Status == verify.CheckStatusWarning && strings.Contains(check.Error, wantCommand) {

--- a/internal/cli/run_engram_download_test.go
+++ b/internal/cli/run_engram_download_test.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"context"
+	"errors"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -11,6 +12,7 @@ import (
 	"github.com/gentleman-programming/gentle-ai/v2/internal/components/engram"
 	"github.com/gentleman-programming/gentle-ai/v2/internal/model"
 	"github.com/gentleman-programming/gentle-ai/v2/internal/system"
+	"github.com/gentleman-programming/gentle-ai/v2/internal/verify"
 )
 
 // TestRunInstallLinuxEngramUsesDownloadNotGoInstall verifies that after the fix,
@@ -679,3 +681,47 @@ func TestRunInstallBetaEngramUsesMainGoInstallAndInstalledBinary(t *testing.T) {
 
 // Make sure the engram package's DownloadLatestBinary is accessible.
 var _ = engram.DownloadLatestBinary
+
+// TestRunInstallSDDCompletesWhenAutoAddedEngramCannotBeInstalled pins #3725:
+// engram is auto-added by sdd, and when its release cannot be fetched the
+// whole pipeline exited 1 with nothing installed. The requested component must
+// land and the missing dependency must be reported as a warning naming its own
+// install command.
+func TestRunInstallSDDCompletesWhenAutoAddedEngramCannotBeInstalled(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("PATH", t.TempDir())
+	restoreHome := osUserHomeDir
+	restoreCommand := runCommand
+	restoreLookPath := cmdLookPath
+	restoreDownload := engramDownloadFn
+	t.Cleanup(func() {
+		osUserHomeDir = restoreHome
+		runCommand = restoreCommand
+		cmdLookPath = restoreLookPath
+		engramDownloadFn = restoreDownload
+	})
+	osUserHomeDir = func() (string, error) { return home, nil }
+	runCommand = func(string, ...string) error { return nil }
+	cmdLookPath = missingBinaryLookPath
+	engramDownloadFn = func(system.PlatformProfile) (string, error) {
+		return "", errors.New("GitHub API returned HTTP 403")
+	}
+
+	result, err := RunInstall([]string{"--agent", "claude-code", "--components", "sdd"}, linuxDetectionResult(system.LinuxDistroUbuntu, "apt"))
+	if err != nil {
+		t.Fatalf("RunInstall() error = %v; an auto-added dependency must not abort the requested components", err)
+	}
+	if !result.Verify.Ready {
+		t.Fatalf("verification ready = false, report = %#v", result.Verify)
+	}
+	if _, err := os.Stat(filepath.Join(home, ".claude", "CLAUDE.md")); err != nil {
+		t.Fatalf("requested sdd component did not land: %v", err)
+	}
+	const wantCommand = "gentle-ai install --agent claude-code --components engram"
+	for _, check := range result.Verify.Checks {
+		if check.Status == verify.CheckStatusWarning && strings.Contains(check.Error, wantCommand) {
+			return
+		}
+	}
+	t.Fatalf("no warning names %q; report = %#v", wantCommand, result.Verify)
+}

--- a/internal/cli/run_xdg_test.go
+++ b/internal/cli/run_xdg_test.go
@@ -1,0 +1,57 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/gentleman-programming/gentle-ai/v2/internal/components/sdd"
+	"github.com/gentleman-programming/gentle-ai/v2/internal/system"
+)
+
+// TestRunInstallOpenCodeSDDVerifiesUnderXDGConfigHome pins #3219: the SDD
+// writer resolves the OpenCode config directory through the adapter, so with
+// XDG_CONFIG_HOME set every plugin lands under $XDG_CONFIG_HOME/opencode.
+// Verification then looked for the same files under ~/.config/opencode, failed,
+// and the rollback deleted the files the writer had just produced.
+func TestRunInstallOpenCodeSDDVerifiesUnderXDGConfigHome(t *testing.T) {
+	home := t.TempDir()
+	xdg := filepath.Join(home, ".xdg")
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	t.Setenv("XDG_CONFIG_HOME", xdg)
+
+	restoreHome := osUserHomeDir
+	restoreCommand := runCommand
+	restoreLookPath := cmdLookPath
+	restoreDownload := engramDownloadFn
+	t.Cleanup(func() {
+		osUserHomeDir = restoreHome
+		runCommand = restoreCommand
+		cmdLookPath = restoreLookPath
+		engramDownloadFn = restoreDownload
+	})
+	osUserHomeDir = func() (string, error) { return home, nil }
+	runCommand = func(string, ...string) error { return nil }
+	cmdLookPath = missingBinaryLookPath
+	engramDownloadFn = func(system.PlatformProfile) (string, error) {
+		return filepath.Join(t.TempDir(), "engram"), nil
+	}
+
+	result, err := RunInstall([]string{"--agent", "opencode", "--component", "sdd"}, linuxDetectionResult(system.LinuxDistroUbuntu, "apt"))
+	if err != nil {
+		t.Fatalf("RunInstall() error = %v", err)
+	}
+	if !result.Verify.Ready {
+		t.Fatalf("verification ready = false, report = %#v", result.Verify)
+	}
+	for _, name := range sdd.ManagedOpenCodePluginNames() {
+		path := filepath.Join(xdg, "opencode", "plugins", name)
+		if _, err := os.Stat(path); err != nil {
+			t.Fatalf("managed plugin %q missing after install: %v", path, err)
+		}
+	}
+	if _, err := os.Stat(filepath.Join(home, ".config", "opencode")); !os.IsNotExist(err) {
+		t.Fatalf("install touched ~/.config/opencode although XDG_CONFIG_HOME is set (stat err = %v)", err)
+	}
+}

--- a/internal/components/uninstall/service.go
+++ b/internal/components/uninstall/service.go
@@ -794,12 +794,11 @@ func (s *Service) componentOperations(adapter agents.Adapter, componentID model.
 
 			ops = append(ops, rewriteOpenCodeSDDSettings(path, defaultPlan, paths...))
 
-			pluginDir := filepath.Join(homeDir, ".config", "opencode", "plugins")
-			for _, pluginPath := range []string{
-				filepath.Join(pluginDir, "background-agents.ts"),
-				filepath.Join(pluginDir, "model-variants.ts"),
-				filepath.Join(pluginDir, "skill-registry.ts"),
-			} {
+			// The SDD plugin writer resolves the config directory through the
+			// adapter and owns the plugin list; uninstall must match it (#3219).
+			pluginDir := filepath.Join(adapter.GlobalConfigDir(homeDir), "plugins")
+			for _, name := range append([]string{"background-agents.ts"}, sdd.OpenCodePluginLifecycleNames(adapter.Agent())...) {
+				pluginPath := filepath.Join(pluginDir, name)
 				targets = append(targets, pluginPath)
 				ops = append(ops, removeFile(pluginPath))
 			}

--- a/internal/components/uninstall/service_test.go
+++ b/internal/components/uninstall/service_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/gentleman-programming/gentle-ai/v2/internal/backup"
 	"github.com/gentleman-programming/gentle-ai/v2/internal/components/communitytool"
 	"github.com/gentleman-programming/gentle-ai/v2/internal/components/engram"
+	"github.com/gentleman-programming/gentle-ai/v2/internal/components/sdd"
 	"github.com/gentleman-programming/gentle-ai/v2/internal/model"
 	opencodeactivation "github.com/gentleman-programming/gentle-ai/v2/internal/opencode"
 	"github.com/gentleman-programming/gentle-ai/v2/internal/state"
@@ -1330,5 +1331,49 @@ func TestComponentOperationsSDD_CodexRemovesSkillRegistryHook(t *testing.T) {
 	}
 	if !strings.Contains(text, "echo keep") || !strings.Contains(text, "echo pre") {
 		t.Fatalf("unrelated hooks should be preserved:\n%s", text)
+	}
+}
+
+// TestComponentOperationsSDD_OpenCodeRemovesManagedPluginsUnderXDGConfigHome
+// pins #3219 for uninstall: the plugin writer resolves the OpenCode config
+// directory through the adapter, so uninstall must look in the same place.
+func TestComponentOperationsSDD_OpenCodeRemovesManagedPluginsUnderXDGConfigHome(t *testing.T) {
+	homeDir := t.TempDir()
+	xdg := filepath.Join(homeDir, ".xdg")
+	t.Setenv("HOME", homeDir)
+	t.Setenv("USERPROFILE", homeDir)
+	t.Setenv("XDG_CONFIG_HOME", xdg)
+
+	svc, err := NewService(homeDir, t.TempDir(), "dev")
+	if err != nil {
+		t.Fatalf("NewService() error = %v", err)
+	}
+	adapter, ok := svc.registry.Get(model.AgentOpenCode)
+	if !ok {
+		t.Fatal("openCode adapter not found in registry")
+	}
+
+	pluginDir := filepath.Join(xdg, "opencode", "plugins")
+	managed := append([]string{"background-agents.ts"}, sdd.OpenCodePluginLifecycleNames(model.AgentOpenCode)...)
+	for _, name := range managed {
+		path := filepath.Join(pluginDir, name)
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(path, []byte("managed"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	applySDDOpenCodeOperations(t, svc, adapter)
+
+	for _, name := range managed {
+		path := filepath.Join(pluginDir, name)
+		if _, err := os.Stat(path); !os.IsNotExist(err) {
+			t.Fatalf("managed plugin %q should be removed; stat err = %v", path, err)
+		}
+	}
+	if _, err := os.Stat(filepath.Join(homeDir, ".config", "opencode")); !os.IsNotExist(err) {
+		t.Fatalf("uninstall touched ~/.config/opencode although XDG_CONFIG_HOME is set (stat err = %v)", err)
 	}
 }

--- a/internal/sddstatus/engram_archived_test.go
+++ b/internal/sddstatus/engram_archived_test.go
@@ -1,7 +1,9 @@
 package sddstatus
 
 import (
+	"path/filepath"
 	"slices"
+	"strings"
 	"testing"
 )
 
@@ -70,5 +72,34 @@ func TestArchiveReportAloneDoesNotCreateAChange(t *testing.T) {
 	}, "demo")
 	if len(changes) != 0 {
 		t.Fatalf("collectEngramChanges = %v, want none", changes)
+	}
+}
+
+// TestNamedArchivedEngramChangeDoesNotRecommendArchive pins #3480's residue:
+// naming an archived Engram change still answered `archive: ready` and
+// `nextRecommended: archive`, so an orchestrator was told to archive a change
+// whose archive report already exists.
+func TestNamedArchivedEngramChangeDoesNotRecommendArchive(t *testing.T) {
+	root := t.TempDir()
+	write(t, filepath.Join(root, "openspec", "config.yaml"), "sdd:\n  artifact_store: engram\n")
+	t.Setenv("ENGRAM_PROJECT", "gentle-ai")
+	t.Cleanup(stubEngramExport(t, []engramObservation{
+		{Title: "sdd/wave-one/proposal", Content: "# Proposal\n", Project: "gentle-ai", Scope: "project"},
+		{Title: "sdd/wave-one/spec", Content: "### Requirement: Wave\n#### Scenario: Done\n", Project: "gentle-ai", Scope: "project"},
+		{Title: "sdd/wave-one/design", Content: "# Design\n", Project: "gentle-ai", Scope: "project"},
+		{Title: "sdd/wave-one/tasks", Content: "- [x] 1.1 Work\n", Project: "gentle-ai", Scope: "project"},
+		{Title: "sdd/wave-one/verify-report", Content: testVerifyEnvelope("pass", 0, 0, "1/1", "1/1", 0, 0), Project: "gentle-ai", Scope: "project"},
+		{Title: "sdd/wave-one/archive-report", Content: "# Archive\n", Project: "gentle-ai", Scope: "project"},
+	}))
+
+	status, err := Resolve(ResolveOptions{CWD: root, ChangeName: "wave-one"})
+	if err != nil {
+		t.Fatalf("Resolve() error = %v", err)
+	}
+	if status.NextRecommended == string(PhaseArchive) || status.Dependencies.Archive == DependencyReady {
+		t.Fatalf("archived change routed to archive again: archive %q next %q", status.Dependencies.Archive, status.NextRecommended)
+	}
+	if !slices.ContainsFunc(status.BlockedReasons, func(reason string) bool { return strings.Contains(reason, "sdd/wave-one/archive-report") }) {
+		t.Fatalf("blocked reasons do not name the archive report: %v", status.BlockedReasons)
 	}
 }

--- a/internal/sddstatus/status.go
+++ b/internal/sddstatus/status.go
@@ -914,6 +914,15 @@ func resolveEngramStatus(workspaceRoot string, requestedChange string, includeIn
 		applyNativeRuntimeRouting(&status)
 	}
 	applyReviewOfferRouting(context.Background(), &status, workspaceRoot, reviewDisabled)
+	if _, archived := artifactsByType["archive-report"]; archived {
+		// The archive phase wrote the archive report, so the change is closed.
+		// Discovery already skips it (#3008); naming it must not send an
+		// orchestrator back to archive (#3480). The same closure OpenSpec reports
+		// as "Active OpenSpec change not found".
+		status.Dependencies.Archive = DependencyAllDone
+		status.NextRecommended = "sdd-new"
+		status.BlockedReasons = append(status.BlockedReasons, fmt.Sprintf("Engram change %s is archived: sdd/%s/archive-report exists, so no phase remains. List the active changes with `gentle-ai sdd-status --cwd %s`.", changeName, changeName, pathquote.Quote(workspaceRoot)))
+	}
 	status.BlockedReasons = blockedReasons.finalize(status.NextRecommended, status.BlockedReasons)
 	if runtimeRemediationComplete && status.Dependencies.Verify == DependencyReady && status.Dependencies.Archive == DependencyBlocked && status.NextRecommended == string(PhaseVerify) {
 		status.verifyRefreshReason = runtimeRemediationVerifyRefreshInstruction

--- a/internal/update/upgrade/executor.go
+++ b/internal/update/upgrade/executor.go
@@ -248,8 +248,13 @@ func managedAgentBackupPaths(homeDir string, adapter agents.Adapter, diagnostics
 		add(theme.VisualThemePaths(homeDir, adapter)...)
 	case model.AgentOpenCode:
 		add(theme.VisualThemePaths(homeDir, adapter)...)
+		// The SDD plugin writer resolves the config directory through the
+		// adapter and owns the plugin list; the snapshot must match it (#3219).
+		pluginsDir := filepath.Join(adapter.GlobalConfigDir(homeDir), "plugins")
+		for _, name := range append([]string{"background-agents.ts"}, sdd.OpenCodePluginLifecycleNames(adapter.Agent())...) {
+			add(filepath.Join(pluginsDir, name))
+		}
 		add(
-			filepath.Join(homeDir, ".config", "opencode", "plugins", "background-agents.ts"),
 			filepath.Join(homeDir, ".config", "opencode", "tui-plugins", "gentle-logo.tsx"),
 			filepath.Join(homeDir, ".config", "opencode", "tui.json"),
 		)

--- a/internal/update/upgrade/executor_test.go
+++ b/internal/update/upgrade/executor_test.go
@@ -12,8 +12,10 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/gentleman-programming/gentle-ai/v2/internal/agents"
 	"github.com/gentleman-programming/gentle-ai/v2/internal/backup"
 	"github.com/gentleman-programming/gentle-ai/v2/internal/components/gga"
+	"github.com/gentleman-programming/gentle-ai/v2/internal/components/sdd"
 	"github.com/gentleman-programming/gentle-ai/v2/internal/model"
 	"github.com/gentleman-programming/gentle-ai/v2/internal/state"
 	"github.com/gentleman-programming/gentle-ai/v2/internal/system"
@@ -1578,4 +1580,40 @@ func mockCmd(name string, args ...string) *exec.Cmd {
 		}
 	}
 	return exec.Command(name, args...)
+}
+
+// TestManagedAgentBackupPathsOpenCodePluginsFollowXDGConfigHome pins #3219 for
+// the pre-upgrade snapshot: the managed OpenCode plugins live wherever the
+// adapter resolves the config directory, so the backup must snapshot them
+// there, and it must cover the current managed plugin set.
+func TestManagedAgentBackupPathsOpenCodePluginsFollowXDGConfigHome(t *testing.T) {
+	homeDir := t.TempDir()
+	xdg := filepath.Join(homeDir, ".xdg")
+	t.Setenv("HOME", homeDir)
+	t.Setenv("USERPROFILE", homeDir)
+	t.Setenv("XDG_CONFIG_HOME", xdg)
+
+	reg, err := agents.NewDefaultRegistry()
+	if err != nil {
+		t.Fatal(err)
+	}
+	adapter, ok := reg.Get(model.AgentOpenCode)
+	if !ok {
+		t.Fatal("opencode adapter not found in registry")
+	}
+
+	paths := managedAgentBackupPaths(homeDir, adapter, log.Writer())
+	pathSet := make(map[string]struct{}, len(paths))
+	for _, p := range paths {
+		pathSet[p] = struct{}{}
+		if strings.HasPrefix(p, filepath.Join(homeDir, ".config", "opencode", "plugins")) {
+			t.Fatalf("backup path %q ignores XDG_CONFIG_HOME", p)
+		}
+	}
+	for _, name := range append([]string{"background-agents.ts"}, sdd.OpenCodePluginLifecycleNames(model.AgentOpenCode)...) {
+		want := filepath.Join(xdg, "opencode", "plugins", name)
+		if _, ok := pathSet[want]; !ok {
+			t.Fatalf("backup paths miss managed plugin %q; got %v", want, paths)
+		}
+	}
 }


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #3219
Closes #3725
Closes #3480

All three reproduced today on current main, each with a test that drives the real route and failed on the unmodified tree.

---

## 🏷️ PR Type

- [x] `type:bug` — Bug fix (non-breaking change that fixes an issue)

---

## 📝 Summary

- **#3219**: `HOME=$H XDG_CONFIG_HOME=$H/.xdg gentle-ai install --agents opencode --components sdd` wrote everything under `$H/.xdg/opencode/`, then verification failed on four hardcoded `$H/.config/opencode/plugins/*.ts` paths and the rollback deleted the XDG-written `opencode.json`, commands, and plugins (worse than reported). Verification (`openCodeSDDPluginPaths`), the upgrade backup, and uninstall now resolve through the adapter's `GlobalConfigDir`, the same resolver the writer uses, and backup/uninstall use `sdd.OpenCodePluginLifecycleNames` so the current plugin set is covered. The legacy background-agents classifier no longer keys on a `.config` literal. Gentle Logo's `tui-plugins`/`tui.json` literals are out of scope (their writer hardcodes the path too, as the issue notes).
- **#3725**: an engram install failure aborted an install that never asked for engram (`Auto-added dependencies: engram`). When engram was auto-added, the failure is now a WARNING with its cause, `engram setup` is skipped, the MCP config is still wired, and the soft `verify:engram:binary` check names the continuation `gentle-ai install --agent <agents> --components engram`. An explicit `--components engram` still fails hard. No flag added.
- **#3480** (narrowed by the maintainer): a named `sdd-status <change>` for an archived Engram change still returned `archive: ready` and `nextRecommended: archive`. With an `archive-report` present, archive is `all_done`, the recommendation is `sdd-new` (the same routing OpenSpec gives a not-found archived change), and a blocked reason names `sdd/<change>/archive-report` with the `gentle-ai sdd-status --cwd <root>` continuation. Artifacts stay resolved (the #3008 audit trail is kept).

---

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/cli/run.go` | Plugin paths through the adapter; auto-added engram failure is a warning naming its install command. |
| `internal/update/upgrade/executor.go`, `internal/components/uninstall/service.go` | Backup and uninstall resolve XDG paths and the current plugin set. |
| `internal/sddstatus/status.go` | Archived Engram change routes to `sdd-new`. |
| Tests | `TestRunInstallOpenCodeSDDVerifiesUnderXDGConfigHome`, `TestComponentOperationsSDD_OpenCodeRemovesManagedPluginsUnderXDGConfigHome`, `TestManagedAgentBackupPathsOpenCodePluginsFollowXDGConfigHome`, `TestRunInstallSDDCompletesWhenAutoAddedEngramCannotBeInstalled`, `TestNamedArchivedEngramChangeDoesNotRecommendArchive`. |

---

## 🤖 AI Assistance

- [ ] **None** — No material AI assistance was used.
- [x] **Material assistance used** — Complete all applicable declaration fields below.

**Tool/model (if known):** Claude Code (Claude Fable 5) with triage, reproduction, and writer agents.

**Material scope:** Reproduction on current main with fresh scratch homes, tests (red first), core change.

**Verification performed:** `go test ./...` on the branch merged with origin/main, `go run ./internal/gofmtcheck`, `GOOS=windows go vet`, deadcode ratchet, driven bench corpus (summary appended). E2E Docker left to CI.

---

## 🧪 Test Plan

**Unit Tests**
```bash
go test ./...
```

**Go Format**
```bash
go run ./internal/gofmtcheck
```

**Benchmark Validation**

Install and status change: driven corpus against a binary built from this branch. Summary line: `journeys: 61 completed, 0 unsupported, 0 failed` (binary built from this branch merged with origin/main).

- [x] Unit tests pass (`go test ./...`)
- [x] Go format passes (`go run ./internal/gofmtcheck`)
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`) (left to CI)
- [x] Manually tested locally

---

## ✅ Contributor Checklist

- [x] PR is linked to an issue with `status:approved`
- [x] PR stays within 400 changed lines, or I have requested/obtained maintainer-applied `size:exception` with rationale documented
- [x] I have added the appropriate `type:*` label to this PR
- [x] Unit tests pass (`go test ./...`)
- [x] Go format passes (`go run ./internal/gofmtcheck`)
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`) (left to CI)
- [x] Benchmark validation completed, or this change is not applicable to the benchmark (explain why in the Test Plan).
- [x] I have updated documentation if necessary
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] I understand, reviewed, and take responsibility for the complete submission
- [x] I selected exactly one AI-assistance option and, if material assistance was used, completed all applicable declaration fields
- [x] My commits do not include `Co-Authored-By` trailers

---

## 💬 Notes for Reviewers

No new state, flag, reason code, or contract row; the fixes delete duplicated path literals and relax one abort. Refusal ratchet baseline untouched. Left out deliberately: the Gentle Logo literals (writer hardcodes them) and a CI grep guard for the literal (new machinery).

https://claude.ai/code/session_01SCnBzvpvtWpFLdbSfsJcCG



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * OpenCode installations now honor custom configuration locations, including `XDG_CONFIG_HOME`, without modifying default configuration directories.
  * OpenCode plugin cleanup and upgrade backups now include the complete set of managed plugins.
  * Automatically added Engram installation failures no longer block requested component installation; a warning and follow-up command are provided.
  * Archived Engram changes are now correctly recognized as closed instead of being routed back to archiving.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


**Native review:** transaction `review-00b407911e6361a9` closed `approved`; acknowledgement burned (`gentle-ai.review-acknowledged/v1`). Two earlier transactions each produced one corroborated finding and were addressed in fresh transactions: the legacy background-agents classifier is a pure path-shape check again (plus the XDG form), and a failed auto-added engram now leaves the engram step without writing its MCP configuration, with verification not requiring its files.
