### PR TITLE
fix(review): retry a malformed targeted validator result once with admission feedback and preserve the refused payloads

### DIFF
--- a/internal/cli/review_capture_validation_retry_test.go
+++ b/internal/cli/review_capture_validation_retry_test.go
@@ -1,0 +1,234 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/gentleman-programming/gentle-ai/v2/internal/model"
+	"github.com/gentleman-programming/gentle-ai/v2/internal/reviewerprovider"
+	"github.com/gentleman-programming/gentle-ai/v2/internal/reviewtransaction"
+)
+
+// Issue #4061: the compiled in-process targeted validator (--agent=claude-code
+// --execute=true) could return a syntactically invalid JSON document (a live
+// claude adapter run hit this: 5 objects opened and closed, 5 arrays opened
+// but only 3 closed, the scan ending mid-payload) and the only exit was
+// relaunching the identical slot and hoping for a different result. The lens
+// role already solves exactly this with one corrective re-invocation carrying
+// the admission error; these tests prove the targeted validator and refuter
+// roles now share that same mechanism, and that a refusal surviving both
+// attempts is classified as a provider-side defect rather than an operator
+// request error.
+
+// truncatedTargetedValidatorPayload cuts a syntactically valid targeted
+// validator result inside an open array, leaving both the outer object and
+// the evidence array unterminated.
+func truncatedTargetedValidatorPayload(request reviewtransaction.TargetedValidationRequest) []byte {
+	return []byte(`{"targeted_validation_request_hash":"` + request.RequestHash +
+		`","correction_target_identity":"` + request.CorrectionTargetIdentity +
+		`","original_criteria":{"passed":true,"evidence":["cut mid array"`)
+}
+
+func TestValidationCaptureRetriesOnceWithAdmissionFeedbackAndPreservesOneRejectedPayload(t *testing.T) {
+	reviewEnabledHome(t)
+	repo, lineage, request := providerCorrectionReadyWithoutVerificationEvidence(t)
+	store, err := reviewtransaction.CompactAuthoritativeStore(context.Background(), repo, lineage)
+	if err != nil {
+		t.Fatal(err)
+	}
+	record, err := store.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	truncated := truncatedTargetedValidatorPayload(request)
+	valid := providerTargetedValidationPayload(t, request)
+	prompts := recordingProviderAdapter(t,
+		func() ([]byte, error) { return truncated, nil },
+		func() ([]byte, error) { return valid, nil },
+	)
+
+	var output bytes.Buffer
+	if err := RunReview([]string{
+		"capture-validation",
+		"--cwd", repo, "--lineage", lineage, "--target", request.CorrectionTargetIdentity,
+		"--expected-revision", record.State.CapturePhaseRevision, "--request-hash", request.RequestHash,
+		"--agent", string(model.AgentClaudeCode), "--execute=true",
+	}, &output); err != nil {
+		t.Fatalf("capture-validation with one corrective attempt: %v\n%s", err, output.String())
+	}
+	if len(*prompts) != 2 {
+		t.Fatalf("provider validator invocations = %d, want exactly 2", len(*prompts))
+	}
+	first, second := (*prompts)[0], (*prompts)[1]
+	if !bytes.HasPrefix(second, first) {
+		t.Fatal("corrective prompt does not start with the original materialized prompt")
+	}
+	for _, want := range []string{reviewProviderCorrectiveFeedbackHeader, "no complete JSON object", "scan ended at byte"} {
+		if !bytes.Contains(second, []byte(want)) {
+			t.Fatalf("corrective prompt lacks %q naming the census error:\n%s", want, second[len(first):])
+		}
+	}
+
+	preserved := readRejectedResults(t, rejectedResultsDir(t, repo, lineage))
+	if len(preserved) != 1 {
+		t.Fatalf("preserved rejected results = %d, want 1", len(preserved))
+	}
+	for _, envelope := range preserved {
+		assertRejectedEnvelope(t, envelope, lineage, string(reviewerprovider.RoleTargetedValidator), 1, truncated)
+	}
+
+	var terminal reviewLastEventClosureResult
+	decodeStrictReviewJSON(t, output.Bytes(), &terminal)
+	if terminal.Operation != "review/capture-validation" || terminal.State != reviewtransaction.StateApproved {
+		t.Fatalf("terminal closure = %#v, want an approved review/capture-validation closure", terminal)
+	}
+}
+
+func TestValidationCaptureRefusedAfterTwoMalformedResultsIsClassifiedAsProviderSide(t *testing.T) {
+	reviewEnabledHome(t)
+	repo, lineage, request := providerCorrectionReadyWithoutVerificationEvidence(t)
+	store, err := reviewtransaction.CompactAuthoritativeStore(context.Background(), repo, lineage)
+	if err != nil {
+		t.Fatal(err)
+	}
+	before, err := store.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	truncated := truncatedTargetedValidatorPayload(request)
+	prompts := recordingProviderAdapter(t,
+		func() ([]byte, error) { return truncated, nil },
+		func() ([]byte, error) { return truncated, nil },
+	)
+
+	var output bytes.Buffer
+	err = RunReview([]string{
+		"capture-validation",
+		"--cwd", repo, "--lineage", lineage, "--target", request.CorrectionTargetIdentity,
+		"--expected-revision", before.State.CapturePhaseRevision, "--request-hash", request.RequestHash,
+		"--agent", string(model.AgentClaudeCode), "--execute=true",
+	}, &output)
+	failure := decodeCaptureRefusalEnvelope(t, err, output.Bytes())
+	if failure.Code != reviewPreflightProviderCaptureRefusedReason.Code || failure.NextAction != "review.status" ||
+		failure.MutationOutcome != ReviewMutationNotStarted {
+		t.Fatalf("refusal envelope = %#v, want code %q, next_action review.status, mutation_outcome not_started",
+			failure, reviewPreflightProviderCaptureRefusedReason.Code)
+	}
+	if failure.Code == reviewIntegrationInvalidRequestCode {
+		t.Fatal("a provider-side malformed result was classified as an operator-correctable request")
+	}
+	if len(*prompts) != 2 {
+		t.Fatalf("provider validator invocations = %d, want exactly 2", len(*prompts))
+	}
+
+	preserved := readRejectedResults(t, rejectedResultsDir(t, repo, lineage))
+	if len(preserved) != 2 {
+		t.Fatalf("preserved rejected results = %d, want 2", len(preserved))
+	}
+	for _, envelope := range preserved {
+		if envelope.Attempt != 1 && envelope.Attempt != 2 {
+			t.Fatalf("unexpected preserved attempt %#v", envelope)
+		}
+	}
+
+	after, err := store.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if after.Revision != before.Revision {
+		t.Fatalf("authority mutated on a fully refused capture: before=%s after=%s", before.Revision, after.Revision)
+	}
+
+	var status ReviewTargetStatusResult
+	var statusOutput bytes.Buffer
+	if err := RunReview([]string{
+		"status", "--cwd", repo, "--lineage", lineage, "--contract", ReviewIntegrationContractV2,
+		"--agent", string(model.AgentClaudeCode), "--next-transition",
+	}, &statusOutput); err != nil {
+		t.Fatalf("status after refused capture: %v\n%s", err, statusOutput.String())
+	}
+	decodeStrictReviewJSON(t, statusOutput.Bytes(), &status)
+	if status.NextTransition == nil || status.NextTransition.ReasonCode != "targeted_validation_required" {
+		t.Fatalf("status after refused capture = %#v, want the same validation slot reoffered", status.NextTransition)
+	}
+}
+
+func TestValidationCaptureTransportErrorIsNotRetried(t *testing.T) {
+	reviewEnabledHome(t)
+	repo, lineage, request := providerCorrectionReadyWithoutVerificationEvidence(t)
+	store, err := reviewtransaction.CompactAuthoritativeStore(context.Background(), repo, lineage)
+	if err != nil {
+		t.Fatal(err)
+	}
+	record, err := store.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	prompts := recordingProviderAdapter(t,
+		func() ([]byte, error) { return nil, errors.New("exit status 137") },
+	)
+
+	var output bytes.Buffer
+	err = RunReview([]string{
+		"capture-validation",
+		"--cwd", repo, "--lineage", lineage, "--target", request.CorrectionTargetIdentity,
+		"--expected-revision", record.State.CapturePhaseRevision, "--request-hash", request.RequestHash,
+		"--agent", string(model.AgentClaudeCode), "--execute=true",
+	}, &output)
+	failure := decodeCaptureRefusalEnvelope(t, err, output.Bytes())
+	if failure.Code == reviewPreflightProviderCaptureRefusedReason.Code {
+		t.Fatalf("a transport failure was classified as a provider result refusal: %#v", failure)
+	}
+	if len(*prompts) != 1 {
+		t.Fatalf("provider validator invocations = %d, want exactly 1 (a transport failure is not retried)", len(*prompts))
+	}
+	if !strings.Contains(err.Error(), "exit status 137") {
+		t.Fatalf("refusal does not name the transport failure: %v", err)
+	}
+}
+
+// The refuter batch capture is a mechanical reuse of the same corrective-retry
+// core: no role-specific sentinel exists for it, so a malformed refuter
+// document gets exactly the same single corrective re-invocation.
+func TestRefuterCaptureRetriesOnceWithAdmissionFeedback(t *testing.T) {
+	reviewEnabledHome(t)
+	repo, store, record, handle := piRefuterReview(t)
+	binding := piRefuterBinding(repo, record, handle)
+	refuterRequest, err := reviewProviderNewRefuterRequest(t.Context(), repo, store.Dir, record.State, record.State.CapturePhaseRevision)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	valid := []byte(`{"refuter_request_hash":"` + refuterRequest.RequestHash + `","results":[{"finding_id":"R3-001","outcome":"corroborated","proof_refs":["independent reproduction"]}]}`)
+	truncated := []byte(`{"refuter_request_hash":"` + refuterRequest.RequestHash + `","results":[{"finding_id":"R3-001","outcome":"corroborated","proof_refs":["cut mid array"`)
+	prompts := recordingProviderAdapter(t,
+		func() ([]byte, error) { return truncated, nil },
+		func() ([]byte, error) { return valid, nil },
+	)
+
+	var output bytes.Buffer
+	if err := RunReview(append(append([]string{"capture-refuter"}, binding...), "--agent", string(model.AgentClaudeCode), "--execute=true"), &output); err != nil {
+		t.Fatalf("capture-refuter with one corrective attempt: %v\n%s", err, output.String())
+	}
+	if len(*prompts) != 2 {
+		t.Fatalf("provider refuter invocations = %d, want exactly 2", len(*prompts))
+	}
+	first, second := (*prompts)[0], (*prompts)[1]
+	if !bytes.HasPrefix(second, first) || !bytes.Contains(second, []byte(reviewProviderCorrectiveFeedbackHeader)) {
+		t.Fatal("corrective refuter prompt does not carry the admission feedback over the original prompt")
+	}
+
+	preserved := readRejectedResults(t, rejectedResultsDir(t, repo, record.State.LineageID))
+	if len(preserved) != 1 {
+		t.Fatalf("preserved rejected results = %d, want 1", len(preserved))
+	}
+	for _, envelope := range preserved {
+		assertRejectedEnvelope(t, envelope, record.State.LineageID, string(reviewerprovider.RoleRefuter), 1, truncated)
+	}
+}

