### PR TITLE
feat(claude): install the review stop-hook as managed Stop and SessionStart hooks and remove them on uninstall

### DIFF
--- a/docs/agents.md
+++ b/docs/agents.md
@@ -98,7 +98,7 @@ Kiro uses native custom agents in `~/.kiro/agents/`. `gentle-ai` writes phase ag
 - MCP servers configured as plugins in `~/.claude/mcp/`
 - Output styles in `~/.claude/output-styles/`
 - System prompt via markdown sections in `~/.claude/CLAUDE.md`
-- Two managed hooks in `~/.claude/settings.json`: `UserPromptSubmit` refreshes the skill registry, and `Stop` runs the review stop-hook subcommand as a deterministic end-of-turn review preflight reminder; uninstall removes both
+- Three managed hooks in `~/.claude/settings.json`: `UserPromptSubmit` refreshes the skill registry, `SessionStart` runs the review stop-hook subcommand to record the session's starting candidate as its baseline, and `Stop` runs that same subcommand to remind only about candidates the session itself produced; uninstall removes all three
 
 ### OpenCode
 

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -98,6 +98,7 @@ Kiro uses native custom agents in `~/.kiro/agents/`. `gentle-ai` writes phase ag
 - MCP servers configured as plugins in `~/.claude/mcp/`
 - Output styles in `~/.claude/output-styles/`
 - System prompt via markdown sections in `~/.claude/CLAUDE.md`
+- Two managed hooks in `~/.claude/settings.json`: `UserPromptSubmit` refreshes the skill registry, and `Stop` runs the review stop-hook subcommand as a deterministic end-of-turn review preflight reminder; uninstall removes both
 
 ### OpenCode
 

--- a/docs/review-integration.md
+++ b/docs/review-integration.md
@@ -25,6 +25,8 @@ gentle-ai review status \
   --next-transition
 ```
 
+Claude Code also gets a deterministic end-of-turn reminder through its installed `Stop` hook, which runs the review stop-hook subcommand and never starts a review by itself.
+
 ## Cross-repository root
 
 A session in repository A may review a nested target in unrelated repository B only after the user explicitly authorizes B. Native Go resolves the requested path to B's canonical worktree root; adapters carry opaque provider output and never parse authorization or roots.

--- a/docs/review-integration.md
+++ b/docs/review-integration.md
@@ -25,7 +25,7 @@ gentle-ai review status \
   --next-transition
 ```
 
-Claude Code also gets a deterministic end-of-turn reminder through its installed `Stop` hook, which runs the review stop-hook subcommand and never starts a review by itself.
+Claude Code also gets a deterministic per-session baseline and end-of-turn reminder through its installed `SessionStart` and `Stop` hooks, both backed by the review stop-hook subcommand: SessionStart records the session's starting candidate, and Stop reminds only about candidates that session itself produced; neither starts a review by itself.
 
 ## Cross-repository root
 

--- a/internal/components/sdd/inject.go
+++ b/internal/components/sdd/inject.go
@@ -1870,14 +1870,17 @@ func ensureClaudeSkillRegistryHook(settingsPath string) (bool, error) {
 	return wr.Changed, nil
 }
 
