### PR TITLE
fix(review): preserve intended untracked terminal scope

### DIFF
--- a/bench/journeys_intended_untracked.go
+++ b/bench/journeys_intended_untracked.go
@@ -322,6 +322,41 @@ func validateUnbornIntendedStagedDelivery(r *journeyRun) error {
 	return requireGateForLineage(observation, r.sandbox.Lineage, false)
 }
 
+const selectedUntrackedTerminalPath = "internal/selected.go"
+
+func selectedUntrackedTerminalCandidate(sandbox *Sandbox) error {
+	return sandbox.write(filepath.Join(sandbox.Repo, selectedUntrackedTerminalPath), "package selected\n\nfunc Value() int { return 1 }\n")
+}
+
+func selectUntrackedCaptureAndResumeTerminal(r *journeyRun) error {
+	start, _, err := frozenLineageSelectedStatus(r, "", selectedUntrackedTerminalPath)
+	if err != nil || start.NextTransition.Kind != "execute" || start.NextTransition.Execute.Operation != "review.start" {
+		return fmt.Errorf("selected untracked START = %+v, %v", start.NextTransition, err)
+	}
+	if err := startFrozenLineageWithConsent(r, start); err != nil {
+		return err
+	}
+	active, _, err := frozenLineageStatus(r, r.sandbox.Lineage)
+	if err != nil || active.Authority.LineageID != r.sandbox.Lineage || active.Authority.State != "reviewing" ||
+		active.NextTransition.Kind != "collect" || active.NextTransition.ReasonCode != "reviewer_results_required" ||
+		len(active.NextTransition.Collect.Inputs) != 1 {
+		return fmt.Errorf("selected untracked reviewer STATUS = authority=%+v transition=%+v err=%v", active.Authority, active.NextTransition, err)
+	}
+	if err := captureFrozenReviewerResult(r, active); err != nil {
+		return err
+	}
+	resumed, _, err := frozenLineageStatus(r, r.sandbox.Lineage)
+	if err != nil || resumed.TargetIdentity != active.TargetIdentity || resumed.Authority.LineageID != r.sandbox.Lineage ||
+		resumed.Authority.State != "approved" || resumed.NextTransition.Kind != "execute" ||
+		resumed.NextTransition.ReasonCode != "approved_acknowledgement_required" ||
+		resumed.NextTransition.Execute.Operation != "review.acknowledge-approved" ||
+		resumed.executeArgument("lineage") != r.sandbox.Lineage || resumed.executeArgument("target") != active.TargetIdentity ||
+		resumed.executeArgument("expected-revision") != resumed.Authority.Revision {
+		return fmt.Errorf("selected untracked terminal resume = authority=%+v target=%q transition=%+v err=%v", resumed.Authority, resumed.TargetIdentity, resumed.NextTransition, err)
+	}
+	return nil
+}
+
 func intendedUntrackedJourneys() []Journey {
 	return []Journey{
 		{
@@ -333,6 +368,17 @@ func intendedUntrackedJourneys() []Journey {
 				{Name: "fixture: repository", Fixture: baseRepo},
 				{Name: "fixture: mixed tracked and intended/unrelated untracked files", Fixture: mixedIntendedUntrackedCandidate},
 				{Name: "STATUS collects selection and printed START freezes only chosen paths", Requires: intendedUntrackedStatusCapability, Composite: selectIntendedUntrackedAndRunPrintedStart},
+			},
+		},
+		{
+			ID:     "j126-selected-untracked-terminal-status-resumes-without-flags",
+			Review: reviewOptedIn,
+			Title:  "#4018: selected untracked reviewer closure resumes its terminal acknowledgement without selection flags",
+			Source: "#4018: an explicit occupied lineage owns its immutable intended-untracked selection through terminal continuation",
+			Steps: []Step{
+				{Name: "fixture: repository", Fixture: baseRepo},
+				{Name: "fixture: selected untracked Go review candidate", Fixture: selectedUntrackedTerminalCandidate},
+				{Name: "select untracked candidate, close its actual reviewer slot, and resume the acknowledgement through lineage STATUS without flags", Requires: frozenLineageStatusCapability, Composite: selectUntrackedCaptureAndResumeTerminal},
 			},
 		},
 		{

--- a/bench/review_declarations.go
+++ b/bench/review_declarations.go
@@ -123,6 +123,7 @@ var coreJourneyReviewModes = map[string]ReviewPrecondition{
 	"j123-rejected-provider-validator-starts-fresh-high-risk-review":            reviewOptedIn,
 	"j124-sdd-attempt-reset-after-selected-untracked-lands":                     reviewOptedIn,
 	"j125-claude-code-stop-hook-reminds-once-per-candidate":                     reviewOptedIn,
+	"j126-selected-untracked-terminal-status-resumes-without-flags":             reviewOptedIn,
 }
 
 func declareCoreJourneyReviewModes(journeys []Journey) []Journey {

--- a/bench/testdata/journeys.manifest
+++ b/bench/testdata/journeys.manifest
@@ -23,6 +23,7 @@ j122-global-review-mode-from-non-git-cwd
 j123-rejected-provider-validator-starts-fresh-high-risk-review
 j124-sdd-attempt-reset-after-selected-untracked-lands
 j125-claude-code-stop-hook-reminds-once-per-candidate
+j126-selected-untracked-terminal-status-resumes-without-flags
 j13-next-transition-runs-verbatim
 j14-abandon-needs-a-hand-built-token
 j17-bare-repository

--- a/internal/cli/review_facade.go
+++ b/internal/cli/review_facade.go
@@ -804,15 +804,47 @@ func runReviewStatus(ctx context.Context, args []string, stdout io.Writer) error
 		// the nested selector here would make fresh target freezing reject a
 		// valid foreign repository before START can bind its lifecycle root.
 		builder := reviewtransaction.SnapshotBuilder{Repo: root}
+		requestedLineage := strings.TrimSpace(*lineage)
+		requestedLineageOccupied := false
+		if *nextTransition && requestedLineage != "" {
+			requestedLineageOccupied, err = reviewtransaction.ExactReviewLineageOccupied(ctx, root, requestedLineage)
+			if err != nil {
+				return fmt.Errorf("inspect negotiated START lineage occupancy: %w", err)
+			}
+		}
 		intendedScope := reviewIntendedUntrackedScope{Intended: []string{}}
+		hydratedIntendedScope := false
 		if selectedProjection == reviewtransaction.ProjectionStaged {
 			if reviewIntendedUntrackedDeclared(untrackedScope, intendedUntracked, expectedUntrackedInventory) {
 				return reviewPreflightError(errors.New("staged projection does not accept intended-untracked selection; remove those flags and rerun `gentle-ai review status --projection staged`"))
 			}
 		} else {
-			intendedScope, err = reviewIntendedUntrackedScopeForTarget(ctx, reviewtransaction.SnapshotBuilder{Repo: root}, untrackedScope, intendedUntracked, expectedUntrackedInventory)
-			if err != nil {
-				return reviewPreflightError(err)
+			if !reviewIntendedUntrackedDeclared(untrackedScope, intendedUntracked, expectedUntrackedInventory) && requestedLineageOccupied {
+				store, storeErr := reviewtransaction.CompactAuthoritativeStore(ctx, root, requestedLineage)
+				if storeErr != nil {
+					return fmt.Errorf("open explicit review lineage: %w", storeErr)
+				}
+				record, loadErr := store.LoadContext(ctx)
+				if loadErr == nil {
+					// Only an approved compact authority that still owns its
+					// acknowledgement can resume its immutable terminal target. Every
+					// other occupied lineage must derive live scope so correction and
+					// recovery detect new untracked artifacts and target changes.
+					if _, pending := reviewtransaction.PendingApprovedCompactAcknowledgement(record); pending {
+						intendedScope = reviewIntendedUntrackedScope{
+							Intended: append([]string{}, record.State.InitialSnapshot.IntendedUntracked...), Declared: true,
+						}
+						hydratedIntendedScope = true
+					}
+				} else if reviewtransaction.IsCompactAuthorityOperationalFailure(loadErr) {
+					return fmt.Errorf("load explicit review lineage: %w", loadErr)
+				}
+			}
+			if !intendedScope.Declared {
+				intendedScope, err = reviewIntendedUntrackedScopeForTarget(ctx, builder, untrackedScope, intendedUntracked, expectedUntrackedInventory)
+				if err != nil {
+					return reviewPreflightError(err)
+				}
 			}
 		}
 		target := reviewtransaction.Target{Kind: reviewtransaction.TargetCurrentChanges, Projection: selectedProjection, IntendedUntracked: []string{}}
@@ -846,14 +878,6 @@ func runReviewStatus(ctx context.Context, args []string, stdout io.Writer) error
 		}
 		var native reviewtransaction.TargetStatusResult
 		var liveSnapshot reviewtransaction.Snapshot
-		requestedLineage := strings.TrimSpace(*lineage)
-		requestedLineageOccupied := false
-		if *nextTransition && requestedLineage != "" {
-			requestedLineageOccupied, err = reviewtransaction.ExactReviewLineageOccupied(ctx, root, requestedLineage)
-			if err != nil {
-				return fmt.Errorf("inspect negotiated START lineage occupancy: %w", err)
-			}
-		}
 		// Issue #3932: a continuation START issued carries the opaque
 		// repository context, so it is a resume of an existing lineage, never
 		// a pre-named fresh START. A process cwd that does not hold that
@@ -907,6 +931,19 @@ func runReviewStatus(ctx context.Context, args []string, stdout io.Writer) error
 		}
 		if selectedBaseTree != "" && native.Projection.BaseTree != selectedBaseTree {
 			return errors.New("--base-tree does not identify an exact Git tree object")
+		}
+		if hydratedIntendedScope && (native.Applicability != reviewtransaction.TargetApplicabilityCurrent || native.LineageID != requestedLineage) {
+			intendedScope, err = reviewIntendedUntrackedScopeForTarget(ctx, builder, untrackedScope, intendedUntracked, expectedUntrackedInventory)
+			if err != nil {
+				return reviewPreflightError(err)
+			}
+			target.IntendedUntracked = intendedScope.Intended
+			native, liveSnapshot, err = reviewtransaction.AssessTargetStatusWithSnapshot(ctx, root, reviewtransaction.TargetStatusRequest{
+				Target: target, LineageID: *lineage, PrePR: prePR,
+			})
+			if err != nil {
+				return fmt.Errorf("reassess negotiated review target: %w", err)
+			}
 		}
 		result := newReviewTargetStatusResultForContract(native, *contract)
 		result.intendedUntracked = intendedScope

--- a/internal/cli/review_frozen_status_test.go
+++ b/internal/cli/review_frozen_status_test.go
@@ -85,6 +85,39 @@ func TestExplicitFrozenReviewingStatusUsesFrozenUntrackedScope(t *testing.T) {
 	}
 }
 
+func TestExplicitFrozenTerminalStatusRestoresUntrackedScope(t *testing.T) {
+	repo, store, record := frozenReviewingStatusFixture(t, reviewtransaction.TargetCurrentChanges, []string{"frozen-untracked.txt"})
+	captureFrozenReviewerResults(t, repo, record, len(record.State.SelectedLenses))
+	pending, err := store.Load()
+	if err != nil {
+		t.Fatalf("load approved pending authority: %v", err)
+	}
+	if pending.State.State != reviewtransaction.StateApproved {
+		t.Fatalf("terminal authority state = %q, want approved", pending.State.State)
+	}
+
+	status := explicitFrozenReviewingStatus(t, repo, record.State.LineageID)
+	if status.TargetIdentity != record.State.InitialSnapshot.Identity ||
+		status.Projection.Kind != reviewtransaction.TargetCurrentChanges ||
+		status.Projection.Projection != reviewtransaction.ProjectionWorkspace ||
+		!reflect.DeepEqual(status.Projection.IntendedUntracked, record.State.InitialSnapshot.IntendedUntracked) ||
+		status.NextTransition == nil || status.NextTransition.Kind != reviewNextTransitionExecute ||
+		status.NextTransition.ReasonCode != "approved_acknowledgement_required" {
+		t.Fatalf("explicit terminal STATUS = %#v", status)
+	}
+	assertApprovedAcknowledgementTransition(t, status.NextTransition.Execute, repo, record.State.LineageID,
+		record.State.InitialSnapshot.Identity, pending.Revision)
+
+	writeUndeclaredWorkspaceFile(t, repo, "frozen-untracked.txt", "changed selected bytes\n", 0o644)
+	changed := explicitFrozenReviewingStatus(t, repo, record.State.LineageID)
+	live := explicitFrozenReviewingStatus(t, repo, "")
+	if changed.TargetIdentity == record.State.InitialSnapshot.Identity ||
+		changed.TargetIdentity != live.TargetIdentity ||
+		changed.NextTransition == nil || changed.NextTransition.ReasonCode == "approved_acknowledgement_required" {
+		t.Fatalf("changed selected bytes reused terminal scope: changed=%#v live=%#v", changed, live)
+	}
+}
+
 func TestExplicitFrozenReviewingStatusRejectsPartialSlotsAndStaleStartLineages(t *testing.T) {
 	t.Run("partial canonical record entry fails closed", func(t *testing.T) {
 		repo, store, record := frozenReviewingStatusFixture(t, reviewtransaction.TargetCurrentChanges, nil)


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #4018

---

## 🏷️ PR Type

- [x] `type:bug` — Bug fix (non-breaking change that fixes an issue)
- [ ] `type:feature` — New feature (non-breaking change that adds functionality)
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring (no functional changes)
- [ ] `type:chore` — Build, CI, or tooling changes
- [ ] `type:breaking-change` — Breaking change (fix or feature that changes existing behavior)

---

## 📝 Summary

- Preserve the frozen intended-untracked selection when an explicit approved lineage resumes its pending acknowledgement.
- Reassess the complete native target status when frozen scope no longer applies, preventing stale transition authority.
- Add unit regression coverage and driven journey `j126` for the complete terminal continuation.

---

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/cli/review_facade.go` | Hydrate eligible terminal lineage scope and fully reassess fallback status against live scope. |
| `internal/cli/review_frozen_status_test.go` | Cover terminal resume and changed selected-untracked bytes. |
| `bench/journeys_intended_untracked.go` | Add driven lifecycle journey `j126`. |
| `bench/review_declarations.go` | Declare review mode for `j126`. |
| `bench/testdata/journeys.manifest` | Register the new journey. |

---

## 🤖 AI Assistance

- [ ] **None** — No material AI assistance was used.
- [x] **Material assistance used** — Complete all applicable declaration fields below.

**Tool/model (if known):** Pi coding agent with OpenAI Codex

**Material scope:** Root-cause investigation, implementation, tests, benchmark journey, and verification orchestration.

**Verification performed:** Strict TDD with independent RED proof; uncached full Go suite; bench vet/tests; driven `j126`; Docker E2E; native bounded reliability review and targeted correction validation.

---

## 🧪 Test Plan

**Unit Tests**
```bash
go test ./... -count=1
```

**Go Format**
```bash
go run ./internal/gofmtcheck
```

**E2E Tests**
```bash
cd e2e && ./docker-test.sh
```

**Benchmark Validation**
```bash
gentle-ai-bench run --binary <locally-built-binary> --only j126-selected-untracked-terminal-status-resumes-without-flags
```

- [x] Unit tests pass (`go test ./...`)
- [x] Go format passes (`go run ./internal/gofmtcheck`)
- [x] E2E tests pass (`cd e2e && ./docker-test.sh`)
- [x] Manually tested locally

Driven result: `1 completed, 0 unsupported, 0 failed`.

---

## ✅ Contributor Checklist

- [x] PR is linked to an issue with `status:approved`
- [x] PR stays within 400 changed lines, or I have requested/obtained maintainer-applied `size:exception` with rationale documented
- [x] I have added the appropriate `type:*` label to this PR
- [x] Unit tests pass (`go test ./...`)
- [x] Go format passes (`go run ./internal/gofmtcheck`)
- [x] E2E tests pass (`cd e2e && ./docker-test.sh`)
- [x] Benchmark validation completed, or this change is not applicable to the benchmark (explain why in the Test Plan).
- [x] I have updated documentation if necessary
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] I understand, reviewed, and take responsibility for the complete submission
- [x] I selected exactly one AI-assistance option and, if material assistance was used, completed all applicable declaration fields
- [x] My commits do not include `Co-Authored-By` trailers

---

## 💬 Notes for Reviewers

The reliability review found and corrected a stale-native-result fallback: after replacing hydrated scope with live scope, STATUS now reruns native assessment so target identity, applicability, lineage, snapshot, and transition remain coherent.

- [x] The changed guard was challenged against legitimate correction/recovery populations with existing regression tests and a changed-byte negative control.
- [x] No new `guard:population` declaration is introduced; `.guard-population-baseline.txt` is unchanged.
- [x] Declaration checks were not used as semantic proof; the driven journey and runtime suites provide behavioral evidence.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resuming a review lineage without explicit selection now preserves the original intended-untracked scope from the approved review authority.
  * Terminal approved reviews now continue to display their frozen scope and the required approval acknowledgement transition.
  * When selected files change, review status correctly falls back to evaluating the current workspace state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->