### PR TITLE
fix(review): resolve OpenCode targets across worktrees

### DIFF
--- a/e2e/organicruntime/organic_runtime_test.go
+++ b/e2e/organicruntime/organic_runtime_test.go
@@ -729,7 +729,15 @@ func TestOpenCodeRuntimeIsPinnedForTheLiveProviderTransport(t *testing.T) {
 		t.Fatalf("OpenCode version = %q, want %q (error %v)", strings.TrimSpace(string(version)), pinnedOpenCodeVersion, err)
 	}
 
-	harness := newOrganicHarness(t)
+	host := newOrganicHarness(t)
+	target := filepath.Join(t.TempDir(), "opencode-review-target")
+	if _, err := organicGitOutput(t.Context(), host.repo.worktree, "worktree", "add", "--quiet", "-b", "opencode-runtime-target", target, "HEAD"); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		_, _ = organicGitOutput(context.Background(), host.repo.worktree, "worktree", "remove", "--force", target)
+	})
+	harness := &organicHarness{t: t, repo: organicRepository{worktree: target}, home: host.home}
 	harness.writeFiles(map[string]string{"internal/provider/candidate.go": "package provider\n\nfunc Value() int { return 1 }\n"})
 	const lineage = "opencode-current-session-poison"
 	_ = organicProviderStart(t, harness, lineage, "opencode")
