### PR TITLE
feat(state): persist external operation transitions

### DIFF
--- a/internal/statecoord/statecoord.go
+++ b/internal/statecoord/statecoord.go
@@ -7,6 +7,7 @@ package statecoord
 import (
 	"errors"
 	"fmt"
+	"os"
 	"path/filepath"
 
 	"github.com/gentleman-programming/gentle-ai/v2/internal/reviewtransaction"
@@ -39,4 +40,139 @@ func WithLock(homeDir string, operation func() error) (err error) {
 		}
 	}()
 	return operation()
+}
+
+// BeginExternalOperation records durable intent before the caller runs an external
+// side effect. The caller owns that work after this function returns.
+func BeginExternalOperation(homeDir string, intent state.ExternalOperation) error {
+	if err := validateExternalOperation(intent); err != nil {
+		return err
+	}
+	if intent.Phase != state.ExternalPhaseIntent {
+		// refusal:by-design state-transition: external operations begin only with durable intent.
+		return errors.New("external operation must begin in intent phase")
+	}
+	return WithLock(homeDir, func() error {
+		current, err := readInstallState(homeDir, true)
+		if err != nil {
+			return err
+		}
+		current.ExternalOperations = state.MergeExternalOperation(current.ExternalOperations, intent)
+		if err := state.WriteReconciled(homeDir, current); err != nil {
+			return fmt.Errorf("persist external operation intent: %w", err)
+		}
+		return nil
+	})
+}
+
+// AdvanceExternalOperation updates a pending operation's transition while retaining
+// the ownership facts captured by BeginExternalOperation.
+func AdvanceExternalOperation(homeDir string, transition state.ExternalOperation) error {
+	if err := validateExternalOperation(transition); err != nil {
+		return err
+	}
+	return WithLock(homeDir, func() error {
+		current, err := readInstallState(homeDir, false)
+		if err != nil {
+			return err
+		}
+		existing, found := matchingExternalOperation(current.ExternalOperations, transition)
+		if !found {
+			// refusal:by-design state-transition: an operation can only advance after its durable intent is recorded.
+			return errors.New("external operation is not pending; begin it before advancing")
+		}
+		if !canAdvanceExternalOperation(existing.Phase, transition.Phase) {
+			// refusal:by-design state-transition: durable external operations may only move forward through known phases.
+			return errors.New("external operation phase transition is invalid")
+		}
+		existing.Phase = transition.Phase
+		existing.Continuation = transition.Continuation
+		current.ExternalOperations = state.MergeExternalOperation(current.ExternalOperations, existing)
+		if err := state.WriteReconciled(homeDir, current); err != nil {
+			return fmt.Errorf("persist external operation transition: %w", err)
+		}
+		return nil
+	})
+}
+
+// SettleExternalOperation atomically applies an optional provenance mutation and
+// clears the matching durable operation record.
+func SettleExternalOperation(homeDir string, operation state.ExternalOperation, mutate func(*state.InstallState) error) error {
+	if err := validateExternalOperation(operation); err != nil {
+		return err
+	}
+	return WithLock(homeDir, func() error {
+		current, err := readInstallState(homeDir, false)
+		if err != nil {
+			return err
+		}
+		if _, found := matchingExternalOperation(current.ExternalOperations, operation); !found {
+			// refusal:by-design state-transition: provenance may only settle an operation whose ownership facts remain durable.
+			return errors.New("external operation is not pending; begin it before settling")
+		}
+		if mutate != nil {
+			if err := mutate(&current); err != nil {
+				return err
+			}
+		}
+		current.ExternalOperations = state.RemoveExternalOperation(current.ExternalOperations, operation)
+		if err := state.WriteReconciled(homeDir, current); err != nil {
+			return fmt.Errorf("persist settled external operation: %w", err)
+		}
+		return nil
+	})
+}
+
+// ClearExternalOperation settles an operation without changing provenance.
+func ClearExternalOperation(homeDir string, operation state.ExternalOperation) error {
+	return SettleExternalOperation(homeDir, operation, nil)
+}
+
+func canAdvanceExternalOperation(from, to state.ExternalPhase) bool {
+	switch from {
+	case state.ExternalPhaseIntent:
+		return to == state.ExternalPhaseIntent || to == state.ExternalPhaseApplied || to == state.ExternalPhaseManual
+	case state.ExternalPhaseApplied:
+		return to == state.ExternalPhaseApplied || to == state.ExternalPhaseManual
+	case state.ExternalPhaseManual:
+		return to == state.ExternalPhaseManual
+	default:
+		return false
+	}
+}
+
+func validateExternalOperation(operation state.ExternalOperation) error {
+	if operation.Tool == "" {
+		// refusal:by-design input-validation: durable records need a tool identity for recovery.
+		return errors.New("external operation tool is required")
+	}
+	if operation.Action == "" {
+		// refusal:by-design input-validation: durable records need an action identity for recovery.
+		return errors.New("external operation action is required")
+	}
+	if operation.Phase == "" {
+		// refusal:by-design input-validation: durable records need a transition phase for recovery.
+		return errors.New("external operation phase is required")
+	}
+	return nil
+}
+
+func readInstallState(homeDir string, allowAbsent bool) (state.InstallState, error) {
+	current, err := state.Read(homeDir)
+	if err == nil {
+		return current, nil
+	}
+	if allowAbsent && errors.Is(err, os.ErrNotExist) {
+		return state.InstallState{}, nil
+	}
+	return state.InstallState{}, fmt.Errorf("read install state: %w", err)
+}
+
+func matchingExternalOperation(operations []state.ExternalOperation, operation state.ExternalOperation) (state.ExternalOperation, bool) {
+	for _, existing := range operations {
+		if len(state.RemoveExternalOperation([]state.ExternalOperation{existing}, operation)) == 0 {
+			return existing, true
+		}
+	}
+	return state.ExternalOperation{}, false
 }

