### PR TITLE
fix(update): serialize cooldown state persistence

### DIFF
--- a/internal/cli/install_state_lock.go
+++ b/internal/cli/install_state_lock.go
@@ -2,10 +2,6 @@ package cli
 
 import "github.com/gentleman-programming/gentle-ai/v2/internal/statecoord"
 
-func installStateLockPath(homeDir string) (string, error) {
-	return statecoord.LockPath(homeDir)
-}
-
 func withInstallStateLock(homeDir string, operation func() error) error {
 	return statecoord.WithLock(homeDir, operation)
 }

--- a/internal/cli/install_state_lock.go
+++ b/internal/cli/install_state_lock.go
@@ -1,43 +1,11 @@
 package cli
 
-import (
-	"errors"
-	"fmt"
-	"path/filepath"
+import "github.com/gentleman-programming/gentle-ai/v2/internal/statecoord"
 
-	"github.com/gentleman-programming/gentle-ai/v2/internal/reviewtransaction"
-	"github.com/gentleman-programming/gentle-ai/v2/internal/state"
-)
-
-// installStateLockPath is the install-state lock under the real home
-// directory. The lock primitive walks every path component below its root
-// with O_NOFOLLOW, so a home whose path crosses a symlink (macOS `/var` ->
-// `/private/var`, a `mktemp -d` HOME) failed with "not a directory" before
-// any state existed (#3926). Resolving the symlinks first keeps the no-follow
-// walk, now over the real path, and lands the lock beside the state file it
-// guards. The home is resolved once, so every process given the same home
-// derives the same lock whether or not the state directory exists yet.
 func installStateLockPath(homeDir string) (string, error) {
-	resolvedHome, err := filepath.EvalSymlinks(homeDir)
-	if err != nil {
-		return "", fmt.Errorf("resolve install state home: %w", err)
-	}
-	return state.Path(resolvedHome) + ".lock", nil
+	return statecoord.LockPath(homeDir)
 }
 
