### PR TITLE
docs(readme): name the Claude Code SDD command prefix beside the bare command names

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,10 +117,10 @@ Once your agents are configured, open your AI agent in a project and run these t
 
 | Command                            | What it does                                                                | When to re-run                                                                 |
 | ---------------------------------- | --------------------------------------------------------------------------- | ------------------------------------------------------------------------------ |
-| `/sdd-init`                        | Detects stack, testing capabilities, activates Strict TDD Mode if available | When your project adds/removes test frameworks, or first time in a new project |
+| `/sdd-init` (`/gentle-sdd-init` in Claude Code) | Detects stack, testing capabilities, activates Strict TDD Mode if available | When your project adds/removes test frameworks, or first time in a new project |
 | `gentle-ai skill-registry refresh` | Scans installed skills and project conventions, builds the registry         | After installing/removing skills, or first time in a new project               |
 
-These are **not required** for basic usage. The SDD orchestrator runs `/sdd-init` automatically if it detects no context. In Claude Code every SDD command carries the `gentle-sdd-` prefix (`/gentle-sdd-init`, `/gentle-sdd-new`, `/gentle-sdd-continue`, ...), because Claude Code resolves a same-named delegate-only skill before a command. Startup hooks normally keep the skill registry fresh for agents that support hooks, including Codex, Claude Code, OpenCode, and Pi through `gentle-pi`. If you start Pi with `pi -ns`, startup skill loading/hooks are skipped, so run the registry refresh manually when you need updated project rules.
+These are **not required** for basic usage. The SDD orchestrator runs `/sdd-init` automatically if it detects no context. In Claude Code every SDD command carries the `gentle-sdd-` prefix (`/gentle-sdd-init`, `/gentle-sdd-new`, `/gentle-sdd-continue`, and so on) because Claude Code resolves a same-named delegate-only skill before a command; the other runtimes keep the bare `/sdd-*` names. Startup hooks normally keep the skill registry fresh for agents that support hooks, including Codex, Claude Code, OpenCode, and Pi through `gentle-pi`. If you start Pi with `pi -ns`, startup skill loading/hooks are skipped, so run the registry refresh manually when you need updated project rules.
 
 Run `gentle-ai doctor` at any time for a read-only health check of your ecosystem (tool binaries, `state.json`, Engram reachability, disk space).
 
@@ -226,7 +226,7 @@ The managed installer tracks the channel's latest version and does not accept an
 
 1. **Install and configure.** Run the installer, select the agents and components you want, then open your agent in a project.
 2. **Use the smallest implementation route.** Keep bounded work direct, delegate actions that need fresh context, and use SDD only after an explicit request or an accepted proposal. SDD artifacts can live in **Engram** for cross-session memory, **OpenSpec** for versioned files, or **hybrid** for both.
-3. **Build with discipline.** `/sdd-init` detects project testing capabilities; when Strict TDD is active, SDD apply works test-first. SDD verify audits RED/GREEN evidence and runs verification. Agents that support delegation use focused subagents instead of one growing conversation.
+3. **Build with discipline.** `/sdd-init` (`/gentle-sdd-init` in Claude Code) detects project testing capabilities; when Strict TDD is active, SDD apply works test-first. SDD verify audits RED/GREEN evidence and runs verification. Agents that support delegation use focused subagents instead of one growing conversation.
 4. **Review one candidate.** After implementation, bounded native review freezes the candidate and reports an informational outcome. Commit, push, PR, and release remain separate decisions under ordinary repository policy; review does not authorize, block, or govern them.
 
 > **Trust what the system can derive, not agent narration.** [Chapter 21 — Verifiable Trust](https://the-amazing-gentleman-programming-book.vercel.app/en/book/Chapter21_Verifiable-Trust) explains the mental model: agents assess the candidate; native review records bounded evidence while ordinary repository policy owns delivery.


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #2644

Follow-up to #3966 (already merged): the README named the SDD commands generically; for Claude Code the real names carry the `gentle-sdd-` prefix since that PR.

---

## 🏷️ PR Type

- [x] `type:docs` — Documentation only

---

## 📝 Summary

Three README mentions now name the command per runtime: the maintenance-command table row (`/sdd-init` (`/gentle-sdd-init` in Claude Code)), the sentence under the table (the prefix note now also states that the other runtimes keep the bare `/sdd-*` names), and step 3 of the intended-usage guide. No other file changes; the shared skill assets that name `/sdd-init` generically are unchanged by the maintainer's decision.

---

## 🧪 Test Plan

Documentation only; `go test ./...` on the branch is green (README is pinned by no test). Not applicable to the benchmark.

- [x] Unit tests pass (`go test ./...`)
- [x] Go format passes (`go run ./internal/gofmtcheck`)
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`) (left to CI)
- [x] Benchmark validation completed, or this change is not applicable to the benchmark (explain why in the Test Plan).

---

## ✅ Contributor Checklist

- [x] PR is linked to an issue with `status:approved`
- [x] PR stays within 400 changed lines, or I have requested/obtained maintainer-applied `size:exception` with rationale documented
- [x] I have added the appropriate `type:*` label to this PR
- [x] Unit tests pass (`go test ./...`)
- [x] Go format passes (`go run ./internal/gofmtcheck`)
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`) (left to CI)
- [x] Benchmark validation completed, or this change is not applicable to the benchmark (explain why in the Test Plan).
- [x] I have updated documentation if necessary
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] I understand, reviewed, and take responsibility for the complete submission
- [x] I selected exactly one AI-assistance option and, if material assistance was used, completed all applicable declaration fields
- [x] My commits do not include `Co-Authored-By` trailers

## 🤖 AI Assistance

- [ ] **None** — No material AI assistance was used.
- [x] **Material assistance used** — Claude Code (Claude Fable 5) drafted the wording under the maintainer's direction; verified by reading the rendered README.

https://claude.ai/code/session_01SCnBzvpvtWpFLdbSfsJcCG


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated setup instructions to include the `/gentle-sdd-init` command alias.
  * Clarified the alias in project-context configuration and core workflow guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


**Native review:** low-risk candidate, zero-lens START closed `approved`; the selectorless STATUS offered the acknowledgement (the #3900 route shipped in #3957) and it was burned (`gentle-ai.review-acknowledged/v1`).