--- a/internal/statecoord/statecoord_test.go
+++ b/internal/statecoord/statecoord_test.go
@@ -3,8 +3,10 @@ package statecoord
 import (
 	"os"
 	"path/filepath"
+	"reflect"
 	"runtime"
 	"testing"
+	"time"
 
 	"github.com/gentleman-programming/gentle-ai/v2/internal/state"
 )
@@ -30,5 +32,178 @@ func TestLockPathResolvesHomeSymlink(t *testing.T) {
 	want := state.Path(resolvedHome) + ".lock"
 	if got != want {
 		t.Fatalf("LockPath() = %q, want %q", got, want)
+	}
+}
+
+func TestBeginExternalOperationReturnsAfterPersistingIntent(t *testing.T) {
+	home := t.TempDir()
+	intent := testOperation("first")
+
+	if err := BeginExternalOperation(home, intent); err != nil {
+		t.Fatalf("BeginExternalOperation() error = %v", err)
+	}
+	if got := readState(t, home).ExternalOperations; len(got) != 1 || got[0].Phase != state.ExternalPhaseIntent {
+		t.Fatalf("journal after BeginExternalOperation() = %#v", got)
+	}
+}
+
+func TestExternalOperationTransitionsValidateInputs(t *testing.T) {
+	home := t.TempDir()
+	if err := BeginExternalOperation(home, state.ExternalOperation{Action: state.ExternalActionInstall, Phase: state.ExternalPhaseIntent}); err == nil {
+		t.Fatal("BeginExternalOperation() error = nil, want missing tool error")
+	}
+	if err := AdvanceExternalOperation(home, state.ExternalOperation{Tool: state.ExternalToolGGA, Phase: state.ExternalPhaseApplied}); err == nil {
+		t.Fatal("AdvanceExternalOperation() error = nil, want missing action error")
+	}
+	if err := ClearExternalOperation(home, state.ExternalOperation{Tool: state.ExternalToolGGA, Action: state.ExternalActionInstall}); err == nil {
+		t.Fatal("ClearExternalOperation() error = nil, want missing phase error")
+	}
+}
+
+func TestExternalOperationTransitionsRejectInvalidPhasesWithoutPersisting(t *testing.T) {
+	tests := []struct {
+		name           string
+		persistedPhase state.ExternalPhase
+		requestedPhase state.ExternalPhase
+		begin          bool
+	}{
+		{name: "begin must record intent", persistedPhase: state.ExternalPhaseIntent, requestedPhase: state.ExternalPhaseApplied, begin: true},
+		{name: "advance rejects unknown phase", persistedPhase: state.ExternalPhaseIntent, requestedPhase: "unknown"},
+		{name: "advance cannot regress from applied", persistedPhase: state.ExternalPhaseApplied, requestedPhase: state.ExternalPhaseIntent},
+		{name: "advance cannot regress from manual", persistedPhase: state.ExternalPhaseManual, requestedPhase: state.ExternalPhaseApplied},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			home := t.TempDir()
+			persisted := testOperation("target")
+			persisted.Phase = tt.persistedPhase
+			initial := state.InstallState{ExternalOperations: []state.ExternalOperation{persisted}}
+			if err := state.Write(home, initial); err != nil {
+				t.Fatal(err)
+			}
+
+			requested := testOperation("target")
+			requested.Phase = tt.requestedPhase
+			var err error
+			if tt.begin {
+				err = BeginExternalOperation(home, requested)
+			} else {
+				err = AdvanceExternalOperation(home, requested)
+			}
+			if err == nil {
+				t.Fatal("external operation transition error = nil, want invalid phase error")
+			}
+			if got := readState(t, home); !reflect.DeepEqual(got, initial) {
+				t.Fatalf("persisted state = %#v, want %#v", got, initial)
+			}
+		})
+	}
+}
+
+func TestExternalOperationTransitionsPreserveLatestStateAndOwnership(t *testing.T) {
+	home := t.TempDir()
+	original := testOperation("target")
+	original.BeforePresent = false
+	original.PathBeforePresence = []state.ExternalPathPresence{{Path: original.Paths[0], Present: false}}
+	unrelated := testOperation("unrelated")
+	if err := state.Write(home, state.InstallState{InstalledAgents: []string{"pi"}, ExternalOperations: []state.ExternalOperation{original, unrelated}}); err != nil {
+		t.Fatal(err)
+	}
+
+	advance := testOperation("target")
+	advance.BeforePresent = true
+	advance.PathBeforePresence = []state.ExternalPathPresence{{Path: advance.Paths[0], Present: true}}
+	advance.Phase = state.ExternalPhaseApplied
+	advance.Continuation = "settle target"
+	if err := AdvanceExternalOperation(home, advance); err != nil {
+		t.Fatal(err)
+	}
+	if err := AdvanceExternalOperation(home, advance); err != nil {
+		t.Fatalf("idempotent AdvanceExternalOperation() error = %v", err)
+	}
+
+	persisted := readState(t, home)
+	if len(persisted.ExternalOperations) != 2 || persisted.InstalledAgents[0] != "pi" {
+		t.Fatalf("latest state was not preserved: %#v", persisted)
+	}
+	got := persisted.ExternalOperations[0]
+	if got.BeforePresent || got.PathBeforePresence[0].Present || got.Phase != state.ExternalPhaseApplied || got.Continuation != "settle target" {
+		t.Fatalf("advanced operation = %#v, want original ownership and new transition", got)
+	}
+}
+
+func TestCallerBlockedExternalPhaseDoesNotHoldStateLock(t *testing.T) {
+	home := t.TempDir()
+	if err := BeginExternalOperation(home, testOperation("first")); err != nil {
+		t.Fatal(err)
+	}
+
+	externalStarted := make(chan struct{})
+	externalRelease := make(chan struct{})
+	externalDone := make(chan struct{})
+	go func() {
+		close(externalStarted)
+		<-externalRelease
+		close(externalDone)
+	}()
+	<-externalStarted
+
+	lockResult := make(chan error, 1)
+	go func() {
+		lockResult <- WithLock(home, func() error { return nil })
+	}()
+	select {
+	case err := <-lockResult:
+		if err != nil {
+			t.Fatal(err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("statecoord operation did not acquire and release the lock while external work was blocked")
+	}
+
+	close(externalRelease)
+	<-externalDone
+}
+
+func TestSettleExternalOperationMutatesProvenanceAndClearsOnlyMatch(t *testing.T) {
+	home := t.TempDir()
+	target, unrelated := testOperation("target"), testOperation("unrelated")
+	if err := state.Write(home, state.InstallState{ExternalOperations: []state.ExternalOperation{target, unrelated}}); err != nil {
+		t.Fatal(err)
+	}
+	if err := SettleExternalOperation(home, target, func(persisted *state.InstallState) error {
+		persisted.ManagedAssetDigest = "digest"
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+	persisted := readState(t, home)
+	if persisted.ManagedAssetDigest != "digest" || len(persisted.ExternalOperations) != 1 || persisted.ExternalOperations[0].Route != unrelated.Route {
+		t.Fatalf("settled state = %#v", persisted)
+	}
+	if err := ClearExternalOperation(home, unrelated); err != nil {
+		t.Fatal(err)
+	}
+	if got := readState(t, home).ExternalOperations; got != nil {
+		t.Fatalf("cleared journal = %#v, want nil", got)
+	}
+}
+
+func readState(t *testing.T, home string) state.InstallState {
+	t.Helper()
+	persisted, err := state.Read(home)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return persisted
+}
+
+func testOperation(route string) state.ExternalOperation {
+	return state.ExternalOperation{
+		Tool:   state.ExternalToolGGA,
+		Action: state.ExternalActionInstall,
+		Route:  route,
+		Paths:  []string{"/home/example/" + route},
+		Phase:  state.ExternalPhaseIntent,
 	}
 }


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #4138

---

## 🏷️ PR Type

- [x] `type:bug` — Bug fix (non-breaking change that fixes an issue)

---

## 📝 Summary

Adds lock-scoped persistent transitions for the external-operation journal introduced by PR #4140. Intent is durable before caller-owned external work begins; advance and settlement re-read the latest state under the shared lock and preserve unrelated operations.

### Chain Context

```text
main <- tracker #4139
          └─ #4140 journal model
               └─ 📍 child 2: persistent transitions
                    └─ later GGA and CodeGraph consumers
```

**Starts:** PR #4140 commit `ab7c4113`.

**Ends:** durable `Begin`, `Advance`, `Settle`, and `Clear` transitions using the existing `statecoord` lock authority.

**Prior dependency:** #4140 supplies the persisted operation model and identity helpers.

**Follow-up work:** GGA and CodeGraph consumers will journal intent before external mutation and settle exact provenance afterward.

**Out of scope:** executing external commands, GGA/CodeGraph provenance, CLI wiring, and any new lock implementation.

---

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/statecoord/statecoord.go` | Adds lock-scoped journal transitions, input validation, and forward-only phase invariants. |
| `internal/statecoord/statecoord_test.go` | Covers durability, latest-state preservation, lock release before caller work, idempotence, selective settlement, and invalid-phase rejection. |

---

## 🤖 AI Assistance

- [ ] **None** — No material AI assistance was used.
- [x] **Material assistance used** — Complete all applicable declaration fields below.

**Tool/model (if known):** Pi/el Gentleman with OpenAI Codex subagents.

**Material scope:** Strict-TDD implementation, architectural validation, bounded correction, full verification, and native review orchestration.

**Verification performed:** Focused state/statecoord tests, full uncached Go suite, vet, check-only gofmt, diff check, and native reliability review with targeted correction validation.

---

## 🧪 Test Plan

```bash
go test ./internal/statecoord -count=1
go test ./internal/state ./internal/statecoord -count=1
go test ./... -count=1
go vet ./...
gofmt -d internal/statecoord/statecoord.go internal/statecoord/statecoord_test.go
git diff --check ab7c4113...HEAD
```

All commands passed on corrected commit `0fee624a`. Benchmark validation: N/A; this child adds internal state coordination primitives without a runtime consumer.

- [x] Unit tests pass (`go test ./... -count=1`)
- [x] Go format passes in check-only mode
- [ ] E2E tests pass — standalone E2E harness not run; full Go runtime/E2E packages passed
- [x] Manually inspected and independently verified

---

## 🤖 Automated Checks

The repository checks remain authoritative.

---

## ✅ Contributor Checklist

- [x] PR is linked to approved issue #4138
- [x] PR contains 311 changed lines, within the 400-line budget
- [ ] Appropriate `type:bug` label has been applied and read back
- [x] Unit tests pass uncached
- [x] Go format check passes
- [x] Benchmark validation is not applicable and is explained
- [x] Documentation is not required for this internal primitive
- [x] Commit follows Conventional Commits
- [x] Material AI assistance is declared
- [x] Commit contains no `Co-Authored-By` trailer

---

## 💬 Notes for Reviewers

The first draft incorrectly held the shared lock while external caller work. Independent validation rejected it before commit. The corrected API persists intent and releases the lock before callers run external commands.

Native review `review-c49f0153549e19c8` found one deterministic phase-invariant defect. The single bounded correction now enforces `intent` at begin and forward-only/idempotent transitions; native targeted validation approved the corrected candidate.

Rollback is commit `0fee624a` only; it removes the two statecoord changes without affecting PR #4140.
