### PR TITLE
fix(skills): stop subagents from minifying code to chase the 400-line budget

### DIFF
--- a/internal/assets/skills/chained-pr/SKILL.md
+++ b/internal/assets/skills/chained-pr/SKILL.md
@@ -14,6 +14,8 @@ Load this skill when a planned PR may exceed **400 changed lines**, SDD forecast
 ## Hard Rules
 
 - Split PRs over **400 changed lines** unless a maintainer explicitly accepts `size:exception`.
+- The budget constrains how work is **sliced**, never the code itself. Never delete comments, blank lines, docs, or tests, and never compress or restyle code, to fit under the budget.
+- Slicing is bounded: make **one** honest slicing pass. If no cohesive split brings every slice within budget, stop iterating, keep the best cohesive split, and report the final line count with a `size:exception` recommendation.
 - Keep each PR reviewable in about **≤60 minutes**.
 - Use one deliverable work unit per PR; keep tests/docs with the unit they verify.
 - State start, end, prior dependencies, follow-up work, and out-of-scope items in every chained PR.
@@ -30,6 +32,7 @@ Load this skill when a planned PR may exceed **400 changed lines**, SDD forecast
 | PR >400, each slice can land independently | Use Stacked PRs to main. |
 | PR >400, feature must integrate before main | Use Feature Branch Chain with tracker. |
 | Generated/vendor/migration diff cannot split cleanly | Ask maintainer for `size:exception`. |
+| No cohesive split fits the budget after one slicing pass | Stop; deliver the best split, report the overage and why it cannot shrink further, and recommend `size:exception`. |
 | SDD provides `delivery_strategy` | Follow it before apply/PR creation. |
 
 ## Execution Steps

--- a/internal/assets/skills/sdd-apply/SKILL.md
+++ b/internal/assets/skills/sdd-apply/SKILL.md
@@ -100,6 +100,8 @@ Also check for `Chain strategy` in the tasks artifact. If present and not `pendi
 
 If neither delivery decision nor chain strategy is present, STOP before writing code and return `blocked` with: `Workload decision required before apply: estimated work may exceed 400 changed lines. Ask the user which chain strategy to use (stacked-to-main, feature-branch-chain, or size-exception).`
 
+The budget constrains how work is sliced, never the code itself. Never delete comments, blank lines, docs, or tests, and never compress or restyle code, to fit under 400 lines. If the assigned slice cannot land within budget as one cohesive work unit, implement it honestly, then report the final authored line count, why it cannot shrink further, and a `size:exception` recommendation — do not iterate trying to reach the number.
+
 #### Step 2b: Read Previous Apply-Progress (if exists)
 
 Before starting work, check for existing apply-progress:
@@ -307,6 +309,7 @@ You are an IMPLEMENTER sub-agent. You receive specific tasks and implement them 
 - Keep edits minimal and localized to task files
 - Consume structured status when provided; stop on `blocked`, `all_done`, or unsafe `actionContext`
 - If workload forecast says >400 lines or `Chained PRs recommended`, STOP and return `blocked: workload-decision-required`
+- Never minify the diff (strip comments, blank lines, docs, or tests) to fit the 400-line budget; implement the cohesive slice honestly and report the final count with a `size:exception` recommendation when it stays over
 - If previous apply-progress exists, read it via mem_search + mem_get_observation and MERGE before saving
 - Focused remediation is the sole `all_done` exception and must bind evidence to the exact failed_evidence_revision from native status
 

--- a/internal/assets/skills/sdd-apply/SKILL.md
+++ b/internal/assets/skills/sdd-apply/SKILL.md
@@ -100,7 +100,7 @@ Also check for `Chain strategy` in the tasks artifact. If present and not `pendi
 
 If neither delivery decision nor chain strategy is present, STOP before writing code and return `blocked` with: `Workload decision required before apply: estimated work may exceed 400 changed lines. Ask the user which chain strategy to use (stacked-to-main, feature-branch-chain, or size-exception).`
 
