### PR TITLE
feat(tui): expose OpenCode native fallback models

### DIFF
--- a/internal/components/sdd/inject_test.go
+++ b/internal/components/sdd/inject_test.go
@@ -4782,6 +4782,35 @@ func TestInjectModelAssignments_VariantInjected(t *testing.T) {
 	}
 }
 
+func TestInjectModelAssignments_NativeFallbackAssignmentWins(t *testing.T) {
+	overlayJSON := []byte(`{
+  "agent": {
+    "general": {"mode": "subagent", "model": "openai/gpt-5.6-terra", "variant": "medium"},
+    "explore": {"mode": "subagent"}
+  }
+}`)
+	assignments := map[string]model.ModelAssignment{
+		"general": {ProviderID: "openai", ModelID: "gpt-5.6-luna", Effort: "max"},
+	}
+
+	result, err := injectModelAssignments(overlayJSON, assignments, "", map[string]bool{"general": true, "explore": true})
+	if err != nil {
+		t.Fatalf("injectModelAssignments() error = %v", err)
+	}
+
+	var parsed map[string]any
+	if err := json.Unmarshal(result, &parsed); err != nil {
+		t.Fatalf("Unmarshal result error = %v", err)
+	}
+	general := parsed["agent"].(map[string]any)["general"].(map[string]any)
+	if got := general["model"]; got != "openai/gpt-5.6-luna" {
+		t.Fatalf("general model = %v, want openai/gpt-5.6-luna", got)
+	}
+	if got := general["variant"]; got != "max" {
+		t.Fatalf("general variant = %v, want max", got)
+	}
+}
+
 // TestInjectModelAssignments_EmptyEffortSetsEmptyVariant verifies that when
 // Effort is empty, the "variant" key is set to "" so the deep merge overwrites
 // any pre-existing variant in the user's config.

--- a/internal/opencode/models.go
+++ b/internal/opencode/models.go
@@ -101,6 +101,15 @@ func JDPhases() []string {
 	}
 }
 
