### PR TITLE
fix(sync): converge managed-asset preflight and diagnose binary skew

### DIFF
--- a/bench/journeys_managed_assets.go
+++ b/bench/journeys_managed_assets.go
@@ -8,6 +8,8 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"slices"
+	"strings"
 )
 
 const (
@@ -79,13 +81,40 @@ func staleManagedAssetsStartIsNotUnknown(r *journeyRun) error {
 		MutationOutcome string `json:"mutation_outcome"`
 		NextAction      string `json:"next_action"`
 		Cause           string `json:"cause"`
+		Context         struct {
+			ManagedAssets *struct {
+				ExpectedDigest  string `json:"expected_digest"`
+				PersistedDigest string `json:"persisted_digest"`
+				BinaryVersion   string `json:"binary_version"`
+				BinaryPath      string `json:"binary_path"`
+				Remediation     string `json:"remediation"`
+			} `json:"managed_assets"`
+		} `json:"context"`
 	}
 	if err := json.Unmarshal([]byte(start.Stdout), &failure); err != nil {
 		return fmt.Errorf("parse stale managed assets START failure: %w (stderr: %s)", err, firstLine(start.Stderr))
 	}
 	if failure.Operation != "review.start" || failure.Phase != "preflight" || failure.Code != "managed_assets_outdated" ||
-		failure.MutationOutcome != "not_started" || failure.NextAction != "stop" || failure.Cause != managedAssetRemediation {
+		failure.MutationOutcome != "not_started" || failure.NextAction != "stop" {
 		return fmt.Errorf("stale managed assets START failure = %#v", failure)
+	}
+	// #3848: the constant remediation sentence stays the stable prefix, and the
+	// cause now names both digests so an operator can see the disagreement.
+	// The runnable same-binary invocation travels in the managed_assets context
+	// because the cause's privacy gate redacts absolute paths.
+	persistedDigest := staleFixtureManagedAssetDigest()
+	if persistedDigest == "" {
+		return fmt.Errorf("stale fixture state carries no managed_asset_digest")
+	}
+	if !strings.HasPrefix(failure.Cause, managedAssetRemediation) ||
+		!strings.Contains(failure.Cause, "expected digest sha256:") || !strings.Contains(failure.Cause, persistedDigest) {
+		return fmt.Errorf("stale managed assets cause = %q, want prefix %q naming both digests", failure.Cause, managedAssetRemediation)
+	}
+	skew := failure.Context.ManagedAssets
+	if skew == nil || skew.PersistedDigest != persistedDigest || !strings.HasPrefix(skew.ExpectedDigest, "sha256:") ||
+		skew.ExpectedDigest == skew.PersistedDigest || skew.BinaryVersion == "" || skew.BinaryPath == "" ||
+		skew.Remediation != "the sync must be run by this same binary: "+skew.BinaryPath+" sync" {
+		return fmt.Errorf("stale managed assets context = %#v", skew)
 	}
 
 	inspection, err := proveInspection(r.sandbox)
@@ -104,7 +133,60 @@ func staleManagedAssetsStartIsNotUnknown(r *journeyRun) error {
 		reconciled.NextTransition.Execute.Operation != "review.start" {
 		return fmt.Errorf("stale managed assets reconciliation STATUS = %+v", reconciled.NextTransition)
 	}
+
+	// #3848 hole 1: the recommended sync used to return its zero-agent no-op
+	// before the managed-asset persistence step, so in a home with no agents
+	// (exactly this sandbox) it exited 0 while leaving the stale digest, and
+	// the refusal above could never converge. Run the remediation with the
+	// same binary and prove the printed START now passes preflight.
+	sync := r.run([]string{"sync"}, false)
+	if sync.ExitCode != 0 {
+		return fmt.Errorf("zero-agent sync exit %d: %s %s", sync.ExitCode, firstLine(sync.Stdout), firstLine(sync.Stderr))
+	}
+	stateBytes, err := os.ReadFile(filepath.Join(r.sandbox.Home, ".gentle-ai", "state.json"))
+	if err != nil {
+		return err
+	}
+	var converged struct {
+		ManagedAssetDigest  string   `json:"managed_asset_digest"`
+		ManagedAssetDigests []string `json:"managed_asset_digests"`
+	}
+	if err := json.Unmarshal(stateBytes, &converged); err != nil {
+		return err
+	}
+	// The zero-agent sync converges additively: the scalar keeps the writing
+	// binary's digest so a second binary sharing this home stays authorized,
+	// and this binary's digest joins the managed_asset_digests set.
+	if converged.ManagedAssetDigest != persistedDigest {
+		return fmt.Errorf("zero-agent sync rewrote the scalar digest to %q, want the writer's %q preserved", converged.ManagedAssetDigest, persistedDigest)
+	}
+	if !slices.Contains(converged.ManagedAssetDigests, skew.ExpectedDigest) {
+		return fmt.Errorf("zero-agent sync set %v does not contain this binary's %q", converged.ManagedAssetDigests, skew.ExpectedDigest)
+	}
+	restarted, err := runPrintedTransition(r, reconciled)
+	if err != nil {
+		return err
+	}
+	var started struct {
+		LineageID string `json:"lineage_id"`
+	}
+	if restarted.ExitCode != 0 || json.Unmarshal([]byte(restarted.Stdout), &started) != nil || started.LineageID == "" {
+		return fmt.Errorf("START after converging sync = exit %d: %s %s", restarted.ExitCode, firstLine(restarted.Stdout), firstLine(restarted.Stderr))
+	}
 	return nil
+}
+
+// staleFixtureManagedAssetDigest reads the digest the predecessor fixture
+// recorded, so assertions compare against the artifact itself instead of a
+// second hand-copied constant.
+func staleFixtureManagedAssetDigest() string {
+	var persisted struct {
+		ManagedAssetDigest string `json:"managed_asset_digest"`
+	}
+	if json.Unmarshal(historicalManagedAssetState, &persisted) != nil {
+		return ""
+	}
+	return persisted.ManagedAssetDigest
 }
 
 func managedAssetJourneys() []Journey {
@@ -112,13 +194,13 @@ func managedAssetJourneys() []Journey {
 		{
 			ID:     "j93-stale-managed-assets-start-is-not-unknown",
 			Review: reviewOptedIn,
-			Title:  "Stale managed assets: v2 OpenCode START stops before authority and STATUS remains usable",
-			Source: "issue #2822: a stale product-created managed-asset digest refuses before START can mutate; negotiated output must not claim native execution",
+			Title:  "Stale managed assets: v2 OpenCode START stops before authority, names both digests, and a zero-agent sync converges the preflight",
+			Source: "issue #2822: a stale product-created managed-asset digest refuses before START can mutate; issue #3848: the refusal names both digests and the same-binary remediation, and a zero-agent sync persists the running binary's digest instead of no-opping past it",
 			Steps: []Step{
 				{Name: "fixture: repository", Fixture: baseRepo},
 				{Name: "fixture: staged prose candidate", Fixture: stageDocs("stale-managed-assets")},
 				{Name: "fixture: predecessor managed asset digest", Fixture: staleManagedAssetState},
-				{Name: "v2 OpenCode START is typed not-started and reconciliation stays usable", Requires: managedAssetsStartCapability, Composite: staleManagedAssetsStartIsNotUnknown},
+				{Name: "v2 OpenCode START is typed not-started with convergence diagnostics, and the same-binary sync unblocks START", Requires: managedAssetsStartCapability, Composite: staleManagedAssetsStartIsNotUnknown},
 			},
 		},
 	}

--- a/contracts/review-integration/v2/schemas/failure.schema.json
+++ b/contracts/review-integration/v2/schemas/failure.schema.json
@@ -30,10 +30,34 @@
     "next_action": {"$ref": "../../v1/schemas/failure.schema.json#/properties/next_action"},
     "cause_category": {"$ref": "../../v1/schemas/failure.schema.json#/properties/cause_category"},
     "cause": {"$ref": "../../v1/schemas/failure.schema.json#/properties/cause"},
-    "context": {"$ref": "../../v1/schemas/failure.schema.json#/properties/context"}
+    "context": {"$ref": "#/$defs/gate_context"}
   },
   "allOf": [
     {"$ref": "../../v1/schemas/failure.schema.json#/allOf/0"},
     {"$ref": "../../v1/schemas/failure.schema.json#/allOf/1"}
-  ]
+  ],
+  "$defs": {
+    "managed_assets": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["expected_digest", "persisted_digest", "binary_version", "binary_path", "remediation"],
+      "properties": {
+        "expected_digest": {"type": "string", "maxLength": 128, "pattern": "^[^\\r\\n]*$"},
+        "persisted_digest": {"type": "string", "minLength": 1, "maxLength": 128, "pattern": "^[^\\r\\n]+$"},
+        "binary_version": {"type": "string", "minLength": 1, "maxLength": 128, "pattern": "^[^\\r\\n]+$"},
+        "binary_path": {"type": "string", "maxLength": 4096, "pattern": "^[^\\r\\n]*$"},
+        "remediation": {"type": "string", "minLength": 1, "maxLength": 4200, "pattern": "^[^\\r\\n]+$"}
+      }
+    },
+    "gate_context": {
+      "type": "object",
+      "additionalProperties": false,
+      "minProperties": 1,
+      "maxProperties": 1,
+      "properties": {
+        "scope_change": {"$ref": "../../v1/schemas/failure.schema.json#/$defs/scope_change"},
+        "managed_assets": {"$ref": "#/$defs/managed_assets"}
+      }
+    }
+  }
 }

