### PR TITLE
docs(readme): add a star history chart to the header

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,22 @@
 <img src="https://img.shields.io/badge/platform-macOS%20%7C%20Linux%20%7C%20Windows-lightgrey" alt="Platform">
 </p>
 
+<!--
+  sealed_token is a GitHub fine-grained token encrypted against Star History's
+  public key, so only the encrypted value is published here. It is required
+  because GitHub restricted the stargazers API to a repository's admins and
+  collaborators on 2026-06-30; without it the chart renders an error placeholder.
+  Regenerate it at https://www.star-history.com/?repos=Gentleman-Programming%2Fgentle-ai&type=date&legend=top-left
+-->
+
+<a href="https://www.star-history.com/?repos=Gentleman-Programming%2Fgentle-ai&type=date&legend=top-left">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=Gentleman-Programming%2Fgentle-ai&type=date&theme=dark&legend=top-left&sealed_token=zwrd_DfwYZeJU7nhGYNtREEheKWYEslW_uzrqORlZ36v-JSMepdqGLkKExp1M-xbNq6t-ebVS5iM3WoPDO26tXbSGkjXC2Jo3kHQ3uNzlRkCrWoqRHkPVQXvosKciY109ObiwGV1z8aajyedcloppmekCGrvVKJb6KWxGLXW_mHcRAVIBZUOa4SzW75D" />
+    <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=Gentleman-Programming%2Fgentle-ai&type=date&legend=top-left&sealed_token=zwrd_DfwYZeJU7nhGYNtREEheKWYEslW_uzrqORlZ36v-JSMepdqGLkKExp1M-xbNq6t-ebVS5iM3WoPDO26tXbSGkjXC2Jo3kHQ3uNzlRkCrWoqRHkPVQXvosKciY109ObiwGV1z8aajyedcloppmekCGrvVKJb6KWxGLXW_mHcRAVIBZUOa4SzW75D" />
+    <img alt="Star History Chart" src="https://api.star-history.com/chart?repos=Gentleman-Programming%2Fgentle-ai&type=date&legend=top-left&sealed_token=zwrd_DfwYZeJU7nhGYNtREEheKWYEslW_uzrqORlZ36v-JSMepdqGLkKExp1M-xbNq6t-ebVS5iM3WoPDO26tXbSGkjXC2Jo3kHQ3uNzlRkCrWoqRHkPVQXvosKciY109ObiwGV1z8aajyedcloppmekCGrvVKJb6KWxGLXW_mHcRAVIBZUOa4SzW75D" />
+  </picture>
+</a>
+
 </div>
 
 ---


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #4068

---

## 🏷️ PR Type

- [x] `type:docs` — Documentation only

---

## 📝 Summary

- Adds a Star History chart to the README header block, directly under the badges, so the growth curve is visible without scrolling.
- Uses star-history's current embed contract: the `/chart` endpoint, `type=date`, `legend=top-left`, and a `<picture>` element so the chart follows the reader's light/dark preference.
- Carries an encrypted `sealed_token`, with an inline comment explaining why it exists and how to regenerate it.

GitHub [restricted the stargazers API](https://github.blog/changelog/2026-06-30-upcoming-access-restrictions-to-public-api-endpoints-and-ui-views/) on 2026-06-30 to a repository's admins and collaborators, to curb scraping of star data for spam. Every token-less star-history embed — for any repository — now returns a placeholder SVG reading "GitHub restricted access to star data", so the sealed token is what makes the chart render at all.

---

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| `README.md` | Star History chart added to the header block, with a theme-aware `<picture>` embed and an explanatory comment |

---

## 🤖 AI Assistance

- [x] **Material assistance used** — Complete all applicable declaration fields below.

**Tool/model (if known):** Claude Code (Opus 5)

**Material scope:** Located the current star-history embed contract, drafted the README block and its explanatory comment, and wrote this PR body and the linked issue.

**Verification performed:**

- Confirmed the repository slug. The originally supplied URL pointed at a non-existent `gentle-ai/gentle-ai`; the correct slug is `Gentleman-Programming/gentle-ai`.
- Confirmed the legacy `api.star-history.com/svg` path `301`-redirects and that `/chart` is the endpoint the site itself emits today. The query contract (`repos`, `type`, `theme`, `logscale`, `legend`, `sealed_token`) was read out of star-history's own frontend bundle rather than copied from a blog snippet.
- Reimplemented star-history's client-side sealing (X25519 + XSalsa20-Poly1305, nonce derived as `SHA-512(ephemeral_pub || server_pub)[0..24]`, output `base64url(ephemeral_pub || ciphertext)`) so the raw GitHub token never had to be pasted into a third-party web form.
- Used the response shape as a diagnostic. A deliberately fake sealed token returns `401 The provided GitHub access token is invalid or expired`; a valid token missing `Contents: Read and write` returns the generic 60125-byte placeholder; a correctly scoped token returns the chart. That distinction is what identified the permission problem on the first token.
- Requested the final embed URL live and confirmed it returns real data: `200`, 64772 bytes, axis labels March–September and 1K–6K, series labelled `gentleman-programming/gentle-ai`. No placeholder, no `401`.

---

## 🧪 Test Plan

Documentation-only change; no Go code, build inputs, or review-lifecycle behavior is touched.

- [x] Unit tests pass (`go test ./...`) — not affected by this change
- [x] Go format passes (`go run ./internal/gofmtcheck`) — no Go files changed
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`) — N/A, no runtime behavior changed
- [x] Manually tested locally — exercised the embed URL live, as described above

**Benchmark validation:** N/A. This change touches no review-lifecycle, gate, recovery, delivery, benchmark implementation, corpus, classifier, or benchmark-claim surface.

---

## ✅ Contributor Checklist

- [x] PR is linked to an issue with `status:approved`
- [x] PR stays within 400 changed lines
- [x] I have added the appropriate `type:*` label to this PR
- [x] Unit tests pass (`go test ./...`)
- [x] Go format passes (`go run ./internal/gofmtcheck`)
- [x] Benchmark validation completed, or this change is not applicable to the benchmark (explain why in the Test Plan).
- [x] I have updated documentation if necessary
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] I understand, reviewed, and take responsibility for the complete submission
- [x] I selected exactly one AI-assistance option and, if material assistance was used, completed all applicable declaration fields
- [x] My commits do not include `Co-Authored-By` trailers

---

## 💬 Notes for Reviewers

One thing worth stating plainly, because it is easy to wave through: **the published sealed value wraps a token that can write to this repository.**

That is not star-history asking for more than it needs. GitHub's fine-grained token model exposes no "prove you are a collaborator" permission, and on a public repository read access proves nothing because everyone already has it. A write grant can only be issued by someone who already holds write, so `Contents: Read and write` is the only permission that doubles as proof of collaborator status — read-only is rejected outright. The classic-token alternative (`public_repo`) is also a write scope and reaches every repository in every org, so the fine-grained token is the tighter of the two.

The token is scoped to this owner's repositories only and is used for nothing else. Its confidentiality rests on star-history's private key: the value here is a NaCl sealed envelope only their server can open. If star-history ever reports a key compromise, revoke the token and regenerate the embed.

https://claude.ai/code/session_015hDNaNWqutTp8CMrBeFRge


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added a Star History chart to the README header.
  - The chart includes light and dark theme visuals and links to the project’s star history page.
  - Updated documentation provides a clearer view of project popularity over time.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->