### PR TITLE
feat(review): extend the concurrent reviewer group contract to every review runtime

### DIFF
--- a/internal/components/sdd/bounded_review_contract_test.go
+++ b/internal/components/sdd/bounded_review_contract_test.go
@@ -375,20 +375,29 @@ func TestOpenCodeOrchestratorAddsOnlyOneConcurrentReviewerGroupContract(t *testi
 		"When one fresh `collect.inputs` set contains multiple distinct independent `review.capture-result` reviewer slots, emit one grouped OpenCode `task` tool-call response with one foreground task per input in provider order. For canonical 4R, preserve `review-risk`, `review-resilience`, `review-readability`, `review-reliability` order.\n\n" +
 		"Each task submits only its own provider-issued `review.capture-result` binding, exact lens as `subagent_type`, and exact binding prompt prefix. Do not set a `background` flag. Do not wait between launches; wait for every foreground task result. Completion order is not authority: shared Go admission/election owns reduction and semantics. The final admitted capture owns reduction and closure. On `approved`, authority is already burned: do not FINALIZE or issue a trailing STATUS. On `correction_required`, continue only through exact bound STATUS and the provider-issued `review.capture-correction-plan` binding. After a malformed or nonterminal capture, reconcile through exact bound STATUS and retry only an identically reoffered slot."
 
+	const concurrentReviewerGroupContract = "### Concurrent Reviewer Group (MANDATORY)\n\n" +
+		"When one fresh `collect.inputs` set contains multiple distinct independent `review.capture-result` reviewer slots, launch every returned capture operation concurrently in provider order: start all without waiting between launches, then wait for every result. For canonical 4R, preserve `review-risk`, `review-resilience`, `review-readability`, `review-reliability` order.\n\n" +
+		"Each launch runs only its own provider-issued `review.capture-result` argument tokens exactly as returned. Completion order is not authority: shared Go admission/election owns reduction and semantics. The final admitted capture owns reduction and closure. On `approved`, authority is already burned: do not FINALIZE or issue a trailing STATUS. On `correction_required`, continue only through exact bound STATUS and the provider-issued `review.capture-correction-plan` binding. After a malformed or nonterminal capture, reconcile through exact bound STATUS and retry only an identically reoffered slot."
+
 	for _, test := range []struct {
-		name  string
-		agent model.AgentID
-		count int
+		name          string
+		agent         model.AgentID
+		openCodeCount int
+		genericCount  int
 	}{
-		{name: "opencode", agent: model.AgentOpenCode, count: 1},
-		{name: "claude", agent: model.AgentClaudeCode},
-		{name: "codex", agent: model.AgentCodex},
+		{name: "opencode", agent: model.AgentOpenCode, openCodeCount: 1},
+		{name: "claude", agent: model.AgentClaudeCode, genericCount: 1},
+		{name: "codex", agent: model.AgentCodex, genericCount: 1},
 		{name: "kilocode", agent: model.AgentKilocode},
-		{name: "generic", agent: model.AgentPi},
+		{name: "generic", agent: model.AgentPi, genericCount: 1},
 	} {
 		t.Run(test.name, func(t *testing.T) {
-			if got := strings.Count(renderSDDOrchestratorAsset(test.agent), openCodeConcurrentReviewerGroupContract); got != test.count {
-				t.Fatalf("rendered %s concurrent reviewer group contract count = %d, want %d", test.name, got, test.count)
+			rendered := renderSDDOrchestratorAsset(test.agent)
+			if got := strings.Count(rendered, openCodeConcurrentReviewerGroupContract); got != test.openCodeCount {
+				t.Fatalf("rendered %s OpenCode concurrent reviewer group contract count = %d, want %d", test.name, got, test.openCodeCount)
+			}
+			if got := strings.Count(rendered, concurrentReviewerGroupContract); got != test.genericCount {
+				t.Fatalf("rendered %s concurrent reviewer group contract count = %d, want %d", test.name, got, test.genericCount)
 			}
 		})
 	}

--- a/internal/components/sdd/boundedreview.go
+++ b/internal/components/sdd/boundedreview.go
@@ -65,6 +65,17 @@ const (
 	openCodeConcurrentReviewerGroupContract = "### OpenCode Concurrent Reviewer Group (MANDATORY)\n\n" +
 		"When one fresh `collect.inputs` set contains multiple distinct independent `review.capture-result` reviewer slots, emit one grouped OpenCode `task` tool-call response with one foreground task per input in provider order. For canonical 4R, preserve `review-risk`, `review-resilience`, `review-readability`, `review-reliability` order.\n\n" +
 		"Each task submits only its own provider-issued `review.capture-result` binding, exact lens as `subagent_type`, and exact binding prompt prefix. Do not set a `background` flag. Do not wait between launches; wait for every foreground task result. Completion order is not authority: shared Go admission/election owns reduction and semantics. The final admitted capture owns reduction and closure. On `approved`, authority is already burned: do not FINALIZE or issue a trailing STATUS. On `correction_required`, continue only through exact bound STATUS and the provider-issued `review.capture-correction-plan` binding. After a malformed or nonterminal capture, reconcile through exact bound STATUS and retry only an identically reoffered slot."
+
+	// concurrentReviewerGroupContract is the transport-neutral counterpart of
+	// the OpenCode block above for every other registered review runtime. The
+	// native side has always permitted this: STATUS offers every uncaptured
+	// lens in one collect.inputs set, all captures in a phase share one
+	// CapturePhaseRevision, and admission is a brief lock-owned CAS merge —
+	// only the absence of this direction made those parents serialize four
+	// reviewer runs that are independent by contract (issue #3989).
+	concurrentReviewerGroupContract = "### Concurrent Reviewer Group (MANDATORY)\n\n" +
+		"When one fresh `collect.inputs` set contains multiple distinct independent `review.capture-result` reviewer slots, launch every returned capture operation concurrently in provider order: start all without waiting between launches, then wait for every result. For canonical 4R, preserve `review-risk`, `review-resilience`, `review-readability`, `review-reliability` order.\n\n" +
+		"Each launch runs only its own provider-issued `review.capture-result` argument tokens exactly as returned. Completion order is not authority: shared Go admission/election owns reduction and semantics. The final admitted capture owns reduction and closure. On `approved`, authority is already burned: do not FINALIZE or issue a trailing STATUS. On `correction_required`, continue only through exact bound STATUS and the provider-issued `review.capture-correction-plan` binding. After a malformed or nonterminal capture, reconcile through exact bound STATUS and retry only an identically reoffered slot."
 )
 
 // boundedReviewContract is the shared contract as any consumer sees it: the
@@ -86,10 +97,13 @@ func renderSDDOrchestratorAsset(agent model.AgentID, options ...OrchestratorRend
 
 func boundedReviewContractFor(agent model.AgentID) string {
 	contract := selectReviewerCaptureTransport(boundedReviewContractSource(), agent)
-	if agent != model.AgentOpenCode {
-		return contract
+	switch {
+	case agent == model.AgentOpenCode:
+		return contract + "\n\n" + openCodeConcurrentReviewerGroupContract
+	case reviewerprovider.RegisteredRuntime(agent):
+		return contract + "\n\n" + concurrentReviewerGroupContract
 	}
-	return contract + "\n\n" + openCodeConcurrentReviewerGroupContract
+	return contract
 }
 
 const (

--- a/internal/reviewerprovider/runtimes.go
+++ b/internal/reviewerprovider/runtimes.go
@@ -1,5 +1,7 @@
 package reviewerprovider
 
+import "github.com/gentleman-programming/gentle-ai/v2/internal/model"
+
 // registeredRuntimeIdentities is deliberately closed. A runtime appears here
 // only after the compiled review boundary admits it: Claude's prompt-carried
 // generated reviewer, Codex's advisory scratch process, and the host-mediated
@@ -17,4 +19,16 @@ var registeredRuntimeIdentities = []string{
 // provider contract admits, in stable lexical order.
 func RegisteredRuntimeIdentities() []string {
 	return append([]string(nil), registeredRuntimeIdentities...)
+}
+
+// RegisteredRuntime reports whether the agent is one of the closed runtime
+// identities above, so consumers can gate runtime-wide contract prose on the
+// same list the compiled review boundary admits instead of restating it.
+func RegisteredRuntime(agent model.AgentID) bool {
+	for _, identity := range registeredRuntimeIdentities {
+		if identity == string(agent) {
+			return true
+		}
+	}
+	return false
 }

--- a/testdata/golden/combined-claude-claudemd.golden
+++ b/testdata/golden/combined-claude-claudemd.golden
@@ -226,6 +226,12 @@ After exact acknowledgement burns terminal `approved` authority, the review life
 
 Historical compatibility commands may read older artifacts manually, but they are never the ordinary lifecycle and never restore delivery authority.
 
+### Concurrent Reviewer Group (MANDATORY)
+
+When one fresh `collect.inputs` set contains multiple distinct independent `review.capture-result` reviewer slots, launch every returned capture operation concurrently in provider order: start all without waiting between launches, then wait for every result. For canonical 4R, preserve `review-risk`, `review-resilience`, `review-readability`, `review-reliability` order.
+
+Each launch runs only its own provider-issued `review.capture-result` argument tokens exactly as returned. Completion order is not authority: shared Go admission/election owns reduction and semantics. The final admitted capture owns reduction and closure. On `approved`, authority is already burned: do not FINALIZE or issue a trailing STATUS. On `correction_required`, continue only through exact bound STATUS and the provider-issued `review.capture-correction-plan` binding. After a malformed or nonterminal capture, reconcile through exact bound STATUS and retry only an identically reoffered slot.
+
 #### Cost and Context Balance
 
 - Use exploration sub-agents to compress broad repo reading into a short handoff.

--- a/testdata/golden/sdd-claude-claudemd.golden
+++ b/testdata/golden/sdd-claude-claudemd.golden
@@ -192,6 +192,12 @@ After exact acknowledgement burns terminal `approved` authority, the review life
 
 Historical compatibility commands may read older artifacts manually, but they are never the ordinary lifecycle and never restore delivery authority.
 
+### Concurrent Reviewer Group (MANDATORY)
+
+When one fresh `collect.inputs` set contains multiple distinct independent `review.capture-result` reviewer slots, launch every returned capture operation concurrently in provider order: start all without waiting between launches, then wait for every result. For canonical 4R, preserve `review-risk`, `review-resilience`, `review-readability`, `review-reliability` order.
+
+Each launch runs only its own provider-issued `review.capture-result` argument tokens exactly as returned. Completion order is not authority: shared Go admission/election owns reduction and semantics. The final admitted capture owns reduction and closure. On `approved`, authority is already burned: do not FINALIZE or issue a trailing STATUS. On `correction_required`, continue only through exact bound STATUS and the provider-issued `review.capture-correction-plan` binding. After a malformed or nonterminal capture, reconcile through exact bound STATUS and retry only an identically reoffered slot.
+
 #### Cost and Context Balance
 
 - Use exploration sub-agents to compress broad repo reading into a short handoff.

--- a/testdata/golden/sdd-codex-agentsmd-lowcost.golden
+++ b/testdata/golden/sdd-codex-agentsmd-lowcost.golden
@@ -192,6 +192,12 @@ After exact acknowledgement burns terminal `approved` authority, the review life
 
 Historical compatibility commands may read older artifacts manually, but they are never the ordinary lifecycle and never restore delivery authority.
 
+### Concurrent Reviewer Group (MANDATORY)
+
+When one fresh `collect.inputs` set contains multiple distinct independent `review.capture-result` reviewer slots, launch every returned capture operation concurrently in provider order: start all without waiting between launches, then wait for every result. For canonical 4R, preserve `review-risk`, `review-resilience`, `review-readability`, `review-reliability` order.
+
+Each launch runs only its own provider-issued `review.capture-result` argument tokens exactly as returned. Completion order is not authority: shared Go admission/election owns reduction and semantics. The final admitted capture owns reduction and closure. On `approved`, authority is already burned: do not FINALIZE or issue a trailing STATUS. On `correction_required`, continue only through exact bound STATUS and the provider-issued `review.capture-correction-plan` binding. After a malformed or nonterminal capture, reconcile through exact bound STATUS and retry only an identically reoffered slot.
+
 ### Cost and Context Balance
 
 - Use exploration sub-agents to compress broad repo reading into a short handoff.

--- a/testdata/golden/sdd-codex-agentsmd-powerful.golden
+++ b/testdata/golden/sdd-codex-agentsmd-powerful.golden
@@ -192,6 +192,12 @@ After exact acknowledgement burns terminal `approved` authority, the review life
 
 Historical compatibility commands may read older artifacts manually, but they are never the ordinary lifecycle and never restore delivery authority.
 
+### Concurrent Reviewer Group (MANDATORY)
+
+When one fresh `collect.inputs` set contains multiple distinct independent `review.capture-result` reviewer slots, launch every returned capture operation concurrently in provider order: start all without waiting between launches, then wait for every result. For canonical 4R, preserve `review-risk`, `review-resilience`, `review-readability`, `review-reliability` order.
+
+Each launch runs only its own provider-issued `review.capture-result` argument tokens exactly as returned. Completion order is not authority: shared Go admission/election owns reduction and semantics. The final admitted capture owns reduction and closure. On `approved`, authority is already burned: do not FINALIZE or issue a trailing STATUS. On `correction_required`, continue only through exact bound STATUS and the provider-issued `review.capture-correction-plan` binding. After a malformed or nonterminal capture, reconcile through exact bound STATUS and retry only an identically reoffered slot.
+
 ### Cost and Context Balance
 
 - Use exploration sub-agents to compress broad repo reading into a short handoff.

--- a/testdata/golden/sdd-codex-agentsmd.golden
+++ b/testdata/golden/sdd-codex-agentsmd.golden
@@ -192,6 +192,12 @@ After exact acknowledgement burns terminal `approved` authority, the review life
 
 Historical compatibility commands may read older artifacts manually, but they are never the ordinary lifecycle and never restore delivery authority.
 
+### Concurrent Reviewer Group (MANDATORY)
+
+When one fresh `collect.inputs` set contains multiple distinct independent `review.capture-result` reviewer slots, launch every returned capture operation concurrently in provider order: start all without waiting between launches, then wait for every result. For canonical 4R, preserve `review-risk`, `review-resilience`, `review-readability`, `review-reliability` order.
+
+Each launch runs only its own provider-issued `review.capture-result` argument tokens exactly as returned. Completion order is not authority: shared Go admission/election owns reduction and semantics. The final admitted capture owns reduction and closure. On `approved`, authority is already burned: do not FINALIZE or issue a trailing STATUS. On `correction_required`, continue only through exact bound STATUS and the provider-issued `review.capture-correction-plan` binding. After a malformed or nonterminal capture, reconcile through exact bound STATUS and retry only an identically reoffered slot.
+
 ### Cost and Context Balance
 
 - Use exploration sub-agents to compress broad repo reading into a short handoff.


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #3989

---

## 🏷️ PR Type

What kind of change does this PR introduce?

- [ ] `type:bug` — Bug fix (non-breaking change that fixes an issue)
- [x] `type:feature` — New feature (non-breaking change that adds functionality)
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring (no functional changes)
- [ ] `type:chore` — Build, CI, or tooling changes
- [ ] `type:breaking-change` — Breaking change (fix or feature that changes existing behavior)

---

## 📝 Summary

- During 4R reviews, only OpenCode ran the four reviewer lenses in parallel; Claude Code, Codex, and Pi serialized them, because `boundedReviewContractFor` appended the concurrent reviewer group block exclusively for OpenCode and the pinning test asserted its absence everywhere else.
- The native side has always permitted concurrency: STATUS offers every uncaptured lens in one `collect.inputs` set, all captures in a phase share one `CapturePhaseRevision`, and admission is a brief lock-owned CAS merge, idempotent for same-slot replays.
- Adds a transport-neutral "Concurrent Reviewer Group (MANDATORY)" block rendered for every registered review runtime through the closed identity list (`RegisteredRuntime`); OpenCode keeps its task-group wording. A four-lens review now costs roughly the slowest single lens instead of four sequential runs.

---

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/components/sdd/boundedreview.go` | New transport-neutral concurrent reviewer group contract; `boundedReviewContractFor` selects per transport. |
| `internal/reviewerprovider/runtimes.go` | `RegisteredRuntime(agent)` predicate over the existing closed identity list. |
| `internal/components/sdd/bounded_review_contract_test.go` | Pinning test now asserts exactly one concurrency block per registered runtime, zero for unsupported ones. |
| `testdata/golden/*.golden` | Regenerated: claude CLAUDE.md (SDD + combined) and the three codex AGENTS.md variants pin the new block. |

---

## 🤖 AI Assistance

Select exactly one option. Do not check both options.

- [ ] **None** — No material AI assistance was used.
- [x] **Material assistance used** — Complete all applicable declaration fields below.

**Tool/model (if known):** Claude Code (Fable 5)

**Material scope:** Root-cause analysis, contract wording, implementation, and test updates.

**Verification performed:** RED-first test update, full `go test ./...` green, `GOOS=windows go vet` green, gofmtcheck green, RDD receipt approved and burned.

Trivial formatting, spelling, minor autocomplete, search/navigation, and trivial, non-substantive mechanical transformations do not need to be itemized. See [AI_POLICY.md](../AI_POLICY.md) for the canonical policy.

---

## 🧪 Test Plan

**Unit Tests**
```bash
go test ./...
```

**Go Format**
```bash
go run ./internal/gofmtcheck
```

**E2E Tests** (Docker required)
```bash
cd e2e && ./docker-test.sh
```

**Benchmark Validation**

N/A — rendered-contract prose and its pinning tests; no review-lifecycle Go state machine, gate, recovery, delivery, or benchmark code path changes. The lens capture/admission semantics are untouched.

- [x] Unit tests pass (`go test ./...`)
- [x] Go format passes (`go run ./internal/gofmtcheck`)
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`) — left to CI (Docker suite)
- [x] Manually tested locally

---

## ✅ Contributor Checklist

- [x] PR is linked to an issue with `status:approved`
- [x] PR stays within 400 changed lines, or I have requested/obtained maintainer-applied `size:exception` with rationale documented
- [x] I have added the appropriate `type:*` label to this PR
- [x] Unit tests pass (`go test ./...`)
- [x] Go format passes (`go run ./internal/gofmtcheck`)
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`) — left to CI
- [x] Benchmark validation completed, or this change is not applicable to the benchmark (explain why in the Test Plan).
- [x] I have updated documentation if necessary
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] I understand, reviewed, and take responsibility for the complete submission
- [x] I selected exactly one AI-assistance option and, if material assistance was used, completed all applicable declaration fields
- [x] My commits do not include `Co-Authored-By` trailers

---

## 💬 Notes for Reviewers

No qualifying security, integrity, admission, repair, or governance guard changed: the additions are rendered-contract prose selection plus a read-only predicate over the existing closed runtime list; capture admission semantics in `internal/reviewtransaction` are untouched. gentle-pi runtime-side parity (concurrent subprocess launches in its relay) is tracked separately in Gentleman-Programming/gentle-pi#533.

https://claude.ai/code/session_01YGgZFbfavEvP84zm1vtFQv


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved concurrent reviewer handling across supported runtimes.
  * Added consistent review contracts for registered runtimes while preserving specialized behavior where needed.
  * Prevented unsupported runtimes from receiving unintended reviewer-group instructions.
* **Tests**
  * Expanded coverage to verify reviewer-group behavior for OpenCode, Claude Code, Codex, Pi, and Kilocode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->