### PR TITLE
fix(hermes): resolve HERMES_HOME and %LOCALAPPDATA% on Windows

### DIFF
--- a/internal/agents/hermes/adapter.go
+++ b/internal/agents/hermes/adapter.go
@@ -6,6 +6,8 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
+	"strings"
 
 	"github.com/gentleman-programming/gentle-ai/v2/internal/agents/capabilitymanifest"
 	"github.com/gentleman-programming/gentle-ai/v2/internal/model"
@@ -162,8 +164,20 @@ func defaultStat(path string) statResult {
 	return statResult{isDir: info.IsDir()}
 }
 
-// ConfigPath returns the path to ~/.hermes, the Hermes global config directory.
+// ConfigPath returns the effective Hermes global config directory.
+// Resolution order:
+// 1. HERMES_HOME environment variable when set.
+// 2. %LOCALAPPDATA%\hermes on native Windows.
+// 3. $HOME/.hermes on Linux, macOS, or as a default fallback.
 func ConfigPath(homeDir string) string {
+	if env := strings.TrimSpace(os.Getenv("HERMES_HOME")); env != "" {
+		return filepath.Clean(env)
+	}
+	if runtime.GOOS == "windows" {
+		if localAppData := strings.TrimSpace(os.Getenv("LOCALAPPDATA")); localAppData != "" {
+			return filepath.Join(localAppData, "hermes")
+		}
+	}
 	return filepath.Join(homeDir, ".hermes")
 }
 

--- a/internal/agents/hermes/adapter_test.go
+++ b/internal/agents/hermes/adapter_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -124,9 +125,10 @@ func TestInstallCommand(t *testing.T) {
 }
 
 func TestConfigPaths(t *testing.T) {
+	t.Setenv("HERMES_HOME", "")
 	a := NewAdapter()
 	homeDir := filepath.Join(string(filepath.Separator), "home", "test")
-	configDir := filepath.Join(homeDir, ".hermes")
+	configDir := ConfigPath(homeDir)
 	configYAML := filepath.Join(configDir, "config.yaml")
 	soulMD := filepath.Join(configDir, "SOUL.md")
 	skillsDir := filepath.Join(configDir, "skills")
@@ -152,6 +154,42 @@ func TestConfigPaths(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestConfigPathResolution(t *testing.T) {
+	homeDir := filepath.Join(string(filepath.Separator), "home", "test")
+	localAppData := filepath.Join(string(filepath.Separator), "LocalAppData", "hermes_appdata")
+
+	t.Run("HERMES_HOME override takes precedence over LOCALAPPDATA", func(t *testing.T) {
+		custom := filepath.Join(string(filepath.Separator), "custom", "hermes")
+		t.Setenv("HERMES_HOME", custom)
+		t.Setenv("LOCALAPPDATA", localAppData)
+		if got := ConfigPath(homeDir); got != filepath.Clean(custom) {
+			t.Fatalf("ConfigPath() with HERMES_HOME = %q, want %q", got, filepath.Clean(custom))
+		}
+	})
+
+	t.Run("Windows LOCALAPPDATA fallback when HERMES_HOME unset", func(t *testing.T) {
+		t.Setenv("HERMES_HOME", "")
+		t.Setenv("LOCALAPPDATA", localAppData)
+		if runtime.GOOS == "windows" {
+			want := filepath.Join(localAppData, "hermes")
+			if got := ConfigPath(homeDir); got != want {
+				t.Fatalf("ConfigPath() Windows LOCALAPPDATA = %q, want %q", got, want)
+			}
+		}
+	})
+
+	t.Run("default fallback without HERMES_HOME", func(t *testing.T) {
+		t.Setenv("HERMES_HOME", "")
+		t.Setenv("LOCALAPPDATA", "")
+		if runtime.GOOS != "windows" {
+			want := filepath.Join(homeDir, ".hermes")
+			if got := ConfigPath(homeDir); got != want {
+				t.Fatalf("ConfigPath() default = %q, want %q", got, want)
+			}
+		}
+	})
 }
 
 func TestCapabilities(t *testing.T) {


### PR DESCRIPTION
Fixes #2094

## Summary
- Resolve the Hermes global config directory from `HERMES_HOME` when set.
- Fall back to `%LOCALAPPDATA%\hermes` on native Windows, retaining `$HOME/.hermes` on Linux/macOS.
- Route detection, prompts, skills, settings and MCP config through the same resolved path.

## Why
On native Windows, Gentle AI writes the managed Hermes files to `%USERPROFILE%\.hermes` while Hermes itself uses `%LOCALAPPDATA%\hermes` (or `HERMES_HOME`). The install reports success but lands in a directory Hermes never reads — SOUL.md, skills and MCP config silently miss. This is the same fix from the approved #2097 (closed without merge); rebuilt against current `main` (v2.5.0) so the bug stops shipping.

## Note for the maintainers
Hoping Alan takes pity on those of us suffering Windows in the next release. :pray: The `HOME`-based `.hermes` assumption is a POSIX habit that leaks on Windows — this makes the adapter follow Hermes' own resolution order.

## Test plan
```bash
go test -v ./internal/agents/hermes -run '^(TestConfigPaths|TestConfigPathResolution)$' -count=1
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Hermes now resolves its global configuration directory using `HERMES_HOME` when set.
  * On Windows, configuration falls back to the local application data directory.
  * Other platforms continue to use the user’s `.hermes` directory by default.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->