--- a/internal/cli/review_asset_provenance.go
+++ b/internal/cli/review_asset_provenance.go
@@ -1,14 +1,70 @@
 package cli
 
 import (
-	"errors"
 	"fmt"
+	"slices"
 
 	"github.com/gentleman-programming/gentle-ai/v2/internal/assets"
 	"github.com/gentleman-programming/gentle-ai/v2/internal/state"
 )
 
 const managedAssetProvenanceRefusal = "managed reviewer assets are outdated; run `gentle-ai sync`"
+
+// managedAssetProvenanceError carries the halves of the provenance refusal a
+// caller needs to actually converge (#3848): the digest this binary expects,
+// the digest state.json recorded, and which executable is doing the comparing.
+// Two different gentle-ai binaries share the one home-scoped digest, and each
+// compares against its OWN embedded assets, so a sync run by any other binary
+// can never satisfy this one's preflight — the remediation must bind the sync
+// to this exact executable, and the bare refusal text used to hide that.
+type managedAssetProvenanceError struct {
+	// ExpectedDigest is this binary's assets.ManagedDigest(); empty when the
+	// digest itself could not be derived.
+	ExpectedDigest string
+	// PersistedDigest is the managed_asset_digest state.json recorded. The
+	// refusal only fires on a recorded digest that disagrees, so it is never
+	// empty here.
+	PersistedDigest string
+	// BinaryVersion is the running binary's own version (`gentle-ai --version`).
+	BinaryVersion string
+	// BinaryPath is os.Executable() for the running binary; empty when the
+	// path could not be resolved.
+	BinaryPath string
+}
+
+// managedAssetSyncInvocation is the exact sync command that converges THIS
+// binary's preflight: the same executable that is refusing, not whichever
+// gentle-ai happens to be first on PATH.
+func (err *managedAssetProvenanceError) managedAssetSyncInvocation() string {
+	if err.BinaryPath == "" {
+		return "gentle-ai sync"
+	}
+	return err.BinaryPath + " sync"
+}
+
+// remediation names the same-binary requirement as one runnable sentence. It
+// is the additive envelope field and the tail of the operator error line.
+func (err *managedAssetProvenanceError) remediation() string {
+	return "the sync must be run by this same binary: " + err.managedAssetSyncInvocation()
+}
+
+// Error keeps the historical refusal sentence as its stable prefix (existing
+// callers and clients match on it) and appends the convergence diagnostics,
+// single-line so the bounded envelope `cause` never truncates it at a newline.
+// Paths sit inside backticks so the envelope's path-redacting privacy gate
+// replaces exactly the path token without swallowing surrounding punctuation.
+func (err *managedAssetProvenanceError) Error() string {
+	expected := err.ExpectedDigest
+	if expected == "" {
+		expected = "underivable"
+	}
+	path := err.BinaryPath
+	if path == "" {
+		path = "an unresolvable executable path"
+	}
+	return fmt.Sprintf("%s (expected digest %s for this binary, persisted digest %s in state.json; this binary is gentle-ai %s at `%s`); the sync must be run by this same binary: `%s`",
+		managedAssetProvenanceRefusal, expected, err.PersistedDigest, err.BinaryVersion, path, err.managedAssetSyncInvocation())
+}
 
 // managedAssetDigest returns a content digest of the managed assets this
 // binary embeds. It deliberately does NOT use the review capabilities build
