### PR TITLE
fix(install): skip routing guidance for agents without a system prompt and retire the Pi agent-routing block

### DIFF
--- a/docs/pi.md
+++ b/docs/pi.md
@@ -19,7 +19,7 @@ gentle-ai install --agent pi
 pi
 ```
 
-Gentle AI detects the `pi` binary first. If Pi is the only selected agent, the installer still provisions the real Engram™ component, but skips persona, ecosystem component selection, and Strict TDD prompts because `gentle-pi` owns those choices inside Pi. Gentle AI writes nothing into the Pi system prompt because `gentle-pi` owns it, so the review execution contract ships as `orchestration/pi.md` in the published provider contract bundle, which `gentle-pi` mirrors and injects at session start. Because `gentle-pi` owns that file, `install` and `sync` also remove any gentle-ai managed blocks an older build left in `~/.pi/agent/APPEND_SYSTEM.md`.
+Gentle AI detects the `pi` binary first. If Pi is the only selected agent, the installer still provisions the real Engram™ component, but skips persona, ecosystem component selection, and Strict TDD prompts because `gentle-pi` owns those choices inside Pi. Gentle AI writes nothing into the Pi system prompt because `gentle-pi` owns it, so the review execution contract ships as `orchestration/pi.md` in the published provider contract bundle, which `gentle-pi` mirrors and injects at session start. Because `gentle-pi` owns that file, `install` and `sync` also remove any gentle-ai managed blocks an older build left in `~/.pi/agent/APPEND_SYSTEM.md`, including the routing guidance block; routing guidance is delivered to every other agent's system prompt, but Pi is skipped for that step too.
 
 ## Installed Packages
 

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -868,6 +868,15 @@ func (s agentRoutingGuidanceStep) Run() error {
 	if err != nil {
 		return fmt.Errorf("create adapter for %q: %w", s.agent, err)
 	}
+
+	// Pi (and any future agent without a managed system prompt) owns its own
+	// prompt delivery outside gentle-ai, so there is nothing to strip or
+	// inject here: skip the step entirely rather than writing routing
+	// guidance into a file gentle-ai does not own (issue #4063).
+	if !adapter.SupportsSystemPrompt() {
+		return nil
+	}
+
 	targetDir := routingGuidanceDir(s.homeDir, s.workspaceDir, s.scope, adapter)
 
 	// Strip first: an installation upgraded from an older release still carries
@@ -2147,6 +2156,12 @@ func claudeMCPSettingsCleanupPaths(homeDir, workspaceDir string, scope InstallSc
 func routingGuidancePaths(homeDir, workspaceDir string, scope InstallScope, adapters []agents.Adapter) []string {
 	paths := []string{}
 	for _, adapter := range adapters {
+		// Mirrors the same skip agentRoutingGuidanceStep.Run() applies: an
+		// agent without a managed system prompt (Pi) gets no routing guidance
+		// write, so it must not be declared as a backup target either.
+		if !adapter.SupportsSystemPrompt() {
+			continue
+		}
 		targetDir := routingGuidanceDir(homeDir, workspaceDir, scope, adapter)
 		routing, err := agentguidance.RoutingPaths(targetDir, adapter.Agent())
 		if err != nil {

--- a/internal/cli/run_component_paths_test.go
+++ b/internal/cli/run_component_paths_test.go
@@ -964,6 +964,39 @@ func TestInstallRoutingGuidanceWorkspaceScopeDeliversOpenCodeToHome(t *testing.T
 	}
 }
 
+// TestAgentRoutingGuidanceStepSkipsAgentsWithoutSystemPrompt covers issue
+// #4063: Pi reports SupportsSystemPrompt()==false because gentle-pi owns its
+// system prompt, so the routing guidance step must leave Pi's
+// APPEND_SYSTEM.md untouched instead of writing an agent-routing block into a
+// file gentle-ai does not own.
+func TestAgentRoutingGuidanceStepSkipsAgentsWithoutSystemPrompt(t *testing.T) {
+	home := t.TempDir()
+	promptPath := systemPromptFileFor(t, home, model.AgentPi)
+	existing := "user text before\n" +
+		"\n" +
+		"<!-- gentle-ai:agent-routing -->\n" +
+		"stale routing body\n" +
+		"<!-- /gentle-ai:agent-routing -->\n" +
+		"\n" +
+		"user text after\n"
+	mustWriteFile(t, promptPath, []byte(existing))
+
+	step := agentRoutingGuidanceStep{
+		id:      "agent-guidance:" + string(model.AgentPi),
+		agent:   model.AgentPi,
+		homeDir: home,
+		scope:   ScopeGlobal,
+	}
+	if err := step.Run(); err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+
+	got := readTextFile(t, promptPath)
+	if got != existing {
+		t.Fatalf("agentRoutingGuidanceStep rewrote Pi's system prompt file, want a no-op:\ngot  = %q\nwant = %q", got, existing)
+	}
+}
+
 func TestRoutingGuidancePathsWorkspaceScopeReportOrchestratorPromptAgentsAtHome(t *testing.T) {
 	home := t.TempDir()
 	workspace := t.TempDir()
@@ -992,6 +1025,26 @@ func TestRoutingGuidancePathsWorkspaceScopeReportOrchestratorPromptAgentsAtHome(
 	claudePrompt := systemPromptFileFor(t, workspace, model.AgentClaudeCode)
 	if !containsPath(paths, claudePrompt) {
 		t.Fatalf("routingGuidancePaths(workspace) lost the workspace-scoped path %q for prompt-file agents\npaths=%v", claudePrompt, paths)
+	}
+}
+
+// TestRoutingGuidancePathsExcludesAgentsWithoutSystemPrompt covers issue
+// #4063: Pi's APPEND_SYSTEM.md must never be listed as a routing guidance
+// target, because the step that would write it is now a no-op for Pi and
+// declaring the path would only add a backup target nothing ever writes.
+func TestRoutingGuidancePathsExcludesAgentsWithoutSystemPrompt(t *testing.T) {
+	home := t.TempDir()
+	adapters := resolveAdapters([]model.AgentID{model.AgentPi, model.AgentClaudeCode})
+
+	paths := routingGuidancePaths(home, "", ScopeGlobal, adapters)
+
+	piPrompt := systemPromptFileFor(t, home, model.AgentPi)
+	if containsPath(paths, piPrompt) {
+		t.Fatalf("routingGuidancePaths() listed Pi's system prompt %q, a file the step no longer writes\npaths=%v", piPrompt, paths)
+	}
+	claudePrompt := systemPromptFileFor(t, home, model.AgentClaudeCode)
+	if !containsPath(paths, claudePrompt) {
+		t.Fatalf("routingGuidancePaths() lost Claude Code's prompt path %q\npaths=%v", claudePrompt, paths)
 	}
 }
 

--- a/internal/cli/sync_test.go
+++ b/internal/cli/sync_test.go
@@ -4529,19 +4529,56 @@ func TestRunSyncWithSelectionPiRetiresStaleSystemPromptBlocks(t *testing.T) {
 		t.Fatalf("RunSyncWithSelection() error = %v", err)
 	}
 
-	// Routing guidance (agent-routing) is refreshed for Pi unconditionally
-	// after the component loop, so it legitimately reappears at the end of
-	// the file; only the leading user content must survive byte-exact.
-	wantPrefix := "user text before\n\nuser text after\n"
+	// Routing guidance is scheduled per agent too, but the step is a no-op for
+	// Pi (issue #4063: gentle-pi owns the Pi system prompt), so nothing writes
+	// an agent-routing block back into the file. Only the leading and trailing
+	// user content must survive, byte-exact.
+	want := "user text before\n\nuser text after\n"
 	got := readTextFile(t, appendSystemPath)
-	if !strings.HasPrefix(got, wantPrefix) {
-		t.Fatalf("APPEND_SYSTEM.md = %q, want prefix %q", got, wantPrefix)
+	if got != want {
+		t.Fatalf("APPEND_SYSTEM.md = %q, want %q", got, want)
 	}
 	if strings.Contains(got, "sdd-orchestrator") || strings.Contains(got, "gentle-ai:persona") {
 		t.Fatalf("APPEND_SYSTEM.md still carries a stale managed block: %q", got)
 	}
 	if result.FilesChanged < 1 {
 		t.Fatalf("FilesChanged = %d, want >= 1", result.FilesChanged)
+	}
+}
+
+// TestRunSyncWithSelectionPiRoutingGuidanceIsNotRewritten covers issue #4063:
+// a sync with Pi selected must not write, or leave behind, a
+// gentle-ai:agent-routing block in ~/.pi/agent/APPEND_SYSTEM.md. Before the
+// fix, agentRoutingGuidanceStep ran for every agent unconditionally, so a
+// pre-existing agent-routing block was rewritten instead of stripped and
+// left alone.
+func TestRunSyncWithSelectionPiRoutingGuidanceIsNotRewritten(t *testing.T) {
+	home := t.TempDir()
+	appendSystemPath := systemPromptFileFor(t, home, model.AgentPi)
+	stale := "user text before\n" +
+		"\n" +
+		"<!-- gentle-ai:agent-routing -->\n" +
+		"stale routing body\n" +
+		"<!-- /gentle-ai:agent-routing -->\n" +
+		"\n" +
+		"user text after\n"
+	mustWriteFile(t, appendSystemPath, []byte(stale))
+	mustWriteFile(t, state.Path(home), []byte(`{"installed_agents":["pi"]}`))
+
+	if _, err := RunSyncWithSelection(home, model.Selection{
+		Agents:     []model.AgentID{model.AgentPi},
+		Components: []model.ComponentID{model.ComponentPersona},
+	}); err != nil {
+		t.Fatalf("RunSyncWithSelection() error = %v", err)
+	}
+
+	got := readTextFile(t, appendSystemPath)
+	if strings.Contains(got, "gentle-ai:agent-routing") {
+		t.Fatalf("APPEND_SYSTEM.md still carries an agent-routing block: %q", got)
+	}
+	want := "user text before\n\nuser text after\n"
+	if got != want {
+		t.Fatalf("APPEND_SYSTEM.md = %q, want %q", got, want)
 	}
 }
 

--- a/internal/components/sdd/inject.go
+++ b/internal/components/sdd/inject.go
@@ -2678,13 +2678,16 @@ func stripBareOrchestratorForFilePrompt(content string) string {
 // Pi install made before the capability manifest started reporting
 // SupportsSystemPrompt()==false for Pi (see 965187e6) could have left behind
 // in the Pi adapter's SystemPromptFile. Nothing manages this file anymore, so
-// none of these blocks self-heal on install/sync/uninstall. The last entry
-// mirrors communitytool.codeGraphGuidanceSectionID, which is unexported.
+// none of these blocks self-heal on install/sync/uninstall. The
+// "codegraph-guidance" entry mirrors communitytool.codeGraphGuidanceSectionID,
+// which is unexported; agentguidance.RoutingSectionID covers the routing
+// guidance block a defect once wrote here instead of skipping Pi (#4063).
 var legacyPiSystemPromptSectionIDs = []string{
 	"sdd-orchestrator",
 	"strict-tdd-mode",
 	"persona",
 	"codegraph-guidance",
+	agentguidance.RoutingSectionID,
 }
 
 // RetirePiSystemPromptBlocks removes any gentle-ai managed markdown sections

--- a/internal/components/sdd/inject_pi_cleanup_test.go
+++ b/internal/components/sdd/inject_pi_cleanup_test.go
@@ -61,6 +61,49 @@ func TestRetirePiSystemPromptBlocksStripsManagedSectionsAndPreservesUserContent(
 	}
 }
 
+// TestRetirePiSystemPromptBlocksStripsAgentRoutingBlock covers issue #4063:
+// an older build could have written a gentle-ai:agent-routing block into
+// Pi's APPEND_SYSTEM.md before the routing step learned to skip agents that
+// do not support a managed system prompt. This block is retired the same way
+// as the other legacy sections.
+func TestRetirePiSystemPromptBlocksStripsAgentRoutingBlock(t *testing.T) {
+	home := t.TempDir()
+	adapter := pi.NewAdapter()
+	promptPath := adapter.SystemPromptFile(home)
+
+	fixture := "user text before\n" +
+		"\n" +
+		"<!-- gentle-ai:agent-routing -->\n" +
+		"routing body\n" +
+		"<!-- /gentle-ai:agent-routing -->\n" +
+		"\n" +
+		"user text after\n"
+
+	if err := os.MkdirAll(filepath.Dir(promptPath), 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	if err := os.WriteFile(promptPath, []byte(fixture), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	result, err := RetirePiSystemPromptBlocks(home, adapter)
+	if err != nil {
+		t.Fatalf("RetirePiSystemPromptBlocks() error = %v", err)
+	}
+	if !result.Changed {
+		t.Fatal("RetirePiSystemPromptBlocks() Changed = false, want true")
+	}
+
+	got, err := os.ReadFile(promptPath)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	want := "user text before\n\nuser text after\n"
+	if string(got) != want {
+		t.Fatalf("APPEND_SYSTEM.md content = %q, want %q", string(got), want)
+	}
+}
+
 func TestRetirePiSystemPromptBlocksKeepsWhitespaceOnlyFile(t *testing.T) {
 	home := t.TempDir()
 	adapter := pi.NewAdapter()


### PR DESCRIPTION
Closes #4063.

## Cause

`install` and `sync` schedule the routing guidance step for every selected agent, and its default delivery writes a `gentle-ai:agent-routing` section into the adapter's system prompt file. For Pi that is `~/.pi/agent/APPEND_SYSTEM.md`. The step never consulted the capability manifest, although it reports no system prompt for Pi, every other injector skips that file, and gentle-pi owns the Pi prompt with its own routing ladder. #4057 retired the other stale blocks but had to leave this one because it was rewritten on every sync.

## Fix

- `agentRoutingGuidanceStep.Run` returns without stripping or injecting when the adapter reports no system prompt; `routingGuidancePaths` applies the same gate so the Pi file is never listed as a backup target.
- `sdd.RetirePiSystemPromptBlocks` now also strips `agent-routing`, so an older install loses the block on the next install or sync.
- `docs/pi.md` names the routing guidance block among the retired ones.

## Verification

- Full `go test ./... -count=1` green in the foreground; `go vet ./...` and `GOOS=windows go vet ./...` clean; `gofmt -l` empty; dead-code ratchet clean.
- New tests: the step and the path reporter skip agents without a system prompt; a Pi sync leaves no `agent-routing` block and strips a stale one; the retirement helper strips the block. The pre-existing Pi retirement test now asserts an exact file, since the behavior it tolerated is gone.
- Native review: lineage `review-ad749af28e06344b`, tier high, four lenses, approved on the last admitted event and acknowledged (`gentle-ai.review-acknowledged/v1`, authority burned). Consent was answered `granted` under the maintainer's standing authorization.

Follow-up to #4056, #4057, and gentle-pi#560.

https://claude.ai/code/session_01WYGtotXyhPmbnEeAZAbSbj


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Pi system prompts are no longer rewritten with routing guidance during installation or synchronization.
  * Existing managed routing sections are cleaned up while preserving surrounding user content.
  * Backup handling now excludes Pi system-prompt files when routing guidance is not managed there.

* **Documentation**
  * Updated Pi quick-start guidance to clarify routing behavior and cleanup of legacy managed sections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->