+// NativeFallbackPhases returns OpenCode's built-in delegation agents managed
+// by Gentle AI. They are global runtime agents, not profile-scoped SDD phases.
+func NativeFallbackPhases() []string {
+	return []string{
+		"general",
+		"explore",
+	}
+}
+
 const (
 	ReviewRefuterAgent   = "review-refuter"
 	ReviewValidatorAgent = "review-validator"
@@ -130,6 +139,7 @@ func ReviewPhases() []string {
 func ConfigurableAgentPhases() []string {
 	phases := SDDPhases()
 	phases = append(phases, JDPhases()...)
+	phases = append(phases, NativeFallbackPhases()...)
 	phases = append(phases, ReviewPhases()...)
 	return phases
 }

--- a/internal/opencode/models_test.go
+++ b/internal/opencode/models_test.go
@@ -41,3 +41,24 @@ func TestReviewPhasesCompleteRuntimeSet(t *testing.T) {
 		t.Fatalf("ConfigurableAgentPhases() review suffix = %v, want %v", got, want)
 	}
 }
+
+func TestNativeFallbackPhasesAreConfigurable(t *testing.T) {
+	want := []string{"general", "explore"}
+	if got := NativeFallbackPhases(); !reflect.DeepEqual(got, want) {
+		t.Fatalf("NativeFallbackPhases() = %v, want %v", got, want)
+	}
+
+	configurable := ConfigurableAgentPhases()
+	for _, phase := range want {
+		found := false
+		for _, candidate := range configurable {
+			if candidate == phase {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("ConfigurableAgentPhases() missing native fallback %q: %v", phase, configurable)
+		}
+	}
+}

--- a/internal/tui/screens/model_picker.go
+++ b/internal/tui/screens/model_picker.go
@@ -207,7 +207,7 @@ func modelPickerRowsWithCustom(includeReview bool, customAgents []string) []stri
 }
 
 func modelPickerRowsWithCustomIdentity(includeReview bool, customAgents []string) []ModelPickerRow {
-	rows := make([]ModelPickerRow, 0, 2+len(opencode.SDDPhases())+1+len(opencode.JDPhases())+1+len(opencode.ReviewPhases())+len(customAgents)+2)
+	rows := make([]ModelPickerRow, 0, 2+len(opencode.SDDPhases())+1+len(opencode.JDPhases())+1+len(opencode.NativeFallbackPhases())+1+len(opencode.ReviewPhases())+len(customAgents)+2)
 	rows = append(rows,
 		ModelPickerRow{Kind: ModelPickerRowKindAgent, Label: SDDOrchestratorPhase, AgentID: SDDOrchestratorPhase},
 		ModelPickerRow{Kind: ModelPickerRowKindSetAllSDD, Label: "Set all SDD phases"},
@@ -218,6 +218,12 @@ func modelPickerRowsWithCustomIdentity(includeReview bool, customAgents []string
 	if len(opencode.JDPhases()) > 0 {
 		rows = append(rows, ModelPickerRow{Kind: ModelPickerRowKindSeparator, Label: "--- Judgment Day ---"})
 		for _, phase := range opencode.JDPhases() {
+			rows = append(rows, ModelPickerRow{Kind: ModelPickerRowKindAgent, Label: phase, AgentID: phase})
+		}
+	}
+	if includeReview && len(opencode.NativeFallbackPhases()) > 0 {
+		rows = append(rows, ModelPickerRow{Kind: ModelPickerRowKindSeparator, Label: "--- OpenCode native agents ---"})
+		for _, phase := range opencode.NativeFallbackPhases() {
 			rows = append(rows, ModelPickerRow{Kind: ModelPickerRowKindAgent, Label: phase, AgentID: phase})
 		}
 	}

--- a/internal/tui/screens/model_picker_test.go
+++ b/internal/tui/screens/model_picker_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -33,9 +34,51 @@ func makeTestState(phaseIdx int) *ModelPickerState {
 
 func TestModelPickerRows_Count(t *testing.T) {
 	rows := ModelPickerRows()
-	want := 2 + len(opencode.SDDPhases()) + 1 + len(opencode.JDPhases()) + 1 + len(opencode.ReviewPhases())
+	want := 2 + len(opencode.SDDPhases()) + 1 + len(opencode.JDPhases()) + 1 + len(opencode.NativeFallbackPhases()) + 1 + len(opencode.ReviewPhases())
 	if len(rows) != want {
 		t.Fatalf("ModelPickerRows() len = %d, want %d; rows = %v", len(rows), want, rows)
+	}
+}
+
+func TestModelPickerRows_NativeFallbackAgentsAreConfigurable(t *testing.T) {
+	rows := ModelPickerRows()
+	want := append([]string{"--- OpenCode native agents ---"}, opencode.NativeFallbackPhases()...)
+	reviewSeparator := -1
+	for i, row := range rows {
+		if row == "--- Review agents ---" {
+			reviewSeparator = i
+			break
+		}
+	}
+	if reviewSeparator < len(want) {
+		t.Fatalf("native fallback section missing before review agents: %v", rows)
+	}
+	if got := rows[reviewSeparator-len(want) : reviewSeparator]; !reflect.DeepEqual(got, want) {
+		t.Fatalf("native fallback rows = %v, want %v", got, want)
+	}
+}
+
+func TestHandleModelNav_AssignsGeneralFallback(t *testing.T) {
+	rows := ModelPickerRows()
+	generalIndex := -1
+	for i, row := range rows {
+		if row == "general" {
+			generalIndex = i
+			break
+		}
+	}
+	if generalIndex < 0 {
+		t.Fatal("general fallback row is missing")
+	}
+
+	state := makeTestState(generalIndex)
+	handled, assignments := handleModelNav("enter", state, map[string]model.ModelAssignment{})
+	if !handled {
+		t.Fatal("general fallback selection was not handled")
+	}
+	want := model.ModelAssignment{ProviderID: "test-provider", ModelID: "model-alpha"}
+	if got := assignments["general"]; got != want {
+		t.Fatalf("general assignment = %#v, want %#v", got, want)
 	}
 }
 


### PR DESCRIPTION
## Linked Issue

Closes #2197

## PR Type

- [ ] `type:bug` - Bug fix
- [x] `type:feature` - New feature
- [ ] `type:docs` - Documentation only
- [ ] `type:refactor` - Code refactoring
- [ ] `type:chore` - Build, CI, or tooling changes
- [ ] `type:breaking-change` - Breaking change

## Summary

- Exposes OpenCode's managed `general` and `explore` fallback agents in the global model picker.
- Persists their provider, model, and reasoning-effort assignments through the existing OpenCode sync pipeline.
- Keeps native fallback agents out of named profiles because they remain global runtime roles.

## Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/opencode/models.go` | Defines native fallback phases and includes them in the configurable agent inventory. |
| `internal/tui/screens/model_picker.go` | Adds a dedicated global section for `general` and `explore`. |
| Tests | Covers picker rows, `general` selection, and generated model/variant replacement. |

## AI Assistance

- [ ] **None** - No material AI assistance was used.
- [x] **Material assistance used** - Complete all applicable declaration fields below.

**Tool/model (if known):** OpenCode / GPT-5.6 Sol

**Material scope:** Root-cause tracing, implementation, and test authoring.

**Verification performed:** Reviewed the complete diff; ran focused Go packages, format validation, and a local OpenCode sync using `general = openai/gpt-5.6-luna`, `variant = max`.

## Test Plan

**Passing**

```bash
go test ./internal/opencode ./internal/tui/screens ./internal/components/sdd ./internal/tui ./internal/app
go run ./internal/gofmtcheck
```

**Local runtime verification**

```bash
gentle-ai sync --agent opencode
```

Verified that both `~/.gentle-ai/state.json` and `~/.config/opencode/opencode.json` retain `general = openai/gpt-5.6-luna` with `max` effort after sync.

`go test ./...` was also attempted on Windows. The unrelated `e2e/organicruntime` symlink tests require a Windows privilege unavailable in the local environment; the affected packages above pass. Docker E2E was not run locally. Benchmark validation is N/A because this change does not touch review lifecycle, gates, recovery, delivery, or benchmark code.

- [ ] Unit tests pass (`go test ./...`)
- [x] Go format passes (`go run ./internal/gofmtcheck`)
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`)
- [x] Manually tested locally

## Contributor Checklist

- [x] PR is linked to an issue with `status:approved`
- [x] PR stays within 400 changed lines
- [ ] A maintainer must add `type:feature`; the contributor account has read-only permission on the upstream repository
- [ ] Unit tests pass (`go test ./...`); focused affected packages pass, full Windows run is privilege-blocked as documented above
- [x] Go format passes (`go run ./internal/gofmtcheck`)
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`); deferred to CI
- [x] Benchmark validation is not applicable, as explained in the Test Plan
- [x] Documentation is not necessary; the picker labels are self-describing and the approved issue requests this UI exposure
- [x] My commits follow Conventional Commits format
- [x] I understand, reviewed, and take responsibility for the complete submission
- [x] I selected exactly one AI-assistance option and completed the declaration fields
- [x] My commits do not include `Co-Authored-By` trailers

## Notes for Reviewers

The existing assignment injector already gives explicit TUI assignments precedence over managed defaults and existing config. This PR exposes the two previously reserved-but-hidden native roles to that established path instead of adding a parallel persistence mechanism.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added selectable OpenCode native agents, including `general` and `explore`, to the model picker.
  * Native agents can now be assigned specific models and effort variants.
  * Explicit model selections take precedence over existing fallback settings.

* **Bug Fixes**
  * Corrected model assignment behavior when configuring native fallback agents.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->