### PR TITLE
feat(sdd): project a positive archived terminal status

### DIFF
--- a/internal/sddstatus/archived_projection_test.go
+++ b/internal/sddstatus/archived_projection_test.go
@@ -1,0 +1,177 @@
+package sddstatus
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// #4002: an archived change is a positive terminal fact, not a blocker.
+// OpenSpec proves closure by the folder that moved into
+// openspec/changes/archive/YYYY-MM-DD-<change>; naming that change used to
+// answer "Active OpenSpec change not found" through the blocked channel, so an
+// orchestrator could not tell a finished change from a typo. These tests pin
+// the positive projection gentle-pi already ships (gentle-pi#538): terminal,
+// unblocked, nextRecommended "archived", and the archive location on the wire.
+
+func allDoneStatusDependencies() Dependencies {
+	return Dependencies{
+		Proposal: DependencyAllDone,
+		Specs:    DependencyAllDone,
+		Design:   DependencyAllDone,
+		Tasks:    DependencyAllDone,
+		Apply:    DependencyAllDone,
+		Verify:   DependencyAllDone,
+		Archive:  DependencyAllDone,
+	}
+}
+
+func assertArchivedTerminal(t *testing.T, status Status, wantPath string) {
+	t.Helper()
+	if status.NextRecommended != "archived" {
+		t.Fatalf("NextRecommended = %q, want %q", status.NextRecommended, "archived")
+	}
+	if len(status.BlockedReasons) != 0 {
+		t.Fatalf("BlockedReasons = %v, want none: archived is a positive terminal state", status.BlockedReasons)
+	}
+	if status.Dependencies != allDoneStatusDependencies() {
+		t.Fatalf("Dependencies = %#v, want every phase all_done", status.Dependencies)
+	}
+	if status.ApplyState != ApplyAllDone {
+		t.Fatalf("ApplyState = %q, want %q", status.ApplyState, ApplyAllDone)
+	}
+	if status.Archived == nil {
+		t.Fatal("Archived is nil, want the archive location projected")
+	}
+	if status.Archived.Path != wantPath {
+		t.Fatalf("Archived.Path = %q, want %q", status.Archived.Path, wantPath)
+	}
+	// The change is closed; never route back to the archive phase (#3480).
+	if status.NextRecommended == string(PhaseArchive) || status.Dependencies.Archive == DependencyReady {
+		t.Fatalf("archived change routed to archive again: archive %q next %q", status.Dependencies.Archive, status.NextRecommended)
+	}
+}
+
+func TestNamedArchivedOpenSpecChangeProjectsPositiveTerminal(t *testing.T) {
+	root := t.TempDir()
+	write(t, filepath.Join(root, "openspec", "changes", "archive", "2026-08-30-wave-one", "proposal.md"), "# Proposal\n")
+
+	status, err := Resolve(ResolveOptions{CWD: root, ChangeName: "wave-one"})
+	if err != nil {
+		t.Fatalf("Resolve() error = %v", err)
+	}
+	if status.ArtifactStore != ArtifactStoreOpenSpec {
+		t.Fatalf("ArtifactStore = %q, want %q", status.ArtifactStore, ArtifactStoreOpenSpec)
+	}
+	if status.ChangeName == nil || *status.ChangeName != "wave-one" {
+		t.Fatalf("ChangeName = %v, want wave-one", ptrValue(status.ChangeName))
+	}
+	assertArchivedTerminal(t, status, filepath.Join("openspec", "changes", "archive", "2026-08-30-wave-one"))
+}
+
+func TestArchivedOpenSpecChangeNewestDateWins(t *testing.T) {
+	root := t.TempDir()
+	mkdir(t, filepath.Join(root, "openspec", "changes", "archive", "2026-01-02-wave-one"))
+	mkdir(t, filepath.Join(root, "openspec", "changes", "archive", "2026-03-04-wave-one"))
+	mkdir(t, filepath.Join(root, "openspec", "changes", "archive", "2025-12-31-wave-one"))
+
+	status, err := Resolve(ResolveOptions{CWD: root, ChangeName: "wave-one"})
+	if err != nil {
+		t.Fatalf("Resolve() error = %v", err)
+	}
+	assertArchivedTerminal(t, status, filepath.Join("openspec", "changes", "archive", "2026-03-04-wave-one"))
+}
+
+// TestArchivedOpenSpecChangeRequiresExactSuffix guards the match discipline: a
+// change name matches only the exact suffix after the 11-character date
+// prefix. "foo-bar" must not claim "2026-01-01-foo-bar-baz", "bar" must not
+// claim "2026-01-01-foo-bar", and an entry without a date prefix is not an
+// archive entry.
+func TestArchivedOpenSpecChangeRequiresExactSuffix(t *testing.T) {
+	root := t.TempDir()
+	mkdir(t, filepath.Join(root, "openspec", "changes", "archive", "2026-01-01-foo-bar-baz"))
+	mkdir(t, filepath.Join(root, "openspec", "changes", "archive", "foo-bar"))
+
+	for _, change := range []string{"foo-bar", "bar-baz", "baz"} {
+		status, err := Resolve(ResolveOptions{CWD: root, ChangeName: change})
+		if err != nil {
+			t.Fatalf("Resolve(%q) error = %v", change, err)
+		}
+		if status.Archived != nil || status.NextRecommended == "archived" {
+			t.Fatalf("Resolve(%q) projected archived %v next %q; only the exact date-prefixed suffix may match", change, status.Archived, status.NextRecommended)
+		}
+	}
+}
+
+// TestNeverExistedChangeKeepsNotFoundBlock pins the pre-#4002 contract for a
+// change with no active folder and no archive entry: the exact not-found
+// block, byte for byte.
+func TestNeverExistedChangeKeepsNotFoundBlock(t *testing.T) {
+	root := t.TempDir()
+	mkdir(t, filepath.Join(root, "openspec", "changes", "archive", "2026-08-30-wave-one"))
+
+	status, err := Resolve(ResolveOptions{CWD: root, ChangeName: "ghost"})
+	if err != nil {
+		t.Fatalf("Resolve() error = %v", err)
+	}
+	if status.NextRecommended != "sdd-new" {
+		t.Fatalf("NextRecommended = %q, want %q", status.NextRecommended, "sdd-new")
+	}
+	if len(status.BlockedReasons) != 1 || status.BlockedReasons[0] != "Active OpenSpec change not found: ghost." {
+		t.Fatalf("BlockedReasons = %v, want exactly the not-found reason", status.BlockedReasons)
+	}
+	if status.Archived != nil {
+		t.Fatalf("Archived = %v, want nil for a change that never existed", status.Archived)
+	}
+}
+
+func TestStatusV2ProjectionCarriesArchivedField(t *testing.T) {
+	root := t.TempDir()
+	mkdir(t, filepath.Join(root, "openspec", "changes", "archive", "2026-08-30-wave-one"))
+
+	status, err := Resolve(ResolveOptions{CWD: root, ChangeName: "wave-one"})
+	if err != nil {
+		t.Fatalf("Resolve() error = %v", err)
+	}
+	projected, err := ProjectStatusV2(status)
+	if err != nil {
+		t.Fatalf("ProjectStatusV2() error = %v", err)
+	}
+	if projected.NextRecommended != "archived" {
+		t.Fatalf("projected NextRecommended = %q, want %q", projected.NextRecommended, "archived")
+	}
+	if projected.Archived == nil || projected.Archived.Path != filepath.Join("openspec", "changes", "archive", "2026-08-30-wave-one") {
+		t.Fatalf("projected Archived = %v, want the archive path on the wire", projected.Archived)
+	}
+
+	serialized, err := marshalStatusV2Indent(status)
+	if err != nil {
+		t.Fatalf("marshalStatusV2Indent() error = %v", err)
+	}
+	if !strings.Contains(string(serialized), `"archived"`) {
+		t.Fatalf("serialized v2 document carries no archived field:\n%s", serialized)
+	}
+}
+
+// TestStatusV2ProjectionOmitsArchivedForActiveChange keeps the field
+// structurally absent everywhere else — the optional-block discipline
+// ReviewOffer established.
+func TestStatusV2ProjectionOmitsArchivedForActiveChange(t *testing.T) {
+	root := t.TempDir()
+	seedReadyChange(t, root, "in-flight", "- [ ] 1.1 Work\n")
+
+	status, err := Resolve(ResolveOptions{CWD: root, ChangeName: "in-flight"})
+	if err != nil {
+		t.Fatalf("Resolve() error = %v", err)
+	}
+	if status.Archived != nil {
+		t.Fatalf("Archived = %v, want nil for an active change", status.Archived)
+	}
+	serialized, err := marshalStatusV2Indent(status)
+	if err != nil {
+		t.Fatalf("marshalStatusV2Indent() error = %v", err)
+	}
+	if strings.Contains(string(serialized), `"archived"`) {
+		t.Fatalf("serialized v2 document carries archived for an active change:\n%s", serialized)
+	}
+}

