### PR TITLE
test(e2e): keep OpenCode 4R bootstrap egress off the reviewer barrier

### DIFF
--- a/e2e/organicruntime/organic_runtime_test.go
+++ b/e2e/organicruntime/organic_runtime_test.go
@@ -631,6 +631,22 @@ func (proxy *loopbackDenyingProxy) deniedRequests() int {
 	return proxy.requests
 }
 
+// loopbackDenyingProxyEnvironment routes every proxied protocol of a child
+// process through the loopback-denying proxy while loopback stays direct, so
+// an external request is refused instead of reaching the host network.
+func loopbackDenyingProxyEnvironment(proxy *loopbackDenyingProxy) []string {
+	return []string{
+		"HTTP_PROXY=" + proxy.URL,
+		"HTTPS_PROXY=" + proxy.URL,
+		"ALL_PROXY=" + proxy.URL,
+		"http_proxy=" + proxy.URL,
+		"https_proxy=" + proxy.URL,
+		"all_proxy=" + proxy.URL,
+		"NO_PROXY=127.0.0.1,localhost,::1",
+		"no_proxy=127.0.0.1,localhost,::1",
+	}
+}
+
 func denyingProxyTargetIsExternal(request *http.Request) bool {
 	host := request.URL.Hostname()
 	if host == "" {
@@ -1169,6 +1185,8 @@ func TestOpenCodeRuntimeRunsFourBoundReviewersConcurrently(t *testing.T) {
 		writeOpenCodeChatText(writer, "review task group complete")
 	}))
 	defer server.Close()
+	proxy := newLoopbackDenyingProxy(t)
+	defer proxy.Close()
 
 	configDirectory := t.TempDir()
 	pluginDirectory := filepath.Join(configDirectory, "plugins")
@@ -1203,13 +1221,21 @@ func TestOpenCodeRuntimeRunsFourBoundReviewersConcurrently(t *testing.T) {
 	}
 	ctx, cancel := context.WithTimeout(t.Context(), organicAgentTimeout)
 	defer cancel()
-	command := exec.CommandContext(ctx, binary, "run", "--format", "json", "--dir", harness.repo.worktree, "--model", "loopback/loopback", "start the grouped Go-bound reviewer tasks")
+	command := organicCommandContext(ctx, binary, "run", "--format", "json", "--dir", harness.repo.worktree, "--model", "loopback/loopback", "start the grouped Go-bound reviewer tasks")
 	command.Dir = harness.repo.worktree
 	command.Env = append(harness.environment(),
 		"OPENCODE_CONFIG_DIR="+configDirectory,
 		"OPENCODE_CONFIG_CONTENT="+string(config),
 		"PATH="+filepath.Dir(organicBinary)+string(os.PathListSeparator)+os.Getenv("PATH"),
+		// OpenCode startup bootstraps @opencode-ai/plugin into every config
+		// directory through npm Arborist and refreshes models.dev before it
+		// issues the first model request. Against the fresh HOME, that egress can
+		// outlast the barrier, so the loopback proxy refuses it and the models.dev
+		// refresh is switched off. The transport plugin's import of
+		// @opencode-ai/plugin is type-only, so the refused install costs nothing.
+		"OPENCODE_DISABLE_MODELS_FETCH=1",
 	)