-func withInstallStateLock(homeDir string, operation func() error) (err error) {
-	lockPath, err := installStateLockPath(homeDir)
-	if err != nil {
-		return fmt.Errorf("acquire install state lock: %w", err)
-	}
-	lock, err := reviewtransaction.AcquireAuthorityFileLock(lockPath)
-	if err != nil {
-		return fmt.Errorf("acquire install state lock: %w", err)
-	}
-	defer func() {
-		if releaseErr := lock.Release(); releaseErr != nil {
-			err = errors.Join(err, fmt.Errorf("release install state lock: %w", releaseErr))
-		}
-	}()
-	return operation()
+func withInstallStateLock(homeDir string, operation func() error) error {
+	return statecoord.WithLock(homeDir, operation)
 }

--- a/internal/cli/install_state_lock_test.go
+++ b/internal/cli/install_state_lock_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/gentleman-programming/gentle-ai/v2/internal/model"
 	"github.com/gentleman-programming/gentle-ai/v2/internal/reviewtransaction"
 	"github.com/gentleman-programming/gentle-ai/v2/internal/state"
+	"github.com/gentleman-programming/gentle-ai/v2/internal/statecoord"
 )
 
 func TestPersistSyncManagedAssetStateReReadsLatestStateAfterLockContention(t *testing.T) {
@@ -105,7 +106,7 @@ func TestInstallStateLockAcceptsSymlinkedHome(t *testing.T) {
 
 func mustInstallStateLockPath(t *testing.T, home string) string {
 	t.Helper()
-	lockPath, err := installStateLockPath(home)
+	lockPath, err := statecoord.LockPath(home)
 	if err != nil {
 		t.Fatalf("install state lock path: %v", err)
 	}
@@ -129,7 +130,7 @@ func TestInstallStateLockPathIsStableAcrossStateDirectoryCreation(t *testing.T) 
 	if after := mustInstallStateLockPath(t, link); after != before || after != state.Path(real)+".lock" {
 		t.Fatalf("lock path depends on filesystem state: before %s, after %s", before, after)
 	}
-	if _, err := installStateLockPath(filepath.Join(real, "missing-home")); err == nil {
+	if _, err := statecoord.LockPath(filepath.Join(real, "missing-home")); err == nil {
 		t.Fatal("a home that does not resolve must fail closed instead of guessing a lock path")
 	}
 }

--- a/internal/statecoord/statecoord.go
+++ b/internal/statecoord/statecoord.go
@@ -1,4 +1,7 @@
-// Package statecoord serializes mutations of the shared install state.
+// Package statecoord serializes read-modify-write mutations of the shared install
+// state. All such operations use one lock identity derived from the resolved
+// home directory, so each mutation reads the latest state and writes it before
+// releasing the shared lock.
 package statecoord
 
 import (
@@ -19,7 +22,8 @@ func LockPath(homeDir string) (string, error) {
 	return state.Path(resolvedHome) + ".lock", nil
 }
 
-// WithLock runs operation while holding the canonical install-state lock.
+// WithLock runs operation while holding the canonical install-state lock shared
+// by every install-state read-modify-write operation for the resolved home.
 func WithLock(homeDir string, operation func() error) (err error) {
 	lockPath, err := LockPath(homeDir)
 	if err != nil {

--- a/internal/statecoord/statecoord.go
+++ b/internal/statecoord/statecoord.go
@@ -1,0 +1,38 @@
+// Package statecoord serializes mutations of the shared install state.
+package statecoord
+
+import (
+	"errors"
+	"fmt"
+	"path/filepath"
+
+	"github.com/gentleman-programming/gentle-ai/v2/internal/reviewtransaction"
+	"github.com/gentleman-programming/gentle-ai/v2/internal/state"
+)
+
+// LockPath returns the canonical install-state lock path for homeDir.
+func LockPath(homeDir string) (string, error) {
+	resolvedHome, err := filepath.EvalSymlinks(homeDir)
+	if err != nil {
+		return "", fmt.Errorf("resolve install state home: %w", err)
+	}
+	return state.Path(resolvedHome) + ".lock", nil
+}
+
+// WithLock runs operation while holding the canonical install-state lock.
+func WithLock(homeDir string, operation func() error) (err error) {
+	lockPath, err := LockPath(homeDir)
+	if err != nil {
+		return fmt.Errorf("acquire install state lock: %w", err)
+	}
+	lock, err := reviewtransaction.AcquireAuthorityFileLock(lockPath)
+	if err != nil {
+		return fmt.Errorf("acquire install state lock: %w", err)
+	}
+	defer func() {
+		if releaseErr := lock.Release(); releaseErr != nil {
+			err = errors.Join(err, fmt.Errorf("release install state lock: %w", releaseErr))
+		}
+	}()
+	return operation()
+}

--- a/internal/statecoord/statecoord_test.go
+++ b/internal/statecoord/statecoord_test.go
@@ -1,0 +1,30 @@
+package statecoord
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/gentleman-programming/gentle-ai/v2/internal/state"
+)
+
+func TestLockPathResolvesHomeSymlink(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Windows symlink creation requires privileges unavailable in standard test environments")
+	}
+	realHome := t.TempDir()
+	linkedHome := filepath.Join(t.TempDir(), "home")
+	if err := os.Symlink(realHome, linkedHome); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := LockPath(linkedHome)
+	if err != nil {
+		t.Fatalf("LockPath() error = %v", err)
+	}
+	want := state.Path(realHome) + ".lock"
+	if got != want {
+		t.Fatalf("LockPath() = %q, want %q", got, want)
+	}
+}

--- a/internal/statecoord/statecoord_test.go
+++ b/internal/statecoord/statecoord_test.go
@@ -23,7 +23,11 @@ func TestLockPathResolvesHomeSymlink(t *testing.T) {
 	if err != nil {
 		t.Fatalf("LockPath() error = %v", err)
 	}
-	want := state.Path(realHome) + ".lock"
+	resolvedHome, err := filepath.EvalSymlinks(realHome)
+	if err != nil {
+		t.Fatalf("EvalSymlinks(real home): %v", err)
+	}
+	want := state.Path(resolvedHome) + ".lock"
 	if got != want {
 		t.Fatalf("LockPath() = %q, want %q", got, want)
 	}

--- a/internal/update/cooldown.go
+++ b/internal/update/cooldown.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/gentleman-programming/gentle-ai/v2/internal/state"
+	"github.com/gentleman-programming/gentle-ai/v2/internal/statecoord"
 	"github.com/gentleman-programming/gentle-ai/v2/internal/system"
 )
 
@@ -40,6 +41,19 @@ func CheckAllWithCooldown(
 	nowFn func() time.Time,
 	checkFn checkAllFn,
 ) []UpdateResult {
+	return checkAllWithCooldown(ctx, currentVersion, profile, homeDir, ttl, nowFn, checkFn, persistLastUpdateCheck)
+}
+
+func checkAllWithCooldown(
+	ctx context.Context,
+	currentVersion string,
+	profile system.PlatformProfile,
+	homeDir string,
+	ttl time.Duration,
+	nowFn func() time.Time,
+	checkFn checkAllFn,
+	persistTimestamp func(string, time.Time) error,
+) []UpdateResult {
 	now := nowFn()
 
 	// When homeDir is empty (home resolution failed), skip both state read and
@@ -67,23 +81,25 @@ func CheckAllWithCooldown(
 	// non-failed result, or empty-but-no-error; never if all are CheckFailed).
 	// Also skip write when homeDir is empty.
 	if homeDir != "" && checkSucceeded(results) {
-		// Re-read state to avoid clobbering unrelated fields written concurrently.
-		current, readErr := state.Read(homeDir)
-		if readErr != nil {
-			if !errors.Is(readErr, os.ErrNotExist) {
-				// File exists but is unreadable/corrupt — do not overwrite; skip
-				// persisting the timestamp this round to avoid data loss.
-				return results
-			}
-			// File genuinely missing (first run) — start fresh.
-			current = state.InstallState{}
-		}
-		current.LastUpdateCheck = &now
-		// Ignore write errors — non-fatal; next launch will retry.
-		_ = state.Write(homeDir, current)
+		// Ignore persistence errors — non-fatal; next launch will retry.
+		_ = persistTimestamp(homeDir, now)
 	}
 
 	return results
+}
+
+func persistLastUpdateCheck(homeDir string, timestamp time.Time) error {
+	return statecoord.WithLock(homeDir, func() error {
+		current, err := state.Read(homeDir)
+		if err != nil {
+			if !errors.Is(err, os.ErrNotExist) {
+				return err
+			}
+			current = state.InstallState{}
+		}
+		current.LastUpdateCheck = &timestamp
+		return state.WriteReconciled(homeDir, current)
+	})
 }
 
 // checkSucceeded returns true when the result set should be considered a

--- a/internal/update/cooldown.go
+++ b/internal/update/cooldown.go
@@ -19,6 +19,8 @@ const UpdateCheckTTL = 6 * time.Hour
 // allow injection of a stub in tests.
 type checkAllFn func(ctx context.Context, currentVersion string, profile system.PlatformProfile) []UpdateResult
 
+type installStateWriter func(string, state.InstallState) error
+
 // CheckAllWithCooldown gates CheckAll behind a TTL-based cooldown. It reads
 // LastUpdateCheck from state.json in homeDir; if the elapsed time since the
 // last successful check is less than ttl, it returns nil (no network call).
@@ -89,6 +91,10 @@ func checkAllWithCooldown(
 }
 
 func persistLastUpdateCheck(homeDir string, timestamp time.Time) error {
+	return persistLastUpdateCheckWithWriter(homeDir, timestamp, state.WriteReconciled)
+}
+
+func persistLastUpdateCheckWithWriter(homeDir string, timestamp time.Time, write installStateWriter) error {
 	return statecoord.WithLock(homeDir, func() error {
 		current, err := state.Read(homeDir)
 		if err != nil {
@@ -98,7 +104,7 @@ func persistLastUpdateCheck(homeDir string, timestamp time.Time) error {
 			current = state.InstallState{}
 		}
 		current.LastUpdateCheck = &timestamp
-		return state.WriteReconciled(homeDir, current)
+		return write(homeDir, current)
 	})
 }
 

--- a/internal/update/cooldown_concurrency_test.go
+++ b/internal/update/cooldown_concurrency_test.go
@@ -5,7 +5,8 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"strings"
+	"reflect"
+	"runtime"
 	"sync"
 	"testing"
 	"time"
@@ -28,6 +29,8 @@ func TestCheckAllWithCooldown_ConcurrentReviewModeDisablePreservesMode(t *testin
 	}
 
 	binary := buildCandidateBinary(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
 	persistReached := make(chan struct{}, 1)
 	releasePersist := make(chan struct{})
 	var releaseOnce sync.Once
@@ -38,7 +41,7 @@ func TestCheckAllWithCooldown_ConcurrentReviewModeDisablePreservesMode(t *testin
 	go func() {
 		defer close(actorADone)
 		checkAllWithCooldown(
-			context.Background(),
+			ctx,
 			"1.0.0",
 			system.PlatformProfile{OS: "darwin", PackageManager: "brew"},
 			home,
@@ -49,19 +52,19 @@ func TestCheckAllWithCooldown_ConcurrentReviewModeDisablePreservesMode(t *testin
 			},
 			func(homeDir string, timestamp time.Time) error {
 				persistReached <- struct{}{}
-				<-releasePersist
-				return persistLastUpdateCheck(homeDir, timestamp)
+				select {
+				case <-releasePersist:
+					return persistLastUpdateCheck(homeDir, timestamp)
+				case <-ctx.Done():
+					return ctx.Err()
+				}
 			},
 		)
 	}()
 
-	select {
-	case <-persistReached:
-	case <-time.After(10 * time.Second):
-		t.Fatal("actor A did not reach timestamp persistence before actor B disables review mode")
-	}
+	awaitSignal(t, ctx, persistReached, "actor A did not reach timestamp persistence before actor B disables review mode")
 
-	actorB := exec.Command(binary, "review", "mode", "disable", "--scope", "global")
+	actorB := exec.CommandContext(ctx, binary, "review", "mode", "disable", "--scope", "global")
 	actorB.Dir = repositoryRoot(t)
 	actorB.Env = append(os.Environ(), "HOME="+home, "USERPROFILE="+home)
 	if output, err := actorB.CombinedOutput(); err != nil {
@@ -80,11 +83,7 @@ func TestCheckAllWithCooldown_ConcurrentReviewModeDisablePreservesMode(t *testin
 	}
 
 	release()
-	select {
-	case <-actorADone:
-	case <-time.After(10 * time.Second):
-		t.Fatal("actor A did not complete after its write boundary was released")
-	}
+	awaitSignal(t, ctx, actorADone, "actor A did not complete after its write boundary was released")
 
 	final, err := state.Read(home)
 	if err != nil {
@@ -98,10 +97,123 @@ func TestCheckAllWithCooldown_ConcurrentReviewModeDisablePreservesMode(t *testin
 	}
 }
 
+func TestCheckAllWithCooldown_ContendedPersistenceRejectsReviewModeDisable(t *testing.T) {
+	home := t.TempDir()
+	now := time.Date(2026, 6, 14, 12, 0, 0, 0, time.UTC)
+	stale := now.Add(-7 * time.Hour)
+	recordedAt := now.Add(-time.Hour)
+	initial := state.InstallState{
+		LastUpdateCheck:   &stale,
+		RDDMode:           "on",
+		RDDModeRecordedAt: &recordedAt,
+	}
+	if err := state.Write(home, initial); err != nil {
+		t.Fatalf("state.Write initial state: %v", err)
+	}
+
+	binary := buildCandidateBinary(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	writerEntered := make(chan struct{}, 1)
+	releaseWriter := make(chan struct{})
+	var releaseOnce sync.Once
+	release := func() { releaseOnce.Do(func() { close(releaseWriter) }) }
+	t.Cleanup(release)
+	actorADone := make(chan struct{})
+
+	go func() {
+		defer close(actorADone)
+		checkAllWithCooldown(
+			ctx,
+			"1.0.0",
+			system.PlatformProfile{OS: "darwin", PackageManager: "brew"},
+			home,
+			6*time.Hour,
+			func() time.Time { return now },
+			func(context.Context, string, system.PlatformProfile) []UpdateResult {
+				return []UpdateResult{{Status: UpToDate}}
+			},
+			func(homeDir string, timestamp time.Time) error {
+				return persistLastUpdateCheckWithWriter(homeDir, timestamp, func(homeDir string, updated state.InstallState) error {
+					writerEntered <- struct{}{}
+					select {
+					case <-releaseWriter:
+						return state.WriteReconciled(homeDir, updated)
+					case <-ctx.Done():
+						return ctx.Err()
+					}
+				})
+			},
+		)
+	}()
+
+	awaitSignal(t, ctx, writerEntered, "actor A did not hold the install-state lock after updating the timestamp")
+	before, err := state.Read(home)
+	if err != nil {
+		t.Fatalf("state.Read before contended actor B: %v", err)
+	}
+
+	actorBContext, cancelActorB := context.WithTimeout(ctx, 5*time.Second)
+	defer cancelActorB()
+	actorB := exec.CommandContext(actorBContext, binary, "review", "mode", "disable", "--scope", "global")
+	actorB.Dir = repositoryRoot(t)
+	actorB.Env = append(os.Environ(), "HOME="+home, "USERPROFILE="+home)
+	if output, err := actorB.CombinedOutput(); err == nil {
+		t.Fatalf("actor B unexpectedly disabled review mode while cooldown held the lock: %s", output)
+	}
+
+	afterAttempt, err := state.Read(home)
+	if err != nil {
+		t.Fatalf("state.Read after contended actor B: %v", err)
+	}
+	if !reflect.DeepEqual(before, afterAttempt) {
+		t.Fatalf("contended actor B changed persisted state: before %#v, after %#v", before, afterAttempt)
+	}
+
+	release()
+	awaitSignal(t, ctx, actorADone, "actor A did not complete after its write boundary was released")
+
+	afterActorA, err := state.Read(home)
+	if err != nil {
+		t.Fatalf("state.Read after actor A: %v", err)
+	}
+	if afterActorA.RDDMode != "on" || afterActorA.LastUpdateCheck == nil || !afterActorA.LastUpdateCheck.Equal(now) {
+		t.Fatalf("actor A state = %#v, want mode on with timestamp %v", afterActorA, now)
+	}
+
+	retryContext, cancelRetry := context.WithTimeout(ctx, 5*time.Second)
+	defer cancelRetry()
+	retry := exec.CommandContext(retryContext, binary, "review", "mode", "disable", "--scope", "global")
+	retry.Dir = repositoryRoot(t)
+	retry.Env = append(os.Environ(), "HOME="+home, "USERPROFILE="+home)
+	if output, err := retry.CombinedOutput(); err != nil {
+		t.Fatalf("actor B retry review mode disable failed: %v\n%s", err, output)
+	}
+
+	final, err := state.Read(home)
+	if err != nil {
+		t.Fatalf("state.Read after actor B retry: %v", err)
+	}
+	if final.RDDMode != "off" || final.LastUpdateCheck == nil || !final.LastUpdateCheck.Equal(now) {
+		t.Fatalf("final state = %#v, want mode off with timestamp %v", final, now)
+	}
+}
+
+func awaitSignal(t *testing.T, ctx context.Context, signal <-chan struct{}, message string) {
+	t.Helper()
+	select {
+	case <-signal:
+	case <-ctx.Done():
+		t.Fatalf("%s: %v", message, ctx.Err())
+	}
+}
+
 func buildCandidateBinary(t *testing.T) string {
 	t.Helper()
 	binary := filepath.Join(t.TempDir(), "gentle-ai")
-	command := exec.Command("go", "build", "-o", binary, "./cmd/gentle-ai")
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	command := exec.CommandContext(ctx, "go", "build", "-o", binary, "./cmd/gentle-ai")
 	command.Dir = repositoryRoot(t)
 	if output, err := command.CombinedOutput(); err != nil {
 		t.Fatalf("build candidate gentle-ai binary: %v\n%s", err, output)
@@ -111,14 +223,9 @@ func buildCandidateBinary(t *testing.T) string {
 
 func repositoryRoot(t *testing.T) string {
 	t.Helper()
-	command := exec.Command("git", "rev-parse", "--show-toplevel")
-	output, err := command.Output()
-	if err != nil {
-		t.Fatalf("discover repository root: %v", err)
+	_, sourceFile, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("discover repository root from runtime caller")
 	}
-	root := strings.TrimSpace(string(output))
-	if root == "" {
-		t.Fatal("discover repository root returned an empty path")
-	}
-	return root
+	return filepath.Clean(filepath.Join(filepath.Dir(sourceFile), "..", ".."))
 }

--- a/internal/update/cooldown_concurrency_test.go
+++ b/internal/update/cooldown_concurrency_test.go
@@ -1,0 +1,124 @@
+package update
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/gentleman-programming/gentle-ai/v2/internal/state"
+	"github.com/gentleman-programming/gentle-ai/v2/internal/system"
+)
+
+func TestCheckAllWithCooldown_ConcurrentReviewModeDisablePreservesMode(t *testing.T) {
+	home := t.TempDir()
+	now := time.Date(2026, 6, 14, 12, 0, 0, 0, time.UTC)
+	stale := now.Add(-7 * time.Hour)
+	recordedAt := now.Add(-time.Hour)
+	if err := state.Write(home, state.InstallState{
+		LastUpdateCheck:   &stale,
+		RDDMode:           "on",
+		RDDModeRecordedAt: &recordedAt,
+	}); err != nil {
+		t.Fatalf("state.Write initial state: %v", err)
+	}
+
+	binary := buildCandidateBinary(t)
+	persistReached := make(chan struct{}, 1)
+	releasePersist := make(chan struct{})
+	var releaseOnce sync.Once
+	release := func() { releaseOnce.Do(func() { close(releasePersist) }) }
+	t.Cleanup(release)
+	actorADone := make(chan struct{})
+
+	go func() {
+		defer close(actorADone)
+		checkAllWithCooldown(
+			context.Background(),
+			"1.0.0",
+			system.PlatformProfile{OS: "darwin", PackageManager: "brew"},
+			home,
+			6*time.Hour,
+			func() time.Time { return now },
+			func(context.Context, string, system.PlatformProfile) []UpdateResult {
+				return []UpdateResult{{Status: UpToDate}}
+			},
+			func(homeDir string, timestamp time.Time) error {
+				persistReached <- struct{}{}
+				<-releasePersist
+				return persistLastUpdateCheck(homeDir, timestamp)
+			},
+		)
+	}()
+
+	select {
+	case <-persistReached:
+	case <-time.After(10 * time.Second):
+		t.Fatal("actor A did not reach timestamp persistence before actor B disables review mode")
+	}
+
+	actorB := exec.Command(binary, "review", "mode", "disable", "--scope", "global")
+	actorB.Dir = repositoryRoot(t)
+	actorB.Env = append(os.Environ(), "HOME="+home, "USERPROFILE="+home)
+	if output, err := actorB.CombinedOutput(); err != nil {
+		t.Fatalf("actor B review mode disable failed: %v\n%s", err, output)
+	}
+
+	intermediate, err := state.Read(home)
+	if err != nil {
+		t.Fatalf("state.Read after actor B: %v", err)
+	}
+	if intermediate.RDDMode != "off" {
+		t.Fatalf("actor B did not persist disabled review mode while actor A was blocked: got %q, want off", intermediate.RDDMode)
+	}
+	if intermediate.LastUpdateCheck == nil || !intermediate.LastUpdateCheck.Equal(stale) {
+		t.Fatalf("actor B changed the timestamp while disabling review mode: got %v, want %v", intermediate.LastUpdateCheck, stale)
+	}
+
+	release()
+	select {
+	case <-actorADone:
+	case <-time.After(10 * time.Second):
+		t.Fatal("actor A did not complete after its write boundary was released")
+	}
+
+	final, err := state.Read(home)
+	if err != nil {
+		t.Fatalf("state.Read after actor A: %v", err)
+	}
+	if final.LastUpdateCheck == nil || !final.LastUpdateCheck.Equal(now) {
+		t.Fatalf("last_update_check = %v, want %v after actor A writes", final.LastUpdateCheck, now)
+	}
+	if final.RDDMode != "off" {
+		t.Fatalf("stale cooldown write reverted actor B's persisted disabled review mode: got %q, want off", final.RDDMode)
+	}
+}
+
+func buildCandidateBinary(t *testing.T) string {
+	t.Helper()
+	binary := filepath.Join(t.TempDir(), "gentle-ai")
+	command := exec.Command("go", "build", "-o", binary, "./cmd/gentle-ai")
+	command.Dir = repositoryRoot(t)
+	if output, err := command.CombinedOutput(); err != nil {
+		t.Fatalf("build candidate gentle-ai binary: %v\n%s", err, output)
+	}
+	return binary
+}
+
+func repositoryRoot(t *testing.T) string {
+	t.Helper()
+	command := exec.Command("git", "rev-parse", "--show-toplevel")
+	output, err := command.Output()
+	if err != nil {
+		t.Fatalf("discover repository root: %v", err)
+	}
+	root := strings.TrimSpace(string(output))
+	if root == "" {
+		t.Fatal("discover repository root returned an empty path")
+	}
+	return root
+}


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #4086

Related parent: #1809 remains open for the remaining install-state writers outside this cooldown slice.

---

## 🏷️ PR Type

- [x] `type:bug` — Bug fix (non-breaking change that fixes an issue)
- [ ] `type:feature` — New feature
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring
- [ ] `type:chore` — Build, CI, or tooling changes
- [ ] `type:breaking-change` — Breaking change

---

## 📝 Summary

- Move canonical install-state lock ownership into `internal/statecoord` so cooldown and existing CLI writers derive the same lock identity.
- Persist `LastUpdateCheck` through a locked fresh read and reconciled write without clobbering unrelated fields.
- Cover both successful cross-process preservation and explicit lock contention with mutation-sensitive candidate-built tests.

---

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/statecoord/` | Owns canonical resolved-home lock derivation and full read-modify-write coordination. |
| `internal/cli/install_state_lock.go` | Delegates the live CLI compatibility wrapper to `statecoord`; removes the unreachable path wrapper. |
| `internal/cli/install_state_lock_test.go` | Tests canonical paths directly through `statecoord.LockPath`. |
| `internal/update/cooldown.go` | Reads latest state and writes only the timestamp while holding the canonical lock. |
| `internal/update/cooldown_concurrency_test.go` | Drives real candidate-built processes across success and contention interleavings. |

---

## 🤖 AI Assistance

- [ ] **None** — No material AI assistance was used.
- [x] **Material assistance used**

**Tool/model (if known):** Pi coding agent using OpenAI GPT-5.6-series models.

**Material scope:** Current-main root-cause analysis, implementation, deterministic concurrency tests, isolated mutation testing, verification orchestration, and native four-lens advisory review.

**Verification performed:** The complete six-file diff and causal invariant were reviewed. Strict RED/GREEN evidence, lock-bypass mutation testing, race testing, dead-code checks, vet, formatting, Windows cross-compilation, the complete Go suite, and candidate-bound RDD were completed. The contributor explicitly confirmed understanding and responsibility before submission.

---

## 🧪 Test Plan

### Cross-process behavior

```bash
go test ./internal/update -run '^TestCheckAllWithCooldown_(ConcurrentReviewModeDisablePreservesMode|ContendedPersistenceRejectsReviewModeDisable)$' -count=3
go test -race ./internal/update -run '^TestCheckAllWithCooldown_(ConcurrentReviewModeDisablePreservesMode|ContendedPersistenceRejectsReviewModeDisable)$' -count=2
```

The tests build the candidate CLI, isolate its home, and verify two distinct operator flows:

1. A successful global review-mode disable completed before cooldown persistence remains `off` after the timestamp update.
2. A disable attempted while cooldown owns the full read-to-write lock fails without mutation; after release, a real-process retry succeeds and preserves the fresh timestamp.

### Mutation oracle

An isolated final-candidate copy was changed to bypass only cooldown's `statecoord.WithLock` while retaining the fresh read, timestamp mutation, and write. The contention test then failed at the intended business oracle:

```text
actor B unexpectedly disabled review mode while cooldown held the lock
MUTANT_ORACLE=CONFIRMED
```

This proves the new test detects removal of the lock itself, not merely stale whole-state publication.

### Full verification

```bash
go test -timeout 600s ./...
./scripts/deadcode-ratchet.sh
go vet ./internal/cli ./internal/statecoord ./internal/update
go run ./internal/gofmtcheck
GOOS=windows GOARCH=amd64 go test -c ./internal/cli
GOOS=windows GOARCH=amd64 go test -c ./internal/statecoord
GOOS=windows GOARCH=amd64 go test -c ./internal/update
```

All listed non-Docker commands passed locally. Docker is unavailable locally, and all Docker-backed E2E lanes passed in GitHub Actions on corrected head `a1d9c7f0`.

### RDD

Native high-tier 4R reviewed the exact complete committed range:

```text
lineage: review-c9379bec9222a232
target:  sha256:cbe6eeda2fa427bdc6b9fe6a70b17541772bcbe6e11edd0983511e3b03dd469e
result:  approved, acknowledged, no correction
```

One advisory-only warning remains: lock contention requires retry. This is non-blocking for #4086 because acquisition is fail-fast, cooldown persistence is intentionally fail-open and retries on later launches, and a contended global mode command returns failure without mutating state.

### Benchmark validation

N/A. This change preserves install-state integrity during cooldown persistence; it does not change review lifecycle, gates, recovery, delivery UX, benchmark implementation, corpus, classifier, or benchmark claims. The cross-process test is direct functional runtime evidence, not a performance claim.

- [x] Unit tests pass (`go test ./...`)
- [x] Go format passes (`go run ./internal/gofmtcheck`)
- [x] E2E tests pass in GitHub Actions on the corrected head
- [x] Manually tested through candidate-built cross-process behavior and lock-bypass mutation evidence

---

## 🤖 Automated Checks

| Check | Status | Description |
|-------|--------|-------------|
| Check PR Cognitive Load | ✅ | Passed at 404 lines with maintainer-approved `size:exception`. |
| Check Issue Reference | ✅ | Passed with `Closes #4086`. |
| Check Issue Has `status:approved` | ✅ | Passed for child issue #4086. |
| Check PR Has type label | ✅ | Passed with exactly `type:bug`. |
| Unit Tests | ✅ | Passed on corrected head `a1d9c7f0`. |
| Go Format | ✅ | Passed on corrected head `a1d9c7f0`. |
| E2E Tests | ✅ | Ubuntu, Arch, Fedora, organic Linux, and organic Windows lanes passed. |

---

## ✅ Contributor Checklist

- [x] PR is linked to approved issue #4086
- [x] Maintainer approved `size:exception` for the cohesive 404-line work unit
- [x] Exactly one `type:*` label is applied: `type:bug`
- [x] Unit tests pass locally
- [x] Go format passes locally
- [x] Docker and organic runtime E2E lanes pass in GitHub Actions
- [x] Benchmark validation is not applicable, as explained above
- [x] Documentation is not required because the public interface and user workflow are unchanged
- [x] Commits follow Conventional Commits
- [x] I understand, reviewed, and take responsibility for the complete submission
- [x] Material AI assistance is disclosed
- [x] Commits contain no `Co-Authored-By` trailers

---

## 💬 Notes for Reviewers

The scoped invariant is: cooldown timestamp persistence and cooperative CLI install-state mutations derive the same canonical `<resolved-home>/.gentle-ai/state.json.lock`, and cooldown holds it from the latest read through reconciled publication.

This PR intentionally does not claim that every install-state writer is migrated. Parent issue #1809 remains open for persona migration, TUI, self-update, uninstall, and other independent owners.

For the `internal/cli` guard checklist: no security, integrity-admission, repair, or governance guard was introduced or changed. The CLI production edit only delegates canonical lock acquisition to `internal/statecoord`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved coordination of installation-state updates during concurrent operations.
  * Prevented background update-check timestamps from overwriting changes made to review mode.
  * Preserved existing installation settings when state data is unreadable or corrupted.
  * Improved reliability when multiple commands attempt to update installation settings at the same time.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->