### PR TITLE
docs: exclude terminally approved unchanged candidates from fresh PR-readiness review

### DIFF
--- a/docs/intended-usage.md
+++ b/docs/intended-usage.md
@@ -120,7 +120,7 @@ The orchestrator must stop acting as a monolithic executor when complexity appea
 - **PR rule**: review can provide fresh evidence for a commit, push, or PR, but it never authorizes delivery. Receipt-driven development is opt-in with `gentle-ai review mode enable --scope global`; whether it is on or off, ordinary repository policy decides delivery.
 - **Incident rule**: after wrong cwd, worktree/git accident, merge recovery, confusing test command, or environment workaround, run a fresh audit before continuing.
 - **Long-session rule**: after roughly 20 tool calls, 5 exploratory reads, or 2 non-mechanical edits with growing complexity, pause and delegate, re-plan, or justify why not.
-- **Fresh review rule**: use fresh context for adversarial review of diffs, conflicts, PR readiness, and incidents when the agent platform supports it.
+- **Fresh review rule**: use fresh context for adversarial review of diffs, conflicts, PR readiness for unreviewed or changed candidates, and incidents when the agent platform supports it; an unchanged candidate that already reached terminal approval is never reviewed again solely because delivery preparation begins.
 
 ---
 

--- a/internal/assets/skills/hermes-ephemeral-delegation/SKILL.md
+++ b/internal/assets/skills/hermes-ephemeral-delegation/SKILL.md
@@ -14,7 +14,7 @@ Load this skill when you are acting as the parent orchestrator and the work ahea
 - Broad exploration (4+ files to understand, codebase mapping, approach comparison)
 - Multi-file implementation (touching 2+ non-trivial files)
 - Test or build execution
-- Fresh adversarial review (diffs, unreviewed or changed PR readiness, incident audit)
+- Fresh adversarial review (diffs, PR readiness for unreviewed or changed candidates, incident audit)
 - Multi-step debugging that would flood the parent context
 
 Do NOT load this skill if you are already inside a delegated child task — you are the executor, not the orchestrator.

--- a/internal/assets/skills/hermes-ephemeral-delegation/SKILL.md
+++ b/internal/assets/skills/hermes-ephemeral-delegation/SKILL.md
@@ -14,7 +14,7 @@ Load this skill when you are acting as the parent orchestrator and the work ahea
 - Broad exploration (4+ files to understand, codebase mapping, approach comparison)
 - Multi-file implementation (touching 2+ non-trivial files)
 - Test or build execution
-- Fresh adversarial review (diffs, PR readiness, incident audit)
+- Fresh adversarial review (diffs, unreviewed or changed PR readiness, incident audit)
 - Multi-step debugging that would flood the parent context
 
 Do NOT load this skill if you are already inside a delegated child task — you are the executor, not the orchestrator.


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #3738

---

## 🏷️ PR Type

What kind of change does this PR introduce?

- [ ] `type:bug` — Bug fix (non-breaking change that fixes an issue)
- [ ] `type:feature` — New feature (non-breaking change that adds functionality)
- [x] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring (no functional changes)
- [ ] `type:chore` — Build, CI, or tooling changes
- [ ] `type:breaking-change` — Breaking change (fix or feature that changes existing behavior)

---

## 📝 Summary

- Clarifies the "Fresh review rule" in `docs/intended-usage.md` so that terminally approved unchanged candidates are not subjected to fresh review solely because PR readiness / delivery preparation begins.
- Aligns the sibling delegation guidance in `internal/assets/skills/hermes-ephemeral-delegation/SKILL.md` to specify unreviewed or changed candidates.

---

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| `docs/intended-usage.md` | Clarify that terminally approved unchanged candidates are not reviewed again solely due to delivery preparation |
| `internal/assets/skills/hermes-ephemeral-delegation/SKILL.md` | Align fresh adversarial review trigger to unreviewed or changed PR readiness |

---

## 🤖 AI Assistance

Select exactly one option. Do not check both options.

- [ ] **None** — No material AI assistance was used.
- [x] **Material assistance used** — Complete all applicable declaration fields below.

**Tool/model (if known):**
OpenCode / gemini-3.8-flash-high

**Material scope:**
Drafting the phrasing update in `docs/intended-usage.md` and `internal/assets/skills/hermes-ephemeral-delegation/SKILL.md` to resolve the instruction-layer contradiction reported in #3738.

**Verification performed:**
Inspected diff against review contracts (`README.md`, `internal/assets/opencode/sdd-orchestrator.md`, and `review-ledger-contract.md`), ran `go run ./internal/gofmtcheck`, and verified skill linting.

---

## 🧪 Test Plan

This is a documentation-only update.

- [x] Unit tests pass (`go test ./...` / assets & skill linting)
- [x] Go format passes (`go run ./internal/gofmtcheck`)
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`) (N/A — docs only)
- [x] Manually tested locally

Benchmark validation: N/A — documentation-only wording update.

---

## ✅ Contributor Checklist

- [x] PR is linked to an issue with `status:approved`
- [x] PR stays within 400 changed lines, or I have requested/obtained maintainer-applied `size:exception` with rationale documented
- [x] I have added the appropriate `type:*` label to this PR
- [x] Unit tests pass (`go test ./...`)
- [x] Go format passes (`go run ./internal/gofmtcheck`)
- [x] E2E tests pass (`cd e2e && ./docker-test.sh`)
- [x] Benchmark validation completed, or this change is not applicable to the benchmark (explain why in the Test Plan).
- [x] I have updated documentation if necessary
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] I understand, reviewed, and take responsibility for the complete submission
- [x] I selected exactly one AI-assistance option and, if material assistance was used, completed all applicable declaration fields
- [x] My commits do not include `Co-Authored-By` trailers


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Clarified when fresh-context adversarial reviews apply, including diffs, conflicts, PR readiness for unreviewed or changed candidates, and incident audits where supported.
  - Documented that unchanged candidates with terminal approval are not reviewed again solely because delivery preparation begins.
  - Updated delegation guidance to reflect the expanded review scope.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->