+	command.Env = append(command.Env, loopbackDenyingProxyEnvironment(proxy)...)
 	type runResult struct {
 		output []byte
 		err    error
@@ -1220,12 +1246,25 @@ func TestOpenCodeRuntimeRunsFourBoundReviewersConcurrently(t *testing.T) {
 		run <- runResult{output: output, err: err}
 	}()
 
+	// barrierState reads the reviewer-group counters under the lock so every
+	// failure before the barrier carries the same diagnostics.
+	barrierState := func() string {
+		lock.Lock()
+		defer lock.Unlock()
+		return fmt.Sprintf("tasksIssued=%t arrived=%d/%d arrivals=%v maxInFlight=%d settled=%d handlerFailure=%q deniedEgress=%d",
+			tasksIssued, arrived, len(wantLenses), arrivals, maxInFlight, settled, handlerFailure, proxy.deniedRequests())
+	}
 	select {
 	case <-allArrived:
 	case result := <-run:
-		t.Fatalf("OpenCode ended before every foreground reviewer reached the barrier: %v\n%s", result.err, result.output)
+		t.Fatalf("OpenCode ended before every foreground reviewer reached the barrier: %v\n%s\n%s", result.err, barrierState(), result.output)
 	case <-time.After(30 * time.Second):
-		t.Fatal("OpenCode did not schedule all four foreground reviewer requests")
+		// Zero arrivals at the deadline say only that the session had not
+		// reached the provider yet; they do not show 4R scheduling serialized.
+		// Cancel the subprocess so its output can be collected with the state.
+		cancel()
+		result := <-run
+		t.Fatalf("OpenCode did not reach the four-reviewer barrier within 30s; the stall may sit anywhere before it (startup, plugin bootstrap, transport, or scheduling): process=%v\n%s\n%s", result.err, barrierState(), result.output)
 	}
 	lock.Lock()
 	if maxInFlight != len(wantLenses) {


### PR DESCRIPTION
## Linked Issue

Closes #4121

---

## PR Type

- [x] `type:bug` — Bug fix (non-breaking change that fixes an issue)

---

## Summary

`TestOpenCodeRuntimeRunsFourBoundReviewersConcurrently` starts OpenCode 1.18.10 against a fresh HOME. Before the first model request, OpenCode bootstraps `@opencode-ai/plugin@1.18.10` into every config directory (the temp HOME's `~/.config/opencode` and `OPENCODE_CONFIG_DIR`) through npm Arborist and refreshes models.dev; because the config directory carries an external plugin, plugin loading waits for that install. When the egress outlasts the 30 s barrier the test fails without ever reaching the loopback provider, the message blames 4R scheduling, and nothing is printed because the subprocess is still alive.

This PR keeps the accepted scope from the issue thread:

- reuses the loopback-denying proxy from the pinned transport test (new `loopbackDenyingProxyEnvironment` helper) so the bootstrap egress is refused at once, and sets `OPENCODE_DISABLE_MODELS_FETCH=1`; the transport plugin's `@opencode-ai/plugin` import is type-only, so the refused install has no effect on the session;
- keeps the 30 s barrier and the four-reviewer assertions unchanged;
- on the deadline, cancels the subprocess (through the shared `organicCommandContext`, which bounds the wait) and reports the barrier state (`tasksIssued`, `arrived`, `arrivals`, `maxInFlight`, `settled`, `handlerFailure`, denied egress count) with the collected output under a stage-neutral message; the early-exit branch reports the same state.

Measured on two Linux hosts with opencode 1.18.10: base fails at about 31 s while opencode holds dozens of concurrent TLS sockets to registry.npmjs.org (28 to 57 across runs on two hosts) plus one to api.opencode.ai, and none to models.dev; with this change the test passes in a few seconds (3.9 s on one host, 6.6 to 7.0 s on another), well inside the 30 s barrier, with zero external connections. Forcing a stall (never-answering proxy) now yields the new message with `process=signal: killed` and `tasksIssued=false arrived=0/4`.

---

## Changes

| File / Area | What Changed |
|-------------|-------------|
| `e2e/organicruntime/organic_runtime_test.go` | `loopbackDenyingProxyEnvironment` helper; 4R test runs OpenCode behind the loopback-denying proxy with `OPENCODE_DISABLE_MODELS_FETCH=1`; timeout branch cancels the subprocess and reports barrier state plus output with a stage-neutral message |

---

## AI Assistance

- [x] **Material assistance used** — Complete all applicable declaration fields below.

**Tool/model (if known):** Claude Code (Claude, model claude-fable-5-1)

**Material scope:** investigation of the OpenCode 1.18.10 startup path (Arborist install and models.dev refresh), the test change in `organic_runtime_test.go`, and the local verification runs.

**Verification performed:** commands in the Test Plan, executed on Linux (WSL2) with the pinned opencode 1.18.10; RED on `adf47dac` under natural conditions (five runs on the author host plus one on the audit host, all FAIL at about 31 s), GREEN on this branch on both hosts (all PASS in a few seconds with no external sockets), and a forced-stall run showing the new diagnostics.

---

## Test Plan

**Unit Tests**
```bash
go test ./e2e/organicruntime -count=1
```

**Go Format**
```bash
go run ./internal/gofmtcheck
```

**Targeted E2E (Linux, pinned opencode 1.18.10)**
```bash
GENTLE_AI_OPENCODE_RUNTIME_E2E=1 go test ./e2e/organicruntime -run 'TestOpenCodeRuntimeRunsFourBoundReviewersConcurrently$' -count=1 -v
```

**Benchmark Validation:** N/A — e2e harness change only; no review-lifecycle, gate, recovery, delivery, or benchmark code touched.

- [x] Unit tests pass (`go test ./e2e/organicruntime -count=1`: ok, 23 PASS / 6 env-gated SKIP)
- [x] Go format passes (`go run ./internal/gofmtcheck`)
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`) — not run locally (no Docker on the verification host); relying on CI
- [x] Manually tested locally: targeted test PASS in 3.9 s on this branch versus FAIL at 30.85 s on `adf47dac`; `TestOpenCodeRuntimeIsPinnedForTheLiveProviderTransport` could not run locally (no strace) and is unchanged

---

## Notes for Reviewers

The proxy makes the two Arborist installs fail immediately; OpenCode logs `NpmInstallFailedError (cause: rF: 403 Forbidden - GET https://registry.npmjs.org/@opencode-ai%2fplugin)` twice per run (once per config directory) in its own log under the temp HOME, not in the output the test collects; the run then proceeds because the plugin never needs the package at runtime. The sibling transport test keeps its inline proxy block; it can adopt the helper in a follow-up if desired.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved end-to-end coverage for concurrent bound-reviewer workflows.
  * Added validation that runtime operations behave correctly when outbound network access is restricted.
  * Enhanced failure reporting for timed-out workflows, including captured process output and reviewer activity details.
  * Prevented unnecessary model metadata refreshes during the test scenario.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->