--- a/internal/cli/review_capture_validation_retry_test.go
+++ b/internal/cli/review_capture_validation_retry_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -230,5 +231,23 @@ func TestRefuterCaptureRetriesOnceWithAdmissionFeedback(t *testing.T) {
 	}
 	for _, envelope := range preserved {
 		assertRejectedEnvelope(t, envelope, record.State.LineageID, string(reviewerprovider.RoleRefuter), 1, truncated)
+	}
+}
+
+// R3-refuter-capture-guard-identity: a drifted request TargetIdentity must be
+// refused before any authority write, ahead of payload canonicalization.
+func TestRefuterCaptureRefusesRequestTargetIdentityDriftFromState(t *testing.T) {
+	reviewEnabledHome(t)
+	repo, store, record, _ := piRefuterReview(t)
+	request, err := reviewProviderNewRefuterRequest(t.Context(), repo, store.Dir, record.State, record.State.CapturePhaseRevision)
+	if err != nil {
+		t.Fatal(err)
+	}
+	request.TargetIdentity = "sha256:" + strings.Repeat("a", 64)
+	if _, err := reviewProviderCaptureAdmittedRefuterResult(t.Context(), repo, store, record.State, record.State.CapturePhaseRevision, request, facadeRefuterResult{}, nil); err == nil {
+		t.Fatal("expected refusal on a drifted request target identity")
+	}
+	if after, loadErr := store.Load(); loadErr != nil || !reflect.DeepEqual(after.State, record.State) {
+		t.Fatalf("refused capture mutated reviewing authority: after=%#v err=%v", after.State, loadErr)
 	}
 }

