### PR TITLE
fix(install): require only SDD paths OpenCode writes

### DIFF
--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -2210,8 +2210,11 @@ func componentPathsWithWorkspaceScoped(homeDir, workspaceDir string, scope Insta
 			}
 		case model.ComponentSDD:
 			// Jinja modular hubs (e.g. Kimi KIMI.md) are appended once below so SDD+Persona
-			// do not duplicate the same system prompt path.
-			if adapter.SupportsSystemPrompt() && adapter.SystemPromptStrategy() != model.StrategyJinjaModules {
+			// do not duplicate the same system prompt path. OpenCode-compatible adapters
+			// write the SDD orchestrator to their settings file instead (#3975).
+			if adapter.SupportsSystemPrompt() &&
+				!sdd.AgentReceivesManagedOpenCodePlugins(adapter.Agent()) &&
+				adapter.SystemPromptStrategy() != model.StrategyJinjaModules {
 				paths = append(paths, adapter.SystemPromptFile(targetDir))
 			}
 			if adapter.SupportsSlashCommands() {

--- a/internal/cli/run_component_paths_test.go
+++ b/internal/cli/run_component_paths_test.go
@@ -16,11 +16,10 @@ import (
 	"github.com/gentleman-programming/gentle-ai/v2/internal/system"
 )
 
-func TestComponentPathsSDDIncludesSystemPromptForAllSupportedAgents(t *testing.T) {
+func TestComponentPathsSDDIncludesSystemPromptForPromptFileAdapters(t *testing.T) {
 	home := t.TempDir()
 	adapters := resolveAdapters([]model.AgentID{
 		model.AgentClaudeCode,
-		model.AgentOpenCode,
 		model.AgentGeminiCLI,
 		model.AgentCursor,
 		model.AgentVSCodeCopilot,
@@ -32,6 +31,25 @@ func TestComponentPathsSDDIncludesSystemPromptForAllSupportedAgents(t *testing.T
 		p := adapter.SystemPromptFile(home)
 		if !containsPath(paths, p) {
 			t.Fatalf("componentPaths(sdd) missing system prompt path %q\npaths=%v", p, paths)
+		}
+	}
+}
+
+// TestComponentPathsSDDExcludesSystemPromptForManagedOpenCodeAgents pins issue
+// #3975: the SDD injector scopes the orchestrator to the gentle-orchestrator
+// agent in the settings file for OpenCode and Kilocode in every mode, so SDD
+// must not require, back up, or verify the AGENTS.md it never writes.
+func TestComponentPathsSDDExcludesSystemPromptForManagedOpenCodeAgents(t *testing.T) {
+	home := t.TempDir()
+	adapters := resolveAdapters([]model.AgentID{model.AgentOpenCode, model.AgentKilocode})
+
+	for _, mode := range []model.SDDModeID{"", model.SDDModeSingle, model.SDDModeMulti} {
+		paths := componentPaths(home, model.Selection{SDDMode: mode}, adapters, model.ComponentSDD)
+		for _, adapter := range adapters {
+			p := adapter.SystemPromptFile(home)
+			if containsPath(paths, p) {
+				t.Fatalf("componentPaths(sdd, mode=%q) lists %q, which the SDD injector never writes for %s\npaths=%v", mode, p, adapter.Agent(), paths)
+			}
 		}
 	}
 }

--- a/internal/cli/run_engram_download_test.go
+++ b/internal/cli/run_engram_download_test.go
@@ -714,8 +714,12 @@ func TestRunInstallSDDCompletesWhenAutoAddedEngramCannotBeInstalled(t *testing.T
 	if !result.Verify.Ready {
 		t.Fatalf("verification ready = false, report = %#v", result.Verify)
 	}
-	if _, err := os.Stat(filepath.Join(home, ".claude", "CLAUDE.md")); err != nil {
+	claudeMD := filepath.Join(home, ".claude", "CLAUDE.md")
+	if _, err := os.Stat(claudeMD); err != nil {
 		t.Fatalf("requested sdd component did not land: %v", err)
+	}
+	if !verifyReportRequiresFile(result.Verify, claudeMD) {
+		t.Fatalf("SDD writes %s, so verification must still require it; report = %#v", claudeMD, result.Verify)
 	}
 	if raw, err := os.ReadFile(filepath.Join(home, ".claude.json")); err == nil && strings.Contains(string(raw), "\"engram\"") {
 		t.Fatalf("engram MCP configuration was written for a binary that does not exist:\n%s", raw)
@@ -727,4 +731,57 @@ func TestRunInstallSDDCompletesWhenAutoAddedEngramCannotBeInstalled(t *testing.T
 		}
 	}
 	t.Fatalf("no warning names %q; report = %#v", wantCommand, result.Verify)
+}
+
+// TestRunInstallOpenCodeMultiSDDCompletesWhenAutoAddedEngramCannotBeInstalled
+// pins issue #3975: in multi mode the SDD injector writes nothing into the
+// OpenCode AGENTS.md (the phases live in opencode.json and prompts/sdd/*), so
+// SDD must not demand that file. Before the fix the file existed only because
+// the auto-added engram step created it, and a skipped engram failed the
+// install on `verify:file:.../.config/opencode/AGENTS.md`.
+func TestRunInstallOpenCodeMultiSDDCompletesWhenAutoAddedEngramCannotBeInstalled(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("PATH", t.TempDir())
+	restoreHome := osUserHomeDir
+	restoreCommand := runCommand
+	restoreLookPath := cmdLookPath
+	restoreDownload := engramDownloadFn
+	t.Cleanup(func() {
+		osUserHomeDir = restoreHome
+		runCommand = restoreCommand
+		cmdLookPath = restoreLookPath
+		engramDownloadFn = restoreDownload
+	})
+	osUserHomeDir = func() (string, error) { return home, nil }
+	runCommand = func(string, ...string) error { return nil }
+	cmdLookPath = missingBinaryLookPath
+	engramDownloadFn = func(system.PlatformProfile) (string, error) {
+		return "", errors.New("GitHub API returned HTTP 403")
+	}
+
+	result, err := RunInstall([]string{"--agent", "opencode", "--components", "sdd", "--sdd-mode", "multi"}, linuxDetectionResult(system.LinuxDistroUbuntu, "apt"))
+	if err != nil {
+		t.Fatalf("RunInstall() error = %v; an auto-added dependency must not abort the requested components", err)
+	}
+	if !result.Verify.Ready {
+		t.Fatalf("verification ready = false, report = %#v", result.Verify)
+	}
+	if _, err := os.Stat(filepath.Join(home, ".config", "opencode", "opencode.json")); err != nil {
+		t.Fatalf("requested sdd component did not land: %v", err)
+	}
+	agentsMD := filepath.Join(home, ".config", "opencode", "AGENTS.md")
+	if verifyReportRequiresFile(result.Verify, agentsMD) {
+		t.Fatalf("SDD never writes %s for OpenCode, so verification must not require it; report = %#v", agentsMD, result.Verify)
+	}
+}
+
+// verifyReportRequiresFile reports whether the post-apply verification listed
+// path as a required file, regardless of whether that check passed.
+func verifyReportRequiresFile(report verify.Report, path string) bool {
+	for _, check := range report.Checks {
+		if check.ID == "verify:file:"+path {
+			return true
+		}
+	}
+	return false
 }


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #3975

---

## 🏷️ PR Type

- [x] `type:bug` — Bug fix (non-breaking change that fixes an issue)
- [ ] `type:feature` — New feature (non-breaking change that adds functionality)
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring (no functional changes)
- [ ] `type:chore` — Build, CI, or tooling changes
- [ ] `type:breaking-change` — Breaking change (fix or feature that changes existing behavior)

---

## 📝 Summary

- Require only the OpenCode-compatible SDD files that the injector actually writes.
- Keep prompt-file adapters covered and prove the unavailable auto-added Engram path completes in OpenCode multi mode.

---

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/cli/run.go` | Exclude managed OpenCode-compatible system prompt files from SDD required paths. |
| `internal/cli/run_component_paths_test.go` | Cover all SDD modes for OpenCode and Kilocode, plus prompt-file adapter coverage. |
| `internal/cli/run_engram_download_test.go` | Reproduce the unavailable auto-added Engram failure boundary. |

---

## 🤖 AI Assistance

- [ ] **None** — No material AI assistance was used.
- [x] **Material assistance used** — Complete all applicable declaration fields below.

**Tool/model (if known):** openai/gpt-5.6-terra

**Material scope:** Investigation, implementation, test authoring, and verification.

**Verification performed:** Red replay, focused and full Go tests, formatting, direct CLI harness, and Docker E2E.

---

## 🧪 Test Plan

**Unit Tests**
- [x] `go test ./...`

**Go Format**
- [x] `go run ./internal/gofmtcheck`

**E2E Tests**
- [x] `e2e/docker-test.sh` (Tier 1 passed on Ubuntu, Arch, and Fedora)

**Runtime harness**
- [x] Built the candidate binary, used an empty HOME and a refused HTTPS proxy, then ran `gentle-ai install --agent opencode --components sdd --sdd-mode multi`. The command exited 0 with 49 verification checks passed, one expected Engram warning, and no generated `AGENTS.md`.

**Benchmark Validation**
N/A: this install-path declaration fix does not change the review-lifecycle corpus, classifier, or driven benchmark harness.

---

## ✅ Contributor Checklist

- [x] PR is linked to an issue with `status:approved`
- [x] PR stays within 400 changed lines (88 changed lines)
- [x] I have added the appropriate `type:*` label to this PR
- [x] Unit tests pass (`go test ./...`)
- [x] Go format passes (`go run ./internal/gofmtcheck`)
- [x] E2E tests pass (`e2e/docker-test.sh`)
- [x] Benchmark validation completed, or this change is not applicable to the benchmark (explained above).
- [x] I have updated documentation if necessary
- [x] My commits follow Conventional Commits
- [x] I understand, reviewed, and take responsibility for the complete submission
- [x] I selected exactly one AI-assistance option and completed all applicable declaration fields
- [x] My commits do not include `Co-Authored-By` trailers

---

## 💬 Notes for Reviewers

- The post-apply verification population is now aligned with the SDD injector: managed OpenCode-compatible adapters write the orchestrator in their settings file, not `AGENTS.md`; prompt-file adapters remain required. No guard registration or guard-population baseline changed.
- Rollback boundary: reverting commit `cd382c0e` restores only SDD required-path enumeration and its regression tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed SDD installation verification for OpenCode and Kilocode configurations.
  * OpenCode SDD setups no longer incorrectly require an `AGENTS.md` file.
  * Improved installation checks to verify the configuration files actually created for each supported setup.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->