@@ -910,8 +918,8 @@ exec "$GENTLE_AI_RUNTIME_TRACE_BINARY" -ff -o "$GENTLE_AI_RUNTIME_TRACE_LOG" -e 
 `), 0o755); err != nil {
 		t.Fatal(err)
 	}
-	command := exec.CommandContext(context, wrapper, "run", "--format", "json", "--dir", harness.repo.worktree, "--model", "loopback/loopback", "start the Go-bound reviewer task")
-	command.Dir = harness.repo.worktree
+	command := exec.CommandContext(context, wrapper, "run", "--format", "json", "--dir", host.repo.worktree, "--model", "loopback/loopback", "start the Go-bound reviewer task")
+	command.Dir = host.repo.worktree
 	command.Env = append(harness.environment(),
 		"OPENCODE_CONFIG_DIR="+configDirectory,
 		"OPENCODE_CONFIG_CONTENT="+string(config),
@@ -955,6 +963,9 @@ exec "$GENTLE_AI_RUNTIME_TRACE_BINARY" -ff -o "$GENTLE_AI_RUNTIME_TRACE_LOG" -e 
 	harness.assertReviewAcknowledgedAndBurned(lineage, organicFinalizeResult{
 		LineageID: lineage, State: organicStateApproved, Acknowledgement: acknowledgement,
 	})
+	if status := organicProviderStatus(t, host, lineage, "opencode"); status.Authority.LineageID != "" {
+		t.Fatalf("A-hosted OpenCode transport retained B authority: %#v", status.Authority)
+	}
 }
 
 // TestOpenCodeRuntimeRunsFourBoundReviewersConcurrently exercises the real

--- a/internal/cli/review_opencode_host_binding_test.go
+++ b/internal/cli/review_opencode_host_binding_test.go
@@ -35,9 +35,9 @@ func hostLensReviewFixture(t *testing.T) (repo string, store reviewtransaction.C
 		t.Fatal(err)
 	}
 	subject = mustArtifactSubject(t, repo, record, lens, 0)
-	// The managed shim starts this relay inside the repository it reviews, and
-	// the transport takes no flags, so process cwd is the repository the
-	// provider-issued context digest is verified against.
+	// The relay runs in a host worktree, which may differ from the provider-bound
+	// repository. The rctx2 handle discovers exactly one common-directory
+	// registered target, whose compact authority admits review.
 	t.Chdir(repo)
 	return repo, store, record, lens, contextHandle, subject
 }

--- a/internal/cli/review_opencode_transport.go
+++ b/internal/cli/review_opencode_transport.go
@@ -312,47 +312,25 @@ func openCodeTransportStartBound(ctx context.Context, taskPrompt string) (openCo
 	if err != nil {
 		return openCodeTransportSession{}, err
 	}
-	// The transport runs inside the repository it reviews, and it takes no
-	// flags, so the process cwd is the independent source the provider-issued
-	// context digest is checked against.
-	root, err := (reviewtransaction.SnapshotBuilder{Repo: "."}).ResolveRepositoryRoot(ctx)
-	if err != nil {
-		return openCodeTransportSession{}, openCodeTransportFailure("opencode_review_transport_materialization_unavailable")
-	}
-	store, record, err := discoverCompactFacadeReview(ctx, root, binding.LineageID, false)
-	if err != nil {
-		// A host frame naming a lineage this repository does not hold is a
-		// tampered binding, not an unavailable materialization.
-		return openCodeTransportSession{}, openCodeTransportBindingInvalid("Task lineage does not match live compact review authority")
-	}
 	requested := reviewtransaction.ReviewRepositoryContextBinding{
 		LineageID: binding.LineageID, TargetIdentity: binding.TargetIdentity, Revision: binding.Revision,
 	}
-	contextBinding, contextErr := requested, error(nil)
-	if _, resolved, err := reviewtransaction.ResolveReviewRepositoryContextBinding(ctx, root, binding.RepositoryContext, requested); err == nil {
-		contextBinding = resolved
-	} else {
-		// The digest commits to one exact repository and binding, so a mismatch
-		// is a tampered frame. Let the binding validator below name the field
-		// the live authority disagrees with instead of collapsing every tamper
-		// into one generic materialization failure.
-		contextErr = err
-		contextBinding = reviewtransaction.ReviewRepositoryContextBinding{
-			LineageID: record.State.LineageID, TargetIdentity: record.State.InitialSnapshot.Identity,
-			Revision: record.State.CapturePhaseRevision,
-		}
-		if record.State.State != reviewtransaction.StateReviewing {
-			contextBinding.TargetIdentity = record.State.CurrentSnapshot.Identity
-		}
+	// OpenCode exposes the host process cwd but not the Task target cwd. Resolve
+	// the opaque binding only through Git's registered sibling worktrees, then
+	// keep all authority, materialization, and capture operations on that root.
+	root, contextBinding, err := reviewtransaction.ResolveReviewRepositoryContextBindingFromHost(ctx, ".", binding.RepositoryContext, requested)
+	if err != nil {
+		return openCodeTransportSession{}, openCodeTransportBindingInvalid("Task repository context does not match the repository and binding it commits to")
+	}
+	store, record, err := discoverCompactFacadeReview(ctx, root, binding.LineageID, false)
+	if err != nil {
+		return openCodeTransportSession{}, openCodeTransportBindingInvalid("Task lineage does not match live compact review authority")
 	}
 	if err := validateReviewProviderTaskAuthorityBinding(ReviewTransitionBinding{
 		LineageID: binding.LineageID, Revision: binding.Revision, TargetIdentity: binding.TargetIdentity,
 		RepositoryContext: binding.RepositoryContext,
 	}, contextBinding, record); err != nil {
 		return openCodeTransportSession{}, err
-	}
-	if contextErr != nil {
-		return openCodeTransportSession{}, openCodeTransportBindingInvalid("Task repository context does not match the repository and binding it commits to")
 	}
 	if err := authorizeReviewAuthorityMutation(ctx, root); err != nil {
 		return openCodeTransportSession{}, openCodeTransportAuthorityUnavailable(err)

--- a/internal/cli/review_opencode_transport_test.go
+++ b/internal/cli/review_opencode_transport_test.go
@@ -90,6 +90,54 @@ func TestOpenCodeReviewTransportLeavesNoContextEmissionSidecar(t *testing.T) {
 	}
 }
 
+func TestOpenCodeReviewTransportResolvesARegisteredTargetWorktreeFromTheHost(t *testing.T) {
+	reviewEnabledHome(t)
+	target, _, store, record := newArtifactReview(t, false)
+	host := filepath.Join(t.TempDir(), "opencode-host")
+	runReviewCLIGit(t, target, "worktree", "add", "-q", "-b", "opencode-registered-host", host, "HEAD")
+	t.Cleanup(func() { runReviewCLIGit(t, target, "worktree", "remove", "--force", host) })
+	lens := record.State.SelectedLenses[0]
+	relay := startOpenCodeTransportRelay(t, host, openCodeLensTransportStart(t, target, record, lens))
+	hostOutput := string(admittedReviewerPayloadForTest(t, target, record, lens, 0))
+	if _, err := relay.complete(openCodeTransportEnvelope{
+		Schema: openCodeReviewTransportSchema, Operation: "complete", Nonce: relay.prompt.Nonce, Output: &hostOutput,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	assertApprovedCompactAuthorityBurned(t, store, record.State.LineageID)
+	if _, _, err := discoverCompactFacadeReview(t.Context(), host, record.State.LineageID, false); err == nil {
+		t.Fatal("A-hosted relay created or selected authority outside target worktree B")
+	}
+}
+
+func TestOpenCodeReviewTransportRefusesAnUnrelatedHostAndReoffersTargetSlots(t *testing.T) {
+	reviewEnabledHome(t)
+	target, started, store, record := newArtifactReview(t, false)
+	host := initReviewCLIRepo(t)
+	t.Chdir(host)
+	start := openCodeLensTransportStart(t, target, record, record.State.SelectedLenses[0])
+	payload, err := json.Marshal(start)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var output bytes.Buffer
+	err = runReviewOpenCodeTransport(nil, bytes.NewReader(payload), &output)
+	var bindingErr *openCodeTransportBindingError
+	if !errors.As(err, &bindingErr) || output.Len() != 0 {
+		t.Fatalf("unrelated host transport = error %v, output %q", err, output.String())
+	}
+	assertOpenCodeRelayAuthorityUnchanged(t, target, started.LineageID, store, record)
+	var statusOutput bytes.Buffer
+	if err := RunReviewStatus([]string{"--cwd", target, "--lineage", started.LineageID, "--contract", ReviewIntegrationContractV2, "--agent", "opencode", "--next-transition"}, &statusOutput); err != nil {
+		t.Fatal(err)
+	}
+	var status ReviewTargetStatusResult
+	decodeStrictReviewJSON(t, statusOutput.Bytes(), &status)
+	if status.NextTransition == nil || status.NextTransition.Collect == nil || len(status.NextTransition.Collect.Inputs) != len(record.State.SelectedLenses) {
+		t.Fatalf("unrelated host did not reoffer B reviewer slots: %#v", status.NextTransition)
+	}
+}
+
 func TestOpenCodeReviewTransportRefusesStandaloneCompletionWithoutAuthorityMutation(t *testing.T) {
 	repo, _, store, record := newArtifactReview(t, false)
 	lens := record.State.SelectedLenses[0]
@@ -702,9 +750,9 @@ type openCodeTransportRelay struct {
 
 func startOpenCodeTransportRelay(t *testing.T, repo string, start openCodeTransportEnvelope) openCodeTransportRelay {
 	t.Helper()
-	// The managed shim starts this relay inside the repository it reviews, and
-	// the transport takes no flags, so process cwd is the repository the
-	// provider-issued context digest is verified against.
+	// The relay runs in OpenCode's host worktree, which may differ from the
+	// provider-bound repository. The rctx2 handle discovers exactly one
+	// common-directory registered target, whose compact authority admits review.
 	t.Chdir(repo)
 	inputReader, input := io.Pipe()
 	outputReader, output := io.Pipe()

--- a/internal/reviewtransaction/repository_context_test.go
+++ b/internal/reviewtransaction/repository_context_test.go
@@ -137,6 +137,95 @@ func TestRctx2HandleResolvesAgainstTheCallerRepositoryWithoutMutation(t *testing
 	}
 }
 
+func TestRctx2HandleResolvesFromARegisteredHostWorktreeWithoutMutation(t *testing.T) {
+	host, target, store, binding, handle := registeredRctx2HostFixture(t, "rctx2-registered-host")
+	before, err := os.ReadFile(store.StatePath())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, repo := range []string{target, host} {
+		root, resolved, err := ResolveReviewRepositoryContextBindingFromHost(t.Context(), repo, handle, binding)
+		if err != nil || root != target || resolved != binding {
+			t.Fatalf("rctx2 host resolution from %q = root %q, binding %#v, error %v", repo, root, resolved, err)
+		}
+	}
+	after, err := os.ReadFile(store.StatePath())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(after) != string(before) {
+		t.Fatal("registered-host rctx2 resolution mutated compact authority")
+	}
+}
+
+func TestRctx2HostResolverRefusesUnregisteredAndUnrelatedWorktreesWithoutMutation(t *testing.T) {
+	t.Run("unrelated clone", func(t *testing.T) {
+		host, _, store, binding, handle := registeredRctx2HostFixture(t, "rctx2-unrelated-host")
+		unrelated := filepath.Join(t.TempDir(), "unrelated-clone")
+		if err := runSnapshotGit(host, "clone", "--quiet", host, unrelated); err != nil {
+			t.Fatal(err)
+		}
+		assertRctx2HostResolutionRefusedWithoutMutation(t, unrelated, store, handle, binding)
+	})
+
+	t.Run("moved registered target", func(t *testing.T) {
+		host, target, store, binding, handle := registeredRctx2HostFixture(t, "rctx2-moved-host")
+		moved := target + "-moved"
+		if err := os.Rename(target, moved); err != nil {
+			t.Fatal(err)
+		}
+		t.Cleanup(func() {
+			if err := os.Rename(moved, target); err != nil {
+				t.Errorf("restore moved worktree: %v", err)
+			}
+		})
+		assertRctx2HostResolutionRefusedWithoutMutation(t, host, store, handle, binding)
+	})
+}
+
+func registeredRctx2HostFixture(t *testing.T, lineage string) (string, string, CompactStore, ReviewRepositoryContextBinding, string) {
+	t.Helper()
+	host := initSnapshotRepo(t)
+	target := filepath.Join(t.TempDir(), "review-target")
+	if err := runSnapshotGit(host, "worktree", "add", "-q", "-b", lineage+"-target", target, "HEAD"); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = runSnapshotGit(host, "worktree", "remove", "--force", target) })
+	record, _ := pristineReviewingFixture(t, target, lineage)
+	store, err := CompactAuthoritativeStore(t.Context(), target, lineage)
+	if err != nil {
+		t.Fatal(err)
+	}
+	binding := ReviewRepositoryContextBinding{
+		LineageID: record.State.LineageID, TargetIdentity: record.State.InitialSnapshot.Identity, Revision: record.State.CapturePhaseRevision,
+	}
+	handle, err := deriveReviewRepositoryContextV2Token(t.Context(), target, binding)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return host, target, store, binding, handle
+}
+
+func assertRctx2HostResolutionRefusedWithoutMutation(t *testing.T, host string, store CompactStore, handle string, binding ReviewRepositoryContextBinding) {
+	t.Helper()
+	before, err := os.ReadFile(store.StatePath())
+	if err != nil {
+		t.Fatal(err)
+	}
+	root, resolved, err := ResolveReviewRepositoryContextBindingFromHost(t.Context(), host, handle, binding)
+	if err == nil || root != "" || resolved != (ReviewRepositoryContextBinding{}) {
+		t.Fatalf("invalid host resolution = root %q, binding %#v, error %v", root, resolved, err)
+	}
+	after, err := os.ReadFile(store.StatePath())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(after) != string(before) {
+		t.Fatal("refused host resolution mutated compact authority")
+	}
+}
+
 func TestRctx2HandleRefusesTamperAndConfinementWithoutMutation(t *testing.T) {
 	fixture := newCompactReviewerCaptureFixture(t, "rctx2-refusals")
 	record, err := fixture.store.Load()

--- a/internal/reviewtransaction/repository_locator.go
+++ b/internal/reviewtransaction/repository_locator.go
@@ -428,6 +428,59 @@ func ResolveReviewRepositoryContextBinding(ctx context.Context, repo, handle str
 	return root, resolved, nil
 }
 
+// ResolveReviewRepositoryContextBindingFromHost resolves a provider-issued rctx2
+// handle from the host worktree that launched a review task. It searches only
+// Git-registered worktrees that share the host's common directory; no
+// caller-authored target path participates in this discovery.
+func ResolveReviewRepositoryContextBindingFromHost(ctx context.Context, host, handle string, binding ReviewRepositoryContextBinding) (string, ReviewRepositoryContextBinding, error) {
+	if ctx == nil || ctx.Err() != nil || validateReviewRepositoryContextBinding(binding) != nil || !validReviewRepositoryContextV2Handle(handle) {
+		return "", ReviewRepositoryContextBinding{}, errInvalidReviewRepositoryContextV2
+	}
+	hostLease, err := OpenRepositoryIdentityLease(ctx, host)
+	if err != nil || hostLease.Validate(ctx) != nil {
+		return "", ReviewRepositoryContextBinding{}, errInvalidReviewRepositoryContextV2
+	}
+	hostIdentity := hostLease.Identity()
+	worktrees, err := linkedWorktreeDirectories(ctx, hostIdentity.RepositoryRoot)
+	if err != nil {
+		return "", ReviewRepositoryContextBinding{}, invalidReviewRepositoryContextV2Resolution(err)
+	}
+
+	type match struct {
+		root    string
+		binding ReviewRepositoryContextBinding
+	}
+	var matches []match
+	for _, worktree := range worktrees {
+		lease, err := OpenRepositoryIdentityLease(ctx, worktree)
+		if err != nil || lease.Validate(ctx) != nil {
+			return "", ReviewRepositoryContextBinding{}, errInvalidReviewRepositoryContextV2
+		}
+		identity := lease.Identity()
+		if identity.GitCommonDir != hostIdentity.GitCommonDir {
+			continue
+		}
+		root, resolved, err := ResolveReviewRepositoryContextBinding(ctx, identity.RepositoryRoot, handle, binding)
+		if err != nil {
+			continue
+		}
+		duplicate := false
+		for _, existing := range matches {
+			duplicate = existing.root == root
+			if duplicate {
+				break
+			}
+		}
+		if !duplicate {
+			matches = append(matches, match{root: root, binding: resolved})
+		}
+	}
+	if err := hostLease.Validate(ctx); err != nil || len(matches) != 1 {
+		return "", ReviewRepositoryContextBinding{}, errInvalidReviewRepositoryContextV2
+	}
+	return matches[0].root, matches[0].binding, nil
+}
+
 func resolveReviewRepositoryContext(ctx context.Context, repo, handle string, binding ReviewRepositoryContextBinding) (string, ReviewRepositoryContextBinding, error) {
 	if !strings.HasPrefix(handle, reviewRepositoryContextV2HandlePrefix) {
 		return "", ReviewRepositoryContextBinding{}, errInvalidReviewRepositoryContextV2


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #3987

---

## 🏷️ PR Type

- [x] `type:bug` — Bug fix (non-breaking change that fixes an issue)
- [ ] `type:feature` — New feature (non-breaking change that adds functionality)
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring (no functional changes)
- [ ] `type:chore` — Build, CI, or tooling changes
- [ ] `type:breaking-change` — Breaking change (fix or feature that changes existing behavior)

---

## 📝 Summary

- Resolve provider-issued OpenCode repository contexts across registered sibling worktrees.
- Keep authority, materialization, capture, and acknowledgement bound to the unique target worktree.
- Refuse unrelated clones and stale or unregistered targets without mutating review authority.

---

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/reviewtransaction` | Resolve opaque review context only among registered worktrees sharing the host Git common directory. |
| `internal/cli` | Route OpenCode transport through the resolved target and cover positive and fail-closed behavior. |
| `e2e/organicruntime` | Drive the real pinned OpenCode runtime from host A against target worktree B. |

