### PR TITLE
feat(review): add the review stop-hook subcommand that hands Claude Code the preflight route once per session candidate

### DIFF
--- a/bench/journeys.go
+++ b/bench/journeys.go
@@ -832,6 +832,7 @@ func Journeys() []Journey {
 	journeys = append(journeys, issue3813Journeys()...)
 	journeys = append(journeys, issue3842Journeys()...)
 	journeys = append(journeys, handoffJourneys()...)
+	journeys = append(journeys, stopHookJourneys()...)
 	journeys = removeRetiredAtomicJourneys(journeys)
 	return declareCoreJourneyReviewModes(journeys)
 }

--- a/bench/journeys_id_collision_test.go
+++ b/bench/journeys_id_collision_test.go
@@ -31,6 +31,7 @@ func journeySources() []journeySource {
 		{"journeys_issue3094.go", issue3094Journeys()},
 		{"journeys_issue_3065.go", issue3065Journeys()},
 		{"journeys_handoff.go", handoffJourneys()},
+		{"journeys_stop_hook.go", stopHookJourneys()},
 		{"journeys_sdd_untracked.go", selectedUntrackedSDDJourneys()},
 		{"journeys_capture_evidence_v5.go", captureEvidenceDescriptorJourneys()},
 		{"journeys_scope_changed_fixture.go", scopeChangedFixtureJourneys()},

--- a/bench/journeys_stop_hook.go
+++ b/bench/journeys_stop_hook.go
@@ -1,0 +1,74 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+)
+
+// stopHookJourneys drives #4064's `gentle-ai review stop-hook --agent
+// claude-code`: the Claude Code Stop hook that reminds the agent to run the
+// selectorless STATUS preflight once per session and candidate, instead of
+// letting it report completion with an unreviewed candidate sitting in the
+// repository. The stdin payload's own cwd is left empty here because Step's
+// Stdin field is a literal string, not a per-sandbox template like Args; the
+// sandbox path is supplied through --cwd via productArgs instead, exactly as
+// the hook's own --cwd override is documented to take precedence.
+func stopHookJourneys() []Journey {
+	stdin := `{"session_id":"bench-stop-hook","cwd":"","hook_event_name":"Stop","stop_hook_active":false}`
+	stdinActive := `{"session_id":"bench-stop-hook","cwd":"","hook_event_name":"Stop","stop_hook_active":true}`
+	return []Journey{{
+		ID:     "j125-claude-code-stop-hook-reminds-once-per-candidate",
+		Review: reviewOptedIn,
+		Title:  "Claude Code Stop hook reminds once per session and candidate",
+		Source: "#4064: the hook hands the agent the STATUS preflight route instead of letting it report completion silently",
+		Steps: []Step{
+			{Name: "fixture: repo", Fixture: baseRepo},
+			{Name: "fixture: stage docs", Fixture: stageDocs("stop-hook")},
+			{
+				Name:  "an unreviewed candidate blocks with the STATUS preflight route",
+				Args:  productArgs("review", "stop-hook", "--agent", "claude-code"),
+				Stdin: stdin,
+				After: func(_ *Sandbox, observation Observation) error {
+					if observation.ExitCode != 0 {
+						return fmt.Errorf("stop-hook exited %d, want 0: %s", observation.ExitCode, observation.Stderr)
+					}
+					if !strings.Contains(observation.Stdout, `"decision":"block"`) {
+						return fmt.Errorf("stdout missing %q: %s", `"decision":"block"`, observation.Stdout)
+					}
+					if !strings.Contains(observation.Stdout, "gentle-ai review start") {
+						return fmt.Errorf("stdout missing %q: %s", "gentle-ai review start", observation.Stdout)
+					}
+					return nil
+				},
+			},
+			{
+				Name:  "the same session and candidate is reminded only once",
+				Args:  productArgs("review", "stop-hook", "--agent", "claude-code"),
+				Stdin: stdin,
+				After: func(_ *Sandbox, observation Observation) error {
+					if observation.ExitCode != 0 {
+						return fmt.Errorf("stop-hook exited %d, want 0: %s", observation.ExitCode, observation.Stderr)
+					}
+					if strings.TrimSpace(observation.Stdout) != "" {
+						return fmt.Errorf("expected empty stdout on the repeat reminder, got: %s", observation.Stdout)
+					}
+					return nil
+				},
+			},
+			{
+				Name:  "an active Stop hook never reminds",
+				Args:  productArgs("review", "stop-hook", "--agent", "claude-code"),
+				Stdin: stdinActive,
+				After: func(_ *Sandbox, observation Observation) error {
+					if observation.ExitCode != 0 {
+						return fmt.Errorf("stop-hook exited %d, want 0: %s", observation.ExitCode, observation.Stderr)
+					}
+					if strings.TrimSpace(observation.Stdout) != "" {
+						return fmt.Errorf("expected empty stdout while stop_hook_active is true, got: %s", observation.Stdout)
+					}
+					return nil
+				},
+			},
+		},
+	}}
+}

--- a/bench/journeys_stop_hook.go
+++ b/bench/journeys_stop_hook.go
@@ -6,14 +6,17 @@ import (
 )
 
 // stopHookJourneys drives #4064's `gentle-ai review stop-hook --agent