--- a/internal/sddstatus/engram_archived_test.go
+++ b/internal/sddstatus/engram_archived_test.go
@@ -3,7 +3,6 @@ package sddstatus
 import (
 	"path/filepath"
 	"slices"
-	"strings"
 	"testing"
 )
 
@@ -78,7 +77,10 @@ func TestArchiveReportAloneDoesNotCreateAChange(t *testing.T) {
 // TestNamedArchivedEngramChangeDoesNotRecommendArchive pins #3480's residue:
 // naming an archived Engram change still answered `archive: ready` and
 // `nextRecommended: archive`, so an orchestrator was told to archive a change
-// whose archive report already exists.
+// whose archive report already exists. #4002 upgrades #3480's suppression from
+// a blocked-channel prose reason to the same positive terminal projection
+// OpenSpec gets for an archived folder: the location fact this store can
+// expose is the archive report topic key the reason used to name.
 func TestNamedArchivedEngramChangeDoesNotRecommendArchive(t *testing.T) {
 	root := t.TempDir()
 	write(t, filepath.Join(root, "openspec", "config.yaml"), "sdd:\n  artifact_store: engram\n")
@@ -99,7 +101,8 @@ func TestNamedArchivedEngramChangeDoesNotRecommendArchive(t *testing.T) {
 	if status.NextRecommended == string(PhaseArchive) || status.Dependencies.Archive == DependencyReady {
 		t.Fatalf("archived change routed to archive again: archive %q next %q", status.Dependencies.Archive, status.NextRecommended)
 	}
-	if !slices.ContainsFunc(status.BlockedReasons, func(reason string) bool { return strings.Contains(reason, "sdd/wave-one/archive-report") }) {
-		t.Fatalf("blocked reasons do not name the archive report: %v", status.BlockedReasons)
+	assertArchivedTerminal(t, status, "sdd/wave-one/archive-report")
+	if status.RemediationState.Required {
+		t.Fatalf("RemediationState = %#v, want no remediation on a closed change", status.RemediationState)
 	}
 }

--- a/internal/sddstatus/status.go
+++ b/internal/sddstatus/status.go
@@ -181,10 +181,15 @@ type Status struct {
 	// granted choice names the exact runnable grant invocation. Structural
 	// absence (nil, omitempty) everywhere else — the same optional-block
 	// discipline ReviewOffer established.
-	Consent           *SDDIntegrationConsentResult `json:"consent,omitempty"`
-	PhaseInstructions *PhaseInstructions           `json:"phaseInstructions,omitempty"`
-	NextRecommended   string                       `json:"nextRecommended"`
-	BlockedReasons    []string                     `json:"blockedReasons"`
+	Consent *SDDIntegrationConsentResult `json:"consent,omitempty"`
+	// Archived is #4002's positive terminal projection: present exactly when
+	// the named change is already archived, so closure stops answering through
+	// the blocked channel. Structural absence (nil, omitempty) everywhere else
+	// — the same optional-block discipline ReviewOffer established.
+	Archived          *ArchivedProjection `json:"archived,omitempty"`
+	PhaseInstructions *PhaseInstructions  `json:"phaseInstructions,omitempty"`
+	NextRecommended   string              `json:"nextRecommended"`
+	BlockedReasons    []string            `json:"blockedReasons"`
 	// runtimeAttemptTokens carries the ledger's live attempt tokens alongside
 	// RuntimeStatus so status can ask the one readiness predicate the same
 	// question compact acquire asks, and name the same continuation acquire
@@ -201,6 +206,17 @@ type Status struct {
 type ReviewOfferBlock struct {
 	Available  bool   `json:"available"`
 	Invocation string `json:"invocation"`
+}
+
+// ArchivedProjection is the positive terminal projection for a change that is
+// already archived. Path names the location fact the resolving store can
+// expose: the repo-relative archive folder for OpenSpec
+// (openspec/changes/archive/YYYY-MM-DD-<change>), the archive report topic key
+// for Engram (sdd/<change>/archive-report). When present, NextRecommended is
+// "archived", no phase remains, and nothing is blocked (#4002; gentle-pi#538
+// ships the same contract).
+type ArchivedProjection struct {
+	Path string `json:"path"`
 }
 
 // applyReviewOfferRouting is status's one review edge. It runs only after strict
@@ -324,6 +340,64 @@ func listActiveOpenSpecChanges(workspaceRoot string) ([]string, error) {
 	}
 	sort.Strings(changes)
 	return changes, nil
+}
+
+// archiveDatePrefixPattern matches the 11-character YYYY-MM-DD- prefix the
+// archive phase stamps on every openspec/changes/archive/ entry.
+var archiveDatePrefixPattern = regexp.MustCompile(`^\d{4}-\d{2}-\d{2}-$`)
+
+// newestArchivedOpenSpecEntry returns the newest archive entry for a change.
+// Archive folders are named YYYY-MM-DD-<change>; only an exact <change> suffix
+// after a full date prefix matches (change "foo-bar" never matches
+// "2026-01-01-foo-bar-baz"). Date prefixes sort lexicographically, so the
+// greatest match is the newest one.
+func newestArchivedOpenSpecEntry(workspaceRoot, changeName string) (string, bool) {
+	entries, err := os.ReadDir(filepath.Join(workspaceRoot, "openspec", "changes", "archive"))
+	if err != nil {
+		return "", false
+	}
+	newest := ""
+	for _, entry := range entries {
+		name := entry.Name()
+		if !entry.IsDir() || len(name) != 11+len(changeName) ||
+			!archiveDatePrefixPattern.MatchString(name[:11]) || name[11:] != changeName {
+			continue
+		}
+		if name > newest {
+			newest = name
+		}
+	}
+	return newest, newest != ""
+}
+
+// archivedOpenSpecStatus is the positive terminal projection for a change
+// whose folder moved into openspec/changes/archive/ (#4002): every phase is
+// all_done, nothing is blocked, and the repo-relative archive folder is the
+// location fact on the wire.
+func archivedOpenSpecStatus(workspaceRoot, changeName, archiveEntry string, includeInstructions bool) Status {
+	status := baseStatus(ArtifactStoreOpenSpec, workspaceRoot, nil, &changeName, nil, "archived", nil)
+	status.Dependencies = allDoneDependencies()
+	status.ApplyState = ApplyAllDone
+	status.Archived = &ArchivedProjection{Path: filepath.Join("openspec", "changes", "archive", archiveEntry)}
+	if includeInstructions {
+		instructions := renderPhaseInstructions(status)
+		status.PhaseInstructions = &instructions
+	}
+	return status
+}
+
+// allDoneDependencies is the terminal dependency vector an archived change
+// reports: no phase remains, so every phase answers all_done.
+func allDoneDependencies() Dependencies {
+	return Dependencies{
+		Proposal: DependencyAllDone,
+		Specs:    DependencyAllDone,
+		Design:   DependencyAllDone,
+		Tasks:    DependencyAllDone,
+		Apply:    DependencyAllDone,
+		Verify:   DependencyAllDone,
+		Archive:  DependencyAllDone,
+	}
 }
 
 // openSpecChangeContainer reports whether a directory under openspec/changes
@@ -517,6 +591,11 @@ func resolveByPreferenceOrder(options ResolveOptions) (Status, error) {
 	if !contains(activeChanges, changeName) {
 		if status, ok, err := resolveEngramStatus(workspaceRoot, changeName, options.IncludeInstructions, reviewDisabled); ok || err != nil {
 			return status, err
+		}
+		// #4002: an absent active folder may mean the change was archived, and
+		// closure is a positive terminal fact, not a not-found block.
+		if archiveEntry, ok := newestArchivedOpenSpecEntry(workspaceRoot, changeName); ok {
+			return archivedOpenSpecStatus(workspaceRoot, changeName, archiveEntry, options.IncludeInstructions), nil
 		}
 		return blockedStatus(ArtifactStoreOpenSpec, workspaceRoot, &changeName, nil, "sdd-new", []string{fmt.Sprintf("Active OpenSpec change not found: %s.", changeName)}, options.IncludeInstructions), nil
 	}
@@ -917,13 +996,20 @@ func resolveEngramStatus(workspaceRoot string, requestedChange string, includeIn
 	if _, archived := artifactsByType["archive-report"]; archived {
 		// The archive phase wrote the archive report, so the change is closed.
 		// Discovery already skips it (#3008); naming it must not send an
-		// orchestrator back to archive (#3480). The same closure OpenSpec reports
-		// as "Active OpenSpec change not found".
-		status.Dependencies.Archive = DependencyAllDone
-		status.NextRecommended = "sdd-new"
-		status.BlockedReasons = append(status.BlockedReasons, fmt.Sprintf("Engram change %s is archived: sdd/%s/archive-report exists, so no phase remains. List the active changes with `gentle-ai sdd-status --cwd %s`.", changeName, changeName, pathquote.Quote(workspaceRoot)))
+		// orchestrator back to archive (#3480). #4002: closure is a positive
+		// terminal fact, not a blocker — project it the way OpenSpec projects an
+		// archived folder. The location fact this store can expose is the
+		// archive report topic key, and a closed change has nothing left to
+		// block or remediate.
+		status.Dependencies = allDoneDependencies()
+		status.ApplyState = ApplyAllDone
+		status.NextRecommended = "archived"
+		status.Archived = &ArchivedProjection{Path: fmt.Sprintf("sdd/%s/archive-report", changeName)}
+		status.BlockedReasons = []string{}
+		status.RemediationState = RemediationState{}
+	} else {
+		status.BlockedReasons = blockedReasons.finalize(status.NextRecommended, status.BlockedReasons)
 	}
-	status.BlockedReasons = blockedReasons.finalize(status.NextRecommended, status.BlockedReasons)
 	if runtimeRemediationComplete && status.Dependencies.Verify == DependencyReady && status.Dependencies.Archive == DependencyBlocked && status.NextRecommended == string(PhaseVerify) {
 		status.verifyRefreshReason = runtimeRemediationVerifyRefreshInstruction
 	}
@@ -1976,6 +2062,17 @@ func nonPhaseRoutingInstructions(status Status) ([]string, bool) {
 			"",
 			"### Next Selection Operation",
 			fmt.Sprintf("- Rerun with an explicit change name from Blocked Reasons above: `gentle-ai sdd-status --cwd %s <change-name>` or `gentle-ai sdd-continue --cwd %s <change-name>`.", pathquote.Quote(status.ActionContext.WorkspaceRoot), pathquote.Quote(status.ActionContext.WorkspaceRoot)),
+		}, true
+	case "archived":
+		location := ""
+		if status.Archived != nil {
+			location = fmt.Sprintf(" at %s", status.Archived.Path)
+		}
+		return []string{
+			"",
+			"### Archived Change",
+			fmt.Sprintf("- This change is already archived%s; no phase remains and nothing is blocked.", location),
+			fmt.Sprintf("- Start new work with a fresh change: `gentle-ai sdd-status --cwd %s` lists what is active.", pathquote.Quote(status.ActionContext.WorkspaceRoot)),
 		}, true
 	default:
 		return nil, false

--- a/internal/sddstatus/status_v2.go
+++ b/internal/sddstatus/status_v2.go
@@ -28,6 +28,7 @@ type StatusV2Projection struct {
 	RemediationState  remediationStateV2           `json:"remediationState"`
 	ReviewOffer       *ReviewOfferBlock            `json:"reviewOffer,omitempty"`
 	Consent           *SDDIntegrationConsentResult `json:"consent,omitempty"`
+	Archived          *ArchivedProjection          `json:"archived,omitempty"`
 	PhaseInstructions *phaseInstructionsV2         `json:"phaseInstructions,omitempty"`
 	NextRecommended   string                       `json:"nextRecommended"`
 	BlockedReasons    []string                     `json:"blockedReasons"`
@@ -136,6 +137,7 @@ func ProjectStatusV2(status Status) (StatusV2Projection, error) {
 		},
 		ReviewOffer:     status.ReviewOffer,
 		Consent:         status.Consent,
+		Archived:        status.Archived,
 		NextRecommended: status.NextRecommended,
 		BlockedReasons:  status.BlockedReasons,
 	}
@@ -220,8 +222,11 @@ func statusV2ApplyState(value ApplyState) bool {
 }
 
 func statusV2NextRecommended(value string) bool {
+	// "archived" is #4002's positive terminal route: the change is closed, no
+	// phase remains, and the archived block carries the location fact. This is
+	// an additive v2 enum value; no existing value or field changes.
 	switch value {
-	case "apply", "verify", "remediate", "archive", "resolve-blockers", "sdd-new", "select-change", "propose", "spec", "design", "tasks":
+	case "apply", "verify", "remediate", "archive", "archived", "resolve-blockers", "sdd-new", "select-change", "propose", "spec", "design", "tasks":
 		return true
 	default:
 		return false


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #4002

---

## 🏷️ PR Type

- [ ] `type:bug` — Bug fix (non-breaking change that fixes an issue)
- [x] `type:feature` — New feature (non-breaking change that adds functionality)
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring (no functional changes)
- [ ] `type:chore` — Build, CI, or tooling changes
- [ ] `type:breaking-change` — Breaking change (fix or feature that changes existing behavior)

---

## 📝 Summary

Native SDD status now projects a positive archived terminal state. Previously an archived change reported completion only negatively: OpenSpec resolved to a not-found block recommending `sdd-new`, and Engram reported closure through the blocked channel as prose (#3480's re-routing suppression). A consumer finishing a full SDD cycle could not tell a successful archive from a change that never existed without hand-built mechanical proof (gentle-pi#535 row 8, cluster B).

The wire contract gains one additive optional field, `archived: { path }`, on the status and the v2 projection, plus the `"archived"` recommended token: every phase `all_done`, nothing blocked, and the store's location fact exposed (repo-relative archive folder for OpenSpec, archive report topic key for Engram). The never-existed path keeps its exact previous not-found block, and the never-recommend-archive guards from #3480/#3008 stay pinned. Mirrors the Pi-side projection shipped in gentle-pi#538 so both surfaces agree.

---

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/sddstatus/status.go` | `ArchivedProjection` type; newest-date exact-suffix archive lookup; positive archived status for OpenSpec; Engram archived branch converted from blocked-channel prose to the same positive projection; `"archived"` routing instructions |
| `internal/sddstatus/status_v2.go` | Additive `archived` field on `StatusV2Projection`; `"archived"` joins the recommended vocabulary |
| `internal/sddstatus/archived_projection_test.go` | New: positive terminal + path, newest-date-wins, exact-suffix guards, byte-identical not-found for never-existed changes, v2 projection carries the field, absence for active changes |
| `internal/sddstatus/engram_archived_test.go` | Updated to the new contract; keeps the #3480 never-recommend-archive guards |

---

## 🤖 AI Assistance

Select exactly one option. Do not check both options.

- [ ] **None** — No material AI assistance was used.
- [x] **Material assistance used** — Complete all applicable declaration fields below.

**Tool/model (if known):** Claude Code (Fable 5)

**Material scope:** Implementation of the archived projection and its tests under maintainer-directed strict TDD; maintainer triaged the defect, approved the design, and reviewed the diff.

**Verification performed:** Failing-first tests before implementation; `go test ./...` full suite green; `go run ./internal/gofmtcheck` clean; native receipt-driven review (4 lenses, high tier) approved with zero blocking findings and the acknowledgement burned (lineage `review-71c63798f3bba241`).

---

## 🧪 Test Plan

- [x] Unit tests pass (`go test ./...`)
- [x] Go format passes (`go run ./internal/gofmtcheck`)
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`) — not run locally; CI runs them. The change is a read-only status projection with no lifecycle mutation.
- [x] Manually tested locally

**Benchmark Validation:** N/A — this change touches `internal/sddstatus` projection only, none of review-lifecycle, gates, recovery, delivery, or benchmark surfaces.

---

## ✅ Contributor Checklist

- [x] PR is linked to an issue with `status:approved`
- [x] PR stays within 400 changed lines, or I have requested/obtained maintainer-applied `size:exception` with rationale documented
- [x] I have added the appropriate `type:*` label to this PR
- [x] Unit tests pass (`go test ./...`)
- [x] Go format passes (`go run ./internal/gofmtcheck`)
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`) — deferred to CI
- [x] Benchmark validation completed, or this change is not applicable to the benchmark (explain why in the Test Plan).
- [x] I have updated documentation if necessary
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] I understand, reviewed, and take responsibility for the complete submission
- [x] I selected exactly one AI-assistance option and, if material assistance was used, completed all applicable declaration fields
- [x] My commits do not include `Co-Authored-By` trailers

---

## 💬 Notes for Reviewers

No qualifying security/integrity/admission/repair/governance guard was added or changed; `.guard-population-baseline.txt` is untouched. The 19 advisory findings from the receipt-driven review are logged as non-blocking later work.

https://claude.ai/code/session_01P9jxuSzTwn4HFmxRrZJYQd


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Archived changes now appear as completed rather than blocked.
  - Status results identify archived changes and show their archive location.
  - Version 2 status responses include archive details when applicable.
  - Archived changes now support an `"archived"` next-action state.

- **Bug Fixes**
  - Improved archive matching across multiple archive dates.
  - Prevented similarly named changes from being matched incorrectly.
  - Preserved the not-found status for changes that were never created.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->