@@ -44,9 +100,24 @@ func authorizeManagedReviewerAssets() error {
 	if err != nil || persisted.ManagedAssetDigest == "" {
 		return nil
 	}
+	// The scalar names the binary that last wrote the asset files; the set
+	// names every binary a zero-agent sync additionally converged (#3848).
+	// Either grants this binary's preflight, so two binaries sharing one
+	// home stop revoking each other. The refusal keeps reporting the scalar
+	// as persisted_digest — it is the writer identity the diagnostics name.
 	digest, digestErr := managedAssetDigest()
-	if digestErr != nil || persisted.ManagedAssetDigest != digest {
-		return errors.New(managedAssetProvenanceRefusal)
+	if digestErr != nil || (persisted.ManagedAssetDigest != digest && !slices.Contains(persisted.ManagedAssetDigests, digest)) {
+		refusal := &managedAssetProvenanceError{
+			PersistedDigest: persisted.ManagedAssetDigest,
+		}
+		if digestErr == nil {
+			refusal.ExpectedDigest = digest
+		}
+		refusal.BinaryVersion, _ = reviewGentleAIVersionAndCommit()
+		if path, pathErr := reviewCapabilitiesExecutablePath(); pathErr == nil {
+			refusal.BinaryPath = path
+		}
+		return refusal
 	}
 	return nil
 }

--- a/internal/cli/review_asset_provenance_test.go
+++ b/internal/cli/review_asset_provenance_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"testing"
 
@@ -93,6 +94,74 @@ func TestManagedReviewerAssetProvenanceRefusesOnlyRecordedSkew(t *testing.T) {
 	})
 }
 