-// claude-code`: the Claude Code Stop hook that reminds the agent to run the
-// selectorless STATUS preflight once per session and candidate, instead of
-// letting it report completion with an unreviewed candidate sitting in the
-// repository. The stdin payload's own cwd is left empty here because Step's
-// Stdin field is a literal string, not a per-sandbox template like Args; the
-// sandbox path is supplied through --cwd via productArgs instead, exactly as
-// the hook's own --cwd override is documented to take precedence.
+// claude-code`: the Claude Code hook that, on SessionStart, baselines the
+// repository's current unreviewed-candidate identity for the session, and on
+// Stop reminds the agent -- once per session and candidate, and only for a
+// candidate the session itself produced -- to run the selectorless STATUS
+// preflight instead of reporting completion silently. The stdin payloads'
+// own cwd is left empty here because Step's Stdin field is a literal string,
+// not a per-sandbox template like Args; the sandbox path is supplied through
+// --cwd via productArgs instead, exactly as the hook's own --cwd override is
+// documented to take precedence.
 func stopHookJourneys() []Journey {
+	sessionStart := `{"session_id":"bench-stop-hook","hook_event_name":"SessionStart","source":"startup"}`
 	stdin := `{"session_id":"bench-stop-hook","cwd":"","hook_event_name":"Stop","stop_hook_active":false}`
 	stdinActive := `{"session_id":"bench-stop-hook","cwd":"","hook_event_name":"Stop","stop_hook_active":true}`
 	return []Journey{{
@@ -23,6 +26,20 @@ func stopHookJourneys() []Journey {
 		Source: "#4064: the hook hands the agent the STATUS preflight route instead of letting it report completion silently",
 		Steps: []Step{
 			{Name: "fixture: repo", Fixture: baseRepo},
+			{
+				Name:  "SessionStart baselines the clean repository silently",
+				Args:  productArgs("review", "stop-hook", "--agent", "claude-code"),
+				Stdin: sessionStart,
+				After: func(_ *Sandbox, observation Observation) error {
+					if observation.ExitCode != 0 {
+						return fmt.Errorf("stop-hook exited %d, want 0: %s", observation.ExitCode, observation.Stderr)
+					}
+					if strings.TrimSpace(observation.Stdout) != "" {
+						return fmt.Errorf("expected empty stdout on SessionStart, got: %s", observation.Stdout)
+					}
+					return nil
+				},
+			},
 			{Name: "fixture: stage docs", Fixture: stageDocs("stop-hook")},
 			{
 				Name:  "an unreviewed candidate blocks with the STATUS preflight route",

--- a/bench/review_declarations.go
+++ b/bench/review_declarations.go
@@ -122,6 +122,7 @@ var coreJourneyReviewModes = map[string]ReviewPrecondition{
 	"j122-global-review-mode-from-non-git-cwd":                                  reviewUntouched,
 	"j123-rejected-provider-validator-starts-fresh-high-risk-review":            reviewOptedIn,
 	"j124-sdd-attempt-reset-after-selected-untracked-lands":                     reviewOptedIn,
+	"j125-claude-code-stop-hook-reminds-once-per-candidate":                     reviewOptedIn,
 }
 
 func declareCoreJourneyReviewModes(journeys []Journey) []Journey {

--- a/bench/runner.go
+++ b/bench/runner.go
@@ -216,14 +216,25 @@ func (s *Sandbox) invoke(args []string) Observation {
 	return s.invokeAt(s.Repo, args)
 }
 
+// invokeWithStdin is invoke with an explicit stdin payload, for steps whose
+// product surface (a hook, in particular) reads its input from stdin rather
+// than argv.
+func (s *Sandbox) invokeWithStdin(args []string, stdin string) Observation {
+	return s.invokeAtWithStdin(s.Repo, args, stdin)
+}
+
 func (s *Sandbox) invokeAt(dir string, args []string) Observation {
+	return s.invokeAtWithStdin(dir, args, "")
+}
+
+func (s *Sandbox) invokeAtWithStdin(dir string, args []string, stdin string) Observation {
 	cmd := exec.Command(s.Binary, args...)
 	cmd.Dir = dir
 	cmd.Env = s.env()
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
-	cmd.Stdin = strings.NewReader("")
+	cmd.Stdin = strings.NewReader(stdin)
 	err := cmd.Run()
 	exitCode := 0
 	var exitErr *exec.ExitError
@@ -557,6 +568,11 @@ type Step struct {
 	Skip     func(*Sandbox) string
 	Requires *Capability
 	Args     func(*Sandbox) ([]string, error)
+	// Stdin, when non-empty, is piped to the invocation instead of an empty
+	// reader. It is a literal payload, not a template: a step that needs the
+	// sandbox repo path in its stdin JSON resolves it in Args-adjacent setup
+	// and folds the result in here before the step runs.
+	Stdin string
 	// Composite drives a multi-command sub-flow (a lens loop, a rejected
 	// capture and its recapture). It reports its own invocations.
 	Composite func(*journeyRun) error
@@ -849,7 +865,7 @@ func runJourney(binary string, journey Journey) JourneyResult {
 			break
 		}
 
-		observation := sandbox.invoke(args)
+		observation := sandbox.invokeWithStdin(args, step.Stdin)
 		observation.DeclaredDeadEnd = step.DeadEnd
 		observation.DeclaredByDesign = step.ByDesign
 		record := accumulator.observe(step.Name, observation, sandbox.gitCallsSince(), step.ModelRun)

--- a/bench/testdata/journeys.manifest
+++ b/bench/testdata/journeys.manifest
@@ -22,6 +22,7 @@ j121-rdd-tui-controls-global-mode
 j122-global-review-mode-from-non-git-cwd
 j123-rejected-provider-validator-starts-fresh-high-risk-review
 j124-sdd-attempt-reset-after-selected-untracked-lands
+j125-claude-code-stop-hook-reminds-once-per-candidate
 j13-next-transition-runs-verbatim
 j14-abandon-needs-a-hand-built-token
 j17-bare-repository

--- a/internal/cli/review_facade.go
+++ b/internal/cli/review_facade.go
@@ -683,6 +683,8 @@ func runReviewCommand(args []string, stdout io.Writer) error {
 		return RunReviewSchema(args[1:], stdout)
 	case "opencode-transport":
 		return RunReviewOpenCodeTransport(args[1:], stdout)
+	case "stop-hook":
+		return RunReviewStopHook(args[1:], stdout)
 	default:
 		return fmt.Errorf("unknown review command %q", args[0])
 	}

--- a/internal/cli/review_stop_hook.go
+++ b/internal/cli/review_stop_hook.go
@@ -171,12 +171,21 @@ func runReviewStopHookStop(ctx context.Context, payload reviewStopHookPayload, r
 		return nil
 	}
 
-	silent, persistErr := recordReviewStopHookReminder(payload.SessionID, targetIdentity)
-	if persistErr != nil {
-		return fmt.Errorf("review stop-hook: record reminder: %w", persistErr)
-	}
-	if silent {
-		return nil
+	// Check first, persist after delivery below: recording before the write
+	// risks losing the reminder if it fails or the process dies in between.
+	if reviewStopHookSessionIDPattern.MatchString(payload.SessionID) {
+		home, herr := os.UserHomeDir()
+		if herr != nil {
+			return fmt.Errorf("resolve user home directory: %w", herr)
+		}
+		record, hadRecord, rerr := readReviewStopHookRecord(reviewStopHookRecordPath(home, payload.SessionID))
+		if rerr != nil {
+			return rerr
+		}
+		if hadRecord && ((record.BaselineTargetIdentity != "" && record.BaselineTargetIdentity == targetIdentity) ||
+			(record.TargetIdentity != "" && record.TargetIdentity == targetIdentity)) {
+			return nil
+		}
 	}
 
 	output := reviewStopHookOutput{
@@ -188,7 +197,10 @@ func runReviewStopHookStop(ctx context.Context, payload reviewStopHookPayload, r
 	if err != nil {
 		return fmt.Errorf("review stop-hook: encode reminder: %w", err)
 	}
-	_, err = fmt.Fprintln(stdout, string(encoded))
+	if _, err := fmt.Fprintln(stdout, string(encoded)); err != nil {
+		return err
+	}
+	_, err = recordReviewStopHookReminder(payload.SessionID, targetIdentity)
 	return err
 }
 

--- a/internal/cli/review_stop_hook.go
+++ b/internal/cli/review_stop_hook.go
@@ -20,21 +20,25 @@ import (
 // stdout. Claude Code reads "decision" and "reason" as top-level keys.
 const reviewStopHookSchema = "gentle-ai.review-stop-hook/v1"
 
-// reviewStopHookReminderSchema identifies the small per-session dedupe record
-// kept under ~/.gentle-ai/review-stop-hook/v1.
+// reviewStopHookReminderSchema identifies the small per-session record kept
+// under ~/.gentle-ai/review-stop-hook/v1. The schema name is unchanged from
+// its first shape; it now optionally carries baseline_target_identity
+// alongside target_identity (see reviewStopHookReminderRecord).
 const reviewStopHookReminderSchema = "gentle-ai.review-stop-hook-reminder/v1"
 
-// maxReviewStopHookPayloadBytes bounds the Stop hook stdin payload, mirroring
-// the sdd-task-result precedent (internal/cli/sdd_task_result.go): a hook
-// reports a small event, never a large or unbounded stream.
+// maxReviewStopHookPayloadBytes bounds the hook stdin payload, mirroring the
+// sdd-task-result precedent (internal/cli/sdd_task_result.go): a hook reports
+// a small event, never a large or unbounded stream.
 const maxReviewStopHookPayloadBytes = 1 << 20
 
 // reviewStopHookSessionIDPattern is the safe filename alphabet a session id
 // must match before it is used to name a state file.
 var reviewStopHookSessionIDPattern = regexp.MustCompile(`^[A-Za-z0-9._-]{1,128}$`)
 
-// reviewStopHookPayload is Claude Code's Stop hook stdin payload. Unknown
-// fields are ignored by json.Unmarshal, never rejected.
+// reviewStopHookPayload is Claude Code's hook stdin payload, shared by the
+// SessionStart and Stop shapes this command handles. Unknown fields
+// (including SessionStart's "source") are ignored by json.Unmarshal, never
+// rejected.
 type reviewStopHookPayload struct {
 	SessionID      string `json:"session_id"`
 	TranscriptPath string `json:"transcript_path"`
@@ -50,21 +54,28 @@ type reviewStopHookOutput struct {
 	Reason   string `json:"reason"`
 }
 
-// reviewStopHookReminderRecord is the per-session dedupe record: one file
-// keeps the last target_identity a session was reminded about, so a second
-// Stop for the same unreviewed candidate stays silent.
+// reviewStopHookReminderRecord is the per-session state: BaselineTargetIdentity
+// is the unreviewed-candidate identity (if any) that SessionStart observed
+// when the session began, so a Stop later in the same session never reminds
+// about a candidate the session did not produce. TargetIdentity is the
+// identity of the last candidate a Stop actually reminded about, so a repeat
+// Stop for the same candidate stays silent. The two fields are independent
+// and each written without disturbing the other.
 type reviewStopHookReminderRecord struct {
-	Schema         string `json:"schema"`
-	TargetIdentity string `json:"target_identity"`
+	Schema                 string `json:"schema"`
+	TargetIdentity         string `json:"target_identity,omitempty"`
+	BaselineTargetIdentity string `json:"baseline_target_identity,omitempty"`
 }
 
 // RunReviewStopHook is the `gentle-ai review stop-hook` entry point. Claude
-// Code runs it as a Stop hook: it reads one Stop hook payload from stdin and,
-// only when receipt-driven development is enabled and the repository holds an
-// unreviewed candidate, prints one reminder that routes the agent through the
+// Code runs it as both a SessionStart and a Stop hook. On SessionStart it
+// records the repository's current unreviewed-candidate identity (if any) as
+// this session's baseline, with zero output. On Stop it prints one reminder,
+// only when receipt-driven development is enabled and the repository holds a
+// candidate the session did not start with, that routes the agent through the
 // selectorless STATUS preflight before it reports completion. Every other
-// case is silent (exit 0, no output), and this command never starts a review
-// itself.
+// case -- including an unrecognized hook_event_name -- is silent (exit 0, no
+// output), and this command never starts a review itself.
 func RunReviewStopHook(args []string, stdout io.Writer) error {
 	return runReviewStopHook(args, os.Stdin, stdout, os.Stderr)
 }
@@ -73,12 +84,12 @@ func RunReviewStopHook(args []string, stdout io.Writer) error {
 // both explicit so a test can supply a payload and assert on diagnostics
 // without touching the process streams. stderr is also where flag usage/help
 // text is written (never stdout), so stdout stays reserved for the exact one
-// JSON reminder object this command may print.
+// JSON reminder object a Stop event may print.
 func runReviewStopHook(args []string, stdin io.Reader, stdout, stderr io.Writer) error {
 	flags := newReviewFlagSet("review stop-hook", stderr,
-		"Read one Claude Code Stop hook payload from stdin. When receipt-driven development is enabled and the repository holds an unreviewed candidate, print one reminder that routes the agent through the selectorless STATUS preflight before it reports completion. Every other case is silent, and this command never runs review start itself.")
+		"Read one Claude Code hook payload from stdin (SessionStart or Stop). On SessionStart, record the repository's current unreviewed-candidate identity as this session's baseline, with no output. On Stop, when receipt-driven development is enabled and the repository holds a candidate the session did not start with, print one reminder that routes the agent through the selectorless STATUS preflight before it reports completion. Every other case -- including an unrecognized hook_event_name -- is silent, and this command never runs review start itself.")
 	agent := flags.String("agent", "", "required; generated active runtime identity (only claude-code is accepted today)")
-	cwdOverride := flags.String("cwd", "", "optional; overrides the Stop hook payload's cwd")
+	cwdOverride := flags.String("cwd", "", "optional; overrides the hook payload's cwd")
 	if err := parseReviewFlags(flags, args); err != nil {
 		return err
 	}
@@ -97,52 +108,122 @@ func runReviewStopHook(args []string, stdin io.Reader, stdout, stderr io.Writer)
 
 	raw, err := io.ReadAll(io.LimitReader(stdin, maxReviewStopHookPayloadBytes))
 	if err != nil {
-		return fmt.Errorf("review stop-hook: read Stop hook payload: %w", err)
+		return fmt.Errorf("review stop-hook: read hook payload: %w", err)
 	}
 	var payload reviewStopHookPayload
 	if err := json.Unmarshal(raw, &payload); err != nil {
-		return fmt.Errorf("review stop-hook: decode Stop hook payload: %w", err)
-	}
-
-	if payload.StopHookActive {
-		return nil
+		return fmt.Errorf("review stop-hook: decode hook payload: %w", err)
 	}
 
 	repo := strings.TrimSpace(*cwdOverride)
 	if repo == "" {
 		repo = strings.TrimSpace(payload.Cwd)
 	}
-	if repo == "" {
-		return nil
-	}
 
 	ctx := context.Background()
 
-	// Confirm the cwd is inside a Git repository without ever bootstrapping
-	// one: ResolveRepositoryRoot alone (never PrepareReviewRepositoryRoot)
-	// never runs `git init`. This has to happen before resolving the review
-	// mode below: the clone-local override lookup shells out to git, and on a
-	// genuinely non-Git cwd it returns a hard error rather than "no override"
-	// -- so silently exiting here, before that call, is what keeps a
-	// non-repository cwd silent instead of surfacing as an internal error.
-	root, err := (reviewtransaction.SnapshotBuilder{Repo: repo}).ResolveRepositoryRoot(ctx)
+	switch payload.HookEventName {
+	case "SessionStart":
+		return runReviewStopHookSessionStart(ctx, payload.SessionID, repo, runtimeAgent)
+	case "Stop":
+		return runReviewStopHookStop(ctx, payload, repo, runtimeAgent, stdout)
+	default:
+		return nil
+	}
+}
+
+// runReviewStopHookSessionStart records the repository's current
+// unreviewed-candidate identity (if any) as sessionID's baseline. It is
+// always silent: SessionStart never prints a reminder, and every
+// precondition that keeps Stop silent (no usable cwd, RDD off, non-repository
+// cwd) also means there is nothing to baseline here.
+func runReviewStopHookSessionStart(ctx context.Context, sessionID, repo, runtimeAgent string) error {
+	_, targetIdentity, _, ok, err := reviewStopHookResolveTargetIdentity(ctx, repo, runtimeAgent)
 	if err != nil {
+		return err
+	}
+	if !ok {
+		return nil
+	}
+	if err := recordReviewStopHookBaseline(sessionID, targetIdentity); err != nil {
+		return fmt.Errorf("review stop-hook: record baseline: %w", err)
+	}
+	return nil
+}
+
+// runReviewStopHookStop is the original Stop behavior, now also silent when
+// the current candidate matches the session's recorded SessionStart baseline
+// -- that candidate predates the session, so this session did not produce it.
+func runReviewStopHookStop(ctx context.Context, payload reviewStopHookPayload, repo, runtimeAgent string, stdout io.Writer) error {
+	if payload.StopHookActive {
 		return nil
 	}
 
-	// Resolve the effective receipt-driven-development mode exactly like
-	// reviewtransaction.OfferReviewAfterVerify does: global mode plus this
-	// clone's off-only override, with zero side effects. Off means silent.
-	global, err := readGlobalRDDMode()
+	root, targetIdentity, status, ok, err := reviewStopHookResolveTargetIdentity(ctx, repo, runtimeAgent)
 	if err != nil {
-		return fmt.Errorf("review stop-hook: read global review mode: %w", err)
+		return err
 	}
-	rddStatus, err := reviewtransaction.ResolveRDDMode(ctx, root, global)
+	if !ok {
+		return nil
+	}
+	if status.NextTransition == nil || status.NextTransition.Kind != reviewNextTransitionExecute ||
+		status.NextTransition.Execute == nil || status.NextTransition.Execute.Operation != "review.start" {
+		return nil
+	}
+
+	silent, persistErr := recordReviewStopHookReminder(payload.SessionID, targetIdentity)
+	if persistErr != nil {
+		return fmt.Errorf("review stop-hook: record reminder: %w", persistErr)
+	}
+	if silent {
+		return nil
+	}
+
+	output := reviewStopHookOutput{
+		Schema:   reviewStopHookSchema,
+		Decision: "block",
+		Reason:   reviewStopHookReasonText(targetIdentity, root, runtimeAgent, status.NextTransition.Execute.Command),
+	}
+	encoded, err := json.Marshal(output)
 	if err != nil {
-		return fmt.Errorf("review stop-hook: resolve review mode: %w", err)
+		return fmt.Errorf("review stop-hook: encode reminder: %w", err)
+	}
+	_, err = fmt.Fprintln(stdout, string(encoded))
+	return err
+}
+
+// reviewStopHookResolveTargetIdentity resolves the repository root, the
+// effective receipt-driven-development mode, and the current STATUS target
+// identity together -- the read-only preflight both SessionStart and Stop
+// need. ok is false whenever there is nothing to check: no usable cwd, a cwd
+// outside a Git repository (never bootstrapped: ResolveRepositoryRoot alone,
+// never PrepareReviewRepositoryRoot, so `git init` never runs), or RDD off.
+// err is non-nil only for a genuine unexpected internal failure.
+//
+// The Git-repository check runs before resolving RDD mode: the clone-local
+// override lookup shells out to git, and on a genuinely non-Git cwd it
+// returns a hard error rather than "no override" -- so resolving the root
+// first is what keeps a non-repository cwd silent instead of surfacing as an
+// internal error.
+func reviewStopHookResolveTargetIdentity(ctx context.Context, repo, runtimeAgent string) (root, targetIdentity string, status ReviewTargetStatusResult, ok bool, err error) {
+	if repo == "" {
+		return "", "", ReviewTargetStatusResult{}, false, nil
+	}
+	root, rootErr := (reviewtransaction.SnapshotBuilder{Repo: repo}).ResolveRepositoryRoot(ctx)
+	if rootErr != nil {
+		return "", "", ReviewTargetStatusResult{}, false, nil
+	}
+
+	global, globalErr := readGlobalRDDMode()
+	if globalErr != nil {
+		return "", "", ReviewTargetStatusResult{}, false, fmt.Errorf("review stop-hook: read global review mode: %w", globalErr)
+	}
+	rddStatus, rddErr := reviewtransaction.ResolveRDDMode(ctx, root, global)
+	if rddErr != nil {
+		return "", "", ReviewTargetStatusResult{}, false, fmt.Errorf("review stop-hook: resolve review mode: %w", rddErr)
 	}
 	if !rddStatus.Enabled() {
-		return nil
+		return "", "", ReviewTargetStatusResult{}, false, nil
 	}
 
 	// Calling runReviewStatus directly (rather than RunReview) avoids a
@@ -155,36 +236,13 @@ func runReviewStopHook(args []string, stdin io.Reader, stdout, stderr io.Writer)
 		"--agent", runtimeAgent, "--next-transition",
 	}, &statusOutput)
 	if statusErr != nil {
-		return fmt.Errorf("review stop-hook: review status: %w", statusErr)
+		return "", "", ReviewTargetStatusResult{}, false, fmt.Errorf("review stop-hook: review status: %w", statusErr)
 	}
-	var status ReviewTargetStatusResult
-	if err := json.Unmarshal(statusOutput.Bytes(), &status); err != nil {
-		return fmt.Errorf("review stop-hook: decode review status: %w", err)
+	var result ReviewTargetStatusResult
+	if err := json.Unmarshal(statusOutput.Bytes(), &result); err != nil {
+		return "", "", ReviewTargetStatusResult{}, false, fmt.Errorf("review stop-hook: decode review status: %w", err)
 	}
-	if status.NextTransition == nil || status.NextTransition.Kind != reviewNextTransitionExecute ||
-		status.NextTransition.Execute == nil || status.NextTransition.Execute.Operation != "review.start" {
-		return nil
-	}
-
-	alreadyReminded, persistErr := recordReviewStopHookReminder(payload.SessionID, status.TargetIdentity)
-	if persistErr != nil {
-		return fmt.Errorf("review stop-hook: record reminder: %w", persistErr)
-	}
-	if alreadyReminded {
-		return nil
-	}
-
-	output := reviewStopHookOutput{
-		Schema:   reviewStopHookSchema,
-		Decision: "block",
-		Reason:   reviewStopHookReasonText(status.TargetIdentity, root, runtimeAgent, status.NextTransition.Execute.Command),
-	}
-	encoded, err := json.Marshal(output)
-	if err != nil {
-		return fmt.Errorf("review stop-hook: encode reminder: %w", err)
-	}
-	_, err = fmt.Fprintln(stdout, string(encoded))
-	return err
+	return root, result.TargetIdentity, result, true, nil
 }
 
 // reviewStopHookReasonText composes the one-paragraph reminder Claude Code
@@ -204,11 +262,74 @@ func reviewStopHookReasonText(targetIdentity, root, runtimeAgent, startCommand s
 	}, "\n")
 }
 
-// recordReviewStopHookReminder persists that sessionID was reminded about
-// targetIdentity, and reports whether it already had been. An invalid or
-// missing session id still reminds (the caller proceeds) but is never
-// persisted, since there is no safe file name to record it under.
-func recordReviewStopHookReminder(sessionID, targetIdentity string) (alreadyReminded bool, err error) {
+// reviewStopHookRecordPath is the per-session state file path for sessionID.
+func reviewStopHookRecordPath(home, sessionID string) string {
+	return filepath.Join(home, ".gentle-ai", "review-stop-hook", "v1", sessionID+".json")
+}
+
+// readReviewStopHookRecord reads sessionID's existing record, if any. A
+// missing file reports a zero record with ok false and no error; a corrupt
+// file is treated the same as missing, since replacing it is safe (this
+// state is a dedupe hint, not authority).
+func readReviewStopHookRecord(path string) (record reviewStopHookReminderRecord, ok bool, err error) {
+	existing, readErr := os.ReadFile(path)
+	if readErr != nil {
+		if errors.Is(readErr, os.ErrNotExist) {
+			return reviewStopHookReminderRecord{}, false, nil
+		}
+		return reviewStopHookReminderRecord{}, false, readErr
+	}
+	if json.Unmarshal(existing, &record) != nil {
+		return reviewStopHookReminderRecord{}, false, nil
+	}
+	return record, true, nil
+}
+
+// recordReviewStopHookBaseline writes targetIdentity as sessionID's
+// SessionStart baseline, leaving any already-recorded TargetIdentity (the
+// last candidate a Stop reminded about) untouched. An invalid or missing
+// session id is a silent no-op: there is no safe file name to record it
+// under.
+func recordReviewStopHookBaseline(sessionID, targetIdentity string) error {
+	if !reviewStopHookSessionIDPattern.MatchString(sessionID) {
+		return nil
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return fmt.Errorf("resolve user home directory: %w", err)
+	}
+	path := reviewStopHookRecordPath(home, sessionID)
+
+	record, _, err := readReviewStopHookRecord(path)
+	if err != nil {
+		return err
+	}
+	record.Schema = reviewStopHookReminderSchema
+	record.BaselineTargetIdentity = targetIdentity
+
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return err
+	}
+	payload, err := json.Marshal(record)
+	if err != nil {
+		return err
+	}
+	_, err = filemerge.WriteFileAtomic(path, payload, 0o644)
+	return err
+}
+
+// recordReviewStopHookReminder decides, and records, whether a Stop for
+// targetIdentity should stay silent. It reports silent=true when: the session
+// id is invalid (there is nothing safe to record, so the caller still
+// reminds -- see below); the recorded SessionStart baseline equals
+// targetIdentity (the candidate predates this session); or the session was
+// already reminded about this exact targetIdentity. Otherwise it records
+// targetIdentity as the session's last reminder (preserving any recorded
+// baseline untouched) and reports silent=false so the caller reminds.
+//
+// An invalid or missing session id is the one case that reminds (silent
+// false) without persisting: there is no safe file name to record it under.
+func recordReviewStopHookReminder(sessionID, targetIdentity string) (silent bool, err error) {
 	if !reviewStopHookSessionIDPattern.MatchString(sessionID) {
 		return false, nil
 	}
@@ -216,24 +337,27 @@ func recordReviewStopHookReminder(sessionID, targetIdentity string) (alreadyRemi
 	if err != nil {
 		return false, fmt.Errorf("resolve user home directory: %w", err)
 	}
-	dir := filepath.Join(home, ".gentle-ai", "review-stop-hook", "v1")
-	path := filepath.Join(dir, sessionID+".json")
-	existing, readErr := os.ReadFile(path)
-	if readErr == nil {
-		var record reviewStopHookReminderRecord
-		if json.Unmarshal(existing, &record) == nil && record.TargetIdentity == targetIdentity {
-			return true, nil
-		}
-	} else if !errors.Is(readErr, os.ErrNotExist) {
-		return false, readErr
-	}
-	if err := os.MkdirAll(dir, 0o755); err != nil {
+	path := reviewStopHookRecordPath(home, sessionID)
+
+	record, hadRecord, err := readReviewStopHookRecord(path)
+	if err != nil {
 		return false, err
 	}
-	payload, err := json.Marshal(reviewStopHookReminderRecord{
-		Schema:         reviewStopHookReminderSchema,
-		TargetIdentity: targetIdentity,
-	})
+	if hadRecord {
+		if record.BaselineTargetIdentity != "" && record.BaselineTargetIdentity == targetIdentity {
+			return true, nil
+		}
+		if record.TargetIdentity != "" && record.TargetIdentity == targetIdentity {
+			return true, nil
+		}
+	}
+
+	record.Schema = reviewStopHookReminderSchema
+	record.TargetIdentity = targetIdentity
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return false, err
+	}
+	payload, err := json.Marshal(record)
 	if err != nil {
 		return false, err
 	}

--- a/internal/cli/review_stop_hook.go
+++ b/internal/cli/review_stop_hook.go
@@ -1,0 +1,242 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"github.com/gentleman-programming/gentle-ai/v2/internal/components/filemerge"
+	"github.com/gentleman-programming/gentle-ai/v2/internal/reviewtransaction"
+)
+
+// reviewStopHookSchema identifies the reminder envelope this hook prints to
+// stdout. Claude Code reads "decision" and "reason" as top-level keys.
+const reviewStopHookSchema = "gentle-ai.review-stop-hook/v1"
+
+// reviewStopHookReminderSchema identifies the small per-session dedupe record
+// kept under ~/.gentle-ai/review-stop-hook/v1.
+const reviewStopHookReminderSchema = "gentle-ai.review-stop-hook-reminder/v1"
+
+// maxReviewStopHookPayloadBytes bounds the Stop hook stdin payload, mirroring
+// the sdd-task-result precedent (internal/cli/sdd_task_result.go): a hook
+// reports a small event, never a large or unbounded stream.
+const maxReviewStopHookPayloadBytes = 1 << 20
+
+// reviewStopHookSessionIDPattern is the safe filename alphabet a session id
+// must match before it is used to name a state file.
+var reviewStopHookSessionIDPattern = regexp.MustCompile(`^[A-Za-z0-9._-]{1,128}$`)
+
+// reviewStopHookPayload is Claude Code's Stop hook stdin payload. Unknown
+// fields are ignored by json.Unmarshal, never rejected.
+type reviewStopHookPayload struct {
+	SessionID      string `json:"session_id"`
+	TranscriptPath string `json:"transcript_path"`
+	Cwd            string `json:"cwd"`
+	HookEventName  string `json:"hook_event_name"`
+	StopHookActive bool   `json:"stop_hook_active"`
+}
+
+// reviewStopHookOutput is the sole reminder envelope printed to stdout.
+type reviewStopHookOutput struct {
+	Schema   string `json:"schema"`
+	Decision string `json:"decision"`
+	Reason   string `json:"reason"`
+}
+
+// reviewStopHookReminderRecord is the per-session dedupe record: one file
+// keeps the last target_identity a session was reminded about, so a second
+// Stop for the same unreviewed candidate stays silent.
+type reviewStopHookReminderRecord struct {
+	Schema         string `json:"schema"`
+	TargetIdentity string `json:"target_identity"`
+}
+
+// RunReviewStopHook is the `gentle-ai review stop-hook` entry point. Claude
+// Code runs it as a Stop hook: it reads one Stop hook payload from stdin and,
+// only when receipt-driven development is enabled and the repository holds an
+// unreviewed candidate, prints one reminder that routes the agent through the
+// selectorless STATUS preflight before it reports completion. Every other
+// case is silent (exit 0, no output), and this command never starts a review
+// itself.
+func RunReviewStopHook(args []string, stdout io.Writer) error {
+	return runReviewStopHook(args, os.Stdin, stdout, os.Stderr)
+}
+
+// runReviewStopHook is RunReviewStopHook's testable form: stdin and stderr are
+// both explicit so a test can supply a payload and assert on diagnostics
+// without touching the process streams. stderr is also where flag usage/help
+// text is written (never stdout), so stdout stays reserved for the exact one
+// JSON reminder object this command may print.
+func runReviewStopHook(args []string, stdin io.Reader, stdout, stderr io.Writer) error {
+	flags := newReviewFlagSet("review stop-hook", stderr,
+		"Read one Claude Code Stop hook payload from stdin. When receipt-driven development is enabled and the repository holds an unreviewed candidate, print one reminder that routes the agent through the selectorless STATUS preflight before it reports completion. Every other case is silent, and this command never runs review start itself.")
+	agent := flags.String("agent", "", "required; generated active runtime identity (only claude-code is accepted today)")
+	cwdOverride := flags.String("cwd", "", "optional; overrides the Stop hook payload's cwd")
+	if err := parseReviewFlags(flags, args); err != nil {
+		return err
+	}
+	if reviewHelpRequested(args) {
+		return nil
+	}
+	if flags.NArg() != 0 {
+		// refusal:by-design operator-knowledge: only the caller knows which positional token it meant to pass; no runnable command can guess it.
+		return reviewPreflightError(fmt.Errorf("unexpected review stop-hook argument %q", flags.Arg(0)))
+	}
+	runtimeAgent := strings.TrimSpace(*agent)
+	if runtimeAgent != "claude-code" {
+		// refusal:by-design operator-knowledge: only the caller can declare which runtime is executing, and only claude-code is wired to this hook today.
+		return reviewPreflightError(fmt.Errorf("review stop-hook requires --agent to be claude-code; got %q", runtimeAgent))
+	}
+
+	raw, err := io.ReadAll(io.LimitReader(stdin, maxReviewStopHookPayloadBytes))
+	if err != nil {
+		return fmt.Errorf("review stop-hook: read Stop hook payload: %w", err)
+	}
+	var payload reviewStopHookPayload
+	if err := json.Unmarshal(raw, &payload); err != nil {
+		return fmt.Errorf("review stop-hook: decode Stop hook payload: %w", err)
+	}
+
+	if payload.StopHookActive {
+		return nil
+	}
+
+	repo := strings.TrimSpace(*cwdOverride)
+	if repo == "" {
+		repo = strings.TrimSpace(payload.Cwd)
+	}
+	if repo == "" {
+		return nil
+	}
+
+	ctx := context.Background()
+
+	// Confirm the cwd is inside a Git repository without ever bootstrapping
+	// one: ResolveRepositoryRoot alone (never PrepareReviewRepositoryRoot)
+	// never runs `git init`. This has to happen before resolving the review
+	// mode below: the clone-local override lookup shells out to git, and on a
+	// genuinely non-Git cwd it returns a hard error rather than "no override"
+	// -- so silently exiting here, before that call, is what keeps a
+	// non-repository cwd silent instead of surfacing as an internal error.
+	root, err := (reviewtransaction.SnapshotBuilder{Repo: repo}).ResolveRepositoryRoot(ctx)
+	if err != nil {
+		return nil
+	}
+
+	// Resolve the effective receipt-driven-development mode exactly like
+	// reviewtransaction.OfferReviewAfterVerify does: global mode plus this
+	// clone's off-only override, with zero side effects. Off means silent.
+	global, err := readGlobalRDDMode()
+	if err != nil {
+		return fmt.Errorf("review stop-hook: read global review mode: %w", err)
+	}
+	rddStatus, err := reviewtransaction.ResolveRDDMode(ctx, root, global)
+	if err != nil {
+		return fmt.Errorf("review stop-hook: resolve review mode: %w", err)
+	}
+	if !rddStatus.Enabled() {
+		return nil
+	}
+
+	// Calling runReviewStatus directly (rather than RunReview) avoids a
+	// package-level initialization cycle: RunReview's dispatch is reached
+	// through reviewFacadeCommandRunner, a package var whose initializer is
+	// runReviewCommandContext -- the same function that routes to this verb.
+	var statusOutput bytes.Buffer
+	statusErr := runReviewStatus(ctx, []string{
+		"--cwd", root, "--contract", ReviewIntegrationContractV2,
+		"--agent", runtimeAgent, "--next-transition",
+	}, &statusOutput)
+	if statusErr != nil {
+		return fmt.Errorf("review stop-hook: review status: %w", statusErr)
+	}
+	var status ReviewTargetStatusResult
+	if err := json.Unmarshal(statusOutput.Bytes(), &status); err != nil {
+		return fmt.Errorf("review stop-hook: decode review status: %w", err)
+	}
+	if status.NextTransition == nil || status.NextTransition.Kind != reviewNextTransitionExecute ||
+		status.NextTransition.Execute == nil || status.NextTransition.Execute.Operation != "review.start" {
+		return nil
+	}
+
+	alreadyReminded, persistErr := recordReviewStopHookReminder(payload.SessionID, status.TargetIdentity)
+	if persistErr != nil {
+		return fmt.Errorf("review stop-hook: record reminder: %w", persistErr)
+	}
+	if alreadyReminded {
+		return nil
+	}
+
+	output := reviewStopHookOutput{
+		Schema:   reviewStopHookSchema,
+		Decision: "block",
+		Reason:   reviewStopHookReasonText(status.TargetIdentity, root, runtimeAgent, status.NextTransition.Execute.Command),
+	}
+	encoded, err := json.Marshal(output)
+	if err != nil {
+		return fmt.Errorf("review stop-hook: encode reminder: %w", err)
+	}
+	_, err = fmt.Fprintln(stdout, string(encoded))
+	return err
+}
+
+// reviewStopHookReasonText composes the one-paragraph reminder Claude Code
+// reads back. It names the unreviewed candidate, the entry-rule obligation,
+// the canonical selectorless STATUS command, the exact START STATUS returned
+// (carrying --consent=relay), the lossless-relay instruction for any consent
+// envelope that START returns, and the once-per-candidate scope of this hook.
+func reviewStopHookReasonText(targetIdentity, root, runtimeAgent, startCommand string) string {
+	statusCommand := fmt.Sprintf("gentle-ai review status --cwd %s --contract %s --agent %s --next-transition", root, ReviewIntegrationContractV2, runtimeAgent)
+	return strings.Join([]string{
+		"Receipt-driven development is enabled for this repository, and it holds an unreviewed candidate (target_identity " + targetIdentity + ").",
+		"By the review contract entry rule, you must run the selectorless STATUS preflight below and route only from its returned next_transition before reporting completion; never infer a command from prose or a stale reply.",
+		"Run: " + statusCommand,
+		"STATUS returned this exact provider-issued START (carrying --consent=relay); run it unchanged: " + startCommand,
+		"If that START returns a consent envelope, relay it to the human losslessly and never answer it on the human's behalf.",
+		"This hook never runs review start itself, and it reminds once per session and candidate.",
+	}, "\n")
+}
+
+// recordReviewStopHookReminder persists that sessionID was reminded about
+// targetIdentity, and reports whether it already had been. An invalid or
+// missing session id still reminds (the caller proceeds) but is never
+// persisted, since there is no safe file name to record it under.
+func recordReviewStopHookReminder(sessionID, targetIdentity string) (alreadyReminded bool, err error) {
+	if !reviewStopHookSessionIDPattern.MatchString(sessionID) {
+		return false, nil
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return false, fmt.Errorf("resolve user home directory: %w", err)
+	}
+	dir := filepath.Join(home, ".gentle-ai", "review-stop-hook", "v1")
+	path := filepath.Join(dir, sessionID+".json")
+	existing, readErr := os.ReadFile(path)
+	if readErr == nil {
+		var record reviewStopHookReminderRecord
+		if json.Unmarshal(existing, &record) == nil && record.TargetIdentity == targetIdentity {
+			return true, nil
+		}
+	} else if !errors.Is(readErr, os.ErrNotExist) {
+		return false, readErr
+	}
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return false, err
+	}
+	payload, err := json.Marshal(reviewStopHookReminderRecord{
+		Schema:         reviewStopHookReminderSchema,
+		TargetIdentity: targetIdentity,
+	})
+	if err != nil {
+		return false, err
+	}
+	_, err = filemerge.WriteFileAtomic(path, payload, 0o644)
+	return false, err
+}

--- a/internal/cli/review_stop_hook_test.go
+++ b/internal/cli/review_stop_hook_test.go
@@ -1,0 +1,292 @@
+package cli
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// reviewStopHookTestPayload builds one Stop hook stdin payload. Extra fields
+// are accepted through overrides so a test can assert unknown keys are
+// ignored.
+func reviewStopHookTestPayload(t *testing.T, sessionID, cwd string, stopHookActive bool, extra map[string]any) string {
+	t.Helper()
+	fields := map[string]any{
+		"session_id":       sessionID,
+		"transcript_path":  "/tmp/does-not-matter.jsonl",
+		"cwd":              cwd,
+		"hook_event_name":  "Stop",
+		"stop_hook_active": stopHookActive,
+	}
+	for key, value := range extra {
+		fields[key] = value
+	}
+	payload, err := json.Marshal(fields)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(payload)
+}
+
+func stageReviewStopHookCandidate(t *testing.T, repo string) {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(repo, "tracked.txt"), []byte("changed\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func enableReviewStopHookRDD(t *testing.T, repo string) {
+	t.Helper()
+	if err := RunReviewMode([]string{"enable", "--cwd", repo, "--scope", "global"}, io.Discard); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func decodeReviewStopHookResult(t *testing.T, stdout []byte) reviewStopHookOutput {
+	t.Helper()
+	var result reviewStopHookOutput
+	if err := json.Unmarshal(stdout, &result); err != nil {
+		t.Fatalf("decode stop-hook output: %v\n%s", err, stdout)
+	}
+	return result
+}
+
+func reviewStopHookStateFile(home, sessionID string) string {
+	return filepath.Join(home, ".gentle-ai", "review-stop-hook", "v1", sessionID+".json")
+}
+
+func TestReviewStopHookBlocksWithReasonAndBothCommands(t *testing.T) {
+	home := reviewModeHome(t)
+	repo := initReviewCLIRepo(t)
+	stageReviewStopHookCandidate(t, repo)
+	enableReviewStopHookRDD(t, repo)
+
+	stdin := strings.NewReader(reviewStopHookTestPayload(t, "sess-block", repo, false, nil))
+	var stdout, stderr bytes.Buffer
+	if err := runReviewStopHook([]string{"--agent", "claude-code"}, stdin, &stdout, &stderr); err != nil {
+		t.Fatalf("runReviewStopHook: %v\nstderr: %s", err, stderr.String())
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("unexpected stderr: %s", stderr.String())
+	}
+	result := decodeReviewStopHookResult(t, stdout.Bytes())
+	if result.Schema != reviewStopHookSchema || result.Decision != "block" {
+		t.Fatalf("result = %#v", result)
+	}
+	wantStatusCommand := fmt.Sprintf("gentle-ai review status --cwd %s --contract %s --agent claude-code --next-transition", repo, ReviewIntegrationContractV2)
+	if !strings.Contains(result.Reason, wantStatusCommand) {
+		t.Fatalf("reason missing canonical STATUS command:\n%s", result.Reason)
+	}
+	if !strings.Contains(result.Reason, "gentle-ai review start") || !strings.Contains(result.Reason, "--consent=relay") {
+		t.Fatalf("reason missing the returned START command with --consent=relay:\n%s", result.Reason)
+	}
+	if !strings.Contains(result.Reason, "next_transition") {
+		t.Fatalf("reason does not name next_transition routing:\n%s", result.Reason)
+	}
+
+	stateFile := reviewStopHookStateFile(home, "sess-block")
+	if _, err := os.Stat(stateFile); err != nil {
+		t.Fatalf("expected reminder state file: %v", err)
+	}
+}
+
+func TestReviewStopHookSilentWhenStopHookActive(t *testing.T) {
+	reviewModeHome(t)
+	repo := initReviewCLIRepo(t)
+	stageReviewStopHookCandidate(t, repo)
+	enableReviewStopHookRDD(t, repo)
+
+	stdin := strings.NewReader(reviewStopHookTestPayload(t, "sess-active", repo, true, nil))
+	var stdout, stderr bytes.Buffer
+	if err := runReviewStopHook([]string{"--agent", "claude-code"}, stdin, &stdout, &stderr); err != nil {
+		t.Fatalf("runReviewStopHook: %v\nstderr: %s", err, stderr.String())
+	}
+	if stdout.Len() != 0 || stderr.Len() != 0 {
+		t.Fatalf("expected silence, got stdout=%q stderr=%q", stdout.String(), stderr.String())
+	}
+}
+
+func TestReviewStopHookSilentWhenRDDOff(t *testing.T) {
+	home := reviewModeHome(t)
+	repo := initReviewCLIRepo(t)
+	stageReviewStopHookCandidate(t, repo)
+	// Receipt-driven development is opt-in and off by default: no enable call.
+
+	stdin := strings.NewReader(reviewStopHookTestPayload(t, "sess-off", repo, false, nil))
+	var stdout, stderr bytes.Buffer
+	if err := runReviewStopHook([]string{"--agent", "claude-code"}, stdin, &stdout, &stderr); err != nil {
+		t.Fatalf("runReviewStopHook: %v\nstderr: %s", err, stderr.String())
+	}
+	if stdout.Len() != 0 || stderr.Len() != 0 {
+		t.Fatalf("expected silence, got stdout=%q stderr=%q", stdout.String(), stderr.String())
+	}
+	if _, err := os.Stat(reviewStopHookStateFile(home, "sess-off")); !os.IsNotExist(err) {
+		t.Fatalf("expected no reminder state file while RDD is off, stat err=%v", err)
+	}
+}
+
+func TestReviewStopHookSilentForNonRepositoryCwd(t *testing.T) {
+	reviewModeHome(t)
+	nonRepo := t.TempDir()
+
+	stdin := strings.NewReader(reviewStopHookTestPayload(t, "sess-non-repo", nonRepo, false, nil))
+	var stdout, stderr bytes.Buffer
+	if err := runReviewStopHook([]string{"--agent", "claude-code"}, stdin, &stdout, &stderr); err != nil {
+		t.Fatalf("runReviewStopHook: %v\nstderr: %s", err, stderr.String())
+	}
+	if stdout.Len() != 0 || stderr.Len() != 0 {
+		t.Fatalf("expected silence, got stdout=%q stderr=%q", stdout.String(), stderr.String())
+	}
+	if _, err := os.Lstat(filepath.Join(nonRepo, ".git")); !os.IsNotExist(err) {
+		t.Fatalf("expected no git metadata to be bootstrapped, stat err=%v", err)
+	}
+}
+
+func TestReviewStopHookSilentForCleanWorktree(t *testing.T) {
+	reviewModeHome(t)
+	repo := initReviewCLIRepo(t)
+	enableReviewStopHookRDD(t, repo)
+	// No candidate staged: the worktree is clean.
+
+	stdin := strings.NewReader(reviewStopHookTestPayload(t, "sess-clean", repo, false, nil))
+	var stdout, stderr bytes.Buffer
+	if err := runReviewStopHook([]string{"--agent", "claude-code"}, stdin, &stdout, &stderr); err != nil {
+		t.Fatalf("runReviewStopHook: %v\nstderr: %s", err, stderr.String())
+	}
+	if stdout.Len() != 0 || stderr.Len() != 0 {
+		t.Fatalf("expected silence, got stdout=%q stderr=%q", stdout.String(), stderr.String())
+	}
+}
+
+func TestReviewStopHookSecondRunSameSessionIsSilent(t *testing.T) {
+	reviewModeHome(t)
+	repo := initReviewCLIRepo(t)
+	stageReviewStopHookCandidate(t, repo)
+	enableReviewStopHookRDD(t, repo)
+
+	payload := reviewStopHookTestPayload(t, "sess-repeat", repo, false, nil)
+	var first bytes.Buffer
+	if err := runReviewStopHook([]string{"--agent", "claude-code"}, strings.NewReader(payload), &first, io.Discard); err != nil {
+		t.Fatalf("first run: %v", err)
+	}
+	if decodeReviewStopHookResult(t, first.Bytes()).Decision != "block" {
+		t.Fatalf("first run did not block: %s", first.String())
+	}
+
+	var second, stderr bytes.Buffer
+	if err := runReviewStopHook([]string{"--agent", "claude-code"}, strings.NewReader(payload), &second, &stderr); err != nil {
+		t.Fatalf("second run: %v\nstderr: %s", err, stderr.String())
+	}
+	if second.Len() != 0 || stderr.Len() != 0 {
+		t.Fatalf("expected the second run for the same session and candidate to be silent, got stdout=%q stderr=%q", second.String(), stderr.String())
+	}
+}
+
+func TestReviewStopHookDifferentSessionRemindsAgain(t *testing.T) {
+	reviewModeHome(t)
+	repo := initReviewCLIRepo(t)
+	stageReviewStopHookCandidate(t, repo)
+	enableReviewStopHookRDD(t, repo)
+
+	var first bytes.Buffer
+	if err := runReviewStopHook([]string{"--agent", "claude-code"}, strings.NewReader(reviewStopHookTestPayload(t, "sess-a", repo, false, nil)), &first, io.Discard); err != nil {
+		t.Fatalf("first session run: %v", err)
+	}
+	if decodeReviewStopHookResult(t, first.Bytes()).Decision != "block" {
+		t.Fatalf("first session did not block: %s", first.String())
+	}
+
+	var second bytes.Buffer
+	if err := runReviewStopHook([]string{"--agent", "claude-code"}, strings.NewReader(reviewStopHookTestPayload(t, "sess-b", repo, false, nil)), &second, io.Discard); err != nil {
+		t.Fatalf("second session run: %v", err)
+	}
+	if decodeReviewStopHookResult(t, second.Bytes()).Decision != "block" {
+		t.Fatalf("a different session was not reminded: %s", second.String())
+	}
+}
+
+func TestReviewStopHookInvalidSessionIDRemindsWithoutPersisting(t *testing.T) {
+	home := reviewModeHome(t)
+	repo := initReviewCLIRepo(t)
+	stageReviewStopHookCandidate(t, repo)
+	enableReviewStopHookRDD(t, repo)
+
+	stdin := strings.NewReader(reviewStopHookTestPayload(t, "not/a valid id!", repo, false, nil))
+	var stdout, stderr bytes.Buffer
+	if err := runReviewStopHook([]string{"--agent", "claude-code"}, stdin, &stdout, &stderr); err != nil {
+		t.Fatalf("runReviewStopHook: %v\nstderr: %s", err, stderr.String())
+	}
+	if decodeReviewStopHookResult(t, stdout.Bytes()).Decision != "block" {
+		t.Fatalf("invalid session id should still remind: %s", stdout.String())
+	}
+	dir := filepath.Join(home, ".gentle-ai", "review-stop-hook", "v1")
+	entries, err := os.ReadDir(dir)
+	if err != nil && !os.IsNotExist(err) {
+		t.Fatal(err)
+	}
+	if len(entries) != 0 {
+		t.Fatalf("expected no persisted reminder for an invalid session id, found %v", entries)
+	}
+
+	// A missing session id behaves the same way: still remind, never persist.
+	stdin = strings.NewReader(reviewStopHookTestPayload(t, "", repo, false, nil))
+	var stdout2 bytes.Buffer
+	if err := runReviewStopHook([]string{"--agent", "claude-code"}, stdin, &stdout2, io.Discard); err != nil {
+		t.Fatalf("runReviewStopHook (missing session id): %v", err)
+	}
+	if decodeReviewStopHookResult(t, stdout2.Bytes()).Decision != "block" {
+		t.Fatalf("missing session id should still remind: %s", stdout2.String())
+	}
+}
+
+func TestReviewStopHookIgnoresUnknownJSONFields(t *testing.T) {
+	reviewModeHome(t)
+	repo := initReviewCLIRepo(t)
+	stageReviewStopHookCandidate(t, repo)
+	enableReviewStopHookRDD(t, repo)
+
+	stdin := strings.NewReader(reviewStopHookTestPayload(t, "sess-unknown-fields", repo, false, map[string]any{
+		"permission_mode": "default",
+		"some_future_key": []int{1, 2, 3},
+	}))
+	var stdout, stderr bytes.Buffer
+	if err := runReviewStopHook([]string{"--agent", "claude-code"}, stdin, &stdout, &stderr); err != nil {
+		t.Fatalf("runReviewStopHook: %v\nstderr: %s", err, stderr.String())
+	}
+	if decodeReviewStopHookResult(t, stdout.Bytes()).Decision != "block" {
+		t.Fatalf("unknown fields should not change the decision: %s", stdout.String())
+	}
+}
+
+func TestReviewStopHookRequiresSupportedAgent(t *testing.T) {
+	reviewModeHome(t)
+	repo := initReviewCLIRepo(t)
+	stageReviewStopHookCandidate(t, repo)
+	enableReviewStopHookRDD(t, repo)
+
+	tests := []struct {
+		name string
+		args []string
+	}{
+		{name: "missing --agent", args: nil},
+		{name: "unsupported --agent pi", args: []string{"--agent", "pi"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			stdin := strings.NewReader(reviewStopHookTestPayload(t, "sess-agent", repo, false, nil))
+			var stdout, stderr bytes.Buffer
+			err := runReviewStopHook(tt.args, stdin, &stdout, &stderr)
+			if err == nil {
+				t.Fatalf("expected a preflight error, stdout=%q", stdout.String())
+			}
+			if stdout.Len() != 0 {
+				t.Fatalf("expected no stdout on a preflight error, got %q", stdout.String())
+			}
+		})
+	}
+}

--- a/internal/cli/review_stop_hook_test.go
+++ b/internal/cli/review_stop_hook_test.go
@@ -85,6 +85,30 @@ func reviewStopHookStateFile(home, sessionID string) string {
 	return filepath.Join(home, ".gentle-ai", "review-stop-hook", "v1", sessionID+".json")
 }
 
+func TestReviewStopHookFailedWriteDoesNotPersistReminder(t *testing.T) {
+	home := reviewModeHome(t)
+	repo := initReviewCLIRepo(t)
+	stageReviewStopHookCandidate(t, repo)
+	enableReviewStopHookRDD(t, repo)
+
+	payload := reviewStopHookTestPayload(t, "sess-write-fail", repo, false, nil)
+	failWriter := reviewEmitFailureWriter{err: fmt.Errorf("stop-hook stdout write failed")}
+	if err := runReviewStopHook([]string{"--agent", "claude-code"}, strings.NewReader(payload), failWriter, io.Discard); err == nil {
+		t.Fatal("expected an error when the stdout write fails")
+	}
+	if _, statErr := os.Stat(reviewStopHookStateFile(home, "sess-write-fail")); !os.IsNotExist(statErr) {
+		t.Fatalf("expected no reminder recorded after a failed write, stat err=%v", statErr)
+	}
+
+	var second bytes.Buffer
+	if err := runReviewStopHook([]string{"--agent", "claude-code"}, strings.NewReader(payload), &second, io.Discard); err != nil {
+		t.Fatalf("second run: %v", err)
+	}
+	if decodeReviewStopHookResult(t, second.Bytes()).Decision != "block" {
+		t.Fatalf("expected the second run with a working writer to still remind: %s", second.String())
+	}
+}
+
 func TestReviewStopHookBlocksWithReasonAndBothCommands(t *testing.T) {
 	home := reviewModeHome(t)
 	repo := initReviewCLIRepo(t)

--- a/internal/cli/review_stop_hook_test.go
+++ b/internal/cli/review_stop_hook_test.go
@@ -33,6 +33,31 @@ func reviewStopHookTestPayload(t *testing.T, sessionID, cwd string, stopHookActi
 	return string(payload)
 }
 
+// reviewStopHookTestSessionStartPayload builds one SessionStart hook stdin
+// payload.
+func reviewStopHookTestSessionStartPayload(t *testing.T, sessionID, cwd, source string) string {
+	t.Helper()
+	payload, err := json.Marshal(map[string]any{
+		"session_id":      sessionID,
+		"cwd":             cwd,
+		"hook_event_name": "SessionStart",
+		"source":          source,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(payload)
+}
+
+func runReviewStopHookSessionStartTest(t *testing.T, sessionID, repo string) (stdout, stderr bytes.Buffer) {
+	t.Helper()
+	stdin := strings.NewReader(reviewStopHookTestSessionStartPayload(t, sessionID, repo, "startup"))
+	if err := runReviewStopHook([]string{"--agent", "claude-code"}, stdin, &stdout, &stderr); err != nil {
+		t.Fatalf("SessionStart run: %v\nstderr: %s", err, stderr.String())
+	}
+	return stdout, stderr
+}
+
 func stageReviewStopHookCandidate(t *testing.T, repo string) {
 	t.Helper()
 	if err := os.WriteFile(filepath.Join(repo, "tracked.txt"), []byte("changed\n"), 0o644); err != nil {
@@ -288,5 +313,145 @@ func TestReviewStopHookRequiresSupportedAgent(t *testing.T) {
 				t.Fatalf("expected no stdout on a preflight error, got %q", stdout.String())
 			}
 		})
+	}
+}
+
+func TestReviewStopHookSessionStartWritesBaselineSilently(t *testing.T) {
+	home := reviewModeHome(t)
+	repo := initReviewCLIRepo(t)
+	stageReviewStopHookCandidate(t, repo)
+	enableReviewStopHookRDD(t, repo)
+
+	stdout, stderr := runReviewStopHookSessionStartTest(t, "sess-baseline", repo)
+	if stdout.Len() != 0 || stderr.Len() != 0 {
+		t.Fatalf("SessionStart must print nothing, got stdout=%q stderr=%q", stdout.String(), stderr.String())
+	}
+
+	raw, err := os.ReadFile(reviewStopHookStateFile(home, "sess-baseline"))
+	if err != nil {
+		t.Fatalf("expected a baseline state file: %v", err)
+	}
+	var record reviewStopHookReminderRecord
+	if err := json.Unmarshal(raw, &record); err != nil {
+		t.Fatalf("decode baseline record: %v\n%s", err, raw)
+	}
+	if record.Schema != reviewStopHookReminderSchema || record.BaselineTargetIdentity == "" {
+		t.Fatalf("record = %#v", record)
+	}
+}
+
+func TestReviewStopHookStopSilentWhenCandidateMatchesSessionBaseline(t *testing.T) {
+	reviewModeHome(t)
+	repo := initReviewCLIRepo(t)
+	stageReviewStopHookCandidate(t, repo)
+	enableReviewStopHookRDD(t, repo)
+
+	// The candidate already existed when the session started: SessionStart
+	// baselines it, so a Stop for that same candidate must stay silent.
+	stdout, stderr := runReviewStopHookSessionStartTest(t, "sess-preexisting", repo)
+	if stdout.Len() != 0 || stderr.Len() != 0 {
+		t.Fatalf("SessionStart must print nothing, got stdout=%q stderr=%q", stdout.String(), stderr.String())
+	}
+
+	stdin := strings.NewReader(reviewStopHookTestPayload(t, "sess-preexisting", repo, false, nil))
+	var stopStdout, stopStderr bytes.Buffer
+	if err := runReviewStopHook([]string{"--agent", "claude-code"}, stdin, &stopStdout, &stopStderr); err != nil {
+		t.Fatalf("Stop run: %v\nstderr: %s", err, stopStderr.String())
+	}
+	if stopStdout.Len() != 0 || stopStderr.Len() != 0 {
+		t.Fatalf("a candidate matching the session baseline must stay silent, got stdout=%q stderr=%q", stopStdout.String(), stopStderr.String())
+	}
+}
+
+func TestReviewStopHookStopRemindsAfterCandidateChangesFromBaseline(t *testing.T) {
+	reviewModeHome(t)
+	repo := initReviewCLIRepo(t)
+	stageReviewStopHookCandidate(t, repo)
+	enableReviewStopHookRDD(t, repo)
+
+	stdout, stderr := runReviewStopHookSessionStartTest(t, "sess-changed", repo)
+	if stdout.Len() != 0 || stderr.Len() != 0 {
+		t.Fatalf("SessionStart must print nothing, got stdout=%q stderr=%q", stdout.String(), stderr.String())
+	}
+
+	// The session itself changes the candidate after baselining it: the new
+	// candidate identity differs from the recorded baseline, so Stop reminds.
+	// The addition is staged, exactly like stageReviewStopHookCandidate's own
+	// edit, so it is part of the workspace projection STATUS resolves.
+	if err := os.WriteFile(filepath.Join(repo, "session-authored.txt"), []byte("new content\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	runReviewCLIGit(t, repo, "add", "-A")
+
+	stdin := strings.NewReader(reviewStopHookTestPayload(t, "sess-changed", repo, false, nil))
+	var stopStdout, stopStderr bytes.Buffer
+	if err := runReviewStopHook([]string{"--agent", "claude-code"}, stdin, &stopStdout, &stopStderr); err != nil {
+		t.Fatalf("Stop run: %v\nstderr: %s", err, stopStderr.String())
+	}
+	if decodeReviewStopHookResult(t, stopStdout.Bytes()).Decision != "block" {
+		t.Fatalf("a candidate that changed since the session baseline must remind: stdout=%q stderr=%q", stopStdout.String(), stopStderr.String())
+	}
+}
+
+func TestReviewStopHookSessionStartOnCleanWorktreeThenDirtyStopReminds(t *testing.T) {
+	reviewModeHome(t)
+	repo := initReviewCLIRepo(t)
+	enableReviewStopHookRDD(t, repo)
+	// No candidate staged yet: the worktree is clean at session start.
+
+	stdout, stderr := runReviewStopHookSessionStartTest(t, "sess-clean-start", repo)
+	if stdout.Len() != 0 || stderr.Len() != 0 {
+		t.Fatalf("SessionStart must print nothing, got stdout=%q stderr=%q", stdout.String(), stderr.String())
+	}
+
+	// The session then produces a candidate: its identity differs from the
+	// clean baseline, so Stop reminds.
+	stageReviewStopHookCandidate(t, repo)
+
+	stdin := strings.NewReader(reviewStopHookTestPayload(t, "sess-clean-start", repo, false, nil))
+	var stopStdout, stopStderr bytes.Buffer
+	if err := runReviewStopHook([]string{"--agent", "claude-code"}, stdin, &stopStdout, &stopStderr); err != nil {
+		t.Fatalf("Stop run: %v\nstderr: %s", err, stopStderr.String())
+	}
+	if decodeReviewStopHookResult(t, stopStdout.Bytes()).Decision != "block" {
+		t.Fatalf("a candidate produced after a clean-worktree baseline must remind: stdout=%q stderr=%q", stopStdout.String(), stopStderr.String())
+	}
+}
+
+func TestReviewStopHookSessionStartSilentWhenRDDOff(t *testing.T) {
+	home := reviewModeHome(t)
+	repo := initReviewCLIRepo(t)
+	stageReviewStopHookCandidate(t, repo)
+	// Receipt-driven development is opt-in and off by default: no enable call.
+
+	stdout, stderr := runReviewStopHookSessionStartTest(t, "sess-rdd-off", repo)
+	if stdout.Len() != 0 || stderr.Len() != 0 {
+		t.Fatalf("SessionStart must print nothing, got stdout=%q stderr=%q", stdout.String(), stderr.String())
+	}
+	if _, err := os.Stat(reviewStopHookStateFile(home, "sess-rdd-off")); !os.IsNotExist(err) {
+		t.Fatalf("expected no baseline state file while RDD is off, stat err=%v", err)
+	}
+}
+
+func TestReviewStopHookUnknownHookEventNameIsSilent(t *testing.T) {
+	reviewModeHome(t)
+	repo := initReviewCLIRepo(t)
+	stageReviewStopHookCandidate(t, repo)
+	enableReviewStopHookRDD(t, repo)
+
+	payload, err := json.Marshal(map[string]any{
+		"session_id":      "sess-unknown-event",
+		"cwd":             repo,
+		"hook_event_name": "PreToolUse",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var stdout, stderr bytes.Buffer
+	if err := runReviewStopHook([]string{"--agent", "claude-code"}, strings.NewReader(string(payload)), &stdout, &stderr); err != nil {
+		t.Fatalf("runReviewStopHook: %v\nstderr: %s", err, stderr.String())
+	}
+	if stdout.Len() != 0 || stderr.Len() != 0 {
+		t.Fatalf("an unrecognized hook_event_name must be silent, got stdout=%q stderr=%q", stdout.String(), stderr.String())
 	}
 }


### PR DESCRIPTION
Closes #4064 (subcommand; the sibling #4067 installs it as managed `Stop` and `SessionStart` hooks and must merge after this one).

## Cause

With receipt-driven development enabled, whether Claude Code runs the review preflight at the end of a turn depended only on the model honoring the contract's entry rule (#4051). Pi got a deterministic runtime pull (gentle-pi#556). Claude Code has the equivalent primitive, hooks, but no gentle-ai command existed for a hook to call.

## Fix

`gentle-ai review stop-hook --agent claude-code [--cwd <path>]` reads Claude Code's hook payload from stdin and dispatches on `hook_event_name`:

- `SessionStart`: when the switch is on and `cwd` is inside a repository, records the session's starting candidate identity (`baseline_target_identity`) in `~/.gentle-ai/review-stop-hook/v1/<session_id>.json`. Always silent.
- `Stop`: silent when `stop_hook_active` is true, the switch is off, `cwd` is not a repository (no `git init` side effect), the worktree is clean or the candidate already bound, the candidate equals the session baseline (it predates this session), or the same candidate was already reminded in this session. Otherwise it prints one `{"schema":"gentle-ai.review-stop-hook/v1","decision":"block","reason":"..."}` whose reason names the unreviewed target identity, the entry rule, the canonical selectorless STATUS command for the repository root, the exact provider-issued START that STATUS returned (with `--consent=relay`), and the instruction to relay the consent envelope to the human. The reminder is recorded only after the envelope is delivered (native review finding `R4-reminder-persisted-before-emitted`).
- It never runs START, never answers consent, and never mutates review authority; STATUS is computed in process through the same read-only path as `review status`. Unexpected internal errors go to stderr with a non-zero exit so Claude shows a non-blocking notice; no `block` is ever emitted on an error path.
- The agent identity is threaded from the validated `--agent` flag, never a literal, to satisfy the runtime-identity guard (#2440); the two new input refusals carry the by-design annotation the refusal ratchet requires.

Bench: `Step.Stdin` (runner pipes it to the command when set) and journey `j125-claude-code-stop-hook-reminds-once-per-candidate` (SessionStart on a clean repo, staged change, Stop reminds, Stop repeat silent, `stop_hook_active` silent). Driven run: `journeys: 1 completed, 0 unsupported, 0 failed`.

## Size exception

Additions plus deletions exceed 400 (product 366, tests 457, bench 115). The verb is one cohesive unit: splitting the Stop and SessionStart paths would ship a reminder without its baseline (the noise the maintainer asked to avoid), and the test file is the strict-TDD coverage of every silence rule plus the dedupe and delivery-order guarantees, each of which is a user-visible contract. The bench extension is 20 lines of runner plumbing plus one journey.

## Verification

- Full `go test ./... -count=1` green in the foreground; `go vet ./...` and `GOOS=windows go vet ./...` clean; `gofmt -l` empty; dead-code ratchet clean; `bench` declarations green; driven journey completed.
- Native review: lineage `review-a6d28d5d93f63adf`, tier high, four lenses, one CRITICAL finding (record-before-deliver) corrected in 11b3470c within budget, targeted validation passed, approved and acknowledged (`gentle-ai.review-acknowledged/v1`, authority burned). Consent was answered `granted` under the maintainer's standing authorization.

https://claude.ai/code/session_01WYGtotXyhPmbnEeAZAbSbj


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added the `review stop-hook` command for Claude Code SessionStart and Stop hooks.
  - Records a session baseline and provides a one-time reminder when a new review candidate requires attention.
  - Guides agents through STATUS preflight before starting a review.
  - Suppresses reminders when receipt-driven development is disabled, the session is already up to date, or a reminder has already been issued.
  - Handles inactive hooks and non-repository directories silently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->