---

## 🤖 AI Assistance

- [ ] **None** — No material AI assistance was used.
- [x] **Material assistance used** — Complete all applicable declaration fields below.

**Tool/model (if known):** OpenCode with `openai/gpt-5.6-sol` and delegated OpenCode agents.

**Material scope:** Root-cause mapping, implementation, behavior-first tests, review orchestration, and verification.

**Verification performed:** Uncached full Go suites, genuine RED proof against base behavior, pinned OpenCode 1.18.10 organic runtime, native four-lens RDD, and CI-equivalent driven benchmark execution.

---

## 🧪 Test Plan

**Unit Tests**
```bash
go test ./... -count=1
```

**Go Format**
```bash
go run ./internal/gofmtcheck
```

**Benchmark Validation**
```bash
cd bench
go vet ./...
go test ./... -count=1
go build -o <temp>/gentle-ai-bench .
cd ..
go build -trimpath -o <temp>/gentle-ai ./cmd/gentle-ai
<temp>/gentle-ai-bench run --binary <temp>/gentle-ai --out <temp>/bench-portable.json
```

Driven summary: **61 completed, 0 unsupported, 0 failed**. The exact CI `jq` assertion passed. No journey pins the rejected A-host/B-target behavior.

**Live OpenCode Runtime**
```bash
GENTLE_AI_OPENCODE_RUNTIME_E2E=1 go test -tags real_agent_e2e -v ./e2e/organicruntime -run ^TestOpenCodeRuntimeIsPinnedForTheLiveProviderTransport -count=1 -timeout=25m
```

