### PR TITLE
docs(pr-template): use absolute URLs for template links

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -52,7 +52,7 @@ Select exactly one option. Do not check both options.
 
 **Verification performed:**
 
-Trivial formatting, spelling, minor autocomplete, search/navigation, and trivial, non-substantive mechanical transformations do not need to be itemized. See [AI_POLICY.md](../AI_POLICY.md) for the canonical policy.
+Trivial formatting, spelling, minor autocomplete, search/navigation, and trivial, non-substantive mechanical transformations do not need to be itemized. See [AI_POLICY.md](https://github.com/Gentleman-Programming/gentle-ai/blob/main/AI_POLICY.md) for the canonical policy.
 
 ---
 
@@ -75,7 +75,7 @@ cd e2e && ./docker-test.sh
 
 **Benchmark Validation**
 
-See the [benchmark guide](../bench/README.md). Benchmark validation applies to review-lifecycle, gates, recovery, delivery, benchmark implementation/corpus/classifier, and benchmark-claim changes. For unrelated changes, explain `N/A` in the Test Plan.
+See the [benchmark guide](https://github.com/Gentleman-Programming/gentle-ai/blob/main/bench/README.md). Benchmark validation applies to review-lifecycle, gates, recovery, delivery, benchmark implementation/corpus/classifier, and benchmark-claim changes. For unrelated changes, explain `N/A` in the Test Plan.
 
 - [ ] Unit tests pass (`go test ./...`)
 - [ ] Go format passes (`go run ./internal/gofmtcheck`)


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #3297

---

## 🏷️ PR Type

What kind of change does this PR introduce?

- [ ] `type:bug`: Bug fix (non-breaking change that fixes an issue)
- [ ] `type:feature`: New feature (non-breaking change that adds functionality)
- [x] `type:docs`: Documentation only
- [ ] `type:refactor`: Code refactoring (no functional changes)
- [ ] `type:chore`: Build, CI, or tooling changes
- [ ] `type:breaking-change`: Breaking change (fix or feature that changes existing behavior)

---

## 📝 Summary

.github/PULL_REQUEST_TEMPLATE.md linked its AI Assistance and Benchmark Validation sections to AI_POLICY.md and bench/README.md using relative paths: [AI_POLICY.md](../AI_POLICY.md) and [benchmark guide](../bench/README.md). Those paths resolve correctly when viewing the template file directly, because GitHub rewrites relative links on a blob page. They do not resolve once the template text is copied into an actual pull request description: GitHub does not rewrite relative link targets when it renders an issue or pull request body, so the href is left unchanged and the browser resolves it against the PR's own URL, landing on the repository web root instead of the file. Both links 404 from a real PR body, as issue #3297 demonstrated with two already-published PRs that inherited the broken href. This PR replaces both relative paths with absolute blob/main URLs, so they resolve the same way regardless of where the template text is rendered.

---

## 📂 Changes

| File / Area | What Changed |
|---|---|
| `.github/PULL_REQUEST_TEMPLATE.md` | Line 55: `[AI_POLICY.md](../AI_POLICY.md)` changed to `[AI_POLICY.md](https://github.com/Gentleman-Programming/gentle-ai/blob/main/AI_POLICY.md)`. Line 78: `[benchmark guide](../bench/README.md)` changed to `[benchmark guide](https://github.com/Gentleman-Programming/gentle-ai/blob/main/bench/README.md)`. No other template text changed. |

---

## 🤖 AI Assistance

Select exactly one option. Do not check both options.

- [ ] **None**: No material AI assistance was used.
- [x] **Material assistance used**: Complete all applicable declaration fields below.

**Tool/model (if known):** Claude (Claude Sonnet 5), via Anthropic's Claude Cowork, editing directly through GitHub's web file editor.

**Material scope:** The full change: replacing both relative links in `PULL_REQUEST_TEMPLATE.md` with their absolute equivalents, and drafting this PR description from issue #3297 and the repo's PR template.

**Verification performed:** Confirmed via the editor's in-file search that each old relative link occurred exactly once in the file, so no other occurrences needed updating. Confirmed via GitHub's compare view that the resulting diff is exactly 2 additions / 2 deletions, matching the issue's stated scope (two links, one file). The replacement URLs match the absolute form the issue's maintainer comment specified.

Trivial formatting, spelling, minor autocomplete, search/navigation, and trivial, non-substantive mechanical transformations do not need to be itemized. See [AI_POLICY.md](https://github.com/Gentleman-Programming/gentle-ai/blob/main/AI_POLICY.md) for the canonical policy.

---

## 🧪 Test Plan

**Unit Tests:** N/A. This change only edits two markdown link targets in a documentation template; no `.go` source is touched, so `go test ./...` is not applicable.

**Go Format:** N/A, no Go source changed.

**E2E Tests** (Docker required): N/A, no application behavior changed.

**Benchmark Validation:** N/A, this is a documentation-only change with no review-lifecycle, gate, recovery, delivery, or benchmark code involved.

- [ ] Unit tests pass (`go test ./...`)
- [ ] Go format passes (`go run ./internal/gofmtcheck`)
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`)
- [ ] Manually tested locally

All four are N/A for this docs-only change (explained above). Manual verification was confirming both new links resolve to 200 (the `blob/main` form) rather than 404 (the repository-root form the old relative links produced), matching the reproduction steps in issue #3297.

---

## ✅ Contributor Checklist

- [x] PR is linked to an issue with `status:approved`
- [x] PR stays within 400 changed lines, or I have requested/obtained maintainer-applied `size:exception` with rationale documented
- [ ] I have added the appropriate `type:*` label to this PR (no label-write access as an external contributor; `type:docs` is selected above)
- [ ] Unit tests pass (`go test ./...`): N/A, docs-only change (see Test Plan)
- [ ] Go format passes (`go run ./internal/gofmtcheck`): N/A, docs-only change
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`): N/A, docs-only change
- [x] Benchmark validation completed, or this change is not applicable to the benchmark: not applicable (explained in Test Plan)
- [x] I have updated documentation if necessary
- [x] My commits follow Conventional Commits format
- [x] I understand, reviewed, and take responsibility for the complete submission
- [x] I selected exactly one AI-assistance option and, if material assistance was used, completed all applicable declaration fields
- [x] My commits do not include `Co-Authored-By` trailers

---

## 💬 Notes for Reviewers

This is a two-line documentation fix with no code changes, so the production-Go guard-review checklist below does not apply: no `internal/cli`, `internal/reviewtransaction`, or `internal/sddstatus` files are touched by this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated pull request template links to point directly to the corresponding guides on the repository’s main branch.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->