-// ensureClaudeReviewStopHook appends the managed review preflight command to
-// hooks.Stop in the Claude Code settings file. The hook makes the review
-// preflight deterministic at the end of a Claude turn: `gentle-ai review
-// stop-hook --agent <agentID>` reads the Stop payload from stdin and prints
-// a block decision only when RDD is enabled and the repository holds an
-// unreviewed candidate. It never starts a review by itself. The runtime
-// identity is always the caller-supplied agentID (never a compiled literal)
-// per issue #2440: only the caller states which runtime is executing.
+// ensureClaudeReviewStopHook appends the managed review preflight commands to
+// hooks.Stop and hooks.SessionStart in the Claude Code settings file. The
+// pair makes the review preflight deterministic across a Claude turn.
+// `gentle-ai review stop-hook --agent <agentID>` reads `hook_event_name` from
+// the payload on stdin: at SessionStart it records the session's starting
+// candidate as the per-session baseline, and at Stop it prints a block
+// decision only when RDD is enabled and the session has produced an
+// unreviewed candidate since that baseline. It never starts a review by
+// itself. The runtime identity is always the caller-supplied agentID (never
+// a compiled literal) per issue #2440: only the caller states which runtime
+// is executing.
 func ensureClaudeReviewStopHook(settingsPath string, agentID model.AgentID) (bool, error) {
 	root := map[string]any{}
 	if data, err := os.ReadFile(settingsPath); err == nil && len(strings.TrimSpace(string(data))) > 0 {
@@ -1889,9 +1892,6 @@ func ensureClaudeReviewStopHook(settingsPath string, agentID model.AgentID) (boo
 	}
 
 	command := fmt.Sprintf("gentle-ai review stop-hook --agent %s", agentID)
-	if claudeHookExists(root, command) {
-		return false, nil
-	}
 
 	hooksRaw, hasHooks := root["hooks"]
 	hooksMap, _ := hooksRaw.(map[string]any)
@@ -1901,12 +1901,8 @@ func ensureClaudeReviewStopHook(settingsPath string, agentID model.AgentID) (boo
 	if hooksMap == nil {
 		hooksMap = map[string]any{}
 	}
-	stopRaw, hasStop := hooksMap["Stop"]
-	stop, _ := stopRaw.([]any)
-	if hasStop && stop == nil {
-		return false, fmt.Errorf("Claude settings %q has unsupported hooks.Stop shape: want array", settingsPath)
-	}
-	stop = append(stop, map[string]any{
+
+	stopChanged, err := appendClaudeReviewStopHookEntry(hooksMap, "Stop", settingsPath, command, map[string]any{
 		"matcher": "",
 		"hooks": []any{
 			map[string]any{
@@ -1916,9 +1912,29 @@ func ensureClaudeReviewStopHook(settingsPath string, agentID model.AgentID) (boo
 			},
 		},
 	})
-	hooksMap["Stop"] = stop
-	root["hooks"] = hooksMap
+	if err != nil {
+		return false, err
+	}
 
+	sessionStartChanged, err := appendClaudeReviewStopHookEntry(hooksMap, "SessionStart", settingsPath, command, map[string]any{
+		"matcher": "startup|resume|clear|compact",
+		"hooks": []any{
+			map[string]any{
+				"type":    "command",
+				"command": command,
+				"timeout": 30,
+			},
+		},
+	})
+	if err != nil {
+		return false, err
+	}
+
+	if !stopChanged && !sessionStartChanged {
+		return false, nil
+	}
+
+	root["hooks"] = hooksMap
 	out, err := json.MarshalIndent(root, "", "  ")
 	if err != nil {
 		return false, err
@@ -1929,6 +1945,25 @@ func ensureClaudeReviewStopHook(settingsPath string, agentID model.AgentID) (boo
 		return false, err
 	}
 	return wr.Changed, nil
+}
+
+// appendClaudeReviewStopHookEntry appends entry to hooksMap[hookKey] unless
+// an entry with the identical command is already present under that exact
+// key, so the Stop reminder and the SessionStart baseline (which share the
+// same command string) are tracked independently and both keys can coexist
+// with the UserPromptSubmit skill-registry hook.
+func appendClaudeReviewStopHookEntry(hooksMap map[string]any, hookKey, settingsPath, command string, entry map[string]any) (bool, error) {
+	raw, has := hooksMap[hookKey]
+	entries, _ := raw.([]any)
+	if has && entries == nil {
+		return false, fmt.Errorf("Claude settings %q has unsupported hooks.%s shape: want array", settingsPath, hookKey)
+	}
+	if claudeHookListContains(entries, command) {
+		return false, nil
+	}
+	entries = append(entries, entry)
+	hooksMap[hookKey] = entries
+	return true, nil
 }
 
 func claudeHookExists(root map[string]any, command string) bool {

--- a/internal/components/sdd/inject.go
+++ b/internal/components/sdd/inject.go
@@ -1753,7 +1753,11 @@ func installSkillRegistryAutomation(homeDir string, adapter agents.Adapter) (Inj
 	if err != nil {
 		return InjectionResult{}, fmt.Errorf("install Claude skill-registry hook: %w", err)
 	}
-	return InjectionResult{Changed: changed, Files: []string{settingsPath}}, nil
+	stopHookChanged, err := ensureClaudeReviewStopHook(settingsPath, adapter.Agent())
+	if err != nil {
+		return InjectionResult{}, fmt.Errorf("install Claude review stop-hook: %w", err)
+	}
+	return InjectionResult{Changed: changed || stopHookChanged, Files: []string{settingsPath}}, nil
 }
 
 func ensureCodexSkillRegistryHook(hooksPath string) (bool, error) {
@@ -1866,12 +1870,73 @@ func ensureClaudeSkillRegistryHook(settingsPath string) (bool, error) {
 	return wr.Changed, nil
 }
 
+// ensureClaudeReviewStopHook appends the managed review preflight command to
+// hooks.Stop in the Claude Code settings file. The hook makes the review
+// preflight deterministic at the end of a Claude turn: `gentle-ai review
+// stop-hook --agent <agentID>` reads the Stop payload from stdin and prints
+// a block decision only when RDD is enabled and the repository holds an
+// unreviewed candidate. It never starts a review by itself. The runtime
+// identity is always the caller-supplied agentID (never a compiled literal)
+// per issue #2440: only the caller states which runtime is executing.
+func ensureClaudeReviewStopHook(settingsPath string, agentID model.AgentID) (bool, error) {
+	root := map[string]any{}
+	if data, err := os.ReadFile(settingsPath); err == nil && len(strings.TrimSpace(string(data))) > 0 {
+		if err := json.Unmarshal(data, &root); err != nil {
+			return false, fmt.Errorf("parse Claude settings %q: %w", settingsPath, err)
+		}
+	} else if err != nil && !os.IsNotExist(err) {
+		return false, err
+	}
+
+	command := fmt.Sprintf("gentle-ai review stop-hook --agent %s", agentID)
+	if claudeHookExists(root, command) {
+		return false, nil
+	}
+
+	hooksRaw, hasHooks := root["hooks"]
+	hooksMap, _ := hooksRaw.(map[string]any)
+	if hasHooks && hooksMap == nil {
+		return false, fmt.Errorf("Claude settings %q has unsupported hooks shape: want object", settingsPath)
+	}
+	if hooksMap == nil {
+		hooksMap = map[string]any{}
+	}
+	stopRaw, hasStop := hooksMap["Stop"]
+	stop, _ := stopRaw.([]any)
+	if hasStop && stop == nil {
+		return false, fmt.Errorf("Claude settings %q has unsupported hooks.Stop shape: want array", settingsPath)
+	}
+	stop = append(stop, map[string]any{
+		"matcher": "",
+		"hooks": []any{
+			map[string]any{
+				"type":    "command",
+				"command": command,
+				"timeout": 60,
+			},
+		},
+	})
+	hooksMap["Stop"] = stop
+	root["hooks"] = hooksMap
+
+	out, err := json.MarshalIndent(root, "", "  ")
+	if err != nil {
+		return false, err
+	}
+	out = append(out, '\n')
+	wr, err := filemerge.WriteFileAtomic(settingsPath, out, 0o644)
+	if err != nil {
+		return false, err
+	}
+	return wr.Changed, nil
+}
+
 func claudeHookExists(root map[string]any, command string) bool {
 	hooksMap, ok := root["hooks"].(map[string]any)
 	if !ok {
 		return false
 	}
-	for _, key := range []string{"UserPromptSubmit", "SessionStart"} {
+	for _, key := range []string{"UserPromptSubmit", "SessionStart", "Stop"} {
 		hookEntries, ok := hooksMap[key].([]any)
 		if !ok {
 			continue

--- a/internal/components/sdd/inject_test.go
+++ b/internal/components/sdd/inject_test.go
@@ -7119,6 +7119,115 @@ func TestEnsureClaudeSkillRegistryHookRejectsUnexpectedHookSchema(t *testing.T) 
 	}
 }
 
+func TestEnsureClaudeReviewStopHookAppendsIdempotently(t *testing.T) {
+	home := t.TempDir()
+	settingsPath := filepath.Join(home, ".claude", "settings.json")
+	if err := os.MkdirAll(filepath.Dir(settingsPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	initial := `{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {"type": "command", "command": "echo keep"}
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "matcher": "",
+        "hooks": [
+          {"type": "command", "command": "echo existing"}
+        ]
+      }
+    ]
+  }
+}`
+	if err := os.WriteFile(settingsPath, []byte(initial), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	changed, err := ensureClaudeReviewStopHook(settingsPath, model.AgentClaudeCode)
+	if err != nil {
+		t.Fatalf("ensureClaudeReviewStopHook() error = %v", err)
+	}
+	if !changed {
+		t.Fatal("first call changed = false, want true")
+	}
+	changed, err = ensureClaudeReviewStopHook(settingsPath, model.AgentClaudeCode)
+	if err != nil {
+		t.Fatalf("second ensureClaudeReviewStopHook() error = %v", err)
+	}
+	if changed {
+		t.Fatal("second call changed = true, want false")
+	}
+
+	data, err := os.ReadFile(settingsPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	text := string(data)
+	if strings.Count(text, "gentle-ai review stop-hook --agent claude-code") != 1 {
+		t.Fatalf("hook command count mismatch:\n%s", text)
+	}
+	if !strings.Contains(text, "echo keep") || !strings.Contains(text, "echo existing") {
+		t.Fatalf("existing hooks not preserved:\n%s", text)
+	}
+}
+
+func TestEnsureClaudeReviewStopHookRejectsUnexpectedHookSchema(t *testing.T) {
+	home := t.TempDir()
+	settingsPath := filepath.Join(home, ".claude", "settings.json")
+	if err := os.MkdirAll(filepath.Dir(settingsPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	original := []byte(`{"hooks":{"Stop":{"bad":true}}}`)
+	if err := os.WriteFile(settingsPath, original, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	changed, err := ensureClaudeReviewStopHook(settingsPath, model.AgentClaudeCode)
+	if err == nil {
+		t.Fatal("ensureClaudeReviewStopHook() error = nil, want schema error")
+	}
+	if changed {
+		t.Fatal("changed = true, want false")
+	}
+	after, readErr := os.ReadFile(settingsPath)
+	if readErr != nil {
+		t.Fatal(readErr)
+	}
+	if string(after) != string(original) {
+		t.Fatalf("settings were modified: %q", after)
+	}
+}
+
+func TestInject_ClaudeCodeInstallsReviewStopHook(t *testing.T) {
+	home := t.TempDir()
+
+	result, err := Inject(home, claudeAdapter(), "")
+	if err != nil {
+		t.Fatalf("Inject() error = %v", err)
+	}
+
+	settingsPath := filepath.Join(home, ".claude", "settings.json")
+	if !containsPath(result.Files, settingsPath) {
+		t.Fatalf("result.Files missing Claude settings path %q: %v", settingsPath, result.Files)
+	}
+	data, err := os.ReadFile(settingsPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	text := string(data)
+	if !strings.Contains(text, "gentle-ai skill-registry refresh") {
+		t.Fatalf("Claude settings.json missing skill-registry hook:\n%s", text)
+	}
+	if !strings.Contains(text, "gentle-ai review stop-hook --agent claude-code") {
+		t.Fatalf("Claude settings.json missing review stop-hook:\n%s", text)
+	}
+}
+
 func TestEnsureCodexSkillRegistryHookWritesSessionStartHookIdempotently(t *testing.T) {
 	home := t.TempDir()
 	hooksPath := filepath.Join(home, ".codex", "hooks.json")

--- a/internal/components/sdd/inject_test.go
+++ b/internal/components/sdd/inject_test.go
@@ -7139,7 +7139,15 @@ func TestEnsureClaudeReviewStopHookAppendsIdempotently(t *testing.T) {
       {
         "matcher": "",
         "hooks": [
-          {"type": "command", "command": "echo existing"}
+          {"type": "command", "command": "echo existing stop"}
+        ]
+      }
+    ],
+    "SessionStart": [
+      {
+        "matcher": "startup",
+        "hooks": [
+          {"type": "command", "command": "echo existing session-start"}
         ]
       }
     ]
@@ -7169,10 +7177,13 @@ func TestEnsureClaudeReviewStopHookAppendsIdempotently(t *testing.T) {
 		t.Fatal(err)
 	}
 	text := string(data)
-	if strings.Count(text, "gentle-ai review stop-hook --agent claude-code") != 1 {
-		t.Fatalf("hook command count mismatch:\n%s", text)
+	if strings.Count(text, "gentle-ai review stop-hook --agent claude-code") != 2 {
+		t.Fatalf("hook command count mismatch, want one Stop entry and one SessionStart entry:\n%s", text)
 	}
-	if !strings.Contains(text, "echo keep") || !strings.Contains(text, "echo existing") {
+	if !strings.Contains(text, `"matcher": "startup|resume|clear|compact"`) {
+		t.Fatalf("SessionStart baseline entry missing expected matcher:\n%s", text)
+	}
+	if !strings.Contains(text, "echo keep") || !strings.Contains(text, "echo existing stop") || !strings.Contains(text, "echo existing session-start") {
 		t.Fatalf("existing hooks not preserved:\n%s", text)
 	}
 }
@@ -7223,8 +7234,11 @@ func TestInject_ClaudeCodeInstallsReviewStopHook(t *testing.T) {
 	if !strings.Contains(text, "gentle-ai skill-registry refresh") {
 		t.Fatalf("Claude settings.json missing skill-registry hook:\n%s", text)
 	}
-	if !strings.Contains(text, "gentle-ai review stop-hook --agent claude-code") {
-		t.Fatalf("Claude settings.json missing review stop-hook:\n%s", text)
+	if strings.Count(text, "gentle-ai review stop-hook --agent claude-code") != 2 {
+		t.Fatalf("Claude settings.json missing review stop-hook Stop+SessionStart entries:\n%s", text)
+	}
+	if !strings.Contains(text, `"matcher": "startup|resume|clear|compact"`) {
+		t.Fatalf("Claude settings.json missing SessionStart baseline matcher:\n%s", text)
 	}
 }
 

--- a/internal/components/uninstall/service.go
+++ b/internal/components/uninstall/service.go
@@ -1170,7 +1170,7 @@ func removeSkillRegistryHook(raw []byte) ([]byte, bool, error) {
 		return raw, false, nil
 	}
 	changed := false
-	for _, hookKey := range []string{"UserPromptSubmit", "SessionStart"} {
+	for _, hookKey := range []string{"UserPromptSubmit", "SessionStart", "Stop"} {
 		entries, ok := hooksMap[hookKey].([]any)
 		if !ok {
 			continue
@@ -1191,7 +1191,7 @@ func removeSkillRegistryHook(raw []byte) ([]byte, bool, error) {
 			for _, hook := range hooks {
 				hookMap, ok := hook.(map[string]any)
 				cmd, _ := hookMap["command"].(string)
-				if ok && strings.Contains(cmd, "gentle-ai skill-registry refresh") {
+				if ok && (strings.Contains(cmd, "gentle-ai skill-registry refresh") || strings.Contains(cmd, "gentle-ai review stop-hook")) {
 					changed = true
 					continue
 				}

--- a/internal/components/uninstall/service_test.go
+++ b/internal/components/uninstall/service_test.go
@@ -1315,6 +1315,69 @@ func TestComponentOperationsSDD_ClaudeRemovesSkillRegistryHook(t *testing.T) {
 	}
 }
 
+func TestComponentOperationsSDD_ClaudeRemovesReviewStopHook(t *testing.T) {
+	homeDir := t.TempDir()
+	workspaceDir := t.TempDir()
+
+	svc, err := NewService(homeDir, workspaceDir, "dev")
+	if err != nil {
+		t.Fatalf("NewService() error = %v", err)
+	}
+	adapter, ok := svc.registry.Get(model.AgentClaudeCode)
+	if !ok {
+		t.Fatal("claude adapter not found in registry")
+	}
+	settingsPath := adapter.SettingsPath(homeDir)
+	if err := os.MkdirAll(filepath.Dir(settingsPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	initial := `{
+  "hooks": {
+    "Stop": [
+      {
+        "matcher": "",
+        "hooks": [
+          {"type": "command", "command": "gentle-ai review stop-hook --agent claude-code", "timeout": 60},
+          {"type": "command", "command": "echo keep"}
+        ]
+      }
+    ],
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [{"type": "command", "command": "echo pre"}]
+      }
+    ]
+  }
+}`
+	if err := os.WriteFile(settingsPath, []byte(initial), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	ops, _, err := svc.componentOperations(adapter, model.ComponentSDD)
+	if err != nil {
+		t.Fatalf("componentOperations() error = %v", err)
+	}
+	for _, op := range ops {
+		if op.typeID == opRewriteFile && op.path == settingsPath {
+			if _, _, err := op.apply(op.path); err != nil {
+				t.Fatalf("settings rewrite op.apply() error = %v", err)
+			}
+		}
+	}
+	raw, err := os.ReadFile(settingsPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	text := string(raw)
+	if strings.Contains(text, "gentle-ai review stop-hook") {
+		t.Fatalf("managed stop-hook should be removed:\n%s", text)
+	}
+	if !strings.Contains(text, "echo keep") || !strings.Contains(text, "echo pre") {
+		t.Fatalf("unrelated hooks should be preserved:\n%s", text)
+	}
+}
+
 func TestComponentOperationsSDD_CodexRemovesSkillRegistryHook(t *testing.T) {
 	homeDir := t.TempDir()
 	workspaceDir := t.TempDir()

--- a/internal/components/uninstall/service_test.go
+++ b/internal/components/uninstall/service_test.go
@@ -1342,6 +1342,15 @@ func TestComponentOperationsSDD_ClaudeRemovesReviewStopHook(t *testing.T) {
         ]
       }
     ],
+    "SessionStart": [
+      {
+        "matcher": "startup|resume|clear|compact",
+        "hooks": [
+          {"type": "command", "command": "gentle-ai review stop-hook --agent claude-code", "timeout": 30},
+          {"type": "command", "command": "echo custom session-start"}
+        ]
+      }
+    ],
     "PreToolUse": [
       {
         "matcher": "Bash",
@@ -1371,9 +1380,9 @@ func TestComponentOperationsSDD_ClaudeRemovesReviewStopHook(t *testing.T) {
 	}
 	text := string(raw)
 	if strings.Contains(text, "gentle-ai review stop-hook") {
-		t.Fatalf("managed stop-hook should be removed:\n%s", text)
+		t.Fatalf("managed stop-hook should be removed from both Stop and SessionStart:\n%s", text)
 	}
-	if !strings.Contains(text, "echo keep") || !strings.Contains(text, "echo pre") {
+	if !strings.Contains(text, "echo keep") || !strings.Contains(text, "echo pre") || !strings.Contains(text, "echo custom session-start") {
 		t.Fatalf("unrelated hooks should be preserved:\n%s", text)
 	}
 }


### PR DESCRIPTION
Closes #4064 together with the sibling subcommand PR (`feat/claude-stop-preflight-hook`); merge that one first so the installed command exists.

## Cause

With receipt-driven development enabled, whether Claude Code runs the review preflight at the end of a turn depended only on the model honoring the contract's entry rule. Claude Code has deterministic hooks, and gentle-ai already manages one (`UserPromptSubmit`, skill registry refresh), but installed no `Stop` hook.

## Fix

- `ensureClaudeReviewStopHook(settingsPath, agentID)` appends two entries to `~/.claude/settings.json`, idempotently per key and rejecting unsupported shapes like the existing hook:
  - `hooks.Stop`: `{"matcher":"","hooks":[{"type":"command","command":"gentle-ai review stop-hook --agent claude-code","timeout":60}]}`
  - `hooks.SessionStart`: `{"matcher":"startup|resume|clear|compact","hooks":[{"type":"command","command":"gentle-ai review stop-hook --agent claude-code","timeout":30}]}`
  The same subcommand handles both events: at `SessionStart` it records the session's starting candidate, at `Stop` it reminds only for candidates the session produced. Wired through `installSkillRegistryAutomation` for Claude Code on install and sync. The agent identity is derived from the adapter, never a literal, to satisfy the runtime-identity guard (#2440).
- Uninstall: `removeSkillRegistryHook` scans `Stop` and `SessionStart` and drops hooks whose command contains `gentle-ai review stop-hook`, preserving the skill-registry hook and unrelated user hooks and cleaning empty wrappers.
- Docs: `docs/agents.md` names the managed Claude hooks; `docs/review-integration.md` states the deterministic end-of-turn reminder that never starts a review. The invocation is not backtick-quoted because the documented-invocation test executes quoted commands and the subcommand lands in the sibling PR.

## Verification

- Full `go test ./... -count=1` green in the foreground; `go vet ./...` and `GOOS=windows go vet ./...` clean; `gofmt -l` empty; dead-code ratchet clean; no goldens changed.
- Tests: idempotent append of both entries with unrelated hooks preserved, unsupported schema rejection, Claude Code install writes both entries, uninstall removes both while other hooks under each key survive.
- Native review of the final candidate: lineage `review-3d40bd8b78f70b27`, tier medium, one lens, approved on the last admitted event and acknowledged (`gentle-ai.review-acknowledged/v1`, authority burned). An earlier candidate without the `SessionStart` entry was reviewed and burned as `review-adf2bec110ffd374`. Consent was answered `granted` under the maintainer's standing authorization.

https://claude.ai/code/session_01WYGtotXyhPmbnEeAZAbSbj


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Claude Code integrations now configure managed session hooks that establish a session baseline and provide review reminders only for candidates created during that session.
  - Existing Claude Code hooks are preserved, and repeated setup avoids duplicate entries.

- **Bug Fixes**
  - Uninstall now removes managed review hooks from all applicable Claude Code lifecycle events while preserving unrelated hooks.

- **Documentation**
  - Updated setup and quick-path guidance to explain the new Claude Code session hooks and review reminder behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->