### PR TITLE
fix(engram): clarify mem_save content is a string, not an object

### DIFF
--- a/internal/assets/engram/protocol.md
+++ b/internal/assets/engram/protocol.md
@@ -39,11 +39,9 @@ Format for `mem_save`:
 - **scope**: `project` (default) | `personal`
 - **topic_key** (recommended for evolving topics): stable key like `architecture/auth-model`
 - **capture_prompt**: optional; default `true`. Do not set this for normal human/proactive saves. Set `false` only for automated artifacts such as SDD proposal/spec/design/tasks/apply/verify/archive/init reports, testing-capabilities caches, onboarding/state artifacts, or skill-registry output.
-- **content**:
-  - **What**: One sentence — what was done
-  - **Why**: What motivated it (user request, bug, performance, etc.)
-  - **Where**: Files or paths affected
-  - **Learned**: Gotchas, edge cases, things that surprised you (omit if none)
+- **content**: A single JSON string (NOT an object). Use this structure as plain text inside the string:
+  `"What: One sentence — what was done. Why: What motivated it. Where: Files or paths affected. Learned: Gotchas, edge cases (omit if none)."`
+  Example: `content: "What: Fixed race condition in symbol params update. Why: User reported stale SL values after save. Where: bot_manager.py save_symbol_params(). Learned: Thread-safe param sync requires lock before in-memory update."`
 
 Prompt capture behavior (Engram v1.15.3+):
 - `mem_save` captures the user prompt best-effort when the MCP process already has prompt context for the same `project + session_id`.

--- a/internal/components/engram/testdata/protocol-full.md
+++ b/internal/components/engram/testdata/protocol-full.md
@@ -38,11 +38,9 @@ Format for `mem_save`:
 - **scope**: `project` (default) | `personal`
 - **topic_key** (recommended for evolving topics): stable key like `architecture/auth-model`
 - **capture_prompt**: optional; default `true`. Do not set this for normal human/proactive saves. Set `false` only for automated artifacts such as SDD proposal/spec/design/tasks/apply/verify/archive/init reports, testing-capabilities caches, onboarding/state artifacts, or skill-registry output.
-- **content**:
-  - **What**: One sentence — what was done
-  - **Why**: What motivated it (user request, bug, performance, etc.)
-  - **Where**: Files or paths affected
-  - **Learned**: Gotchas, edge cases, things that surprised you (omit if none)
+- **content**: A single JSON string (NOT an object). Use this structure as plain text inside the string:
+  `"What: One sentence — what was done. Why: What motivated it. Where: Files or paths affected. Learned: Gotchas, edge cases (omit if none)."`
+  Example: `content: "What: Fixed race condition in symbol params update. Why: User reported stale SL values after save. Where: bot_manager.py save_symbol_params(). Learned: Thread-safe param sync requires lock before in-memory update."`
 
 Prompt capture behavior (Engram v1.15.3+):
 - `mem_save` captures the user prompt best-effort when the MCP process already has prompt context for the same `project + session_id`.

--- a/testdata/golden/combined-windsurf-global-rules.golden
+++ b/testdata/golden/combined-windsurf-global-rules.golden
@@ -616,11 +616,9 @@ Format for `mem_save`:
 - **scope**: `project` (default) | `personal`
 - **topic_key** (recommended for evolving topics): stable key like `architecture/auth-model`
 - **capture_prompt**: optional; default `true`. Do not set this for normal human/proactive saves. Set `false` only for automated artifacts such as SDD proposal/spec/design/tasks/apply/verify/archive/init reports, testing-capabilities caches, onboarding/state artifacts, or skill-registry output.
-- **content**:
-  - **What**: One sentence — what was done
-  - **Why**: What motivated it (user request, bug, performance, etc.)
-  - **Where**: Files or paths affected
-  - **Learned**: Gotchas, edge cases, things that surprised you (omit if none)
+- **content**: A single JSON string (NOT an object). Use this structure as plain text inside the string:
+  `"What: One sentence — what was done. Why: What motivated it. Where: Files or paths affected. Learned: Gotchas, edge cases (omit if none)."`
+  Example: `content: "What: Fixed race condition in symbol params update. Why: User reported stale SL values after save. Where: bot_manager.py save_symbol_params(). Learned: Thread-safe param sync requires lock before in-memory update."`
 
 Prompt capture behavior (Engram v1.15.3+):
 - `mem_save` captures the user prompt best-effort when the MCP process already has prompt context for the same `project + session_id`.