--- a/internal/cli/review_operation_contract.go
+++ b/internal/cli/review_operation_contract.go
@@ -343,6 +343,19 @@ var reviewPreflightSlotOccupiedReason = reviewPreflightReason{
 	NextAction: "review.status",
 }
 
+// reviewPreflightProviderCaptureRefusedReason classifies a non-lens provider
+// role capture (targeted validator or refuter) refused on both admission
+// attempts, including the single corrective re-invocation: the provider, not
+// the operator's request, produced malformed output twice, so
+// "correct_request" would be an actively wrong instruction (issue #4061).
+// Nothing was captured, and the bound slot is unchanged, so the way out is
+// the same STATUS re-query and relaunch every other capture refusal uses.
+var reviewPreflightProviderCaptureRefusedReason = reviewPreflightReason{
+	Code:       "provider_capture_result_refused",
+	Message:    "The provider role capture result was refused on both admission attempts; the provider, not the request, produced a malformed result.",
+	NextAction: "review.status",
+}
+
 type reviewIntegrationPreflightError struct {
 	cause  error
 	reason *reviewPreflightReason

--- a/internal/cli/review_provider_correction.go
+++ b/internal/cli/review_provider_correction.go
@@ -114,7 +114,7 @@ func reviewProviderCaptureRetry[T any](
 	firstClause := preserve(ctx, 1, firstErr, raw)
 	corrective := reviewProviderCorrectivePrompt(invocation.Prompt(), firstErr)
 	if len(corrective) > reviewLensContextByteBudget {
-		return zero, raw, fmt.Errorf("%w%s; the corrective re-invocation was skipped because its prompt exceeds the native reviewer context budget; re-query %s and run the reoffered capture", firstErr, firstClause, continuation())
+		return zero, raw, &reviewProviderCaptureRefusedError{cause: fmt.Errorf("%w%s; the corrective re-invocation was skipped because its prompt exceeds the native reviewer context budget; re-query %s and run the reoffered capture", firstErr, firstClause, continuation())}
 	}
 	correctiveRaw, err := adapter.Review(ctx, reviewerprovider.NewInvocation(corrective))
 	if err != nil {

--- a/internal/cli/review_provider_correction.go
+++ b/internal/cli/review_provider_correction.go
@@ -13,12 +13,13 @@ import (
 // Every in-process reviewer runtime returns free text, and one out-of-schema
 // nested field or one truncated array used to end the capture with the only
 // exit being a relaunch of the same slot that failed the same way (issues
-// #3942, #2791). The runtime never learned what was wrong. The capture now
-// grants exactly one corrective re-invocation whose prompt is the original
-// materialized prompt plus the exact admission error and the three rules the
-// result broke. The bound is a named constant, the retry lives only here, and
-// it never applies to --input submissions or the OpenCode host relay: those
-// hosts own their reviewer and receive the same preserved payload instead.
+// #3942, #2791, #4061). The runtime never learned what was wrong. The capture
+// now grants exactly one corrective re-invocation whose prompt is the original
+// materialized prompt plus the exact admission error, so the model can see the
+// census of what it left open. The bound is a named constant, the retry lives
+// only here, and it never applies to --input submissions or the OpenCode host
+// relay: those hosts own their reviewer and receive the same preserved
+// payload instead.
 const (
 	maxReviewerResultAdmissionAttempts     = 2
 	reviewProviderCorrectiveFeedbackHeader = "GENTLE_AI_REVIEW_ADMISSION_FEEDBACK"
@@ -46,41 +47,97 @@ func (capture reviewProviderCapture) preserve(ctx context.Context, attempt int, 
 }
 
 func (capture reviewProviderCapture) continuation() string {
-	return fmt.Sprintf("gentle-ai review status --cwd <repo> --contract %s --agent %s --lineage %s --next-transition", ReviewIntegrationContractV2, capture.runtime, capture.state.LineageID)
+	return reviewProviderCaptureContinuation(capture.runtime, capture.state.LineageID)
 }
+
+// reviewProviderCaptureContinuation names the exact STATUS re-query every
+// capture role points a caller at once its bound slot is reoffered.
+func reviewProviderCaptureContinuation(runtime model.AgentID, lineageID string) string {
+	return fmt.Sprintf("gentle-ai review status --cwd <repo> --contract %s --agent %s --lineage %s --next-transition", ReviewIntegrationContractV2, runtime, lineageID)
+}
+
+// reviewProviderCaptureRefusedError wraps the final refusal after both
+// admission attempts failed, so a caller can classify it as a provider-side
+// defect -- the provider returned malformed output twice -- distinctly from a
+// transport failure or a role-specific sentinel such as an inconclusive
+// targeted validation.
+type reviewProviderCaptureRefusedError struct{ cause error }
+
+func (err *reviewProviderCaptureRefusedError) Error() string { return err.cause.Error() }
+func (err *reviewProviderCaptureRefusedError) Unwrap() error { return err.cause }
 
 // reviewProviderCaptureWithOneCorrection invokes the reviewer, admits its raw
 // bytes, and on an admission failure invokes it once more with feedback. A
 // transport failure is not an admission failure and is returned as is.
 func reviewProviderCaptureWithOneCorrection(ctx context.Context, capture reviewProviderCapture, invocation reviewerprovider.Invocation) (reviewProviderAdmittedResult, []byte, error) {
-	raw, err := capture.adapter.Review(ctx, invocation)
+	return reviewProviderCaptureRetry(ctx, capture.adapter, invocation, capture.admit, capture.preserve, capture.continuation, nil)
+}
+
+// reviewProviderCaptureRetryable reports whether an admission failure should
+// consume the single corrective re-invocation. A nil predicate always
+// retries, matching the lens role. The targeted validator role opts a
+// sentinel out of it: an inconclusive verdict already owns its own retry
+// ladder (relaunch after the validator regains tree access, not an in-process
+// correction), so routing it through this mechanism would consume the wrong
+// budget for the wrong reason.
+type reviewProviderCaptureRetryable func(error) bool
+
+// reviewProviderCaptureRetry is the shared corrective re-invocation core every
+// in-process provider role capture uses: invoke, admit, and on one admission
+// failure that the role considers retryable, invoke once more with the exact
+// admission error appended to the original prompt. Both rejected payloads are
+// preserved outside the authority store. It is parameterized by the role's
+// admitted result type so the lens, refuter, and targeted validator roles can
+// each keep their own native admission and durable-capture logic while
+// sharing exactly this retry shape.
+func reviewProviderCaptureRetry[T any](
+	ctx context.Context,
+	adapter reviewerprovider.Adapter,
+	invocation reviewerprovider.Invocation,
+	admit func(ctx context.Context, raw []byte) (T, error),
+	preserve func(ctx context.Context, attempt int, admission error, raw []byte) string,
+	continuation func() string,
+	retryable reviewProviderCaptureRetryable,
+) (T, []byte, error) {
+	var zero T
+	raw, err := adapter.Review(ctx, invocation)
 	if err != nil {
-		return reviewProviderAdmittedResult{}, nil, fmt.Errorf("invoke provider reviewer: %w", err)
+		return zero, nil, fmt.Errorf("invoke provider reviewer: %w", err)
 	}
-	admitted, firstErr := capture.admit(ctx, raw)
+	admitted, firstErr := admit(ctx, raw)
 	if firstErr == nil {
 		return admitted, raw, nil
 	}
-	firstClause := capture.preserve(ctx, 1, firstErr, raw)
+	if retryable != nil && !retryable(firstErr) {
+		return zero, raw, firstErr
+	}
+	firstClause := preserve(ctx, 1, firstErr, raw)
 	corrective := reviewProviderCorrectivePrompt(invocation.Prompt(), firstErr)
 	if len(corrective) > reviewLensContextByteBudget {
-		return reviewProviderAdmittedResult{}, nil, fmt.Errorf("%w%s; the corrective re-invocation was skipped because its prompt exceeds the native reviewer context budget; re-query %s and run the reoffered capture", firstErr, firstClause, capture.continuation())
+		return zero, raw, fmt.Errorf("%w%s; the corrective re-invocation was skipped because its prompt exceeds the native reviewer context budget; re-query %s and run the reoffered capture", firstErr, firstClause, continuation())
 	}
-	raw, err = capture.adapter.Review(ctx, reviewerprovider.NewInvocation(corrective))
+	correctiveRaw, err := adapter.Review(ctx, reviewerprovider.NewInvocation(corrective))
 	if err != nil {
-		return reviewProviderAdmittedResult{}, nil, fmt.Errorf("invoke provider reviewer on corrective attempt %d of %d: %w (attempt 1 was refused: %v%s)", maxReviewerResultAdmissionAttempts, maxReviewerResultAdmissionAttempts, err, firstErr, firstClause)
+		return zero, nil, fmt.Errorf("invoke provider reviewer on corrective attempt %d of %d: %w (attempt 1 was refused: %v%s)", maxReviewerResultAdmissionAttempts, maxReviewerResultAdmissionAttempts, err, firstErr, firstClause)
 	}
-	admitted, secondErr := capture.admit(ctx, raw)
+	admitted, secondErr := admit(ctx, correctiveRaw)
 	if secondErr == nil {
-		return admitted, raw, nil
+		return admitted, correctiveRaw, nil
 	}
-	secondClause := capture.preserve(ctx, maxReviewerResultAdmissionAttempts, secondErr, raw)
-	return reviewProviderAdmittedResult{}, nil, fmt.Errorf("provider reviewer result was refused on both admission attempts for lens %q: attempt 1: %v%s; corrective attempt %d: %w%s; re-query %s and run the reoffered capture", capture.subject.Lens, firstErr, firstClause, maxReviewerResultAdmissionAttempts, secondErr, secondClause, capture.continuation())
+	if retryable != nil && !retryable(secondErr) {
+		return zero, correctiveRaw, secondErr
+	}
+	secondClause := preserve(ctx, maxReviewerResultAdmissionAttempts, secondErr, correctiveRaw)
+	return zero, correctiveRaw, &reviewProviderCaptureRefusedError{cause: fmt.Errorf("provider reviewer result was refused on both admission attempts: attempt 1: %v%s; corrective attempt %d: %w%s; re-query %s and run the reoffered capture", firstErr, firstClause, maxReviewerResultAdmissionAttempts, secondErr, secondClause, continuation())}
 }
 
 // reviewProviderCorrectivePrompt appends the Go-owned feedback section to the
 // original materialized prompt. The section quotes the exact admission error
-// and restates the three rules every rejected result so far has broken.
+// -- for a malformed payload this is the structural census naming what was
+// left open -- and restates the two hard framing rules every provider role
+// shares plus a schema-field rule that stays true for every role because it
+// names the schema already declared earlier in the same prompt rather than
+// restating one role's fields.
 func reviewProviderCorrectivePrompt(original []byte, admission error) []byte {
 	var prompt bytes.Buffer
 	prompt.Write(original)
@@ -89,7 +146,7 @@ func reviewProviderCorrectivePrompt(original []byte, admission error) []byte {
 	prompt.WriteString("This is the single corrective attempt. Three hard rules:\n")
 	prompt.WriteString("1. Return exactly one JSON object and nothing else: no prose, no code fence, no second object.\n")
 	prompt.WriteString("2. Close every object and array; a truncated payload is rejected.\n")
-	prompt.WriteString("3. Use only the fields declared in the " + reviewLensContextResultSchema + " block: \"inspection\" accepts only \"status\" and \"paths\"; \"lens\" is allowed only at the top level and inside findings; any other field is rejected.\n")
+	prompt.WriteString("3. Use only the fields declared in this prompt's output schema; any other field is rejected.\n")
 	prompt.WriteString(reviewProviderCorrectiveFeedbackHeader + "_END\n")
 	return prompt.Bytes()
 }

--- a/internal/cli/review_provider_correction_test.go
+++ b/internal/cli/review_provider_correction_test.go
@@ -242,6 +242,32 @@ func TestProviderCaptureTransportErrorSkipsCorrectionAndPreservation(t *testing.
 	}
 }
 
+// R4-budget-skip-unclassified: an over-budget corrective prompt must still
+// classify as *reviewProviderCaptureRefusedError, carry the preserved clause,
+// and skip the second invocation.
+func TestProviderCaptureSkipsCorrectionOverBudgetAndClassifiesAsRefused(t *testing.T) {
+	invocation := reviewerprovider.NewInvocation([]byte("original prompt"))
+	admit := func(_ context.Context, _ []byte) (string, error) {
+		return "", errors.New(strings.Repeat("x", reviewLensContextByteBudget))
+	}
+	preserve := func(_ context.Context, _ int, _ error, _ []byte) string { return "preserved-clause" }
+	continuation := func() string { return "gentle-ai review status --next-transition" }
+	reviewCalls := 0
+	adapter := providerTestAdapterFunc(func(_ context.Context, _ reviewerprovider.Invocation) ([]byte, error) {
+		reviewCalls++
+		return []byte("raw reviewer output"), nil
+	})
+
+	_, _, err := reviewProviderCaptureRetry(context.Background(), adapter, invocation, admit, preserve, continuation, nil)
+	var refused *reviewProviderCaptureRefusedError
+	if !errors.As(err, &refused) || !strings.Contains(err.Error(), "preserved-clause") {
+		t.Fatalf("over-budget error is not a classified refusal carrying the preserved clause: %v", err)
+	}
+	if reviewCalls != 1 {
+		t.Fatalf("adapter invocations = %d, want exactly 1 (no corrective re-invocation)", reviewCalls)
+	}
+}
+
 func TestRawInputCapturePreservesRejectedResultWithoutInvokingProvider(t *testing.T) {
 	repo, binding, record, _ := newCandidateInspectionReview(t, "candidate\n", false)
 	lens := record.State.SelectedLenses[0]

--- a/internal/cli/review_provider_role_capture.go
+++ b/internal/cli/review_provider_role_capture.go
@@ -190,21 +190,22 @@ func RunReviewCaptureRefuter(args []string, stdout io.Writer) error {
 		}
 		return nil
 	}
-	var raw []byte
 	if reviewProviderCaptureRuntime(binding.runtime) {
 		adapter, adapterErr := reviewProviderAdapter(reviewProviderRoleRefuter, binding.runtime)
 		if adapterErr != nil {
 			return reviewPreflightError(adapterErr)
 		}
-		raw, err = adapter.Review(ctx, request.Invocation)
+		if err := reviewProviderCaptureRefuterWithOneCorrection(ctx, binding, adapter, store, state, request); err != nil {
+			return err
+		}
 	} else {
-		raw, err = reviewProviderRoleHostAdapter().Review(ctx, request.Invocation)
-	}
-	if err != nil {
-		return reviewPreflightError(fmt.Errorf("invoke provider refuter: %w", err))
-	}
-	if _, err := reviewProviderCaptureRefuterRaw(ctx, binding.root, store, state, state.CapturePhaseRevision, raw); err != nil {
-		return reviewPreflightError(err)
+		raw, hostErr := reviewProviderRoleHostAdapter().Review(ctx, request.Invocation)
+		if hostErr != nil {
+			return reviewPreflightError(fmt.Errorf("invoke provider refuter: %w", hostErr))
+		}
+		if _, err := reviewProviderCaptureRefuterRaw(ctx, binding.root, store, state, state.CapturePhaseRevision, raw); err != nil {
+			return reviewPreflightError(err)
+		}
 	}
 	currentRecord, currentErr := store.LoadContext(ctx)
 	if currentErr != nil {
@@ -260,22 +261,112 @@ func RunReviewCaptureValidation(args []string, stdout io.Writer) error {
 		}
 		return nil
 	}
-	var raw []byte
 	if reviewProviderCaptureRuntime(binding.runtime) {
 		adapter, adapterErr := reviewProviderAdapter(reviewProviderRoleTargetedValidator, binding.runtime)
 		if adapterErr != nil {
 			return reviewPreflightError(adapterErr)
 		}
-		raw, err = adapter.Review(ctx, request.Invocation)
-	} else {
-		raw, err = reviewProviderRoleHostAdapter().Review(ctx, request.Invocation)
+		closure, err := reviewProviderCaptureValidationWithOneCorrection(ctx, binding, adapter, store, state, correction, request)
+		if err != nil {
+			return err
+		}
+		return encodeReviewJSON(stdout, closure)
 	}
-	if err != nil {
-		return reviewPreflightError(fmt.Errorf("invoke provider targeted validator: %w", err))
+	raw, hostErr := reviewProviderRoleHostAdapter().Review(ctx, request.Invocation)
+	if hostErr != nil {
+		return reviewPreflightError(fmt.Errorf("invoke provider targeted validator: %w", hostErr))
 	}
 	_, _, closure, err := reviewProviderCloseTargetedValidatorRaw(ctx, binding.root, store, state, state.CapturePhaseRevision, raw)
 	if err != nil {
 		return reviewPreflightError(err)
 	}
 	return encodeReviewJSON(stdout, closure)
+}
+
+// reviewProviderCaptureRefuterAdmission bundles the one refuter admission
+// result so the shared corrective-retry core can carry it as a single type
+// parameter.
+type reviewProviderCaptureRefuterAdmission struct {
+	result facadeRefuterResult
+}
+
+// reviewProviderCaptureRefuterWithOneCorrection grants the compiled runtime
+// (claude, codex) the same single corrective re-invocation the lens role
+// already had (issue #4061): a malformed refuter document is retried once
+// with the exact admission error before it is durably captured. The Pi host
+// relay keeps its own reviewer process and is not routed through this path.
+func reviewProviderCaptureRefuterWithOneCorrection(ctx context.Context, binding *reviewProviderRoleCaptureBinding, adapter reviewerprovider.Adapter, store reviewtransaction.CompactStore, state reviewtransaction.CompactState, request reviewProviderRefuterRequest) error {
+	admit := func(_ context.Context, raw []byte) (reviewProviderCaptureRefuterAdmission, error) {
+		result, err := reviewProviderAdmitRefuterRaw(request, raw)
+		return reviewProviderCaptureRefuterAdmission{result: result}, err
+	}
+	preserve := func(ctx context.Context, attempt int, admission error, raw []byte) string {
+		return reviewRejectedResultClause(ctx, binding.root, reviewRejectedResultMeta{
+			LineageID: state.LineageID, Lens: reviewProviderRoleRefuter, Attempt: attempt, Reason: admission.Error(),
+		}, raw)
+	}
+	continuation := func() string { return reviewProviderCaptureContinuation(binding.runtime, state.LineageID) }
+
+	captured, raw, err := reviewProviderCaptureRetry(ctx, adapter, request.Invocation, admit, preserve, continuation, nil)
+	if err != nil {
+		var refused *reviewProviderCaptureRefusedError
+		if errors.As(err, &refused) {
+			return reviewPreflightRefusal(reviewPreflightProviderCaptureRefusedReason, err)
+		}
+		return reviewPreflightError(err)
+	}
+	if _, err := reviewProviderCaptureAdmittedRefuterResult(ctx, binding.root, store, state.CapturePhaseRevision, request, captured.result, raw); err != nil {
+		return reviewPreflightError(err)
+	}
+	return nil
+}
+
+// reviewProviderCaptureValidatorAdmission bundles the one targeted validator
+// admission result so the shared corrective-retry core can carry it as a
+// single type parameter.
+type reviewProviderCaptureValidatorAdmission struct {
+	result facadeValidationResult
+	native reviewtransaction.ScopedValidationResult
+}
+
+// reviewProviderCaptureValidationWithOneCorrection grants the compiled
+// runtime the same single corrective re-invocation the lens role already had
+// (issue #4061): a syntactically invalid validator document -- the defect a
+// live claude adapter run actually hit -- is retried once with the exact
+// admission census before it is durably captured. An inconclusive verdict is
+// not retried here: it already owns its own retry ladder (relaunch once the
+// validator regains access to the frozen trees), so it is recorded on the
+// ledger exactly as it was before this correction existed.
+func reviewProviderCaptureValidationWithOneCorrection(ctx context.Context, binding *reviewProviderRoleCaptureBinding, adapter reviewerprovider.Adapter, store reviewtransaction.CompactStore, state reviewtransaction.CompactState, correction reviewtransaction.Snapshot, request reviewProviderTargetedValidatorRequest) (*reviewLastEventClosureResult, error) {
+	admit := func(_ context.Context, raw []byte) (reviewProviderCaptureValidatorAdmission, error) {
+		result, native, err := reviewProviderAdmitTargetedValidatorRaw(request, raw)
+		return reviewProviderCaptureValidatorAdmission{result: result, native: native}, err
+	}
+	preserve := func(ctx context.Context, attempt int, admission error, raw []byte) string {
+		return reviewRejectedResultClause(ctx, binding.root, reviewRejectedResultMeta{
+			LineageID: state.LineageID, Lens: reviewProviderRoleTargetedValidator, Attempt: attempt, Reason: admission.Error(),
+		}, raw)
+	}
+	continuation := func() string { return reviewProviderCaptureContinuation(binding.runtime, state.LineageID) }
+	retryable := func(err error) bool { return !errors.Is(err, errReviewTargetedValidationInconclusive) }
+
+	captured, raw, err := reviewProviderCaptureRetry(ctx, adapter, request.Invocation, admit, preserve, continuation, retryable)
+	if err != nil {
+		if errors.Is(err, errReviewTargetedValidationInconclusive) {
+			if _, ledgerErr := store.RecordInconclusiveTargetedValidatorAttempt(ctx, request.ValidationRequest, facadePayloadHash(raw)); ledgerErr != nil {
+				return nil, reviewPreflightError(ledgerErr)
+			}
+			return nil, reviewPreflightError(err)
+		}
+		var refused *reviewProviderCaptureRefusedError
+		if errors.As(err, &refused) {
+			return nil, reviewPreflightRefusal(reviewPreflightProviderCaptureRefusedReason, err)
+		}
+		return nil, reviewPreflightError(err)
+	}
+	closure, err := reviewProviderCaptureAdmittedTargetedValidatorResult(ctx, binding.root, store, state, correction, request, captured.result, captured.native)
+	if err != nil {
+		return nil, reviewPreflightError(err)
+	}
+	return closure, nil
 }

--- a/internal/cli/review_provider_role_capture.go
+++ b/internal/cli/review_provider_role_capture.go
@@ -315,7 +315,7 @@ func reviewProviderCaptureRefuterWithOneCorrection(ctx context.Context, binding 
 		}
 		return reviewPreflightError(err)
 	}
-	if _, err := reviewProviderCaptureAdmittedRefuterResult(ctx, binding.root, store, state.CapturePhaseRevision, request, captured.result, raw); err != nil {
+	if _, err := reviewProviderCaptureAdmittedRefuterResult(ctx, binding.root, store, state, state.CapturePhaseRevision, request, captured.result, raw); err != nil {
 		return reviewPreflightError(err)
 	}
 	return nil

--- a/internal/cli/review_provider_roles.go
+++ b/internal/cli/review_provider_roles.go
@@ -412,12 +412,21 @@ func reviewProviderCaptureRefuterRaw(ctx context.Context, repo string, store rev
 	if err != nil {
 		return facadeRefuterResult{}, err
 	}
+	return reviewProviderCaptureAdmittedRefuterResult(ctx, repo, store, revision, request, result, raw)
+}
+
+// reviewProviderCaptureAdmittedRefuterResult durably captures a refuter
+// result the caller already admitted from raw provider bytes. It stays split
+// from admission so a caller that grants the compiled runtime a corrective
+// re-invocation on a rejected result (issue #4061) can retry admission alone
+// and only ever durably capture the one payload that was actually admitted.
+func reviewProviderCaptureAdmittedRefuterResult(ctx context.Context, repo string, store reviewtransaction.CompactStore, revision string, request reviewProviderRefuterRequest, result facadeRefuterResult, raw []byte) (facadeRefuterResult, error) {
 	payload, err := canonicalProviderRoleResult(compactProviderRefuterResult{Results: result.native()})
 	if err != nil {
 		return facadeRefuterResult{}, err
 	}
 	err = store.CaptureAdmittedRefuterResult(ctx, reviewtransaction.CompactAdmittedRefuterResultRequest{
-		ExpectedRevision: revision, TargetIdentity: state.InitialSnapshot.Identity, RequestHash: request.RequestHash, Payload: payload,
+		ExpectedRevision: revision, TargetIdentity: request.TargetIdentity, RequestHash: request.RequestHash, Payload: payload,
 		PreparePublication: func(current reviewtransaction.CompactState) error {
 			currentRequest, err := reviewProviderNewRefuterRequest(ctx, repo, store.Dir, current, revision)
 			if err != nil {
@@ -546,12 +555,24 @@ func reviewProviderCloseTargetedValidatorRaw(ctx context.Context, repo string, s
 		}
 		return facadeValidationResult{}, reviewtransaction.ScopedValidationResult{}, nil, err
 	}
+	closure, err := reviewProviderCaptureAdmittedTargetedValidatorResult(ctx, repo, store, state, correction, request, result, native)
+	return result, native, closure, err
+}
+
+// reviewProviderCaptureAdmittedTargetedValidatorResult durably captures a
+// targeted validator verdict the caller already admitted from raw provider
+// bytes. It stays split from admission and from the inconclusive-attempt
+// ledger recording above so a caller that grants the compiled runtime a
+// corrective re-invocation on a rejected result (issue #4061) can retry
+// admission alone and only ever durably capture the one verdict that was
+// actually admitted.
+func reviewProviderCaptureAdmittedTargetedValidatorResult(ctx context.Context, repo string, store reviewtransaction.CompactStore, state reviewtransaction.CompactState, correction reviewtransaction.Snapshot, request reviewProviderTargetedValidatorRequest, result facadeValidationResult, native reviewtransaction.ScopedValidationResult) (*reviewLastEventClosureResult, error) {
 	evidence := reviewProviderTargetedValidatorEvidence(result)
 	payload, err := canonicalProviderRoleResult(compactProviderTargetedValidatorResult{
 		Outcome: reviewProviderTargetedValidatorOutcome(native), Evidence: evidence,
 	})
 	if err != nil {
-		return facadeValidationResult{}, reviewtransaction.ScopedValidationResult{}, nil, err
+		return nil, err
 	}
 	capture := reviewtransaction.CompactAdmittedTargetedValidatorResultRequest{
 		ExpectedRequest: request.ValidationRequest, Payload: payload, Evidence: &evidence, Validation: &native,
@@ -559,35 +580,27 @@ func reviewProviderCloseTargetedValidatorRaw(ctx context.Context, repo string, s
 	if reviewProviderTargetedValidatorOutcome(native) == "failed" {
 		actual, err := (reviewtransaction.SnapshotBuilder{Repo: repo}).ChangedLines(ctx, correction)
 		if err != nil {
-			return facadeValidationResult{}, reviewtransaction.ScopedValidationResult{}, nil, err
+			return nil, err
 		}
 		complete, err := (reviewtransaction.SnapshotBuilder{Repo: repo}).BuildCorrectedCandidate(ctx, state.InitialSnapshot, correction)
 		if err != nil {
-			return facadeValidationResult{}, reviewtransaction.ScopedValidationResult{}, nil, err
+			return nil, err
 		}
 		capture.Complete = func(next *reviewtransaction.CompactState) error {
 			return next.CompleteCorrectionVerification(correction, actual, native, complete)
 		}
 	}
 	if err := store.CaptureAdmittedTargetedValidatorResult(ctx, capture); err != nil {
-		return facadeValidationResult{}, reviewtransaction.ScopedValidationResult{}, nil, err
+		return nil, err
 	}
 	current, err := store.LoadContext(ctx)
 	if err != nil {
-		return facadeValidationResult{}, reviewtransaction.ScopedValidationResult{}, nil, err
+		return nil, err
 	}
 	if reviewProviderTargetedValidatorOutcome(native) == "passed" {
-		closure, err := closeCorrectionOnCapturedValidator(ctx, repo, store, current, correction, request.ValidationRequest, native)
-		if err != nil {
-			return facadeValidationResult{}, reviewtransaction.ScopedValidationResult{}, nil, err
-		}
-		return result, native, closure, nil
+		return closeCorrectionOnCapturedValidator(ctx, repo, store, current, correction, request.ValidationRequest, native)
 	}
-	closure, err := newCorrectionCapturedValidatorClosure(repo, current.State, current.Revision, request.ValidationRequest)
-	if err != nil {
-		return facadeValidationResult{}, reviewtransaction.ScopedValidationResult{}, nil, err
-	}
-	return result, native, closure, nil
+	return newCorrectionCapturedValidatorClosure(repo, current.State, current.Revision, request.ValidationRequest)
 }
 
 func reviewProviderTargetedValidatorEvidence(result facadeValidationResult) reviewtransaction.CompactTargetedValidatorEvidence {

--- a/internal/cli/review_provider_roles.go
+++ b/internal/cli/review_provider_roles.go
@@ -412,7 +412,7 @@ func reviewProviderCaptureRefuterRaw(ctx context.Context, repo string, store rev
 	if err != nil {
 		return facadeRefuterResult{}, err
 	}
-	return reviewProviderCaptureAdmittedRefuterResult(ctx, repo, store, revision, request, result, raw)
+	return reviewProviderCaptureAdmittedRefuterResult(ctx, repo, store, state, revision, request, result, raw)
 }
 
 // reviewProviderCaptureAdmittedRefuterResult durably captures a refuter
@@ -420,13 +420,16 @@ func reviewProviderCaptureRefuterRaw(ctx context.Context, repo string, store rev
 // from admission so a caller that grants the compiled runtime a corrective
 // re-invocation on a rejected result (issue #4061) can retry admission alone
 // and only ever durably capture the one payload that was actually admitted.
-func reviewProviderCaptureAdmittedRefuterResult(ctx context.Context, repo string, store reviewtransaction.CompactStore, revision string, request reviewProviderRefuterRequest, result facadeRefuterResult, raw []byte) (facadeRefuterResult, error) {
+func reviewProviderCaptureAdmittedRefuterResult(ctx context.Context, repo string, store reviewtransaction.CompactStore, state reviewtransaction.CompactState, revision string, request reviewProviderRefuterRequest, result facadeRefuterResult, raw []byte) (facadeRefuterResult, error) {
+	if request.TargetIdentity != state.InitialSnapshot.Identity {
+		return facadeRefuterResult{}, errors.New("provider refuter request target identity does not match the reviewing authority's initial snapshot identity") // refusal:by-design world-action: this structural compact-authority invariant requires a provider code fix; no operator command can safely repair it
+	}
 	payload, err := canonicalProviderRoleResult(compactProviderRefuterResult{Results: result.native()})
 	if err != nil {
 		return facadeRefuterResult{}, err
 	}
 	err = store.CaptureAdmittedRefuterResult(ctx, reviewtransaction.CompactAdmittedRefuterResultRequest{
-		ExpectedRevision: revision, TargetIdentity: request.TargetIdentity, RequestHash: request.RequestHash, Payload: payload,
+		ExpectedRevision: revision, TargetIdentity: state.InitialSnapshot.Identity, RequestHash: request.RequestHash, Payload: payload,
 		PreparePublication: func(current reviewtransaction.CompactState) error {
 			currentRequest, err := reviewProviderNewRefuterRequest(ctx, repo, store.Dir, current, revision)
 			if err != nil {


### PR DESCRIPTION
Closes #4061.

## Cause

The in-process targeted validator (`review capture-validation --agent=claude-code --execute=true`) invoked the compiled provider once and, when the `claude` child returned a syntactically invalid JSON document (census: objects balanced, two arrays left open, scan ended at the payload's last byte, far under the 4 MB role limit), refused it through the generic preflight path: `invalid_request` with `next_action: correct_request`, although the operator can correct nothing, and the refused bytes were discarded. The lens role already had the right mechanism (`reviewProviderCaptureWithOneCorrection`: preserve the refused payload, re-invoke once with admission feedback, refuse with both payloads preserved); the validator and refuter roles never used it.

## Fix

- `reviewProviderCaptureWithOneCorrection` is generalized into one core (`reviewProviderCaptureRetry`) reused by the lens (unchanged signature), the targeted validator, and the refuter on the compiled runtimes; the Pi host relay path is untouched, as for the lens. Admission is split from the durable store capture so both paths share it.
- The validator's inconclusive verdict sentinel keeps its own relaunch ladder and is excluded from the retry.
- After the single retry still fails, the failure is classified as `provider_capture_result_refused` with `next_action: review.status` (re-query the bound STATUS and relaunch when the slot is reoffered). The failure schema's `code` is pattern-validated, so no contract bump. The over-budget corrective prompt branch carries the same classification.
- The refuter capture guard keeps comparing against the state's initial snapshot identity (native review finding).

## Verification

- Full `go test ./... -count=1` green in the foreground; `go vet ./...` and `GOOS=windows go vet ./...` clean; `gofmt -l` empty; dead-code ratchet clean.
- New tests: validator retry with admission feedback and one preserved payload; two malformed results refused provider-side with two payloads preserved and no authority mutation; transport error not retried; refuter retry; refuter guard divergence refused; over-budget corrective prompt classified as provider refusal.
- Native review: lineage `review-0045f43a592ac793`, tier high, four lenses, two CRITICAL findings corrected in d4a96112 within budget, targeted validation passed, approved and acknowledged (`gentle-ai.review-acknowledged/v1`, authority burned). Consent was answered `granted` under the maintainer's standing authorization.

## Size exception

Additions plus deletions exceed 400 because the lens-only retry was generalized into one helper used by three roles instead of duplicated per role, and each role's retry, refusal, transport, and guard behaviors carry a black-box test through the real capture entry points.

https://claude.ai/code/session_01WYGtotXyhPmbnEeAZAbSbj


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Provider-generated malformed results now receive one corrective retry with validation feedback.
  * Refused results after both attempts are clearly classified as provider capture failures.
  * Transport errors and inconclusive validation results are not retried.
  * Rejected payloads are not durably captured, preventing invalid results from updating review state.
  * Target identity mismatches are refused before any authority state is changed.

* **Tests**
  * Added coverage for corrective retries, refusal handling, retry limits, and target identity validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->