### PR TITLE
fix(release): expect the provenance archive in post-publication verification and promotion preflight

### DIFF
--- a/internal/update/release_security_test.go
+++ b/internal/update/release_security_test.go
@@ -187,7 +187,7 @@ printf '%s\n' "$*" >>"$GH_CALL_LOG"
 tag=${RELEASE_VERIFICATION_TAG:-$GITHUB_REF_NAME}
 if [[ "$1" == api && "$2" == "repos/$GITHUB_REPOSITORY/releases/tags/$tag" ]]; then
   cat <<JSON
-{"tag_name":"$tag","draft":false,"prerelease":false,"assets":[{"name":"gentle-ai_1.2.3_darwin_amd64.tar.gz"},{"name":"gentle-ai_1.2.3_darwin_arm64.tar.gz"},{"name":"gentle-ai_1.2.3_linux_amd64.tar.gz"},{"name":"gentle-ai_1.2.3_linux_arm64.tar.gz"},{"name":"gentle-ai-review-provider-contract-1.1.0.tar.gz"},{"name":"checksums.txt"},{"name":"checksums.txt.minisig"}]}
+{"tag_name":"$tag","draft":false,"prerelease":false,"assets":[{"name":"gentle-ai_1.2.3_darwin_amd64.tar.gz"},{"name":"gentle-ai_1.2.3_darwin_arm64.tar.gz"},{"name":"gentle-ai_1.2.3_linux_amd64.tar.gz"},{"name":"gentle-ai_1.2.3_linux_arm64.tar.gz"},{"name":"gentle-ai-review-provider-contract-1.1.0.tar.gz"},{"name":"gentle-ai-release-provenance-v1.tar.gz"},{"name":"checksums.txt"},{"name":"checksums.txt.minisig"}]}
 JSON
   exit 0
 fi
@@ -206,7 +206,8 @@ if [[ "$1" == release && "$2" == download && "$3" == "$tag" ]]; then
     printf 'archive %s\n' "$platform" >"$directory/gentle-ai_1.2.3_${platform}.tar.gz"
   done
   printf 'provider contract\n' >"$directory/gentle-ai-review-provider-contract-1.1.0.tar.gz"
-  (cd "$directory" && sha256sum gentle-ai_1.2.3_*.tar.gz gentle-ai-review-provider-contract-1.1.0.tar.gz >checksums.txt)
+  printf 'release provenance\n' >"$directory/gentle-ai-release-provenance-v1.tar.gz"
+  (cd "$directory" && sha256sum gentle-ai_1.2.3_*.tar.gz gentle-ai-review-provider-contract-1.1.0.tar.gz gentle-ai-release-provenance-v1.tar.gz >checksums.txt)
   printf 'test signature\n' >"$directory/checksums.txt.minisig"
   exit 0
 fi
@@ -462,6 +463,7 @@ func TestReleaseSecurityScriptsAreSyntacticallyValidAndFailClosed(t *testing.T) 
 				`MINISIGN_PUBLIC_KEYS`,
 				`sha256sum --check --strict`,
 				`gentle-ai_${version}_linux_amd64.tar.gz`,
+				`gentle-ai-release-provenance-v1.tar.gz`,
 				`checksums.txt.minisig`,
 			},
 		},

--- a/scripts/promote-stable-preflight.sh
+++ b/scripts/promote-stable-preflight.sh
@@ -73,7 +73,7 @@ else
     if jq -e '.draft == true and (.assets | length) == 0' <<<"$release" >/dev/null; then
       recovery_state=reset-empty-draft
     elif jq -e '.draft == false and .prerelease == false and .immutable == true' <<<"$release" >/dev/null &&