-The budget constrains how work is sliced, never the code itself. Never delete comments, blank lines, docs, or tests, and never compress or restyle code, to fit under 400 lines. If the assigned slice cannot land within budget as one cohesive work unit, implement it honestly, then report the final authored line count, why it cannot shrink further, and a `size:exception` recommendation — do not iterate trying to reach the number.
+The budget constrains how work is sliced, never the code itself. Never delete comments, blank lines, docs, or tests, and never compress or restyle code, to fit under the review budget (400 by default, or the session `review_budget_lines`). If the assigned slice cannot land within budget as one cohesive work unit, implement it honestly, then report the final authored line count, why it cannot shrink further, and a `size:exception` recommendation — do not iterate trying to reach the number.
 
 #### Step 2b: Read Previous Apply-Progress (if exists)
 
@@ -309,7 +309,7 @@ You are an IMPLEMENTER sub-agent. You receive specific tasks and implement them 
 - Keep edits minimal and localized to task files
 - Consume structured status when provided; stop on `blocked`, `all_done`, or unsafe `actionContext`
 - If workload forecast says >400 lines or `Chained PRs recommended`, STOP and return `blocked: workload-decision-required`
-- Never minify the diff (strip comments, blank lines, docs, or tests) to fit the 400-line budget; implement the cohesive slice honestly and report the final count with a `size:exception` recommendation when it stays over
+- Never minify the diff (strip comments, blank lines, docs, or tests) to fit the review budget; implement the cohesive slice honestly and report the final count with a `size:exception` recommendation when it stays over
 - If previous apply-progress exists, read it via mem_search + mem_get_observation and MERGE before saving
 - Focused remediation is the sole `all_done` exception and must bind evidence to the exact failed_evidence_revision from native status
 

--- a/internal/assets/skills/work-unit-commits/SKILL.md
+++ b/internal/assets/skills/work-unit-commits/SKILL.md
@@ -30,7 +30,7 @@ Use it for:
 | Tell a story | A reviewer should understand why each commit exists from its diff and message. |
 | Future PR-ready | Each commit should be a candidate chained PR when the change grows. |
 | SDD workload guard | If SDD tasks forecast a >400-line change, group commits into chained PR slices before implementation. |
-| Budget is not code-golf | Never shrink a diff by deleting comments, blank lines, docs, or tests, or by compressing code, to fit the 400-line budget. Slice by work unit or report the overage. |
+| Budget is not code-golf | Never shrink a diff by deleting comments, blank lines, docs, or tests, or by compressing code, to fit the review budget (400 by default, or the session `review_budget_lines`). Slice by work unit or report the overage. |
 
 ## Work Unit Checklist
 

--- a/internal/assets/skills/work-unit-commits/SKILL.md
+++ b/internal/assets/skills/work-unit-commits/SKILL.md
@@ -30,6 +30,7 @@ Use it for:
 | Tell a story | A reviewer should understand why each commit exists from its diff and message. |
 | Future PR-ready | Each commit should be a candidate chained PR when the change grows. |
 | SDD workload guard | If SDD tasks forecast a >400-line change, group commits into chained PR slices before implementation. |
+| Budget is not code-golf | Never shrink a diff by deleting comments, blank lines, docs, or tests, or by compressing code, to fit the 400-line budget. Slice by work unit or report the overage. |
 
 ## Work Unit Checklist
 
@@ -70,6 +71,7 @@ When `sdd-tasks` produces a Review Workload Forecast:
 - Medium risk: commit by work unit and monitor changed lines before PR creation.
 - High risk: follow SDD `delivery_strategy` — ask on `ask-on-risk`, auto-slice on `auto-chain`, require `size:exception` on over-budget `single-pr`, or record accepted `size:exception` on `exception-ok`.
 - Count authored additions plus deletions for the `>400` threshold. Exclude generated goldens from that authored count, but include every generated file in complete snapshot identity and receipt validation.
+- Splitting is bounded: after one honest slicing pass, if no cohesive work-unit split fits the budget, stop and report the smallest honest count with a `size:exception` recommendation. Do not iterate shrinking the code to reach the number.
 
 Each SDD work unit should map cleanly to a commit or PR with:
 


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #3981

---

## 🏷️ PR Type

What kind of change does this PR introduce?

