### PR TITLE
fix(orchestrator): apply model assignments to organic delegation

### DIFF
--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -795,21 +795,37 @@ func TestTuiSyncClaudeModelConfigWritesSelectedAssignments(t *testing.T) {
 		t.Fatalf("sdd-apply agent did not receive selected model; got:\n%s", body)
 	}
 
+	promptPath := filepath.Join(home, ".claude", "CLAUDE.md")
+	body, err = os.ReadFile(promptPath)
+	if err != nil {
+		t.Fatalf("ReadFile(%s): %v", promptPath, err)
+	}
+	if strings.Contains(string(body), "| orchestrator |") {
+		t.Fatalf("Claude parent prompt should not expose orchestrator as a configurable model row; got:\n%s", body)
+	}
+	for _, want := range []string{
+		"| sdd-apply | haiku | default | Implementation |",
+		"| default | haiku | default | Generic and SDD/JD delegation fallback |",
+		"Every Claude Agent tool call MUST include `model`",
+		"Gentle AI does not configure the main orchestrator model",
+	} {
+		if !strings.Contains(string(body), want) {
+			t.Fatalf("Claude parent prompt missing %q; got:\n%s", want, body)
+		}
+	}
+
 	workflowPath := filepath.Join(home, ".claude", "skills", "_shared", "sdd-orchestrator-workflow.md")
 	body, err = os.ReadFile(workflowPath)
 	if err != nil {
 		t.Fatalf("ReadFile(%s): %v", workflowPath, err)
 	}
