### PR TITLE
test(review): read the held LOCK through the holder's handle and canonicalize the rctx2 worktree on Windows

### DIFF
--- a/internal/reviewtransaction/repository_context_test.go
+++ b/internal/reviewtransaction/repository_context_test.go
@@ -187,7 +187,9 @@ func TestRctx2HostResolverRefusesUnregisteredAndUnrelatedWorktreesWithoutMutatio
 func registeredRctx2HostFixture(t *testing.T, lineage string) (string, string, CompactStore, ReviewRepositoryContextBinding, string) {
 	t.Helper()
 	host := initSnapshotRepo(t)
-	target := filepath.Join(t.TempDir(), "review-target")
+	// canonicalTempDir, not t.TempDir: the resolver answers with the canonical
+	// worktree root, and the Windows runner's TEMP is an 8.3 short name.
+	target := filepath.Join(canonicalTempDir(t), "review-target")
 	if err := runSnapshotGit(host, "worktree", "add", "-q", "-b", lineage+"-target", target, "HEAD"); err != nil {
 		t.Fatal(err)
 	}

--- a/internal/reviewtransaction/status_test.go
+++ b/internal/reviewtransaction/status_test.go
@@ -3,6 +3,7 @@ package reviewtransaction
 import (
 	"context"
 	"errors"
+	"io"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -133,6 +134,7 @@ func TestInventoryAuthorityDistinguishesReleasedBusyAndMalformedLockTruth(t *tes
 				t.Fatal(err)
 			}
 			var release func() error
+			readLock := func() ([]byte, error) { return os.ReadFile(lockPath) }
 			if tt.hold {
 				if runtime.GOOS == "windows" {
 					file, openErr := os.OpenFile(lockPath, os.O_RDWR, 0o600)
@@ -144,6 +146,15 @@ func TestInventoryAuthorityDistinguishesReleasedBusyAndMalformedLockTruth(t *tes
 						t.Fatalf("hold advisory lock = %t, %v", locked, lockErr)
 					}
 					release = func() error { return errors.Join(unlockFile(file), file.Close()) }
+					// Windows byte-range locks are mandatory: the held coordination
+					// byte is unreadable from any other handle, so the held LOCK is
+					// read through the holder's own handle.
+					readLock = func() ([]byte, error) {
+						if _, err := file.Seek(0, io.SeekStart); err != nil {
+							return nil, err
+						}
+						return io.ReadAll(file)
+					}
 				} else {
 					held, lockErr := acquireStoreLock(lockPath)
 					if lockErr != nil {
@@ -170,7 +181,7 @@ func TestInventoryAuthorityDistinguishesReleasedBusyAndMalformedLockTruth(t *tes
 				t.Fatalf("lock report = %#v", report)
 			}
 			// Read before release: release itself clears the owner payload (#2504).
-			after, err := os.ReadFile(lockPath)
+			after, err := readLock()
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/internal/reviewtransaction/store_lock_release_test.go
+++ b/internal/reviewtransaction/store_lock_release_test.go
@@ -1,6 +1,7 @@
 package reviewtransaction
 
 import (
+	"io"
 	"os"
 	"path/filepath"
 	"testing"
@@ -9,12 +10,20 @@ import (
 // #2504: release clears the owner payload so a later observer never reads an
 // exited process as the holder; kernel advisory ownership stays the truth.
 func TestStoreLockReleaseClearsOwnerPayload(t *testing.T) {
-	path := filepath.Join(t.TempDir(), "LOCK")
+	// canonicalTempDir, not t.TempDir: the secure open walk refuses a symlinked
+	// component, and macOS keeps its per-user temp root behind /var -> /private/var.
+	path := filepath.Join(canonicalTempDir(t), "LOCK")
 	held, err := acquireStoreLock(path)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if before, err := os.ReadFile(path); err != nil || len(before) == 0 {
+	// Windows byte-range locks are mandatory: while the coordination byte is
+	// held, every read of it from another handle fails, so the held payload is
+	// read through the holder's own handle, which is legal on every platform.
+	if _, err := held.file.Seek(0, io.SeekStart); err != nil {
+		t.Fatal(err)
+	}
+	if before, err := io.ReadAll(held.file); err != nil || len(before) == 0 {
 		t.Fatalf("held LOCK payload = %q err=%v", before, err)
 	}
 	if err := held.release(); err != nil {


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #4013

---

## 🏷️ PR Type

- [x] `type:bug` — Bug fix (non-breaking change that fixes an issue)
- [ ] `type:feature` — New feature (non-breaking change that adds functionality)
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring (no functional changes)
- [ ] `type:chore` — Build, CI, or tooling changes
- [ ] `type:breaking-change` — Breaking change (fix or feature that changes existing behavior)

---

## 📝 Summary

- The Windows Full Suite lane has failed on every push to `main` since #3951 (`589c5458`); the last green run was on `529842bf`. Three tests in `internal/reviewtransaction` fail consistently, and none of them points at production code.
- Windows byte-range locks are mandatory: while the coordination byte is held, reading it from any other handle fails. #3951 added a test that reads the held `LOCK` with `os.ReadFile`, and moved the inventory test's `after` read to before release, where the Windows branch still holds the lock through its own handle. Both reads now go through the holder's handle, which is legal on every platform.
- #3992's rctx2 host fixture built the target worktree under a raw `t.TempDir()` while the resolver answers the canonical root; on the Windows runner `TEMP` is the 8.3 short name `RUNNER~1`. The target now derives from `canonicalTempDir`, like the host already did.
- `canonicalTempDir` also fixes the release test on macOS, where the secure open walk refused the symlinked `/var -> /private/var` temp root.
- `TestLegacyCloneOverrideConcurrentMigrationKeepsOneWinner` appeared once in the red runs (2 s lock timeout under shard load); that is #3239 and stays out of scope.

---

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/reviewtransaction/store_lock_release_test.go` | Read the held payload through `held.file`; derive the lock path from `canonicalTempDir` |
| `internal/reviewtransaction/status_test.go` | Windows hold branch reads the held `LOCK` through its own handle via a `readLock` closure; the non-hold rows keep `os.ReadFile` |
| `internal/reviewtransaction/repository_context_test.go` | `registeredRctx2HostFixture` builds the target worktree under `canonicalTempDir` |

---

## 🤖 AI Assistance

Select exactly one option. Do not check both options.

- [ ] **None** — No material AI assistance was used.
- [x] **Material assistance used** — Complete all applicable declaration fields below.

**Tool/model (if known):** Claude Code (Claude Opus 5)

**Material scope:** Diagnosis from the Windows Full Suite run logs, the three test edits, and this PR text.

**Verification performed:** I reviewed the diff and the reasoning behind each edit; the targeted tests pass on macOS, `go vet` passes for `darwin` and `GOOS=windows`, `gofmtcheck` passes, and the Windows Full Suite is dispatched on this branch.

---

## 🧪 Test Plan

- `go test ./internal/reviewtransaction/ -run 'TestStoreLockReleaseClearsOwnerPayload|TestInventoryAuthorityDistinguishesReleasedBusyAndMalformedLockTruth|TestRctx2Handle' -count=1` — passes on macOS (the release test failed there before this change).
- `go vet ./internal/reviewtransaction/` and `GOOS=windows go vet ./internal/reviewtransaction/` — clean.
- `go run ./internal/gofmtcheck` — clean.
- Windows Full Suite dispatched on this branch via `workflow_dispatch`; the merge requirement is a green `reviewtransaction-d-k` and `reviewtransaction-l-z` shard.

https://claude.ai/code/session_01434g6iQJNsDdvBTUNiC9yw


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved transaction and lock-handling test reliability on Windows.
  * Added coverage for mandatory file locking and lock-content verification.
  * Standardized temporary directory handling to avoid issues caused by alternate or shortened paths.
  * Strengthened validation of lock release and inventory behavior across supported environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->