### PR TITLE
docs(uninstall): correct rewriteJSONFile mode-preservation comment

### DIFF
--- a/internal/components/uninstall/service.go
+++ b/internal/components/uninstall/service.go
@@ -1088,9 +1088,8 @@ func rewriteJSONFile(path string, jsonPaths ...jsonPath) operation {
 				}
 				return true, true, nil
 			}
-			// Preserve the file's existing mode: ~/.claude.json is injected
-			// with 0600 because it holds the OAuth session, and an uninstall
-			// rewrite must not widen it.
+			// Preserve the agent settings/MCP config file's existing mode so an
+			// uninstall rewrite never widens permissions the user or agent set.
 			perm := os.FileMode(0o644)
 			if info, statErr := os.Lstat(path); statErr == nil {
 				perm = info.Mode().Perm()


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #3160

---

## 🏷️ PR Type

- [x] `type:docs` — Documentation only

---

## 📝 Summary

Correct the stale comment above `rewriteJSONFile`'s mode-preserving write. The old text incorrectly attributed the behavior to `~/.claude.json` and the OAuth session; that file is owned by `rewriteClaudeUserConfig`. `rewriteJSONFile` only rewrites agent settings and MCP config paths.

---

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/components/uninstall/service.go` | Rewrote the mode-preservation comment to describe the files this function actually receives |

---

## 🤖 AI Assistance

- [ ] **None** — No material AI assistance was used.
- [x] **Material assistance used** — Complete all applicable declaration fields below.

**Tool/model (if known):** Cursor Composer agent (composer-2.5 sub-agent review)

**Material scope:** Issue triage, comment wording, PR preparation

**Verification performed:** `go test ./internal/components/uninstall/...` and `go run ./internal/gofmtcheck`

---

## 🧪 Test Plan

Comment-only change; no runtime behavior modified.

**Unit Tests**
```bash
go test ./internal/components/uninstall/... -count=1
```
Result: PASS

**Go Format**
```bash
go run ./internal/gofmtcheck
```
Result: PASS

**Benchmark Validation:** N/A — comment-only documentation fix with no review-lifecycle or benchmark impact.

- [x] Unit tests pass for affected package
- [x] Go format passes (`go run ./internal/gofmtcheck`)
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`) — skipped; comment-only, no functional change
- [x] Manually verified comment matches maintainer guidance on #3160

---

## ✅ Contributor Checklist

- [x] PR is linked to an issue with `status:approved`
- [x] PR stays within 400 changed lines
- [ ] I have added the appropriate `type:*` label to this PR (CI/maintainer)
- [x] Unit tests pass for affected package
- [x] Go format passes
- [ ] E2E tests — N/A for comment-only change
- [x] Benchmark validation N/A
- [x] My commits follow Conventional Commits format
- [x] I understand, reviewed, and take responsibility for the complete submission
- [x] Material AI assistance disclosed above
- [x] My commits do not include `Co-Authored-By` trailers

---

## 💬 Notes for Reviewers

Maintainer guidance on #3160 (decode2): comment-only, do not mention `~/.claude.json`, do not change runtime code. Composer-2.5 review: APPROVE.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that uninstall rewrites preserve the existing permissions of agent settings and MCP configuration files, preventing permission widening.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->