-	if strings.Contains(string(body), "| orchestrator |") {
-		t.Fatalf("lazy SDD workflow should not expose orchestrator as a configurable model row; got:\n%s", body)
-	}
-	for _, want := range []string{
-		"| sdd-apply | haiku | default | Implementation |",
-		"| default | haiku | default | SDD/JD phase fallback |",
-		"Gentle AI does not configure the main orchestrator model",
+	for _, unwanted := range []string{
+		"<!-- gentle-ai:sdd-model-assignments -->",
+		"## Model Assignments",
+		"Every Claude Agent tool call MUST include `model`",
 	} {
-		if !strings.Contains(string(body), want) {
-			t.Fatalf("lazy SDD workflow missing %q; got:\n%s", want, body)
+		if strings.Contains(string(body), unwanted) {
+			t.Fatalf("lazy SDD workflow retained model-assignment policy %q; got:\n%s", unwanted, body)
 		}
 	}
 }

--- a/internal/assets/claude/commands/gentle-sdd-continue.md
+++ b/internal/assets/claude/commands/gentle-sdd-continue.md
@@ -3,7 +3,7 @@ description: Continue the next SDD phase in the dependency chain
 ---
 
 Read the SDD workflow FIRST: `.claude/skills/_shared/sdd-orchestrator-workflow.md` under the workspace when a workspace-scope install wrote it there, otherwise `~/.claude/skills/_shared/sdd-orchestrator-workflow.md`. Then treat it as the authoritative SDD workflow instructions for this command.
-The Claude Code session model is controlled by Claude Code; Gentle AI only configures models for Agent tool calls to phase sub-agents.
+The Claude Code session model is controlled by Claude Code; Gentle AI's always-on Model Assignments policy resolves every Agent tool call, including generic/organic delegation through `default`.
 
 WORKFLOW:
 

--- a/internal/assets/claude/commands/gentle-sdd-ff.md
+++ b/internal/assets/claude/commands/gentle-sdd-ff.md
@@ -3,7 +3,7 @@ description: Fast-forward all SDD planning phases — proposal through tasks
 ---
 
 Read the SDD workflow FIRST: `.claude/skills/_shared/sdd-orchestrator-workflow.md` under the workspace when a workspace-scope install wrote it there, otherwise `~/.claude/skills/_shared/sdd-orchestrator-workflow.md`. Then treat it as the authoritative SDD workflow instructions for this command.
-The Claude Code session model is controlled by Claude Code; Gentle AI only configures models for Agent tool calls to phase sub-agents.
+The Claude Code session model is controlled by Claude Code; Gentle AI's always-on Model Assignments policy resolves every Agent tool call, including generic/organic delegation through `default`.
 
 WORKFLOW:
 Honor the cached execution mode from SDD Session Preflight.

--- a/internal/assets/claude/commands/gentle-sdd-new.md
+++ b/internal/assets/claude/commands/gentle-sdd-new.md
@@ -3,7 +3,7 @@ description: Start a new SDD change — runs exploration then creates a proposal
 ---
 
 Read the SDD workflow FIRST: `.claude/skills/_shared/sdd-orchestrator-workflow.md` under the workspace when a workspace-scope install wrote it there, otherwise `~/.claude/skills/_shared/sdd-orchestrator-workflow.md`. Then treat it as the authoritative SDD workflow instructions for this command.
-The Claude Code session model is controlled by Claude Code; Gentle AI only configures models for Agent tool calls to phase sub-agents.
+The Claude Code session model is controlled by Claude Code; Gentle AI's always-on Model Assignments policy resolves every Agent tool call, including generic/organic delegation through `default`.
 
 WORKFLOW:
 

--- a/internal/assets/claude/sdd-orchestrator-workflow.md
+++ b/internal/assets/claude/sdd-orchestrator-workflow.md
@@ -210,30 +210,6 @@ Always pass the resolved `delivery_strategy`, `chain_strategy`, and PR boundary/
 
 When launching `sdd-apply`, always include the resolved `delivery_strategy`, `chain_strategy`, and any chosen PR boundary/exception in the prompt.
 
-<!-- gentle-ai:sdd-model-assignments -->
-
-## Model Assignments
-
-Read this table before the first SDD/Judgment-Day delegation in a session, cache it, and use the mapped alias only for SDD/Judgment-Day phase agents. If a phase is missing, use `default`. If the assigned model is unavailable, substitute `sonnet` and continue.
-
-The Claude Code session model is controlled by Claude Code itself; Gentle AI does not configure the main orchestrator model. This table applies only to Agent tool calls for SDD/Judgment-Day phase sub-agents, not generic delegation.
-
-**Mandatory phase model gate:** Agent tool calls for SDD/Judgment-Day phase agents MUST include `model`. Generic/non-SDD delegation MUST NOT use this table; omit `model` unless the user explicitly requested an override.
-
-| Phase       | Default Model | Effort  | Reason                                     |
-| ----------- | ------------- | ------- | ------------------------------------------ |
-| sdd-explore | sonnet        | default | Reads code, structural - not architectural |
-| sdd-propose | opus          | default | Architectural decisions                    |
-| sdd-spec    | sonnet        | default | Structured writing                         |
-| sdd-design  | opus          | default | Architecture decisions                     |
-| sdd-tasks   | sonnet        | default | Mechanical breakdown                       |
-| sdd-apply   | sonnet        | default | Implementation                             |
-| sdd-verify  | sonnet        | default | Validation against spec                    |
-| sdd-archive | haiku         | default | Copy and close                             |
-| default     | sonnet        | default | SDD/JD phase fallback                      |
-
-<!-- /gentle-ai:sdd-model-assignments -->
-
 ### Sub-Agent Launch Deduplication (MANDATORY)
 
 Maintain a session-scoped launch log of `(phase, task-fingerprint)` pairs. If the same pair already exists, do NOT launch again. Emit exactly one launch per distinct task and append the pair after launch.
@@ -241,13 +217,6 @@ Maintain a session-scoped launch log of `(phase, task-fingerprint)` pairs. If th
 ### Sub-Agent Launch Protocol
 
 ALL sub-agent launch prompts that involve reading, writing, or reviewing code MUST include pre-resolved skill paths from the skill registry. Follow `~/.claude/skills/_shared/skill-resolver.md`.
-
-Pre-flight before every SDD/Judgment-Day Agent call:
-
-1. Identify the phase key (`sdd-apply`, `sdd-verify`, `jd-judge-a`, etc.).
-2. Look up the model alias in the Model Assignments table.
-3. Include `model: "<alias>"` in SDD/Judgment-Day Agent calls.
-4. For generic/non-SDD delegation, omit `model` unless the user explicitly requested one.
 
 Resolve skills once per session, cache the registry, and pass exact `SKILL.md` paths. If a delegated result reports `skill_resolution` as `fallback-registry`, `fallback-path`, or `none`, re-read the registry before subsequent delegations.
 

--- a/internal/assets/claude/sdd-orchestrator.md
+++ b/internal/assets/claude/sdd-orchestrator.md
@@ -110,10 +110,13 @@ The canonical native bounded-review contract is injected from the shared provide
 
 {{GENTLE_AI_RESEARCH_LIFECYCLE}}
 
+<!-- gentle-ai:sdd-model-assignments -->
+<!-- /gentle-ai:sdd-model-assignments -->
+
 ## SDD Workflow (lazy-loaded)
 
 The detailed SDD procedure is intentionally NOT embedded in this always-on parent thread. Before handling any SDD command, meta-command, continuation, apply/verify/archive routing, or SDD/Judgment-Day phase delegation, read:
 
 `.claude/skills/_shared/sdd-orchestrator-workflow.md` under the workspace when a workspace-scope install wrote it there, otherwise `~/.claude/skills/_shared/sdd-orchestrator-workflow.md`
 
-That lazy surface contains the SDD commands, init/dispatcher guards, execution-mode gatekeeper, artifact store policy, delivery strategy, dependency graph, review workload guard, model assignments, sub-agent launch protocol, context protocol, topic keys, and recovery rules.
+That lazy surface contains the SDD commands, init/dispatcher guards, execution-mode gatekeeper, artifact store policy, delivery strategy, dependency graph, review workload guard, sub-agent launch protocol, context protocol, topic keys, and recovery rules.

--- a/internal/components/sdd/inject.go
+++ b/internal/components/sdd/inject.go
@@ -705,7 +705,7 @@ func Inject(homeDir string, adapter agents.Adapter, sddMode model.SDDModeID, opt
 	// workflow procedure is installed as a lazy shared skill document and read
 	// only when an SDD command or SDD/Judgment-Day delegation needs it.
 	if adapter.Agent() == model.AgentClaudeCode {
-		workflowResult, workflowErr := writeClaudeLazySDDWorkflow(homeDir, adapter, opts.ClaudeModelAssignments, opts.ClaudePhaseAssignments)
+		workflowResult, workflowErr := writeClaudeLazySDDWorkflow(homeDir, adapter)
 		if workflowErr != nil {
 			return InjectionResult{}, workflowErr
 		}
@@ -2752,6 +2752,13 @@ func stripBareOrchestratorSection(content string) string {
 func injectMarkdownSections(homeDir string, adapter agents.Adapter, legacyAssignments map[string]model.ClaudeModelAlias, phaseAssignments map[string]model.ClaudePhaseAssignment, renderOptions OrchestratorRenderOptions) (InjectionResult, error) {
 	promptPath := adapter.SystemPromptFile(homeDir)
 	content := renderSDDOrchestratorAsset(adapter.Agent(), renderOptions)
+	if adapter.Agent() == model.AgentClaudeCode {
+		var err error
+		content, err = injectClaudePhaseAssignments(content, legacyAssignments, phaseAssignments)
+		if err != nil {
+			return InjectionResult{}, err
+		}
+	}
 
 	existing, err := readFileOrEmpty(promptPath)
 	if err != nil {
@@ -2778,7 +2785,7 @@ func injectMarkdownSections(homeDir string, adapter agents.Adapter, legacyAssign
 	return InjectionResult{Changed: writeResult.Changed, Files: []string{promptPath}}, nil
 }
 
-func writeClaudeLazySDDWorkflow(homeDir string, adapter agents.Adapter, legacyAssignments map[string]model.ClaudeModelAlias, phaseAssignments map[string]model.ClaudePhaseAssignment) (InjectionResult, error) {
+func writeClaudeLazySDDWorkflow(homeDir string, adapter agents.Adapter) (InjectionResult, error) {
 	if adapter.Agent() != model.AgentClaudeCode {
 		return InjectionResult{}, nil
 	}
@@ -2788,13 +2795,6 @@ func writeClaudeLazySDDWorkflow(homeDir string, adapter agents.Adapter, legacyAs
 	}
 
 	content := renderBoundedReviewAsset(model.AgentClaudeCode, "claude/sdd-orchestrator-workflow.md")
-	if len(legacyAssignments) > 0 || len(phaseAssignments) > 0 {
-		var err error
-		content, err = injectClaudePhaseAssignments(content, legacyAssignments, phaseAssignments)
-		if err != nil {
-			return InjectionResult{}, err
-		}
-	}
 
 	path := filepath.Join(skillDir, "_shared", "sdd-orchestrator-workflow.md")
 	writeResult, err := filemerge.WriteFileAtomic(path, []byte(content), 0o644)
@@ -2836,7 +2836,7 @@ var claudeModelAssignmentReasons = map[string]string{
 	"jd-judge-a":   "Adversarial review — blind judge A",
 	"jd-judge-b":   "Adversarial review — blind judge B",
 	"jd-fix-agent": "Surgical fixes from confirmed issues",
-	"default":      "SDD/JD phase fallback",
+	"default":      "Generic and SDD/JD delegation fallback",
 }
 
 func injectClaudeModelAssignments(content string, assignments map[string]model.ClaudeModelAlias) (string, error) {
@@ -2917,9 +2917,9 @@ func renderClaudeEffortFrontmatter(assignment model.ClaudePhaseAssignment) strin
 func renderClaudeModelAssignmentsSection(assignments map[string]model.ClaudePhaseAssignment) string {
 	var b strings.Builder
 	b.WriteString("## Model Assignments\n\n")
-	b.WriteString("Read this table at session start (or before first SDD/Judgment-Day delegation), cache it for the session, and use the mapped alias only for SDD/Judgment-Day phase agents. If an SDD/Judgment-Day phase is missing, use the `default` fallback row. If you do not have access to the assigned model (for example, no Opus access), substitute `sonnet` and continue.\n\n")
-	b.WriteString("The Claude Code session model is controlled by Claude Code itself; Gentle AI does not configure the main orchestrator model. This table applies only to Agent tool calls for SDD/Judgment-Day phase sub-agents, not generic delegation.\n\n")
-	b.WriteString("**Mandatory phase model gate:** Agent tool calls for SDD/Judgment-Day phase agents MUST include `model`. Generic/non-SDD delegation MUST NOT use this table; omit `model` unless the user explicitly requested an override. Before each SDD/Judgment-Day Agent call, resolve the target phase to an alias from this table.\n\n")
+	b.WriteString("Read this table at session start (or before the first Claude Agent delegation), cache it for the session, and use the mapped alias for every Claude Agent call. Named SDD/Judgment-Day roles use their named row; organic explorer/mapper/writer/verifier and other generic delegations use the `default` assignment. If a named SDD/Judgment-Day role is missing, use the `default` row. If you do not have access to the assigned model (for example, no Opus access), substitute `sonnet` and continue.\n\n")
+	b.WriteString("The Claude Code session model is controlled by Claude Code itself; Gentle AI does not configure the main orchestrator model.\n\n")
+	b.WriteString("**Mandatory model gate:** Every Claude Agent tool call MUST include `model`. Before each Claude Agent call, resolve named SDD/Judgment-Day roles from this table; for organic explorer/mapper/writer/verifier and other generic delegations, use the `default` assignment.\n\n")
 	b.WriteString("| Phase | Default Model | Effort | Reason |\n")
 	b.WriteString("|-------|---------------|--------|--------|\n")
 	for _, key := range claudeModelAssignmentRowOrder {

--- a/internal/components/sdd/inject_test.go
+++ b/internal/components/sdd/inject_test.go
@@ -429,7 +429,7 @@ func TestInjectClaudeRetiresUnprefixedCommands(t *testing.T) {
 	}
 }
 
-func TestInjectClaudeCustomModelAssignments(t *testing.T) {
+func TestInjectClaudeCustomModelAssignmentsApplyToEveryDelegation(t *testing.T) {
 	home := t.TempDir()
 
 	opts := InjectOptions{ClaudeModelAssignments: map[string]model.ClaudeModelAlias{
@@ -446,49 +446,66 @@ func TestInjectClaudeCustomModelAssignments(t *testing.T) {
 		t.Fatal("Inject(claude, custom assignments) changed = false")
 	}
 
-	content, err := os.ReadFile(filepath.Join(home, ".claude", "skills", "_shared", "sdd-orchestrator-workflow.md"))
+	promptContent, err := os.ReadFile(filepath.Join(home, ".claude", "CLAUDE.md"))
+	if err != nil {
+		t.Fatalf("ReadFile(CLAUDE.md) error = %v", err)
+	}
+	prompt := string(promptContent)
+	for _, want := range []string{
+		"<!-- gentle-ai:sdd-model-assignments -->",
+		"<!-- /gentle-ai:sdd-model-assignments -->",
+		"| sdd-design | sonnet | default | Architecture decisions |",
+		"| sdd-propose | fable | default | Architectural decisions |",
+		"| default | haiku | default | Generic and SDD/JD delegation fallback |",
+		"Every Claude Agent tool call MUST include `model`",
+		"organic explorer/mapper/writer/verifier and other generic delegations use the `default` assignment",
+	} {
+		if !strings.Contains(prompt, want) {
+			t.Fatalf("CLAUDE.md missing every-delegation model policy %q", want)
+		}
+	}
+
+	lazyContent, err := os.ReadFile(filepath.Join(home, ".claude", "skills", "_shared", "sdd-orchestrator-workflow.md"))
 	if err != nil {
 		t.Fatalf("ReadFile(sdd-orchestrator-workflow.md) error = %v", err)
 	}
-
-	text := string(content)
-	if strings.Contains(text, "| orchestrator |") {
-		t.Fatal("lazy workflow should not expose orchestrator as a configurable model row")
-	}
-	for _, want := range []string{
-		"| sdd-design | sonnet | default | Architecture decisions |",
-		"| sdd-propose | fable | default | Architectural decisions |",
-		"| default | haiku | default | SDD/JD phase fallback |",
-		"Gentle AI does not configure the main orchestrator model",
-	} {
-		if !strings.Contains(text, want) {
-			t.Fatalf("lazy workflow missing custom table row %q", want)
-		}
-	}
-
-	if !strings.Contains(text, "<!-- gentle-ai:sdd-model-assignments -->") {
-		t.Fatal("lazy workflow missing model assignment open marker")
-	}
-	if !strings.Contains(text, "<!-- /gentle-ai:sdd-model-assignments -->") {
-		t.Fatal("lazy workflow missing model assignment close marker")
-	}
-	for _, want := range []string{
-		"Agent tool calls for SDD/Judgment-Day phase agents MUST include `model`",
+	lazy := string(lazyContent)
+	for _, forbidden := range []string{
+		"<!-- gentle-ai:sdd-model-assignments -->",
+		"## Model Assignments",
 		"Generic/non-SDD delegation MUST NOT use this table",
 		"omit `model` unless the user explicitly requested an override",
+		"model assignments",
 	} {
-		if !strings.Contains(text, want) {
-			t.Fatalf("lazy workflow missing scoped model gate text %q", want)
+		if strings.Contains(lazy, forbidden) {
+			t.Fatalf("lazy workflow retains model-routing content %q", forbidden)
 		}
 	}
-	for _, forbidden := range []string{
-		"Every Agent tool call MUST include `model`",
-		"for general/non-SDD delegation use `default`",
-		"Non-SDD general delegation",
-	} {
-		if strings.Contains(text, forbidden) {
-			t.Fatalf("lazy workflow contains legacy generic delegation model routing text %q", forbidden)
-		}
+}
+
+func TestInjectClaudeCommandModelAssignmentsApplyToEveryDelegation(t *testing.T) {
+	home := t.TempDir()
+
+	if _, err := Inject(home, claudeAdapter(), ""); err != nil {
+		t.Fatalf("Inject(claude) error = %v", err)
+	}
+
+	const stale = "Gentle AI only configures models for Agent tool calls to phase sub-agents."
+	const want = "The Claude Code session model is controlled by Claude Code; Gentle AI's always-on Model Assignments policy resolves every Agent tool call, including generic/organic delegation through `default`."
+	for _, name := range []string{"gentle-sdd-new.md", "gentle-sdd-ff.md", "gentle-sdd-continue.md"} {
+		t.Run(name, func(t *testing.T) {
+			content, err := os.ReadFile(filepath.Join(home, ".claude", "commands", name))
+			if err != nil {
+				t.Fatalf("ReadFile(%s) error = %v", name, err)
+			}
+			text := string(content)
+			if strings.Contains(text, stale) {
+				t.Fatalf("installed command retains phase-only model wording %q", stale)
+			}
+			if !strings.Contains(text, want) {
+				t.Fatalf("installed command missing always-on model wording %q", want)
+			}
+		})
 	}
 }
 

--- a/testdata/golden/combined-claude-claudemd.golden
+++ b/testdata/golden/combined-claude-claudemd.golden
@@ -245,13 +245,41 @@ Each launch runs only its own provider-issued `review.capture-result` argument t
 
 ### Research and Pre-Proposal Gate (MANDATORY) — Offer `sdd-research` immediately after `sdd-explore`; selection makes completion mandatory. Before every `propose`, invoke `sdd-propose` only when selected research is `done` or research is unselected, product decisions are `confirmed`, evidence references are valid, and the selected artifact-store state is ready. The orchestrator owns product discovery. Automatic unresolved choices require one lossless grouped prompt with all context, options, consequences, allowed answers, and exact tokens; it MUST persist the pending state before prompting, then STOP without invoking `sdd-propose`. The proposer receives a confirmed pre-proposal handoff and MUST NOT interview or infer consent. Native `gentle-ai.sdd-status/v2` is the sole status contract.
 
+<!-- gentle-ai:sdd-model-assignments -->
+## Model Assignments
+
+Read this table at session start (or before the first Claude Agent delegation), cache it for the session, and use the mapped alias for every Claude Agent call. Named SDD/Judgment-Day roles use their named row; organic explorer/mapper/writer/verifier and other generic delegations use the `default` assignment. If a named SDD/Judgment-Day role is missing, use the `default` row. If you do not have access to the assigned model (for example, no Opus access), substitute `sonnet` and continue.
+
+The Claude Code session model is controlled by Claude Code itself; Gentle AI does not configure the main orchestrator model.
+
+**Mandatory model gate:** Every Claude Agent tool call MUST include `model`. Before each Claude Agent call, resolve named SDD/Judgment-Day roles from this table; for organic explorer/mapper/writer/verifier and other generic delegations, use the `default` assignment.
+
+| Phase | Default Model | Effort | Reason |
+|-------|---------------|--------|--------|
+| sdd-explore | sonnet | default | Reads code, structural - not architectural |
+| sdd-research | sonnet | default | Collects source-backed evidence |
+| sdd-propose | opus | default | Architectural decisions |
+| sdd-spec | sonnet | default | Structured writing |
+| sdd-design | opus | default | Architecture decisions |
+| sdd-tasks | sonnet | default | Mechanical breakdown |
+| sdd-apply | sonnet | default | Implementation |
+| sdd-verify | sonnet | default | Validation against spec |
+| sdd-archive | haiku | default | Copy and close |
+| sdd-onboard | haiku | default | Guided walkthrough, pedagogical |
+| jd-judge-a | sonnet | default | Adversarial review — blind judge A |
+| jd-judge-b | sonnet | default | Adversarial review — blind judge B |
+| jd-fix-agent | sonnet | default | Surgical fixes from confirmed issues |
+| default | sonnet | default | Generic and SDD/JD delegation fallback |
+
+<!-- /gentle-ai:sdd-model-assignments -->
+
 ## SDD Workflow (lazy-loaded)
 
 The detailed SDD procedure is intentionally NOT embedded in this always-on parent thread. Before handling any SDD command, meta-command, continuation, apply/verify/archive routing, or SDD/Judgment-Day phase delegation, read:
 
 `.claude/skills/_shared/sdd-orchestrator-workflow.md` under the workspace when a workspace-scope install wrote it there, otherwise `~/.claude/skills/_shared/sdd-orchestrator-workflow.md`
 
-That lazy surface contains the SDD commands, init/dispatcher guards, execution-mode gatekeeper, artifact store policy, delivery strategy, dependency graph, review workload guard, model assignments, sub-agent launch protocol, context protocol, topic keys, and recovery rules.
+That lazy surface contains the SDD commands, init/dispatcher guards, execution-mode gatekeeper, artifact store policy, delivery strategy, dependency graph, review workload guard, sub-agent launch protocol, context protocol, topic keys, and recovery rules.
 <!-- /gentle-ai:sdd-orchestrator -->
 
 <!-- gentle-ai:engram-protocol -->

--- a/testdata/golden/sdd-claude-claudemd.golden
+++ b/testdata/golden/sdd-claude-claudemd.golden
@@ -211,11 +211,39 @@ Each launch runs only its own provider-issued `review.capture-result` argument t
 
 ### Research and Pre-Proposal Gate (MANDATORY) — Offer `sdd-research` immediately after `sdd-explore`; selection makes completion mandatory. Before every `propose`, invoke `sdd-propose` only when selected research is `done` or research is unselected, product decisions are `confirmed`, evidence references are valid, and the selected artifact-store state is ready. The orchestrator owns product discovery. Automatic unresolved choices require one lossless grouped prompt with all context, options, consequences, allowed answers, and exact tokens; it MUST persist the pending state before prompting, then STOP without invoking `sdd-propose`. The proposer receives a confirmed pre-proposal handoff and MUST NOT interview or infer consent. Native `gentle-ai.sdd-status/v2` is the sole status contract.
 
+<!-- gentle-ai:sdd-model-assignments -->
+## Model Assignments
+
+Read this table at session start (or before the first Claude Agent delegation), cache it for the session, and use the mapped alias for every Claude Agent call. Named SDD/Judgment-Day roles use their named row; organic explorer/mapper/writer/verifier and other generic delegations use the `default` assignment. If a named SDD/Judgment-Day role is missing, use the `default` row. If you do not have access to the assigned model (for example, no Opus access), substitute `sonnet` and continue.
+
+The Claude Code session model is controlled by Claude Code itself; Gentle AI does not configure the main orchestrator model.
+
+**Mandatory model gate:** Every Claude Agent tool call MUST include `model`. Before each Claude Agent call, resolve named SDD/Judgment-Day roles from this table; for organic explorer/mapper/writer/verifier and other generic delegations, use the `default` assignment.
+
+| Phase | Default Model | Effort | Reason |
+|-------|---------------|--------|--------|
+| sdd-explore | sonnet | default | Reads code, structural - not architectural |
+| sdd-research | sonnet | default | Collects source-backed evidence |
+| sdd-propose | opus | default | Architectural decisions |
+| sdd-spec | sonnet | default | Structured writing |
+| sdd-design | opus | default | Architecture decisions |
+| sdd-tasks | sonnet | default | Mechanical breakdown |
+| sdd-apply | sonnet | default | Implementation |
+| sdd-verify | sonnet | default | Validation against spec |
+| sdd-archive | haiku | default | Copy and close |
+| sdd-onboard | haiku | default | Guided walkthrough, pedagogical |
+| jd-judge-a | sonnet | default | Adversarial review — blind judge A |
+| jd-judge-b | sonnet | default | Adversarial review — blind judge B |
+| jd-fix-agent | sonnet | default | Surgical fixes from confirmed issues |
+| default | sonnet | default | Generic and SDD/JD delegation fallback |
+
+<!-- /gentle-ai:sdd-model-assignments -->
+
 ## SDD Workflow (lazy-loaded)
 
 The detailed SDD procedure is intentionally NOT embedded in this always-on parent thread. Before handling any SDD command, meta-command, continuation, apply/verify/archive routing, or SDD/Judgment-Day phase delegation, read:
 
 `.claude/skills/_shared/sdd-orchestrator-workflow.md` under the workspace when a workspace-scope install wrote it there, otherwise `~/.claude/skills/_shared/sdd-orchestrator-workflow.md`
 
-That lazy surface contains the SDD commands, init/dispatcher guards, execution-mode gatekeeper, artifact store policy, delivery strategy, dependency graph, review workload guard, model assignments, sub-agent launch protocol, context protocol, topic keys, and recovery rules.
+That lazy surface contains the SDD commands, init/dispatcher guards, execution-mode gatekeeper, artifact store policy, delivery strategy, dependency graph, review workload guard, sub-agent launch protocol, context protocol, topic keys, and recovery rules.
 <!-- /gentle-ai:sdd-orchestrator -->

--- a/testdata/golden/sdd-claude-cmd-gentle-sdd-continue.golden
+++ b/testdata/golden/sdd-claude-cmd-gentle-sdd-continue.golden
@@ -3,7 +3,7 @@ description: Continue the next SDD phase in the dependency chain
 ---
 
 Read the SDD workflow FIRST: `.claude/skills/_shared/sdd-orchestrator-workflow.md` under the workspace when a workspace-scope install wrote it there, otherwise `~/.claude/skills/_shared/sdd-orchestrator-workflow.md`. Then treat it as the authoritative SDD workflow instructions for this command.
-The Claude Code session model is controlled by Claude Code; Gentle AI only configures models for Agent tool calls to phase sub-agents.
+The Claude Code session model is controlled by Claude Code; Gentle AI's always-on Model Assignments policy resolves every Agent tool call, including generic/organic delegation through `default`.
 
 WORKFLOW:
 

--- a/testdata/golden/sdd-claude-cmd-gentle-sdd-ff.golden
+++ b/testdata/golden/sdd-claude-cmd-gentle-sdd-ff.golden
@@ -3,7 +3,7 @@ description: Fast-forward all SDD planning phases — proposal through tasks
 ---
 
 Read the SDD workflow FIRST: `.claude/skills/_shared/sdd-orchestrator-workflow.md` under the workspace when a workspace-scope install wrote it there, otherwise `~/.claude/skills/_shared/sdd-orchestrator-workflow.md`. Then treat it as the authoritative SDD workflow instructions for this command.
-The Claude Code session model is controlled by Claude Code; Gentle AI only configures models for Agent tool calls to phase sub-agents.
+The Claude Code session model is controlled by Claude Code; Gentle AI's always-on Model Assignments policy resolves every Agent tool call, including generic/organic delegation through `default`.
 
 WORKFLOW:
 Honor the cached execution mode from SDD Session Preflight.

--- a/testdata/golden/sdd-claude-cmd-gentle-sdd-new.golden
+++ b/testdata/golden/sdd-claude-cmd-gentle-sdd-new.golden
@@ -3,7 +3,7 @@ description: Start a new SDD change — runs exploration then creates a proposal
 ---
 
 Read the SDD workflow FIRST: `.claude/skills/_shared/sdd-orchestrator-workflow.md` under the workspace when a workspace-scope install wrote it there, otherwise `~/.claude/skills/_shared/sdd-orchestrator-workflow.md`. Then treat it as the authoritative SDD workflow instructions for this command.
-The Claude Code session model is controlled by Claude Code; Gentle AI only configures models for Agent tool calls to phase sub-agents.
+The Claude Code session model is controlled by Claude Code; Gentle AI's always-on Model Assignments policy resolves every Agent tool call, including generic/organic delegation through `default`.
 
 WORKFLOW:
 


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #4054

---

## 🏷️ PR Type

- [x] `type:bug` — Bug fix (non-breaking change that fixes an issue)
- [ ] `type:feature` — New feature (non-breaking change that adds functionality)
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring (no functional changes)
- [ ] `type:chore` — Build, CI, or tooling changes
- [ ] `type:breaking-change` — Breaking change (fix or feature that changes existing behavior)

---

## 📝 Summary

- Move Claude model assignment policy from the lazy SDD workflow into the always-on orchestrator prompt.
- Require every Claude Agent delegation to resolve a model, using named rows for SDD/Judgment-Day roles and `default` for organic delegation.
- Remove stale phase-only wording and add direct injection, command-surface, TUI sync, and golden regression coverage.

---

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/assets/claude/` | Made model routing always-on and aligned Claude command guidance. |
| `internal/components/sdd/` | Rendered assignments into the parent prompt and added regression coverage. |
| `internal/app/app_test.go` | Verified TUI sync writes custom assignments to `CLAUDE.md`, not the lazy workflow. |
| `testdata/golden/` | Updated the five affected Claude rendering goldens. |

---

## 🤖 AI Assistance

- [ ] **None** — No material AI assistance was used.
- [x] **Material assistance used** — Complete all applicable declaration fields below.

**Tool/model (if known):** Pi/el Gentleman with OpenAI Codex subagents.

**Material scope:** Root-cause mapping, implementation, tests, golden updates, independent verification, and four-lens RDD advisory review.

**Verification performed:** Human-directed review and approval; focused regression tests, uncached root and bench module suites, Go format check, Docker E2E across Ubuntu/Arch/Fedora, diff checks, and native four-lens RDD approval.

---

## 🧪 Test Plan

- [x] Unit tests pass: `go test ./... -count=1`
- [x] Go format passes: `go run ./internal/gofmtcheck`
- [x] E2E tests pass: `cd e2e && ./docker-test.sh` (Ubuntu, Arch, Fedora; 79 passed per image, 0 failed)
- [x] Manually tested locally through focused injection, command-surface, TUI sync, and golden tests
- [x] Bench module declarations pass: `cd bench && go test ./... -count=1`
- [x] Benchmark driven validation: N/A — this changes Claude prompt model-routing policy, not review lifecycle, gates, recovery, delivery, bench implementation, corpus, or classifier behavior; the journey corpus was searched for stale pins and none were found.

Focused checks:

```bash
go test ./internal/components/sdd -run '^TestInjectClaudeCustomModelAssignmentsApplyToEveryDelegation$' -count=1
go test ./internal/components/sdd -run '^TestInjectClaudeCommandModelAssignmentsApplyToEveryDelegation$' -count=1
go test ./internal/components -run '^(TestGoldenSDD_Claude|TestGoldenCombined_Claude)$' -count=1
go test ./internal/app -run '^TestTuiSyncClaudeModelConfigWritesSelectedAssignments$' -count=1
```

---

## ✅ Contributor Checklist

- [x] PR is linked to an issue with `status:approved`
- [x] PR stays within 400 changed lines
- [x] I have added the appropriate `type:*` label to this PR
- [x] Unit tests pass (`go test ./...`)
- [x] Go format passes (`go run ./internal/gofmtcheck`)
- [x] E2E tests pass (`cd e2e && ./docker-test.sh`)
- [x] Benchmark validation completed, or this change is not applicable to the benchmark (explained above)
- [x] I have updated documentation if necessary
- [x] My commits follow Conventional Commits format
- [x] I understand, reviewed, and take responsibility for the complete submission
- [x] I selected exactly one AI-assistance option and completed all applicable declaration fields
- [x] My commits do not include `Co-Authored-By` trailers

---

## 💬 Notes for Reviewers

Review the always-on `CLAUDE.md` rendering first, then verify the lazy workflow and command assets contain no competing model authority. The implementation intentionally reuses the existing assignment resolver and adds no model configuration schema, state, or agent type.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that model-assignment guidance applies to every Claude Agent tool call, including generic delegation.
  * Updated SDD command guidance to distinguish Agent-call model assignments from Claude Code’s session model.
  * Moved model-assignment guidance to the primary `CLAUDE.md` policy, while the lazy SDD workflow no longer includes phase-specific routing details.
* **Tests**
  * Updated coverage to verify the revised model-assignment behavior across commands and workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->