### PR TITLE
fix(docs): use merge-base scope for PR recount

### DIFF
--- a/skills/gentle-ai-collab-perfect/SKILL.md
+++ b/skills/gentle-ai-collab-perfect/SKILL.md
@@ -145,7 +145,7 @@ Every `[x]` in the Contributor Checklist is a public claim that `pr-check.yml` a
    - [ ] Fork workflow approval — 4 runs in `action_required` awaiting a maintainer
    ```
 
-2. **Numbers and file counts must match the API.** If you can't trust the API, recount locally: `git diff --stat <base>..<head>`.
+2. **Numbers and file counts must match the API.** If you can't trust the API, recount locally with merge-base scope, since three-dot preserves `<head>` as the compared side and avoids upstream-only drift: `git diff --stat <base>...<head>`.
 
 3. **Pre-existing failures must be named and methodology stated.** "Tests pass" is dishonest if four packages fail in the `git stash`-absent baseline. State them:
    ```markdown


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #3739

---

## 🏷️ PR Type

What kind of change does this PR introduce?

- [ ] `type:bug`: Bug fix (non-breaking change that fixes an issue)
- [ ] `type:feature`: New feature (non-breaking change that adds functionality)
- [x] `type:docs`: Documentation only
- [ ] `type:refactor`: Code refactoring (no functional changes)
- [ ] `type:chore`: Build, CI, or tooling changes
- [ ] `type:breaking-change`: Breaking change (fix or feature that changes existing behavior)

---

## 📝 Summary

`skills/gentle-ai-collab-perfect/SKILL.md` told contributors to recount a PR's scope with two-dot `git diff --stat <base>..<head>`. Two-dot compares endpoint trees, so when `<base>` has advanced independently of the PR branch, upstream-only files show up as spurious deletions/modifications and misrepresent what the PR actually changed. GitHub's own PR scope is merge-base based, so this PR switches the guidance to three-dot `git diff --stat <base>...<head>`, which diffs from the merge base to `<head>` and preserves `<head>` as the compared side. The explanatory sentence is updated to say why (merge-base scope, avoids upstream-only drift).

---

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| `skills/gentle-ai-collab-perfect/SKILL.md` | Line 148: recount command changed from `<base>..<head>` to `<base>...<head>`, with the surrounding sentence updated to explain the merge-base rationale |

---

## 🤖 AI Assistance

Select exactly one option. Do not check both options.

- [ ] **None**: No material AI assistance was used.
- [x] **Material assistance used**: Complete all applicable declaration fields below.

**Tool/model (if known):** Claude (Claude Sonnet 5), via Anthropic's Claude Cowork, editing directly through GitHub's web file editor.

**Material scope:** The full change: updating the recount command and its explanation in `SKILL.md`, and drafting this PR description from issue #3739 and the repo's PR template.

**Verification performed:** Confirmed via the editor's in-file search that the old two-dot pattern occurred exactly once in the file, so no other occurrences needed updating. Confirmed via GitHub's compare view that the resulting diff is exactly 1 addition / 1 deletion, matching the issue's stated scope. The replacement text matches the "Expected Behavior" wording specified in issue #3739.

Trivial formatting, spelling, minor autocomplete, search/navigation, and trivial, non-substantive mechanical transformations do not need to be itemized. See [AI_POLICY.md](../AI_POLICY.md) for the canonical policy.

---

## 🧪 Test Plan

**Unit Tests**: N/A. This change only edits prose/code-fence text inside a Markdown skill file; no `.go` source is touched, so `go test ./...` is not applicable.

**Go Format**: N/A, no Go source changed.

**E2E Tests** (Docker required): N/A, no application behavior changed.

**Benchmark Validation**: N/A, this is a documentation-only change with no review-lifecycle, gate, recovery, delivery, or benchmark code involved.

- [ ] Unit tests pass (`go test ./...`)
- [ ] Go format passes (`go run ./internal/gofmtcheck`)
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`)
- [ ] Manually tested locally

All four are N/A for this docs-only change (explained above); manual verification was the repro steps in issue #3739 (`git diff --stat main..feature` vs `git diff --stat main...feature` against a scratch repo with upstream-only drift), which confirms two-dot is the wrong guidance and three-dot is correct.

---

## ✅ Contributor Checklist

- [x] PR is linked to an issue with `status:approved`
- [x] PR stays within 400 changed lines, or I have requested/obtained maintainer-applied `size:exception` with rationale documented
- [ ] I have added the appropriate `type:*` label to this PR (no label-write access as an external contributor; `type:docs` is selected above)
- [ ] Unit tests pass (`go test ./...`): N/A, docs-only change (see Test Plan)
- [ ] Go format passes (`go run ./internal/gofmtcheck`): N/A, docs-only change
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`): N/A, docs-only change
- [ ] Benchmark validation completed, or this change is not applicable to the benchmark: not applicable (explained in Test Plan)
- [x] I have updated documentation if necessary
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] I understand, reviewed, and take responsibility for the complete submission
- [x] I selected exactly one AI-assistance option and, if material assistance was used, completed all applicable declaration fields
- [x] My commits do not include `Co-Authored-By` trailers

---

## 💬 Notes for Reviewers

This is a single-line documentation fix with no code changes, so the production-Go guard-review checklist below does not apply: no `internal/cli`, `internal/reviewtransaction`, or `internal/sddstatus` files are touched by this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated guidance for reporting diff statistics to use merge-base comparison, producing more accurate scope and avoiding unrelated upstream changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->