Passed with an isolated OpenCode 1.18.10 installation; global OpenCode remained unchanged.

- [x] Unit tests pass (`go test ./...`)
- [x] Go format passes (`go run ./internal/gofmtcheck`)
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`) — left to the required CI job; the directly affected real organic runtime passed locally.
- [x] Manually tested locally

---

## 🤖 Automated Checks

The required repository checks must pass before merge.

---

## ✅ Contributor Checklist

- [x] PR is linked to an issue with `status:approved`
- [x] PR stays within 400 changed lines, or I have requested/obtained maintainer-applied `size:exception` with rationale documented
- [x] I have added the appropriate `type:*` label to this PR
- [x] Unit tests pass (`go test ./...`)
- [x] Go format passes (`go run ./internal/gofmtcheck`)
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`) — required CI will execute this before merge.
- [x] Benchmark validation completed, or this change is not applicable to the benchmark (explain why in the Test Plan).
- [x] Documentation is not required; behavior and authority invariants are documented adjacent to the implementation and tests.
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] I understand, reviewed, and take responsibility for the complete submission
- [x] I selected exactly one AI-assistance option and, if material assistance was used, completed all applicable declaration fields
- [x] My commits do not include `Co-Authored-By` trailers

---

## 💬 Notes for Reviewers

Native RDD approved and burned lineage `review-d6e57176be85be25` for the exact commit tree. Non-blocking follow-up: a stale registered sibling worktree currently fails closed for the whole resolution attempt; review classified this as informational and did not open correction.

- [x] The qualifying repository-context admission guard was challenged against the legitimate population with a real host-A/target-B runtime and unrelated-clone/moved-target negative controls.
- [x] The guard preserves the existing invalid-context refusal and does not require a `.guard-population-baseline.txt` update.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - OpenCode reviews can now be launched from a host worktree while correctly identifying the associated review repository.
  - Review authority remains tied to the intended target repository, even when commands run from a different worktree.

- **Bug Fixes**
  - Prevented reviews from accidentally using or modifying authority in the host or an unrelated repository.
  - Invalid repository bindings are rejected safely without changing review state or consuming reviewer slots.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->