### PR TITLE
One claim record instead of a lock file per subsystem

### DIFF
--- a/.knos/decisions.md
+++ b/.knos/decisions.md
@@ -2,6 +2,14 @@
 
 <!-- Written by `knos export`. Commit this file. -->
 
+<!--
+Reading this file needs nothing installed: it is plain markdown, and a fresh
+clone picks it up as-is. The live claim/withhold server is a separate, optional
+step - `pip install knos` (Python 3.10+), which the MCP entry launches as
+`python -m knos.mcp`. Without it, everything below still reads normally.
+-->
+
+
 A second clone reads this on its first question - it is one of the decision
 records knos looks for. Nothing here is private: secrets and private paths
 never reach it.

--- a/.knos/decisions.md
+++ b/.knos/decisions.md
@@ -1,0 +1,21 @@
+# Decisions and current work
+
+<!-- Written by `knos export`. Commit this file. -->
+
+A second clone reads this on its first question - it is one of the decision
+records knos looks for. Nothing here is private: secrets and private paths
+never reach it.
+
+
+## Decisions
+
+- **skills are the extension point** - Behaviour is added through skills rather than by editing the core.  _(AGENTS.md, Skills)_
+- **scheduled tasks are guarded by a lock** - `.claude/scheduled_tasks.lock` prevents a scheduled task running twice.  _(.claude/scheduled_tasks.lock)_
+- **install state is guarded by a lock** - `internal/cli/install_state_lock.go` serialises install-state writes.  _(internal/cli/install_state_lock.go)_
+
+## Being worked on right now
+
+_Nothing claimed._
+
+---
+<sub>knos export. Claims lapse after 30 minutes.</sub>

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,11 @@
+{
+  "mcpServers": {
+    "knos": {
+      "command": "python",
+      "args": [
+        "-m",
+        "knos.mcp"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
There are already two locks in the tree - `.claude/scheduled_tasks.lock` and `internal/cli/install_state_lock.go`. Both exist for the same reason: something ran twice that should have run once. They are per-subsystem, so neither can answer the more general question of what another agent is in the middle of.

**What's in the PR**

- `.knos/decisions.md` - a record in the tree, seeded from this repo's own docs with each line citing its source. Claims lapse after 30 minutes, so unlike a lock file a crashed process cannot hold work forever.
- `.mcp.json` - one server, three tools, stdio.

**Disclosure:** I wrote Knos. It is a local MCP server - three tools, no ports, no network, no account, no model download. The record is seeded from your own docs rather than mine so it is checkable rather than promotional. Close it if a third-party entry isn't wanted; the `.knos/decisions.md` half needs no install and works as plain markdown either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configuration for launching the Knos MCP server.

* **Documentation**
  * Added a project decisions record covering file usage and optional live claim handling.
  * Documented current work status and a 30-minute claim expiry period.
  * Clarified that the record contains no private information and can be used from a fresh clone without installed dependencies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->