-      diff -u <(printf '%s\n' "gentle-ai_${version}_darwin_amd64.tar.gz" "gentle-ai_${version}_darwin_arm64.tar.gz" "gentle-ai_${version}_linux_amd64.tar.gz" "gentle-ai_${version}_linux_arm64.tar.gz" "gentle-ai-review-provider-contract-${provider_contract_semver}.tar.gz" checksums.txt checksums.txt.minisig | LC_ALL=C sort) <(jq -r '.assets[].name' <<<"$release" | LC_ALL=C sort); then
+      diff -u <(printf '%s\n' "gentle-ai_${version}_darwin_amd64.tar.gz" "gentle-ai_${version}_darwin_arm64.tar.gz" "gentle-ai_${version}_linux_amd64.tar.gz" "gentle-ai_${version}_linux_arm64.tar.gz" "gentle-ai-review-provider-contract-${provider_contract_semver}.tar.gz" "gentle-ai-release-provenance-v1.tar.gz" checksums.txt checksums.txt.minisig | LC_ALL=C sort) <(jq -r '.assets[].name' <<<"$release" | LC_ALL=C sort); then
       recovery_state=verify-existing
     else
       die "stable release state is incompatible with safe recovery"

--- a/scripts/verify-release-assets.sh
+++ b/scripts/verify-release-assets.sh
@@ -37,6 +37,11 @@ archives=(
   "gentle-ai_${version}_linux_amd64.tar.gz"
   "gentle-ai_${version}_linux_arm64.tar.gz"
   "gentle-ai-review-provider-contract-${contract_semver}.tar.gz"
+  # The deterministic provenance manifest (#3854) is a signed, checksummed
+  # archive like the others: the publication policy requires it, so the
+  # verifier must expect it too, or every stable after v2.4.0 fails here
+  # before a single byte is checked (#4016).
+  "gentle-ai-release-provenance-v1.tar.gz"
 )
 expected_assets=("${archives[@]}" checksums.txt checksums.txt.minisig)
 


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #4016

---

## 🏷️ PR Type

- [x] `type:bug` — Bug fix (non-breaking change that fixes an issue)
- [ ] `type:feature` — New feature (non-breaking change that adds functionality)
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring (no functional changes)
- [ ] `type:chore` — Build, CI, or tooling changes
- [ ] `type:breaking-change` — Breaking change (fix or feature that changes existing behavior)

---

## 📝 Summary

- #3854 added `gentle-ai-release-provenance-v1.tar.gz` to the release and made `internal/releasepolicy` require it, but `scripts/verify-release-assets.sh` and `scripts/promote-stable-preflight.sh` kept the seven-asset set from v2.4.0.
- v2.5.0 — the first stable cut after #3854 — published correctly (immutable, signed, six archives in `checksums.txt`) and then failed its `verify` job on the asset-set diff before checking a single byte ([run 33498063772](https://github.com/Gentleman-Programming/gentle-ai/actions/runs/33498063772)).
- Both scripts now expect the provenance archive. In the verifier the same `archives` list drives the signed-manifest check, which the published `checksums.txt` already satisfies with six entries.

---

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| `scripts/verify-release-assets.sh` | Add `gentle-ai-release-provenance-v1.tar.gz` to `archives` (drives both the asset-set and the signed-manifest checks) |
| `scripts/promote-stable-preflight.sh` | Add the provenance archive to the `verify-existing` recovery-state asset set |

---

## 🤖 AI Assistance

Select exactly one option. Do not check both options.

- [ ] **None** — No material AI assistance was used.
- [x] **Material assistance used** — Complete all applicable declaration fields below.

**Tool/model (if known):** Claude Code (Claude Opus 5)

**Material scope:** Diagnosis from the release run log, the two script edits, and this PR text.

**Verification performed:** I reviewed the diff; `shellcheck` and `bash -n` pass on both scripts; the patched expected-asset set and archive list were diffed locally against the live v2.5.0 release API asset names and against the published `checksums.txt` entries, and both match exactly. I also verified the v2.5.0 `checksums.txt` Minisign signature out of band (trusted comment `repo=Gentleman-Programming/gentle-ai;tag=v2.5.0`) and every archive checksum.

---

## 🧪 Test Plan

- `shellcheck scripts/verify-release-assets.sh scripts/promote-stable-preflight.sh` — clean.
- Local reproduction of the two `diff -u` checks against the live v2.5.0 assets and manifest — both match with the patched lists (they fail on `main`).
- The full script runs only on a tag push; the next stable release exercises it end to end.

https://claude.ai/code/session_01434g6iQJNsDdvBTUNiC9yw


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Release Validation**
  * Stable releases now require a signed release provenance archive.
  * Release verification checks that the provenance archive is included and listed in the checksum manifest.
  * Preflight checks recognize releases containing the complete set of required assets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->