### PR TITLE
fix(sdd): enforce rules.apply parity in model-small sdd-apply

### DIFF
--- a/internal/assets/skills/sdd-apply/SKILL.md
+++ b/internal/assets/skills/sdd-apply/SKILL.md
@@ -312,6 +312,7 @@ You are an IMPLEMENTER sub-agent. You receive specific tasks and implement them 
 - Never minify the diff (strip comments, blank lines, docs, or tests) to fit the review budget; implement the cohesive slice honestly and report the final count with a `size:exception` recommendation when it stays over
 - If previous apply-progress exists, read it via mem_search + mem_get_observation and MERGE before saving
 - Focused remediation is the sole `all_done` exception and must bind evidence to the exact failed_evidence_revision from native status
+- Apply any `rules.apply` from `openspec/config.yaml`
 
 ## Steps
 

--- a/internal/components/sdd/sdd_apply_tier_parity_test.go
+++ b/internal/components/sdd/sdd_apply_tier_parity_test.go
@@ -1,0 +1,77 @@
+package sdd
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/gentleman-programming/gentle-ai/v2/internal/model"
+)
+
+func TestSDDApplyTierParityAtRenderedInstalledBoundaries(t *testing.T) {
+	const phaseRuleInstruction = "Apply any `rules.apply` from `openspec/config.yaml`"
+
+	tests := []struct {
+		name       string
+		capability string
+	}{
+		{
+			name:       "capable",
+			capability: "capable",
+		},
+		{
+			name:       "small",
+			capability: "small",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			home := t.TempDir()
+
+			// Boundary 1: Shared prompt file rendered by WriteSharedPromptFiles
+			phaseCaps := map[string]string{"sdd-apply": tt.capability}
+			if _, err := WriteSharedPromptFiles(home, phaseCaps); err != nil {
+				t.Fatalf("WriteSharedPromptFiles(%s) error = %v", tt.capability, err)
+			}
+			promptPath := filepath.Join(SharedPromptDir(home), "sdd-apply.md")
+			promptBytes, err := os.ReadFile(promptPath)
+			if err != nil {
+				t.Fatalf("ReadFile(%q) error = %v", promptPath, err)
+			}
+
+			// Boundary 2: Agent skill directory installed by InjectSkillDirectoryForAgent
+			skillDir := filepath.Join(home, "installed-skills")
+			if _, err := InjectSkillDirectoryForAgent(skillDir, tt.capability, model.AgentClaudeCode); err != nil {
+				t.Fatalf("InjectSkillDirectoryForAgent(%s) error = %v", tt.capability, err)
+			}
+			skillPath := filepath.Join(skillDir, "sdd-apply", "SKILL.md")
+			skillBytes, err := os.ReadFile(skillPath)
+			if err != nil {
+				t.Fatalf("ReadFile(%q) error = %v", skillPath, err)
+			}
+
+			boundaries := map[string]string{
+				"shared_prompt":   string(promptBytes),
+				"installed_skill": string(skillBytes),
+			}
+
+			for boundary, content := range boundaries {
+				if !strings.Contains(content, phaseRuleInstruction) {
+					t.Errorf("[%s] %s missing phase rule contract %q", tt.name, boundary, phaseRuleInstruction)
+				}
+				for _, leak := range []string{
+					"<!-- section:model-",
+					"<!-- /section:model-",
+					"section:model-capable",
+					"section:model-small",
+				} {
+					if strings.Contains(content, leak) {
+						t.Errorf("[%s] %s leaked model-section marker %q", tt.name, boundary, leak)
+					}
+				}
+			}
+		})
+	}
+}

--- a/internal/components/sdd/sdd_apply_tier_parity_test.go
+++ b/internal/components/sdd/sdd_apply_tier_parity_test.go
@@ -9,6 +9,9 @@ import (
 	"github.com/gentleman-programming/gentle-ai/v2/internal/model"
 )
 
+// TestSDDApplyTierParityAtRenderedInstalledBoundaries verifies that both capable and
+// small model capability tiers preserve the rules.apply phase-rule instruction in
+// rendered shared prompts and installed skill outputs without leaking section markers.
 func TestSDDApplyTierParityAtRenderedInstalledBoundaries(t *testing.T) {
 	const phaseRuleInstruction = "Apply any `rules.apply` from `openspec/config.yaml`"
 


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #4118

---

## 🏷️ PR Type

What kind of change does this PR introduce?

- [x] `type:bug` — Bug fix (non-breaking change that fixes an issue)
- [ ] `type:feature` — New feature (non-breaking change that adds functionality)
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring (no functional changes)
- [ ] `type:chore` — Build, CI, or tooling changes
- [ ] `type:breaking-change` — Breaking change (fix or feature that changes existing behavior)

---

## 📝 Summary

- Adds the missing `rules.apply` instruction from `openspec/config.yaml` to the `model-small` section of the `sdd-apply` skill asset.
- Adds a focused table-driven regression test covering both rendered prompt and installed skill boundaries for `capable` and `small` variants, verifying phase-rule presence and ensuring no section markers leak.

---

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/assets/skills/sdd-apply/SKILL.md` | Added `- Apply any \`rules.apply\` from \`openspec/config.yaml\`` to the `model-small` Rules section |
| `internal/components/sdd/sdd_apply_tier_parity_test.go` | Added `TestSDDApplyTierParityAtRenderedInstalledBoundaries` table-driven regression test |

---

## 🤖 AI Assistance

Select exactly one option. Do not check both options.

- [ ] **None** — No material AI assistance was used.
- [x] **Material assistance used** — Complete all applicable declaration fields below.

**Tool/model (if known):** OpenCode / Claude Code / gemini-3.8-flash-high

**Material scope:** Assisted in identifying the missing instruction in `model-small`, drafting the regression test covering `WriteSharedPromptFiles` and `InjectSkillDirectoryForAgent`, and running checks.

**Verification performed:** Ran `go test` verifying failure prior to fix and passing after fix; verified `go run ./internal/gofmtcheck`; verified no section marker leaks.

---

## 🧪 Test Plan

- [x] Unit tests pass (`go test ./internal/components/sdd -run TestSDDApplyTierParityAtRenderedInstalledBoundaries`)
- [x] Go format passes (`go run ./internal/gofmtcheck`)
- [x] Benchmark validation: N/A (this change is scoped strictly to skill asset prompt instructions and tier-parity test, no review lifecycle/gate/recovery/benchmark surfaces affected)

---

## 🤖 Automated Checks

| Check | Status | Description |
|-------|--------|-------------|
| Check PR Cognitive Load | ⏳ | PR should stay within 400 changed lines (`additions + deletions`) or use `size:exception` |
| Check Issue Reference | ⏳ | PR body must contain `Closes/Fixes/Resolves #N` |
| Check Issue Has `status:approved` | ⏳ | Linked issue must have been approved before work began |
| Check PR Has `type:*` Label | ⏳ | Exactly one `type:*` label must be applied |
| Unit Tests | ⏳ | `go test ./...` must pass |
| Go Format | ⏳ | `go run ./internal/gofmtcheck` must pass |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated application guidance to ensure configured application rules are consistently followed.

* **Bug Fixes**
  * Improved consistency of application instructions across supported rendering and installation paths.
  * Prevented capability-specific model markers from appearing in application guidance.

* **Tests**
  * Added coverage verifying instruction parity across supported capability tiers and delivery paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->