### PR TITLE
fix(hermes): use AppData config on Windows

### DIFF
--- a/internal/agents/hermes/adapter.go
+++ b/internal/agents/hermes/adapter.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 
 	"github.com/gentleman-programming/gentle-ai/v2/internal/agents/capabilitymanifest"
 	"github.com/gentleman-programming/gentle-ai/v2/internal/model"
@@ -104,7 +105,7 @@ func (a *Adapter) MCPStrategy() model.MCPStrategy {
 
 // --- MCP ---
 
-// MCPConfigPath returns the path to ~/.hermes/config.yaml for both context7 and
+// MCPConfigPath returns the shared Hermes config.yaml path for both context7 and
 // engram. Hermes stores all MCP servers in a single YAML config file, so the
 // serverName argument is intentionally ignored.
 func (a *Adapter) MCPConfigPath(homeDir string, _ string) string {
@@ -162,8 +163,15 @@ func defaultStat(path string) statResult {
 	return statResult{isDir: info.IsDir()}
 }
 
-// ConfigPath returns the path to ~/.hermes, the Hermes global config directory.
+// ConfigPath returns the Hermes global config directory.
+// On Windows: %LOCALAPPDATA%/hermes (matches Hermes Desktop).
+// On other platforms: ~/.hermes.
 func ConfigPath(homeDir string) string {
+	if runtime.GOOS == "windows" {
+		if appData := os.Getenv("LOCALAPPDATA"); appData != "" {
+			return filepath.Join(appData, "hermes")
+		}
+	}
 	return filepath.Join(homeDir, ".hermes")
 }
 

--- a/internal/agents/hermes/adapter_test.go
+++ b/internal/agents/hermes/adapter_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -13,6 +14,14 @@ import (
 )
 
 func TestDetect(t *testing.T) {
+	homeDir := filepath.Join(string(filepath.Separator), "home", "test")
+	wantConfigPath := filepath.Join(homeDir, ".hermes")
+	if runtime.GOOS == "windows" {
+		localAppData := filepath.Join(t.TempDir(), "localappdata")
+		t.Setenv("LOCALAPPDATA", localAppData)
+		wantConfigPath = filepath.Join(localAppData, "hermes")
+	}
+
 	tests := []struct {
 		name            string
 		lookPathPath    string
@@ -72,8 +81,6 @@ func TestDetect(t *testing.T) {
 					return tt.stat
 				},
 			}
-			homeDir := filepath.Join(string(filepath.Separator), "home", "test")
-
 			installed, binaryPath, configPath, configFound, err := a.Detect(context.Background(), homeDir)
 			if (err != nil) != tt.wantErr {
 				t.Fatalf("Detect() error = %v, wantErr %v", err, tt.wantErr)
@@ -91,7 +98,6 @@ func TestDetect(t *testing.T) {
 				t.Fatalf("Detect() binaryPath = %q, want %q", binaryPath, tt.wantBinaryPath)
 			}
 
-			wantConfigPath := filepath.Join(homeDir, ".hermes")
 			if configPath != wantConfigPath {
 				t.Fatalf("Detect() configPath = %q, want %q", configPath, wantConfigPath)
 			}
@@ -101,6 +107,38 @@ func TestDetect(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestConfigPath(t *testing.T) {
+	homeDir := filepath.Join(string(filepath.Separator), "home", "test")
+
+	if runtime.GOOS != "windows" {
+		t.Setenv("LOCALAPPDATA", filepath.Join(t.TempDir(), "localappdata"))
+		want := filepath.Join(homeDir, ".hermes")
+		if got := ConfigPath(homeDir); got != want {
+			t.Fatalf("ConfigPath() = %q, want %q", got, want)
+		}
+		return
+	}
+
+	t.Run("uses LOCALAPPDATA", func(t *testing.T) {
+		localAppData := filepath.Join(t.TempDir(), "localappdata")
+		t.Setenv("LOCALAPPDATA", localAppData)
+
+		want := filepath.Join(localAppData, "hermes")
+		if got := ConfigPath(homeDir); got != want {
+			t.Fatalf("ConfigPath() = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("falls back to home directory when LOCALAPPDATA is empty", func(t *testing.T) {
+		t.Setenv("LOCALAPPDATA", "")
+
+		want := filepath.Join(homeDir, ".hermes")
+		if got := ConfigPath(homeDir); got != want {
+			t.Fatalf("ConfigPath() = %q, want %q", got, want)
+		}
+	})
 }
 
 func TestInstallCommand(t *testing.T) {
@@ -127,6 +165,11 @@ func TestConfigPaths(t *testing.T) {
 	a := NewAdapter()
 	homeDir := filepath.Join(string(filepath.Separator), "home", "test")
 	configDir := filepath.Join(homeDir, ".hermes")
+	if runtime.GOOS == "windows" {
+		localAppData := filepath.Join(t.TempDir(), "localappdata")
+		t.Setenv("LOCALAPPDATA", localAppData)
+		configDir = filepath.Join(localAppData, "hermes")
+	}
 	configYAML := filepath.Join(configDir, "config.yaml")
 	soulMD := filepath.Join(configDir, "SOUL.md")
 	skillsDir := filepath.Join(configDir, "skills")


### PR DESCRIPTION
## Summary
- resolve Hermes managed configuration to %LOCALAPPDATA%/hermes on Windows
- preserve ~/.hermes on non-Windows platforms and as the Windows fallback when LOCALAPPDATA is unavailable
- add explicit Windows path and fallback coverage for the Hermes adapter

## Verification
- go test -count=1 ./internal/agents/hermes
- gofmt -d internal/agents/hermes/adapter.go internal/agents/hermes/adapter_test.go
- native Gentle AI review gate passed (review-reliability)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Hermes configuration files now use the standard Windows local application data directory when available.
  * Non-Windows systems and Windows setups without a configured local application data directory continue using the home-directory fallback.

* **Tests**
  * Added coverage for platform-specific configuration paths and fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->