--- a/testdata/golden/engram-antigravity-rulesmd.golden
+++ b/testdata/golden/engram-antigravity-rulesmd.golden
@@ -39,11 +39,9 @@ Format for `mem_save`:
 - **scope**: `project` (default) | `personal`
 - **topic_key** (recommended for evolving topics): stable key like `architecture/auth-model`
 - **capture_prompt**: optional; default `true`. Do not set this for normal human/proactive saves. Set `false` only for automated artifacts such as SDD proposal/spec/design/tasks/apply/verify/archive/init reports, testing-capabilities caches, onboarding/state artifacts, or skill-registry output.
-- **content**:
-  - **What**: One sentence — what was done
-  - **Why**: What motivated it (user request, bug, performance, etc.)
-  - **Where**: Files or paths affected
-  - **Learned**: Gotchas, edge cases, things that surprised you (omit if none)
+- **content**: A single JSON string (NOT an object). Use this structure as plain text inside the string:
+  `"What: One sentence — what was done. Why: What motivated it. Where: Files or paths affected. Learned: Gotchas, edge cases (omit if none)."`
+  Example: `content: "What: Fixed race condition in symbol params update. Why: User reported stale SL values after save. Where: bot_manager.py save_symbol_params(). Learned: Thread-safe param sync requires lock before in-memory update."`
 
 Prompt capture behavior (Engram v1.15.3+):
 - `mem_save` captures the user prompt best-effort when the MCP process already has prompt context for the same `project + session_id`.

--- a/testdata/golden/engram-codex-instructions.golden
+++ b/testdata/golden/engram-codex-instructions.golden
@@ -38,11 +38,9 @@ Format for `mem_save`:
 - **scope**: `project` (default) | `personal`
 - **topic_key** (recommended for evolving topics): stable key like `architecture/auth-model`
 - **capture_prompt**: optional; default `true`. Do not set this for normal human/proactive saves. Set `false` only for automated artifacts such as SDD proposal/spec/design/tasks/apply/verify/archive/init reports, testing-capabilities caches, onboarding/state artifacts, or skill-registry output.
-- **content**:
-  - **What**: One sentence — what was done
-  - **Why**: What motivated it (user request, bug, performance, etc.)
-  - **Where**: Files or paths affected
-  - **Learned**: Gotchas, edge cases, things that surprised you (omit if none)
+- **content**: A single JSON string (NOT an object). Use this structure as plain text inside the string:
+  `"What: One sentence — what was done. Why: What motivated it. Where: Files or paths affected. Learned: Gotchas, edge cases (omit if none)."`
+  Example: `content: "What: Fixed race condition in symbol params update. Why: User reported stale SL values after save. Where: bot_manager.py save_symbol_params(). Learned: Thread-safe param sync requires lock before in-memory update."`
 
 Prompt capture behavior (Engram v1.15.3+):
 - `mem_save` captures the user prompt best-effort when the MCP process already has prompt context for the same `project + session_id`.


### PR DESCRIPTION
## Summary

The engram protocol and AGENTS.md documented `mem_save`'s `content` parameter with a nested `What/Why/Where/Learned` structure that agents interpret as a JSON object. The engram MCP tool expects `content` as a plain string, causing every `mem_save` call from OpenCode agents to fail:

```
content is required for mem_save (use content, or observation for backward-compatible clients)
```

## Changes

- **`internal/assets/engram/protocol.md`**: Changed `content` format from nested object structure to explicit string format with example
- **`internal/components/engram/testdata/protocol-full.md`**: Updated current fixture to match
- **Golden files**: Regenerated `engram-codex-instructions.golden`, `engram-antigravity-rulesmd.golden`, `combined-windsurf-global-rules.golden`
- Left `protocol-old-codex-instructions.md` unchanged (historical pre-consolidation fixture)

## Before

```
- **content**:
  - **What**: One sentence — what was done
  - **Why**: What motivated it (user request, bug, performance, etc.)
  - **Where**: Files or paths affected
  - **Learned**: Gotchas, edge cases, things that surprised you (omit if none)
```

## After

```
- **content**: A single JSON string (NOT an object). Use this structure as plain text inside the string:
  "What: One sentence — what was done. Why: What motivated it. Where: Files or paths affected. Learned: Gotchas, edge cases (omit if none)."
  Example: content: "What: Fixed race condition in symbol params update. Why: User reported stale SL values after save. Where: bot_manager.py save_symbol_params(). Learned: Thread-safe param sync requires lock before in-memory update."
```

## Verification

- Tested `mem_save` with string content: works
- Tested `mem_save` with object content: fails (confirms the bug)
- Engram golden tests pass with `-update` flag
- Related: #3698, #827


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the `mem_save` content format to require a single JSON string containing labeled `What`, `Why`, and `Where` fields, with an optional `Learned` field.
  - Updated protocol examples to reflect the new inline JSON format.
  - Existing nested YAML-style content is no longer the documented format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->