### PR TITLE
fix(install): strip the managed blocks an older build left in the Pi APPEND_SYSTEM.md on install, sync, and uninstall

### DIFF
--- a/docs/pi.md
+++ b/docs/pi.md
@@ -19,7 +19,7 @@ gentle-ai install --agent pi
 pi
 ```
 
-Gentle AI detects the `pi` binary first. If Pi is the only selected agent, the installer still provisions the real Engram™ component, but skips persona, ecosystem component selection, and Strict TDD prompts because `gentle-pi` owns those choices inside Pi.
+Gentle AI detects the `pi` binary first. If Pi is the only selected agent, the installer still provisions the real Engram™ component, but skips persona, ecosystem component selection, and Strict TDD prompts because `gentle-pi` owns those choices inside Pi. Because `gentle-pi` owns the Pi system prompt, `install` and `sync` also remove any gentle-ai managed blocks an older build left in `~/.pi/agent/APPEND_SYSTEM.md`.
 
 ## Installed Packages
 

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -1631,6 +1631,9 @@ func (s componentApplyStep) Run() error {
 						return fmt.Errorf("inject persona for %q: %w", adapter.Agent(), err)
 					}
 				}
+				if _, err := sdd.RetirePiSystemPromptBlocks(s.homeDir, adapter); err != nil {
+					return fmt.Errorf("retire stale Pi system prompt blocks: %w", err)
+				}
 				continue
 			}
 			targetDir := componentInjectionDirScoped(s.homeDir, s.workspaceDir, s.scope, adapter)

--- a/internal/cli/sync.go
+++ b/internal/cli/sync.go
@@ -1195,6 +1195,11 @@ func (s componentSyncStep) Run() error {
 					return fmt.Errorf("sync persona for %q: %w", adapter.Agent(), err)
 				}
 				s.countChanged(boolToInt(res.Changed), res.Files...)
+				retireRes, err := sdd.RetirePiSystemPromptBlocks(s.homeDir, adapter)
+				if err != nil {
+					return fmt.Errorf("retire stale Pi system prompt blocks: %w", err)
+				}
+				s.countChanged(boolToInt(retireRes.Changed), retireRes.Files...)
 				continue
 			}
 			targetDir := componentInjectionDir(s.homeDir, s.workspaceDir, adapter)

--- a/internal/cli/sync_test.go
+++ b/internal/cli/sync_test.go
@@ -4499,6 +4499,83 @@ func TestRunSyncWithSelectionPiCustomPersistedPersonaIsByteStable(t *testing.T) 
 	}
 }
 
+// TestRunSyncWithSelectionPiRetiresStaleSystemPromptBlocks covers issue #4057:
+// a Pi install made before the capability manifest flipped
+// SupportsSystemPrompt()==false for Pi left gentle-ai managed blocks in
+// ~/.pi/agent/APPEND_SYSTEM.md. Nothing reads or rewrites that file for Pi
+// anymore, so sync must retire those stale blocks directly.
+func TestRunSyncWithSelectionPiRetiresStaleSystemPromptBlocks(t *testing.T) {
+	home := t.TempDir()
+	appendSystemPath := systemPromptFileFor(t, home, model.AgentPi)
+	stale := "user text before\n" +
+		"\n" +
+		"<!-- gentle-ai:sdd-orchestrator -->\n" +
+		"SDD body\n" +
+		"<!-- /gentle-ai:sdd-orchestrator -->\n" +
+		"\n" +
+		"<!-- gentle-ai:persona -->\n" +
+		"persona body\n" +
+		"<!-- /gentle-ai:persona -->\n" +
+		"\n" +
+		"user text after\n"
+	mustWriteFile(t, appendSystemPath, []byte(stale))
+	mustWriteFile(t, state.Path(home), []byte(`{"installed_agents":["pi"]}`))
+
+	result, err := RunSyncWithSelection(home, model.Selection{
+		Agents:     []model.AgentID{model.AgentPi},
+		Components: []model.ComponentID{model.ComponentPersona},
+	})
+	if err != nil {
+		t.Fatalf("RunSyncWithSelection() error = %v", err)
+	}
+
+	// Routing guidance (agent-routing) is refreshed for Pi unconditionally
+	// after the component loop, so it legitimately reappears at the end of
+	// the file; only the leading user content must survive byte-exact.
+	wantPrefix := "user text before\n\nuser text after\n"
+	got := readTextFile(t, appendSystemPath)
+	if !strings.HasPrefix(got, wantPrefix) {
+		t.Fatalf("APPEND_SYSTEM.md = %q, want prefix %q", got, wantPrefix)
+	}
+	if strings.Contains(got, "sdd-orchestrator") || strings.Contains(got, "gentle-ai:persona") {
+		t.Fatalf("APPEND_SYSTEM.md still carries a stale managed block: %q", got)
+	}
+	if result.FilesChanged < 1 {
+		t.Fatalf("FilesChanged = %d, want >= 1", result.FilesChanged)
+	}
+}
+
+// TestRunSyncWithSelectionPiRetirementDoesNotTouchOtherAgents guards against
+// the Pi-only stale-block cleanup leaking to other agents' prompt files
+// selected in the same sync run.
+func TestRunSyncWithSelectionPiRetirementDoesNotTouchOtherAgents(t *testing.T) {
+	home := t.TempDir()
+	appendSystemPath := systemPromptFileFor(t, home, model.AgentPi)
+	mustWriteFile(t, appendSystemPath, []byte(
+		"<!-- gentle-ai:sdd-orchestrator -->\nSDD body\n<!-- /gentle-ai:sdd-orchestrator -->\n"))
+
+	claudePath := systemPromptFileFor(t, home, model.AgentClaudeCode)
+	claudeContent := "user preamble\n\n" +
+		"<!-- gentle-ai:sdd-orchestrator -->\nKEEP-CLAUDE-SDD\n<!-- /gentle-ai:sdd-orchestrator -->\n"
+	mustWriteFile(t, claudePath, []byte(claudeContent))
+
+	mustWriteFile(t, state.Path(home), []byte(`{"installed_agents":["pi","claude-code"]}`))
+
+	if _, err := RunSyncWithSelection(home, model.Selection{
+		Agents:     []model.AgentID{model.AgentPi, model.AgentClaudeCode},
+		Components: []model.ComponentID{model.ComponentPersona},
+	}); err != nil {
+		t.Fatalf("RunSyncWithSelection() error = %v", err)
+	}
+
+	if got := readTextFile(t, appendSystemPath); strings.Contains(got, "sdd-orchestrator") {
+		t.Fatalf("Pi APPEND_SYSTEM.md still carries a stale block: %q", got)
+	}
+	if got := readTextFile(t, claudePath); !strings.Contains(got, "KEEP-CLAUDE-SDD") {
+		t.Fatalf("Claude system prompt lost unrelated content: %q", got)
+	}
+}
+
 // ─── TUI path: RunSyncWithSelection persona resolution from state ───────────
 
 // TestRunSyncWithSelection_PersonaResolvesFromStateNeutral verifies that when

--- a/internal/components/sdd/inject.go
+++ b/internal/components/sdd/inject.go
@@ -2695,7 +2695,10 @@ var legacyPiSystemPromptSectionIDs = []string{
 // It is safe to call unconditionally: a missing file is a no-op, and repeated
 // calls are idempotent. Content outside the managed markers is preserved
 // byte-for-byte. If nothing but whitespace remains after stripping, the file
-// is removed instead of being rewritten empty.
+// is rewritten with that whitespace-only remainder rather than deleted: a
+// whitespace-only file is harmless (Pi appends nothing), the rewrite is
+// recoverable and consistent with every other managed-section rewrite, and
+// only the uninstall call site registers a backup target for this file.
 //
 // Only ever call this with the Pi adapter. Unlike the SupportsSystemPrompt()
 // gated helpers elsewhere in this package, it strips these sections
@@ -2718,13 +2721,6 @@ func RetirePiSystemPromptBlocks(homeDir string, adapter agents.Adapter) (Injecti
 
 	if updated == existing {
 		return InjectionResult{}, nil
-	}
-
-	if strings.TrimSpace(updated) == "" {
-		if err := os.Remove(promptPath); err != nil && !os.IsNotExist(err) {
-			return InjectionResult{}, err
-		}
-		return InjectionResult{Changed: true, Files: []string{promptPath}}, nil
 	}
 
 	writeResult, err := filemerge.WriteFileAtomic(promptPath, []byte(updated), 0o644)

--- a/internal/components/sdd/inject.go
+++ b/internal/components/sdd/inject.go
@@ -2674,6 +2674,67 @@ func stripBareOrchestratorForFilePrompt(content string) string {
 	return result
 }
 
+// legacyPiSystemPromptSectionIDs lists every gentle-ai:-marked section that a
+// Pi install made before the capability manifest started reporting
+// SupportsSystemPrompt()==false for Pi (see 965187e6) could have left behind
+// in the Pi adapter's SystemPromptFile. Nothing manages this file anymore, so
+// none of these blocks self-heal on install/sync/uninstall. The last entry
+// mirrors communitytool.codeGraphGuidanceSectionID, which is unexported.
+var legacyPiSystemPromptSectionIDs = []string{
+	"sdd-orchestrator",
+	"strict-tdd-mode",
+	"persona",
+	"codegraph-guidance",
+}
+
+// RetirePiSystemPromptBlocks removes any gentle-ai managed markdown sections
+// (and a bare legacy SDD orchestrator block) that an older gentle-ai build
+// wrote into the Pi adapter's SystemPromptFile. gentle-pi owns the Pi system
+// prompt, so this file should carry no gentle-ai content going forward.
+//
+// It is safe to call unconditionally: a missing file is a no-op, and repeated
+// calls are idempotent. Content outside the managed markers is preserved
+// byte-for-byte. If nothing but whitespace remains after stripping, the file
+// is removed instead of being rewritten empty.
+//
+// Only ever call this with the Pi adapter. Unlike the SupportsSystemPrompt()
+// gated helpers elsewhere in this package, it strips these sections
+// unconditionally regardless of what the adapter reports.
+func RetirePiSystemPromptBlocks(homeDir string, adapter agents.Adapter) (InjectionResult, error) {
+	promptPath := adapter.SystemPromptFile(homeDir)
+
+	existing, err := readFileOrEmpty(promptPath)
+	if err != nil {
+		return InjectionResult{}, err
+	}
+
+	updated := existing
+	if hasLegacyBareOrchestrator(updated) {
+		updated = stripBareOrchestratorForFilePrompt(updated)
+	}
+	for _, sectionID := range legacyPiSystemPromptSectionIDs {
+		updated = filemerge.InjectMarkdownSection(updated, sectionID, "")
+	}
+
+	if updated == existing {
+		return InjectionResult{}, nil
+	}
+
+	if strings.TrimSpace(updated) == "" {
+		if err := os.Remove(promptPath); err != nil && !os.IsNotExist(err) {
+			return InjectionResult{}, err
+		}
+		return InjectionResult{Changed: true, Files: []string{promptPath}}, nil
+	}
+
+	writeResult, err := filemerge.WriteFileAtomic(promptPath, []byte(updated), 0o644)
+	if err != nil {
+		return InjectionResult{}, err
+	}
+
+	return InjectionResult{Changed: writeResult.Changed, Files: []string{promptPath}}, nil
+}
+
 const instructionsFrontmatter = "---\n" +
 	"name: Gentle AI Persona\n" +
 	"description: Gentleman persona with SDD orchestration and Engram protocol\n" +

--- a/internal/components/sdd/inject_pi_cleanup_test.go
+++ b/internal/components/sdd/inject_pi_cleanup_test.go
@@ -61,12 +61,13 @@ func TestRetirePiSystemPromptBlocksStripsManagedSectionsAndPreservesUserContent(
 	}
 }
 
-func TestRetirePiSystemPromptBlocksRemovesWhitespaceOnlyFile(t *testing.T) {
+func TestRetirePiSystemPromptBlocksKeepsWhitespaceOnlyFile(t *testing.T) {
 	home := t.TempDir()
 	adapter := pi.NewAdapter()
 	promptPath := adapter.SystemPromptFile(home)
 
-	fixture := "<!-- gentle-ai:persona -->\n" +
+	fixture := "   \n" +
+		"<!-- gentle-ai:persona -->\n" +
 		"persona body\n" +
 		"<!-- /gentle-ai:persona -->\n"
 
@@ -84,8 +85,14 @@ func TestRetirePiSystemPromptBlocksRemovesWhitespaceOnlyFile(t *testing.T) {
 	if !result.Changed {
 		t.Fatal("RetirePiSystemPromptBlocks() Changed = false, want true")
 	}
-	if _, err := os.Stat(promptPath); !os.IsNotExist(err) {
-		t.Fatalf("APPEND_SYSTEM.md still exists after whitespace-only cleanup, stat err = %v", err)
+
+	got, err := os.ReadFile(promptPath)
+	if err != nil {
+		t.Fatalf("APPEND_SYSTEM.md was removed after whitespace-only cleanup, want it kept: %v", err)
+	}
+	want := "   \n"
+	if string(got) != want {
+		t.Fatalf("APPEND_SYSTEM.md content = %q, want %q", string(got), want)
 	}
 }
 

--- a/internal/components/sdd/inject_pi_cleanup_test.go
+++ b/internal/components/sdd/inject_pi_cleanup_test.go
@@ -1,0 +1,150 @@
+package sdd
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/gentleman-programming/gentle-ai/v2/internal/agents/pi"
+)
+
+func TestRetirePiSystemPromptBlocksStripsManagedSectionsAndPreservesUserContent(t *testing.T) {
+	home := t.TempDir()
+	adapter := pi.NewAdapter()
+	promptPath := adapter.SystemPromptFile(home)
+
+	fixture := "user text before\n" +
+		"\n" +
+		"<!-- gentle-ai:sdd-orchestrator -->\n" +
+		"SDD body\n" +
+		"<!-- /gentle-ai:sdd-orchestrator -->\n" +
+		"\n" +
+		"<!-- gentle-ai:strict-tdd-mode -->\n" +
+		"Strict TDD Mode: enabled\n" +
+		"<!-- /gentle-ai:strict-tdd-mode -->\n" +
+		"\n" +
+		"<!-- gentle-ai:persona -->\n" +
+		"persona body\n" +
+		"<!-- /gentle-ai:persona -->\n" +
+		"\n" +
+		"<!-- gentle-ai:codegraph-guidance -->\n" +
+		"codegraph body\n" +
+		"<!-- /gentle-ai:codegraph-guidance -->\n" +
+		"\n" +
+		"user text after\n"
+
+	if err := os.MkdirAll(filepath.Dir(promptPath), 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	if err := os.WriteFile(promptPath, []byte(fixture), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	result, err := RetirePiSystemPromptBlocks(home, adapter)
+	if err != nil {
+		t.Fatalf("RetirePiSystemPromptBlocks() error = %v", err)
+	}
+	if !result.Changed {
+		t.Fatal("RetirePiSystemPromptBlocks() Changed = false, want true")
+	}
+	if got, want := result.Files, []string{promptPath}; len(got) != 1 || got[0] != want[0] {
+		t.Fatalf("RetirePiSystemPromptBlocks() Files = %v, want %v", got, want)
+	}
+
+	got, err := os.ReadFile(promptPath)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	want := "user text before\n\nuser text after\n"
+	if string(got) != want {
+		t.Fatalf("APPEND_SYSTEM.md content = %q, want %q", string(got), want)
+	}
+}
+
+func TestRetirePiSystemPromptBlocksRemovesWhitespaceOnlyFile(t *testing.T) {
+	home := t.TempDir()
+	adapter := pi.NewAdapter()
+	promptPath := adapter.SystemPromptFile(home)
+
+	fixture := "<!-- gentle-ai:persona -->\n" +
+		"persona body\n" +
+		"<!-- /gentle-ai:persona -->\n"
+
+	if err := os.MkdirAll(filepath.Dir(promptPath), 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	if err := os.WriteFile(promptPath, []byte(fixture), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	result, err := RetirePiSystemPromptBlocks(home, adapter)
+	if err != nil {
+		t.Fatalf("RetirePiSystemPromptBlocks() error = %v", err)
+	}
+	if !result.Changed {
+		t.Fatal("RetirePiSystemPromptBlocks() Changed = false, want true")
+	}
+	if _, err := os.Stat(promptPath); !os.IsNotExist(err) {
+		t.Fatalf("APPEND_SYSTEM.md still exists after whitespace-only cleanup, stat err = %v", err)
+	}
+}
+
+func TestRetirePiSystemPromptBlocksMissingFileIsNoop(t *testing.T) {
+	home := t.TempDir()
+	adapter := pi.NewAdapter()
+	promptPath := adapter.SystemPromptFile(home)
+
+	result, err := RetirePiSystemPromptBlocks(home, adapter)
+	if err != nil {
+		t.Fatalf("RetirePiSystemPromptBlocks() error = %v", err)
+	}
+	if result.Changed {
+		t.Fatal("RetirePiSystemPromptBlocks() Changed = true, want false for missing file")
+	}
+	if _, err := os.Stat(promptPath); !os.IsNotExist(err) {
+		t.Fatalf("RetirePiSystemPromptBlocks() created a file that did not exist before, stat err = %v", err)
+	}
+}
+
+func TestRetirePiSystemPromptBlocksSecondRunIsNoop(t *testing.T) {
+	home := t.TempDir()
+	adapter := pi.NewAdapter()
+	promptPath := adapter.SystemPromptFile(home)
+
+	fixture := "user text\n" +
+		"\n" +
+		"<!-- gentle-ai:sdd-orchestrator -->\n" +
+		"SDD body\n" +
+		"<!-- /gentle-ai:sdd-orchestrator -->\n"
+
+	if err := os.MkdirAll(filepath.Dir(promptPath), 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	if err := os.WriteFile(promptPath, []byte(fixture), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	if _, err := RetirePiSystemPromptBlocks(home, adapter); err != nil {
+		t.Fatalf("first RetirePiSystemPromptBlocks() error = %v", err)
+	}
+	cleaned, err := os.ReadFile(promptPath)
+	if err != nil {
+		t.Fatalf("ReadFile after first run: %v", err)
+	}
+
+	second, err := RetirePiSystemPromptBlocks(home, adapter)
+	if err != nil {
+		t.Fatalf("second RetirePiSystemPromptBlocks() error = %v", err)
+	}
+	if second.Changed {
+		t.Fatal("second RetirePiSystemPromptBlocks() Changed = true, want false (idempotent)")
+	}
+
+	got, err := os.ReadFile(promptPath)
+	if err != nil {
+		t.Fatalf("ReadFile after second run: %v", err)
+	}
+	if string(got) != string(cleaned) {
+		t.Fatalf("second run mutated file: got %q, want %q", string(got), string(cleaned))
+	}
+}

--- a/internal/components/uninstall/service.go
+++ b/internal/components/uninstall/service.go
@@ -405,6 +405,9 @@ func (s *Service) buildPlan(agentIDs []model.AgentID, componentIDs []model.Compo
 		for _, target := range communitytool.PiCodeGraphPaths(s.homeDir, s.workspaceDir) {
 			backupTargets[target] = struct{}{}
 		}
+		if piAdapter, ok := s.registry.Get(model.AgentPi); ok {
+			backupTargets[piAdapter.SystemPromptFile(s.homeDir)] = struct{}{}
+		}
 	}
 	if slices.Contains(agentIDs, model.AgentOpenCode) && removesAllAgentComponents(componentIDs) {
 		for _, path := range opencodeactivation.LauncherPaths(s.homeDir, runtime.GOOS) {
@@ -467,6 +470,28 @@ func (s *Service) executePlan(p plan, agentsToRemove []model.AgentID) (Result, e
 		} else {
 			result.ChangedFiles = append(result.ChangedFiles, piResult.Files...)
 			result.ManualActions = append(result.ManualActions, piResult.ManualActions...)
+		}
+
+		// Pi's SupportsSystemPrompt() gate keeps componentOperations() from
+		// ever queuing a rewrite for its SystemPromptFile, so a stale
+		// gentle-ai block left there by an older install is never cleaned up
+		// by the generic persona/SDD rewrite ops above. Retire it directly.
+		if piAdapter, ok := s.registry.Get(model.AgentPi); ok {
+			promptPath := piAdapter.SystemPromptFile(s.homeDir)
+			retireResult, retireErr := sdd.RetirePiSystemPromptBlocks(s.homeDir, piAdapter)
+			if retireErr != nil {
+				failures = append(failures, operationFailure{
+					path:   promptPath,
+					agents: []model.AgentID{model.AgentPi},
+					err:    fmt.Errorf("retire stale Pi system prompt blocks: %w", retireErr),
+				})
+			} else if retireResult.Changed {
+				if _, statErr := os.Stat(promptPath); os.IsNotExist(statErr) {
+					result.RemovedFiles = append(result.RemovedFiles, promptPath)
+				} else {
+					result.ChangedFiles = append(result.ChangedFiles, retireResult.Files...)
+				}
+			}
 		}
 	}
 

--- a/internal/components/uninstall/service_test.go
+++ b/internal/components/uninstall/service_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/gentleman-programming/gentle-ai/v2/internal/agents"
 	"github.com/gentleman-programming/gentle-ai/v2/internal/agents/claude"
 	"github.com/gentleman-programming/gentle-ai/v2/internal/agents/codex"
+	"github.com/gentleman-programming/gentle-ai/v2/internal/agents/pi"
 	"github.com/gentleman-programming/gentle-ai/v2/internal/backup"
 	"github.com/gentleman-programming/gentle-ai/v2/internal/components/communitytool"
 	"github.com/gentleman-programming/gentle-ai/v2/internal/components/engram"
@@ -115,6 +116,47 @@ func TestBuildPlanSnapshotsPiManifestAndOwnedOverlay(t *testing.T) {
 		if !slices.Contains(plan.backupTargets, path) {
 			t.Fatalf("backup targets = %v, missing Pi artifact %q", plan.backupTargets, path)
 		}
+	}
+	promptPath := pi.NewAdapter().SystemPromptFile(homeDir)
+	if !slices.Contains(plan.backupTargets, promptPath) {
+		t.Fatalf("backup targets = %v, missing Pi system prompt file %q", plan.backupTargets, promptPath)
+	}
+}
+
+// TestExecutePlanRetiresStalePiSystemPromptBlocks covers issue #4057: a Pi
+// install made before SupportsSystemPrompt()==false for Pi left gentle-ai
+// managed blocks in ~/.pi/agent/APPEND_SYSTEM.md. Since adapter.SupportsSystemPrompt()
+// is false, componentOperations() never queues a rewrite op for that file, so
+// uninstall must retire the stale blocks directly.
+func TestExecutePlanRetiresStalePiSystemPromptBlocks(t *testing.T) {
+	home := t.TempDir()
+	svc, err := NewService(home, t.TempDir(), "dev")
+	if err != nil {
+		t.Fatal(err)
+	}
+	svc.snapshotter = stubSnapshotter{}
+
+	promptPath := pi.NewAdapter().SystemPromptFile(home)
+	if err := os.MkdirAll(filepath.Dir(promptPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	stale := "user text\n\n<!-- gentle-ai:sdd-orchestrator -->\nSDD body\n<!-- /gentle-ai:sdd-orchestrator -->\n"
+	if err := os.WriteFile(promptPath, []byte(stale), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := svc.executePlan(plan{}, []model.AgentID{model.AgentPi})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	got := string(mustReadServiceFile(t, promptPath))
+	want := "user text\n"
+	if got != want {
+		t.Fatalf("APPEND_SYSTEM.md = %q, want %q", got, want)
+	}
+	if !slices.Contains(result.ChangedFiles, promptPath) {
+		t.Fatalf("ChangedFiles = %v, want to contain %q", result.ChangedFiles, promptPath)
 	}
 }
 


### PR DESCRIPTION
Closes #4057.

## Cause

A Pi install made before the capability manifest flipped `SystemPrompt: false` for Pi (965187e6) left `gentle-ai:sdd-orchestrator`, `gentle-ai:persona`, and possibly `gentle-ai:strict-tdd-mode` and CodeGraph guidance blocks in `~/.pi/agent/APPEND_SYSTEM.md`. Every later read or rewrite of that file in `sdd.Inject`, `persona.Inject`, and the uninstall service is gated behind `adapter.SupportsSystemPrompt()`, which is false for Pi, so install, sync, and uninstall all skip the file and the stale block keeps shaping every Pi session. The stale block carries an outdated review lifecycle and the generic "always use the plain chat fallback" clause, which is why a Pi session relays the consent envelope as a plain-text list.

## Fix

- `sdd.RetirePiSystemPromptBlocks(homeDir, adapter)`: an unconditional, idempotent retirement of the managed sections `sdd-orchestrator`, `strict-tdd-mode`, `persona`, and `codegraph-guidance` (plus a bare legacy orchestrator) from the Pi adapter's system prompt file, preserving any other content byte for byte and rewriting atomically. The file is never deleted: when only whitespace remains it is rewritten as-is, so the change stays recoverable on install and sync, which register no snapshot (native review finding `R4-retire-deletes-user-file-without-snapshot`, corrected in 105798e9).
- Wired into the existing Pi branches of install (`run.go`) and sync (`sync.go`) right after `persona.InjectPiPersona`, and into the uninstall plan (backup target) and execution next to the Pi CodeGraph removal.
- `docs/pi.md`: one sentence stating that install and sync remove blocks an older build wrote into the Pi file, because gentle-pi owns the Pi system prompt.

Out of scope, noted for a follow-up: `agentguidance` still writes an `agent-routing` section into the Pi file on every install and sync, independent of the system-prompt gate.

## Verification

- Full `go test ./... -count=1` green in the foreground; `go vet ./...` and `GOOS=windows go vet ./...` clean; `gofmt -l` empty.
- New tests: helper (strip and preserve, whitespace-only keeps the file, missing file no-op, second run no-op), sync wiring (retires stale blocks, other agents untouched), uninstall (backup target and execution).
- Native review: lineage `review-02693da345db0299`, tier high, four lenses, one CRITICAL finding corrected within budget (27 changed lines against 183), targeted validation passed, approved and acknowledged (`gentle-ai.review-acknowledged/v1`, authority burned). Consent was answered `granted` under the maintainer's standing authorization, reconfirmed today.

Companions: #4056 (ship the Pi contract in the provider bundle) and Gentleman-Programming/gentle-pi#560.

https://claude.ai/code/session_01WYGtotXyhPmbnEeAZAbSbj


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Pi synchronization and persona setup now remove stale gentle-ai-managed sections from the Pi system prompt file.
  * Uninstall now cleans up previously managed Pi prompt sections while preserving user-authored content.
  * Cleanup is limited to Pi prompt files and does not alter other agents’ configuration.

* **Documentation**
  * Updated the Quick Start guide to explain Pi prompt cleanup during installation and synchronization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->