+// TestZeroAgentSyncConvergesManagedAssetProvenance pins issue #3848 hole 1: a
+// sync that discovers zero agents used to return its no-op before the managed
+// asset persistence step, so a stale recorded digest survived a successful
+// `gentle-ai sync` and the START preflight refused forever with the exact
+// remediation it had already run. The zero-agent no-op must converge this
+// binary additively: its digest joins managed_asset_digests while the scalar
+// stays whatever binary wrote it, so the very next preflight authorizes
+// without revoking another binary's authorization.
+func TestZeroAgentSyncConvergesManagedAssetProvenance(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	staleManagedReviewerAssets(t, home)
+
+	result, err := RunSyncWithSelection(home, model.Selection{})
+	if err != nil || !result.NoOp {
+		t.Fatalf("zero-agent sync = NoOp %v, %v, want a clean no-op", result.NoOp, err)
+	}
+	digest, err := managedAssetDigest()
+	requireManagedAssetProvenanceNoError(t, err)
+	persisted, err := state.Read(home)
+	requireManagedAssetProvenanceNoError(t, err)
+	if persisted.ManagedAssetDigest != "sha256:stale" {
+		t.Fatalf("zero-agent sync rewrote the scalar managed_asset_digest to %q, want the writer's %q preserved", persisted.ManagedAssetDigest, "sha256:stale")
+	}
+	if !slices.Contains(persisted.ManagedAssetDigests, digest) {
+		t.Fatalf("zero-agent sync recorded set %v, want it to contain this binary's %q", persisted.ManagedAssetDigests, digest)
+	}
+	if err := authorizeManagedReviewerAssets(); err != nil {
+		t.Fatalf("preflight after zero-agent sync = %v, want authorized", err)
+	}
+}
+
+// TestZeroAgentSyncDoesNotClobberOtherBinaryDigest pins the two-binary
+// regression: with binary B's digest in the scalar slot, a zero-agent sync by
+// THIS binary must not overwrite it — otherwise B's next sync overwrites ours
+// back and the two preflights revoke each other forever. The zero-agent sync
+// converges additively: the scalar stays B's, this binary's digest joins the
+// managed_asset_digests set (idempotently), and both preflights authorize.
+func TestZeroAgentSyncDoesNotClobberOtherBinaryDigest(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	recordManagedAssetDigest(t, home, "sha256:other-binary")
+
+	for _, pass := range []string{"first", "idempotent second"} {
+		result, err := RunSyncWithSelection(home, model.Selection{})
+		if err != nil || !result.NoOp {
+			t.Fatalf("%s zero-agent sync = NoOp %v, %v, want a clean no-op", pass, result.NoOp, err)
+		}
+	}
+	digest, err := managedAssetDigest()
+	requireManagedAssetProvenanceNoError(t, err)
+	persisted, err := state.Read(home)
+	requireManagedAssetProvenanceNoError(t, err)
+	// The scalar is binary B's authorization: B's own preflight compares its
+	// digest against exactly this field, so it must survive our sync untouched.
+	if persisted.ManagedAssetDigest != "sha256:other-binary" {
+		t.Fatalf("zero-agent sync clobbered the other binary's scalar digest: %q", persisted.ManagedAssetDigest)
+	}
+	if !slices.Equal(persisted.ManagedAssetDigests, []string{digest}) {
+		t.Fatalf("zero-agent sync recorded set %v, want exactly this binary's %q", persisted.ManagedAssetDigests, digest)
+	}
+	if err := authorizeManagedReviewerAssets(); err != nil {
+		t.Fatalf("this binary's preflight after zero-agent sync = %v, want authorized via set membership", err)
+	}
+}
+
 func TestNegotiatedReviewStartClassifiesStaleManagedAssetsBeforeAuthority(t *testing.T) {
 	home, repo := reviewEnabledHome(t), initReviewCLIRepo(t)
 	writeReviewStartCandidate(t, repo, "docs/stale-assets.md", "# Candidate\n", 0o644)
@@ -111,11 +180,88 @@ func TestNegotiatedReviewStartClassifiesStaleManagedAssetsBeforeAuthority(t *tes
 		failure.NextAction != "stop" {
 		t.Fatalf("stale managed assets failure = %#v", failure)
 	}
-	if failure.Cause != managedAssetProvenanceRefusal {
-		t.Fatalf("stale managed assets cause = %q, want %q", failure.Cause, managedAssetProvenanceRefusal)
+	// #3848: the cause keeps its historical sentence as a stable prefix and now
+	// names both digests; the executable path is redacted by the envelope's
+	// privacy gate, so the runnable same-binary invocation travels in the
+	// dedicated managed_assets context instead.
+	expected, digestErr := managedAssetDigest()
+	requireManagedAssetProvenanceNoError(t, digestErr)
+	if !strings.HasPrefix(failure.Cause, managedAssetProvenanceRefusal) ||
+		!strings.Contains(failure.Cause, expected) || !strings.Contains(failure.Cause, "sha256:stale") {
+		t.Fatalf("stale managed assets cause = %q, want prefix %q naming both digests", failure.Cause, managedAssetProvenanceRefusal)
+	}
+	if failure.Context == nil || failure.Context.ManagedAssets == nil ||
+		failure.Context.ManagedAssets.ExpectedDigest != expected ||
+		failure.Context.ManagedAssets.PersistedDigest != "sha256:stale" {
+		t.Fatalf("stale managed assets context = %#v", failure.Context)
 	}
 	if err := failure.Validate(); err != nil {
 		t.Fatalf("stale managed assets failure does not satisfy its published contract: %v", err)
+	}
+	schema := compileWholePublishedReviewSchema(t, "v2", "failure.schema.json")
+	validatePublishedReviewSchema(t, schema, output.Bytes())
+}
+
+// TestManagedAssetProvenanceRefusalCarriesConvergenceDiagnostics pins issue
+// #3848 hole 2: two different gentle-ai binaries share the one home-scoped
+// digest, and each compares against its OWN embedded assets, so a sync run by
+// binary A can never satisfy binary B's preflight. The refusal must therefore
+// name both digests and the running binary's identity, and its remediation
+// must bind the sync to this exact executable.
+func TestManagedAssetProvenanceRefusalCarriesConvergenceDiagnostics(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	staleManagedReviewerAssets(t, home)
+	expected, err := managedAssetDigest()
+	requireManagedAssetProvenanceNoError(t, err)
+	binaryPath, err := reviewCapabilitiesExecutablePath()
+	requireManagedAssetProvenanceNoError(t, err)
+
+	refusal := authorizeManagedReviewerAssets()
+	var skew *managedAssetProvenanceError
+	if !errors.As(refusal, &skew) {
+		t.Fatalf("stale refusal = %T %v, want *managedAssetProvenanceError", refusal, refusal)
+	}
+	if skew.ExpectedDigest != expected || skew.PersistedDigest != "sha256:stale" ||
+		skew.BinaryVersion == "" || skew.BinaryPath != binaryPath {
+		t.Fatalf("refusal diagnostics = %#v, want expected %q, persisted %q, this binary", skew, expected, "sha256:stale")
+	}
+	for _, want := range []string{managedAssetProvenanceRefusal, expected, "sha256:stale", skew.BinaryVersion, binaryPath, binaryPath + " sync"} {
+		if !strings.Contains(refusal.Error(), want) {
+			t.Fatalf("refusal error %q does not name %q", refusal.Error(), want)
+		}
+	}
+	if strings.ContainsAny(refusal.Error(), "\r\n") {
+		t.Fatalf("refusal error is not single-line: %q", refusal.Error())
+	}
+
+	failure := newReviewIntegrationFailure("review.start", []string{"--contract", ReviewIntegrationContractV2},
+		reviewPreflightRefusal(reviewPreflightManagedAssetsReason, refusal))
+	if failure.Code != "managed_assets_outdated" || failure.Context == nil || failure.Context.ManagedAssets == nil {
+		t.Fatalf("stale managed assets envelope = %#v, want managed_assets context", failure)
+	}
+	managed := failure.Context.ManagedAssets
+	if managed.ExpectedDigest != expected || managed.PersistedDigest != "sha256:stale" ||
+		managed.BinaryVersion != skew.BinaryVersion || managed.BinaryPath != binaryPath ||
+		!strings.Contains(managed.Remediation, binaryPath+" sync") {
+		t.Fatalf("managed assets context = %#v", managed)
+	}
+	if err := failure.Validate(); err != nil {
+		t.Fatalf("managed assets envelope does not satisfy its published contract: %v", err)
+	}
+
+	// The v1 contract directory is frozen byte-unchanged, so its gate_context
+	// cannot admit the new diagnostics: a legacy envelope keeps the enriched
+	// cause and carries no context.
+	legacy := newReviewIntegrationFailure("review.start", nil,
+		reviewPreflightRefusal(reviewPreflightManagedAssetsReason, refusal))
+	if legacy.Contract != ReviewIntegrationContractV1 || legacy.Context != nil ||
+		!strings.HasPrefix(legacy.Cause, managedAssetProvenanceRefusal) {
+		t.Fatalf("legacy managed assets envelope = %#v", legacy)
+	}
+	if err := legacy.Validate(); err != nil {
+		t.Fatalf("legacy managed assets envelope does not satisfy its published contract: %v", err)
 	}
 }
 

--- a/internal/cli/review_operation_contract.go
+++ b/internal/cli/review_operation_contract.go
@@ -176,6 +176,30 @@ type ReviewIntegrationFailure struct {
 
 type ReviewIntegrationFailureContext struct {
 	ScopeChange *ReviewIntegrationScopeChange `json:"scope_change,omitempty"`
+	// ManagedAssets is additive (#3848): the managed_assets_outdated refusal
+	// used to carry only its constant cause sentence, which could not reveal
+	// that a DIFFERENT gentle-ai binary had run the recommended sync and
+	// therefore could never converge this binary's preflight.
+	ManagedAssets *ReviewIntegrationManagedAssetSkew `json:"managed_assets,omitempty"`
+}
+
+// ReviewIntegrationManagedAssetSkew names both sides of a managed-asset
+// provenance disagreement and the executable doing the comparing, so a caller
+// can see WHICH binary must run the sync instead of retrying a remediation
+// that already succeeded under another binary.
+type ReviewIntegrationManagedAssetSkew struct {
+	// ExpectedDigest is the running binary's own embedded-asset digest; empty
+	// when the digest could not be derived.
+	ExpectedDigest string `json:"expected_digest"`
+	// PersistedDigest is the managed_asset_digest recorded in state.json.
+	PersistedDigest string `json:"persisted_digest"`
+	// BinaryVersion is the running binary's version (`gentle-ai --version`).
+	BinaryVersion string `json:"binary_version"`
+	// BinaryPath is the running binary's resolved executable path; empty when
+	// it could not be resolved.
+	BinaryPath string `json:"binary_path"`
+	// Remediation is the runnable same-binary sync sentence.
+	Remediation string `json:"remediation"`
 }
 
 type ReviewIntegrationScopeChange struct {
@@ -753,6 +777,19 @@ func newReviewIntegrationFailure(operation string, args []string, runErr error) 
 			preflightFailure.RetrySafe = false
 		}
 		preflightFailure.Cause = reviewIntegrationFailureCause(preflight)
+		// #3848: the managed-asset refusal is the one preflight whose cause
+		// alone cannot make the caller converge -- the remediation depends on
+		// WHICH executable is refusing, and the scrubbed cause prose redacts
+		// paths. The typed diagnostics travel in the additive context field.
+		// v2 only: the v1 contract directory is frozen byte-unchanged (its
+		// gate_context admits scope_change alone), so a legacy envelope keeps
+		// the enriched cause without the structured context.
+		var managedAssets *managedAssetProvenanceError
+		if preflightFailure.Contract == ReviewIntegrationContractV2 && errors.As(preflight, &managedAssets) {
+			preflightFailure.Context = &ReviewIntegrationFailureContext{
+				ManagedAssets: publicReviewManagedAssetSkewContext(managedAssets),
+			}
+		}
 		return preflightFailure
 	}
 	var legacy *reviewtransaction.LegacyReadOnlyError
@@ -969,6 +1006,40 @@ func reviewLockOperationLabel(operation string) string {
 		return metadata.Label
 	}
 	return "Review operation"
+}
+
+// Managed-asset context field bounds; mirrored by the published
+// failure.schema.json `managed_assets` definition.
+const (
+	reviewManagedAssetDigestLimit      = 128
+	reviewManagedAssetVersionLimit     = 128
+	reviewManagedAssetPathLimit        = 4096
+	reviewManagedAssetRemediationLimit = 4200
+)
+
+// publicReviewManagedAssetSkewContext bounds the typed refusal to the
+// published single-line context shape. The digests come from state.json, which
+// hostile or corrupt content can inflate, so every field is cut to its
+// schema-pinned maxLength instead of trusting the source.
+func publicReviewManagedAssetSkewContext(skew *managedAssetProvenanceError) *ReviewIntegrationManagedAssetSkew {
+	return &ReviewIntegrationManagedAssetSkew{
+		ExpectedDigest:  boundReviewManagedAssetContextField(skew.ExpectedDigest, reviewManagedAssetDigestLimit),
+		PersistedDigest: boundReviewManagedAssetContextField(skew.PersistedDigest, reviewManagedAssetDigestLimit),
+		BinaryVersion:   boundReviewManagedAssetContextField(skew.BinaryVersion, reviewManagedAssetVersionLimit),
+		BinaryPath:      boundReviewManagedAssetContextField(skew.BinaryPath, reviewManagedAssetPathLimit),
+		Remediation:     boundReviewManagedAssetContextField(skew.remediation(), reviewManagedAssetRemediationLimit),
+	}
+}
+
+func boundReviewManagedAssetContextField(value string, limit int) string {
+	value = strings.ReplaceAll(value, "\r", "")
+	if newline := strings.IndexByte(value, '\n'); newline >= 0 {
+		value = value[:newline]
+	}
+	if runes := []rune(value); len(runes) > limit {
+		value = string(runes[:limit])
+	}
+	return value
 }
 
 func publicReviewScopeChangeContext(scope *reviewtransaction.GateScopeChangeDiagnostics) *ReviewIntegrationFailureContext {
@@ -1215,16 +1286,31 @@ func (failure ReviewIntegrationFailure) Validate() error {
 		}
 	}
 	if failure.Context != nil {
-		scope := failure.Context.ScopeChange
-		if scope == nil || failure.Operation != ReviewIntegrationOperationValidate {
+		scope, managedAssets := failure.Context.ScopeChange, failure.Context.ManagedAssets
+		if scope != nil && managedAssets != nil {
+			return errors.New("negotiated review failure context carries more than one diagnostic") // refusal:by-design world-action: an envelope carrying two context diagnostics is a construction bug and requires a code fix, not an operator command
+		}
+		if managedAssets != nil {
+			// The frozen v1 contract cannot admit this context; only the v2
+			// failure schema publishes the managed_assets definition.
+			if !nativeGitContract || failure.Code != "managed_assets_outdated" ||
+				!validReviewManagedAssetContextField(managedAssets.ExpectedDigest, reviewManagedAssetDigestLimit, false) ||
+				!validReviewManagedAssetContextField(managedAssets.PersistedDigest, reviewManagedAssetDigestLimit, true) ||
+				!validReviewManagedAssetContextField(managedAssets.BinaryVersion, reviewManagedAssetVersionLimit, true) ||
+				!validReviewManagedAssetContextField(managedAssets.BinaryPath, reviewManagedAssetPathLimit, false) ||
+				!validReviewManagedAssetContextField(managedAssets.Remediation, reviewManagedAssetRemediationLimit, true) {
+				return errors.New("negotiated review managed-asset diagnostics are incomplete") // refusal:by-design world-action: malformed managed-asset diagnostics are a construction bug and require a code fix, not an operator command
+			}
+		}
+		if managedAssets == nil && (scope == nil || failure.Operation != ReviewIntegrationOperationValidate) {
 			return errors.New("negotiated review scope context is not a gate denial")
 		}
-		if failure.Code != "gate_scope_changed" && failure.Code != "receipt_scope_changed" || scope.DifferingPathCount < 0 || scope.DifferingPathCount > 1000000 ||
+		if scope != nil && (failure.Code != "gate_scope_changed" && failure.Code != "receipt_scope_changed" || scope.DifferingPathCount < 0 || scope.DifferingPathCount > 1000000 ||
 			!validReviewGitTree(scope.Expected.CandidateTree) || !validReviewCapabilitySHA256(scope.Expected.PathsDigest) ||
 			!validReviewGitTree(scope.Actual.CandidateTree) || !validReviewCapabilitySHA256(scope.Actual.PathsDigest) || !validReviewCapabilitySHA256(scope.DifferingPathsDigest) ||
 			!validReviewIntegrationLineage(scope.PredecessorLineageID) || !validReviewCapabilitySHA256(scope.PredecessorRevision) ||
 			scope.RecoveryOperation != "review.recover" || !reflect.DeepEqual(failure.RequiredInputs, scope.RecoveryRequiredInputs) ||
-			!reflect.DeepEqual(scope.RecoveryRequiredInputs, []string{"predecessor_lineage_id", "expected_predecessor_revision", "successor_lineage_id", "disposition", "reason", "actor"}) {
+			!reflect.DeepEqual(scope.RecoveryRequiredInputs, []string{"predecessor_lineage_id", "expected_predecessor_revision", "successor_lineage_id", "disposition", "reason", "actor"})) {
 			return errors.New("negotiated review scope-change diagnostics are incomplete")
 		}
 	}
@@ -1254,6 +1340,17 @@ func (failure ReviewIntegrationFailure) Validate() error {
 		}
 	}
 	return nil
+}
+
+// validReviewManagedAssetContextField enforces the published managed_assets
+// context shape: single-line, bounded, and non-empty where the schema pins a
+// minLength (expected_digest and binary_path stay optional because deriving
+// either can itself fail on the machine being diagnosed).
+func validReviewManagedAssetContextField(value string, limit int, required bool) bool {
+	if value == "" {
+		return !required
+	}
+	return !strings.ContainsAny(value, "\r\n") && len([]rune(value)) <= limit
 }
 
 func supportedReviewIntegrationFailureInput(input string) bool {

--- a/internal/cli/sync.go
+++ b/internal/cli/sync.go
@@ -1580,6 +1580,24 @@ func runSyncWithSelection(homeDir string, selection model.Selection, background 
 
 	result, noOp, err := zeroAgentSyncNoOp(homeDir, selection, result)
 	if err != nil || noOp {
+		if err == nil {
+			// #3848: a zero-agent no-op used to return before the managed-asset
+			// persistence step, so a stale recorded digest survived a successful
+			// sync and the review START preflight refused forever with the exact
+			// remediation it had already run. There are no agent asset files to
+			// write here, so persistence is the whole remaining sync — but it
+			// converges ADDITIVELY: it joins this binary's digest to the
+			// managed_asset_digests set and leaves the scalar untouched, so a
+			// second binary sharing this home keeps its own authorization
+			// instead of the two syncs revoking each other alternately.
+			writer, digestErr := managedAssetDigest()
+			if digestErr != nil {
+				return result, fmt.Errorf("derive managed asset writer identity: %w", digestErr)
+			}
+			if persistErr := persistSyncManagedAssetState(homeDir, selection, writer, background.Persist, piBackground.Persist, true); persistErr != nil {
+				return result, fmt.Errorf("persist sync managed asset state: %w", persistErr)
+			}
+		}
 		return result, err
 	}
 
@@ -1671,6 +1689,15 @@ func runSyncWithSelection(homeDir string, selection model.Selection, background 
 }
 
 func persistSyncManagedAssetStateWithBackground(homeDir string, selection model.Selection, writer string, background model.OpenCodeBackgroundIntent, piBackground model.PiBackgroundIntent) error {
+	return persistSyncManagedAssetState(homeDir, selection, writer, background, piBackground, false)
+}
+
+// persistSyncManagedAssetState records which binary's managed assets this home
+// is converged with. A full sync (additiveDigest false) owns the asset files it
+// just wrote, so it claims the scalar digest and resets the set to itself; a
+// zero-agent sync (additiveDigest true) wrote nothing, so it only joins the
+// set and must not clobber another binary's scalar authorization (#3848).
+func persistSyncManagedAssetState(homeDir string, selection model.Selection, writer string, background model.OpenCodeBackgroundIntent, piBackground model.PiBackgroundIntent, additiveDigest bool) error {
 	return withInstallStateLock(homeDir, func() error {
 		latest, err := state.Read(homeDir)
 		if errors.Is(err, os.ErrNotExist) {
@@ -1689,9 +1716,24 @@ func persistSyncManagedAssetStateWithBackground(homeDir string, selection model.
 			latest.InstalledBinaryVersion = AppVersion
 			shouldWrite = true
 		}
-		if latest.ManagedAssetDigest != writer {
-			latest.ManagedAssetDigest = writer
-			shouldWrite = true
+		if additiveDigest {
+			if !slices.Contains(latest.ManagedAssetDigests, writer) {
+				latest.ManagedAssetDigests = append(append([]string(nil), latest.ManagedAssetDigests...), writer)
+				sort.Strings(latest.ManagedAssetDigests)
+				shouldWrite = true
+			}
+		} else {
+			if latest.ManagedAssetDigest != writer {
+				latest.ManagedAssetDigest = writer
+				shouldWrite = true
+			}
+			// A real sync just rewrote the asset files, so digests other
+			// binaries converged against them are stale: reset the set to
+			// exactly this writer instead of accumulating history.
+			if !slices.Equal(latest.ManagedAssetDigests, []string{writer}) {
+				latest.ManagedAssetDigests = []string{writer}
+				shouldWrite = true
+			}
 		}
 		if !latest.CommunityToolsConfigured && selection.CommunityTools != nil {
 			latest.CommunityTools = communityToolIDsToStrings(selection.CommunityTools)

--- a/internal/cli/sync_test.go
+++ b/internal/cli/sync_test.go
@@ -5247,6 +5247,7 @@ func TestRunSyncPreservesCompletePersistedState(t *testing.T) {
 	}
 	expected := before
 	expected.InstalledBinaryVersion = AppVersion
+	expected.ManagedAssetDigests = []string{writer} // #3848: a real sync claims the digest set for its writer
 	if !reflect.DeepEqual(after, expected) {
 		t.Fatalf("CLI sync changed persisted state beyond the version stamp:\nafter:  %#v\nbefore: %#v", after, expected)
 	}

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -41,15 +41,22 @@ type ClaudePhaseAssignmentState struct {
 
 // InstallState holds the persisted user selections from the last install run.
 type InstallState struct {
-	InstalledAgents        []string            `json:"installed_agents"`
-	InstalledBinaryVersion string              `json:"installed_binary_version,omitempty"`
-	ManagedAssetDigest     string              `json:"managed_asset_digest,omitempty"`
-	SelectionConfigured    bool                `json:"selection_configured,omitempty"`
-	Components             []model.ComponentID `json:"components,omitempty"`
-	Skills                 []model.SkillID     `json:"skills,omitempty"`
-	Preset                 model.PresetID      `json:"preset,omitempty"`
-	SDDMode                model.SDDModeID     `json:"sdd_mode,omitempty"`
-	StrictTDD              bool                `json:"strict_tdd,omitempty"`
+	InstalledAgents        []string `json:"installed_agents"`
+	InstalledBinaryVersion string   `json:"installed_binary_version,omitempty"`
+	ManagedAssetDigest     string   `json:"managed_asset_digest,omitempty"`
+	// ManagedAssetDigests is the additive set of binaries (by managed-asset
+	// digest) that have converged this home through a zero-agent sync (#3848).
+	// It exists so two binaries sharing one home stop revoking each other's
+	// review preflight: a zero-agent sync joins the set without touching the
+	// scalar above, and a full sync resets the set to its own digest. Sorted
+	// for deterministic serialization.
+	ManagedAssetDigests []string            `json:"managed_asset_digests,omitempty"`
+	SelectionConfigured bool                `json:"selection_configured,omitempty"`
+	Components          []model.ComponentID `json:"components,omitempty"`
+	Skills              []model.SkillID     `json:"skills,omitempty"`
+	Preset              model.PresetID      `json:"preset,omitempty"`
+	SDDMode             model.SDDModeID     `json:"sdd_mode,omitempty"`
+	StrictTDD           bool                `json:"strict_tdd,omitempty"`
 	// CommunityTools records optional tools explicitly selected in the Gentle AI
 	// installer. Configured distinguishes a completed empty selection from legacy
 	// state files that predate persistence of this choice.
@@ -229,6 +236,7 @@ func MergeAgents(existing InstallState, newAgents []string) InstallState {
 		InstalledAgents:             merged,
 		InstalledBinaryVersion:      existing.InstalledBinaryVersion,
 		ManagedAssetDigest:          existing.ManagedAssetDigest,
+		ManagedAssetDigests:         existing.ManagedAssetDigests,
 		SelectionConfigured:         existing.SelectionConfigured,
 		Components:                  existing.Components,
 		Skills:                      existing.Skills,


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #3848

---

## 🏷️ PR Type

What kind of change does this PR introduce?

- [x] `type:bug` — Bug fix (non-breaking change that fixes an issue)
- [ ] `type:feature` — New feature (non-breaking change that adds functionality)
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring (no functional changes)
- [ ] `type:chore` — Build, CI, or tooling changes
- [ ] `type:breaking-change` — Breaking change (fix or feature that changes existing behavior)

---

## 📝 Summary

`gentle-ai review start` refuses with `managed_assets_outdated` and recommends `gentle-ai sync`, but the remedy never converged. Reproduction on main found two distinct holes behind the one symptom:

1. **Zero-agent no-op sync never persists.** When sync discovers no agents it returns success before the managed-asset persistence step, so `managed_asset_digest` in `~/.gentle-ai/state.json` stays stale forever.
2. **Two binaries share one digest slot.** A client's pinned gentle-ai (e.g. gentle-pi) and the PATH gentle-ai each compare the single home-scoped digest against their **own** embedded assets; sync run by one forever persists the wrong digest for the other, and the refusal never revealed this.

This PR makes the remedy converge and the refusal diagnosable:

- The zero-agent sync path now persists provenance **additively**: the running binary's digest joins a new `managed_asset_digests` set while the scalar `managed_asset_digest` — which may hold another binary's authorization — is left untouched. The full pipeline (agents discovered, asset files written) keeps writing the scalar and resets the set to exactly the writer, so stale digests do not accumulate past a real sync. The preflight authorizes on scalar match OR set membership.
- The `managed_assets_outdated` refusal now carries `context.managed_assets` in the v2 failure envelope: `expected_digest`, `persisted_digest`, `binary_version`, `binary_path`, and a `remediation` naming the exact same-binary sync invocation. Additive only; `contracts/review-integration/v1` stays frozen byte-unchanged and no existing field was renamed or removed.

---

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/cli/sync.go` | Zero-agent no-op branch runs managed-asset persistence; additive vs full-pipeline persist modes |
| `internal/state/state.go` | Additive `managed_asset_digests` (sorted, omitempty) beside the untouched scalar |
| `internal/cli/review_asset_provenance.go` | Preflight accepts scalar match or set membership; typed refusal diagnostics |
| `internal/cli/review_operation_contract.go` | Additive `context.managed_assets` on the v2 failure envelope, admitted only for `managed_assets_outdated` |
| `contracts/review-integration/v2/schemas/failure.schema.json` | Additive `managed_assets` def (v1 untouched) |
| `internal/cli/review_asset_provenance_test.go`, `internal/cli/sync_test.go` | TDD coverage: convergence, two-binary non-clobber regression, envelope schema conformance, v1 no-context pin |
| `bench/journeys_managed_assets.go` | j93 asserts the diagnostics and proves the zero-agent sync remediation converges in-sandbox |

---

## 🤖 AI Assistance

Select exactly one option. Do not check both options.

- [ ] **None** — No material AI assistance was used.
- [x] **Material assistance used** — Complete all applicable declaration fields below.

**Tool/model (if known):** Claude Code / Claude Fable 5

**Material scope:** Reproduction on main, root-cause analysis, implementation, tests, bench journey update, and PR preparation, under maintainer direction and review.

**Verification performed:** Strict TDD (red-first evidence per hole), gofmtcheck, go vet, full `internal/cli` suite, driven bench corpus, and an end-to-end reproduction of the issue's loop converging — details below.

---

## 🧪 Test Plan

- Strict TDD: each hole and the correction had its failing test captured before implementation (`TestZeroAgentSyncConvergesManagedAssetProvenance`, `TestManagedAssetProvenanceRefusalCarriesConvergenceDiagnostics`, `TestZeroAgentSyncDoesNotClobberOtherBinaryDigest`).
- `go run ./internal/gofmtcheck` and `go vet ./...` clean (root and bench modules).
- `go test ./internal/cli -count=1` full suite: ok. `go test ./internal/state -count=1`: ok.
- Driven bench: full corpus 61/61 completed; j93 (stale managed assets) completes with the new diagnostics and a converging zero-agent sync remediation.
- End-to-end with an isolated HOME: stale digest → START refused with both digests + binary identity + same-binary remediation → `sync` (zero agents) exits 0 and persists → fresh candidate START passes preflight and issues a lineage.

---

## 📏 Size exception

The diff is 525 changed lines (498+/27−), over the 400-line guideline. Maintainer-approved exception: the excess is the bounded review correction (the two-binary non-clobber guard demanded a state-schema addition plus its regression tests), contract schema/test conformance coverage, and the bench journey update — none of which can be split without separating the fix from its proof.

## 🧾 RDD

- High-risk four-lens native review ran against the frozen candidate (lineage `review-dc627210cdb75ead`). It raised one CRITICAL finding — the initial zero-agent persist could clobber another binary's authorization — corrected in 139 lines within the 200-line plan (the additive-set design in this PR).
- The correction widened scope to `internal/state/state.go` + one test line; a maintainer-authorized `scope_changed` recovery created successor lineage `review-3848-corrected-scope` with the predecessor preserved.
- The successor's four lenses reduced to `escalated`: severe findings of inconclusive causality, terminal and informational per contract. No approved receipt exists; delivery is an ordinary maintainer decision, taken with the full verification evidence above. Reported honestly here rather than re-running review on unchanged content.

https://claude.ai/code/session_019Fnv65tLLmD1b6H83YZrjq


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved stale managed-asset checks with clearer diagnostics, including expected and recorded asset details.
  * Added structured v2 failure information with remediation guidance.
  * Zero-agent synchronization now safely reconciles asset provenance without removing existing valid records.
  * Successful reconciliation allows subsequent review starts to pass preflight.

* **Bug Fixes**
  * Prevented synchronization from overwriting provenance needed by other binaries.
  * Preserved legacy v1 failure behavior while enriching v2 responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->