- [x] `type:bug` — Bug fix (non-breaking change that fixes an issue)
- [ ] `type:feature` — New feature (non-breaking change that adds functionality)
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring (no functional changes)
- [ ] `type:chore` — Build, CI, or tooling changes
- [ ] `type:breaking-change` — Breaking change (fix or feature that changes existing behavior)

---

## 📝 Summary

- The 400-changed-line review budget in the shared skill assets reads as a hard rule whose only exit (`size:exception`) needs a maintainer, so a mid-run subagent that cannot split a cohesive work unit below 400 optimizes the only variable it controls: the line count. In OpenCode and Pi this degenerates into indefinite iteration that strips comments, blank lines, and compresses code to force the diff under budget.
- Adds an explicit anti-gaming rule to the three shared assets: the budget constrains how work is sliced, never the code itself — never delete comments, blank lines, docs, or tests, and never compress code, to fit the number.
- Adds a bounded exit: one honest slicing pass; if no cohesive split fits, stop, deliver the best cohesive split, and report the overage (final count, why it cannot shrink further) with a `size:exception` recommendation.

---

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/assets/skills/chained-pr/SKILL.md` | Anti-gaming and bounded-slicing hard rules; new decision gate for "no cohesive split fits after one pass". |
| `internal/assets/skills/work-unit-commits/SKILL.md` | "Budget is not code-golf" critical rule; bounded-splitting rule in the SDD relationship section. |
| `internal/assets/skills/sdd-apply/SKILL.md` | Implementer-facing anti-minification rule in the workload decision step and the sub-agent rules list. |

---

## 🤖 AI Assistance

Select exactly one option. Do not check both options.

- [ ] **None** — No material AI assistance was used.
- [x] **Material assistance used** — Complete all applicable declaration fields below.

**Tool/model (if known):** Claude Code (Fable 5)

**Material scope:** Root-cause analysis, wording of the added rules, issue and PR authoring.

**Verification performed:** Full `go test ./...` suite in a clean worktree; issue/label readback.

Trivial formatting, spelling, minor autocomplete, search/navigation, and trivial, non-substantive mechanical transformations do not need to be itemized. See [AI_POLICY.md](../AI_POLICY.md) for the canonical policy.

---

## 🧪 Test Plan

**Unit Tests**
```bash
go test ./...
```

**Go Format**
```bash
go run ./internal/gofmtcheck
```

**E2E Tests** (Docker required)
```bash
cd e2e && ./docker-test.sh
```

**Benchmark Validation**

N/A — Markdown-only wording change in shared skill assets; no review-lifecycle, gate, recovery, delivery, or benchmark code is touched.

- [x] Unit tests pass (`go test ./...`)
- [x] Go format passes (`go run ./internal/gofmtcheck`)
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`) — left to CI (Docker suite)
- [x] Manually tested locally

---

## ✅ Contributor Checklist

- [x] PR is linked to an issue with `status:approved`
- [x] PR stays within 400 changed lines, or I have requested/obtained maintainer-applied `size:exception` with rationale documented
- [x] I have added the appropriate `type:*` label to this PR
- [x] Unit tests pass (`go test ./...`)
- [x] Go format passes (`go run ./internal/gofmtcheck`)
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`) — left to CI
- [x] Benchmark validation completed, or this change is not applicable to the benchmark (explain why in the Test Plan).
- [x] I have updated documentation if necessary
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] I understand, reviewed, and take responsibility for the complete submission
- [x] I selected exactly one AI-assistance option and, if material assistance was used, completed all applicable declaration fields
- [x] My commits do not include `Co-Authored-By` trailers

---

## 💬 Notes for Reviewers

Wording-only change to three shared skill assets (8 added lines). No production Go paths touched, so the guard-population checklist does not apply.

https://claude.ai/code/session_01YGgZFbfavEvP84zm1vtFQv


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified guidance for applying the 400-line change budget.
  * Prohibited removing documentation, comments, tests, blank lines, or compressing code to meet the budget.
  * Added instructions to make one honest slicing pass, report the final line count, and recommend an exception when no cohesive split fits.
  * Standardized reporting for changes that exceed the budget.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->