### PR TITLE
fix(guidance): disambiguate codegraph worktree placement for nested layouts

### DIFF
--- a/internal/components/communitytool/codegraph_guidance.go
+++ b/internal/components/communitytool/codegraph_guidance.go
@@ -37,7 +37,7 @@ func CodeGraphGuidanceMarkdown() string {
 		"",
 		"CodeGraph-aware worktree placement:",
 		"",
-		"- Create Git worktrees that may need CodeGraph under the user's home directory, preferably as a sibling such as `<repo-parent>/<repo-name>-worktrees/<worktree-name>`. Never place a CodeGraph-dependent worktree under `/tmp`, `/var/tmp`, or `/tmp/opencode`; generic temporary-work guidance does not override this rule.",
+		"- Create Git worktrees that may need CodeGraph under the user's home directory. For a repository rooted there, place them as a sibling of the repository root at `<repo-parent>/<repo-name>-worktrees/<worktree-name>`, where `<repo-parent>` is the immediate parent directory of the repository root (repo `~/Projects/Rust/foo` → `~/Projects/Rust/foo-worktrees/<worktree-name>`). Never place a CodeGraph-dependent worktree under `/tmp`, `/var/tmp`, or `/tmp/opencode`; generic temporary-work guidance does not override this rule.",
 		"- Every worktree needs its own `.codegraph/` index. Never copy, symlink, or reuse another checkout's index because its root and checked-out bytes may differ.",
 		"",
 		"CodeGraph intelligence surface:",

--- a/internal/components/communitytool/tool_test.go
+++ b/internal/components/communitytool/tool_test.go
@@ -309,6 +309,8 @@ func TestCodeGraphGuidanceContainsLazyInitAndUsageRules(t *testing.T) {
 		"hard ordering rule",
 		"Create Git worktrees that may need CodeGraph under the user's home directory",
 		"<repo-parent>/<repo-name>-worktrees/<worktree-name>",
+		"immediate parent directory of the repository root",
+		"repo `~/Projects/Rust/foo` → `~/Projects/Rust/foo-worktrees/<worktree-name>`",
 		"Never place a CodeGraph-dependent worktree under `/tmp`, `/var/tmp`, or `/tmp/opencode`",
 		"generic temporary-work guidance does not override this rule",
 		"Every worktree needs its own `.codegraph/` index",

--- a/internal/components/communitytool/tool_test.go
+++ b/internal/components/communitytool/tool_test.go
@@ -302,6 +302,8 @@ func TestInstallWithHomeFailsClosedForEmptyPiSettingsWithoutMCPProcess(t *testin
 	}
 }
 
+// TestCodeGraphGuidanceContainsLazyInitAndUsageRules verifies that the CodeGraph
+// guidance block contains mandatory ordering, initialization, and worktree placement rules.
 func TestCodeGraphGuidanceContainsLazyInitAndUsageRules(t *testing.T) {
 	guidance := CodeGraphGuidanceMarkdown()
 	for _, want := range []string{

--- a/internal/components/communitytool/tool_test.go
+++ b/internal/components/communitytool/tool_test.go
@@ -279,6 +279,8 @@ func TestInstallWithHomeReportsEffectiveMCPAdapterSchema(t *testing.T) {
 	}
 }
 
+// TestInstallWithHomeFailsClosedForEmptyPiSettingsWithoutMCPProcess verifies that
+// installation fails when Pi settings exist but the MCP process probe fails.
 func TestInstallWithHomeFailsClosedForEmptyPiSettingsWithoutMCPProcess(t *testing.T) {
 	home := t.TempDir()
 	mustWrite(t, filepath.Join(home, ".pi", "agent", "settings.json"), `{}`)

--- a/internal/components/communitytool/tool_test.go
+++ b/internal/components/communitytool/tool_test.go
@@ -360,6 +360,8 @@ func TestCodeGraphGuidanceContainsLazyInitAndUsageRules(t *testing.T) {
 	}
 }
 
+// TestCodeGraphGuidanceInjectsForRepresentativeAgents verifies that CodeGraph guidance
+// is correctly injected into configuration files for representative supported agents.
 func TestCodeGraphGuidanceInjectsForRepresentativeAgents(t *testing.T) {
 	home := t.TempDir()
 	mustWrite(t, filepath.Join(home, ".config", "opencode", "opencode.json"), `{"agent":{"worker":{"prompt":"use codegraph_explore"}}}`)


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #3927

---

## 🏷️ PR Type

What kind of change does this PR introduce?

- [x] `type:bug` — Bug fix (non-breaking change that fixes an issue)
- [ ] `type:feature` — New feature (non-breaking change that adds functionality)
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring (no functional changes)
- [ ] `type:chore` — Build, CI, or tooling changes
- [ ] `type:breaking-change` — Breaking change (fix or feature that changes existing behavior)

---

## 📝 Summary

Disambiguates CodeGraph worktree placement guidance in `CodeGraphGuidanceMarkdown` for nested project layouts (e.g. `~/Projects/<lang>/<repo>`) by defining `<repo-parent>` explicitly as the immediate parent directory of the repository root, per maintainer clarification in #3927.

---

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/components/communitytool/codegraph_guidance.go` | Clarify worktree placement rule with deterministic definition of `<repo-parent>` as immediate parent directory |
| `internal/components/communitytool/tool_test.go` | Update `TestCodeGraphGuidanceContainsLazyInitAndUsageRules` to assert the disambiguated rule |

---

## 🤖 AI Assistance

Select exactly one option. Do not check both options.

- [ ] **None** — No material AI assistance was used.
- [x] **Material assistance used** — Complete all applicable declaration fields below.

**Tool/model (if known):** OpenCode / gemini-3.8-flash-high

**Material scope:** Updated guidance wording in `codegraph_guidance.go` and test assertion strings in `tool_test.go` per maintainer clarification.

**Verification performed:** Ran `go run ./internal/gofmtcheck` and unit tests `go test -count=1 ./internal/components/communitytool/...`.

---

## 🧪 Test Plan

**Unit Tests**
```bash
go test -count=1 ./internal/components/communitytool/...
```

**Go Format**
```bash
go run ./internal/gofmtcheck
```

**Benchmark Validation**
N/A — guidance wording change only; does not touch review lifecycle, gates, recovery, delivery, or benchmark implementation/corpus/classifier.

- [x] Unit tests pass (`go test ./internal/components/communitytool/...`)
- [x] Go format passes (`go run ./internal/gofmtcheck`)
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`)
- [x] Manually tested locally

---

## ✅ Contributor Checklist

- [x] PR is linked to an issue with `status:approved`
- [x] PR stays within 400 changed lines, or I have requested/obtained maintainer-applied `size:exception` with rationale documented
- [x] I have added the appropriate `type:*` label to this PR
- [x] Unit tests pass (`go test ./...`)
- [x] Go format passes (`go run ./internal/gofmtcheck`)
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`)
- [x] Benchmark validation completed, or this change is not applicable to the benchmark (explain why in the Test Plan).
- [x] I have updated documentation if necessary
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] I understand, reviewed, and take responsibility for the complete submission
- [x] I selected exactly one AI-assistance option and, if material assistance was used, completed all applicable declaration fields
- [x] My commits do not include `Co-Authored-By` trailers


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified CodeGraph worktree guidance to specify placement under the repository root’s immediate parent.
  * Added an explicit example path for creating worktrees, making the required directory structure easier to understand and follow.
* **Tests**
  * Updated guidance checks to verify the required worktree location and example path remain documented.
  * Added clearer context to the MCP probe failure test.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->