### PR TITLE
test(cli): cover the host-mediated refusal for reviewProviderAdapterFor(pi)

### DIFF
--- a/internal/cli/review_provider_test.go
+++ b/internal/cli/review_provider_test.go
@@ -1,1 +1,107 @@
 package cli
+
+import (
+	"testing"
+
+	"github.com/gentleman-programming/gentle-ai/v2/internal/model"
+	"github.com/gentleman-programming/gentle-ai/v2/internal/reviewerprovider"
+)
+
+func TestReviewProviderAdapterFor(t *testing.T) {
+	contract, err := reviewerprovider.ContractFor(reviewerprovider.RoleLens)
+	if err != nil {
+		t.Fatalf("ContractFor(RoleLens) = %v", err)
+	}
+
+	tests := []struct {
+		name        string
+		agent       model.AgentID
+		wantAdapter func(t *testing.T, adapter reviewerprovider.Adapter)
+		wantErr     string
+	}{
+		{
+			name:  "claude returns compiled adapter",
+			agent: model.AgentClaudeCode,
+			wantAdapter: func(t *testing.T, adapter reviewerprovider.Adapter) {
+				t.Helper()
+				if _, ok := adapter.(*reviewerprovider.ClaudeAdapter); !ok {
+					t.Fatalf("adapter type = %T, want *reviewerprovider.ClaudeAdapter", adapter)
+				}
+			},
+		},
+		{
+			name:  "codex returns compiled adapter",
+			agent: model.AgentCodex,
+			wantAdapter: func(t *testing.T, adapter reviewerprovider.Adapter) {
+				t.Helper()
+				if _, ok := adapter.(*reviewerprovider.CodexAdapter); !ok {
+					t.Fatalf("adapter type = %T, want *reviewerprovider.CodexAdapter", adapter)
+				}
+			},
+		},
+		{
+			name:    "opencode returns host-mediated refusal",
+			agent:   model.AgentOpenCode,
+			wantErr: `reviewer provider runtime "opencode" is host-mediated; launch the provider-issued OpenCode reviewer task`,
+		},
+		{
+			name:    "pi returns distinct host-mediated refusal",
+			agent:   model.AgentPi,
+			wantErr: `reviewer provider runtime "pi" is host-mediated; launch the provider-issued Pi reviewer task`,
+		},
+		{
+			name:    "unsupported runtime returns unregistered adapter refusal",
+			agent:   model.AgentID("unsupported"),
+			wantErr: `reviewer provider runtime "unsupported" has no registered adapter`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			adapter, err := reviewProviderAdapterFor(contract, tt.agent)
+			if tt.wantErr != "" {
+				if err == nil {
+					t.Fatalf("reviewProviderAdapterFor() error = nil, want error %q", tt.wantErr)
+				}
+				if err.Error() != tt.wantErr {
+					t.Fatalf("reviewProviderAdapterFor() error = %q, want %q", err.Error(), tt.wantErr)
+				}
+				if adapter != nil {
+					t.Fatalf("reviewProviderAdapterFor() adapter = %#v, want nil", adapter)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("reviewProviderAdapterFor() unexpected error = %v", err)
+			}
+			if tt.wantAdapter != nil {
+				tt.wantAdapter(t, adapter)
+			}
+		})
+	}
+
+	t.Run("rejects contract without required transport capability before runtime selection", func(t *testing.T) {
+		contractWithoutTransport := reviewerprovider.Contract{
+			Role: reviewerprovider.RoleLens,
+		}
+		for _, agent := range []model.AgentID{
+			model.AgentClaudeCode,
+			model.AgentCodex,
+			model.AgentOpenCode,
+			model.AgentPi,
+			model.AgentID("unsupported"),
+		} {
+			adapter, err := reviewProviderAdapterFor(contractWithoutTransport, agent)
+			if err == nil {
+				t.Fatalf("reviewProviderAdapterFor(%s) error = nil, want transport capability refusal", agent)
+			}
+			want := `reviewer provider role "lens" does not permit the compiled transport`
+			if err.Error() != want {
+				t.Fatalf("reviewProviderAdapterFor(%s) error = %q, want %q", agent, err.Error(), want)
+			}
+			if adapter != nil {
+				t.Fatalf("reviewProviderAdapterFor(%s) adapter = %#v, want nil", agent, adapter)
+			}
+		}
+	})
+}

--- a/internal/cli/review_provider_test.go
+++ b/internal/cli/review_provider_test.go
@@ -7,6 +7,8 @@ import (
 	"github.com/gentleman-programming/gentle-ai/v2/internal/reviewerprovider"
 )
 
+// TestReviewProviderAdapterFor pins #3258: it covers reviewer provider adapter selection
+// and host-mediated or unregistered-adapter refusals across runtime identities.
 func TestReviewProviderAdapterFor(t *testing.T) {
 	contract, err := reviewerprovider.ContractFor(reviewerprovider.RoleLens)
 	if err != nil {


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #3258

---

## 🏷️ PR Type

What kind of change does this PR introduce?

- [ ] `type:bug` — Bug fix (non-breaking change that fixes an issue)
- [ ] `type:feature` — New feature (non-breaking change that adds functionality)
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring (no functional changes)
- [x] `type:chore` — Build, CI, or tooling changes
- [ ] `type:breaking-change` — Breaking change (fix or feature that changes existing behavior)

---

## 📝 Summary

Adds table-driven unit test coverage for `reviewProviderAdapterFor` in `internal/cli/review_provider_test.go`, covering:
- Claude Code returning its compiled adapter
- Codex returning its compiled adapter
- OpenCode returning its host-mediated refusal
- Pi returning its distinct host-mediated refusal
- An unsupported runtime returning the unregistered adapter refusal
- Rejection of contracts lacking the required transport capability before runtime selection

Addresses the missing coverage for Pi's host-mediated refusal branch noted in #3258 and follows the contributor scope clarification.

---

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/cli/review_provider_test.go` | Added `TestReviewProviderAdapterFor` covering runtime selection and refusals |

---

## 🤖 AI Assistance

Select exactly one option. Do not check both options.

- [ ] **None** — No material AI assistance was used.
- [x] **Material assistance used** — Complete all applicable declaration fields below.

**Tool/model (if known):** OpenCode

**Material scope:** Test code generation and validation against issue requirements.

**Verification performed:** Executed `go test -v -run TestReviewProviderAdapterFor ./internal/cli` and `go run ./internal/gofmtcheck`.

---

## 🧪 Test Plan

**Unit Tests**
```bash
go test -v -run TestReviewProviderAdapterFor ./internal/cli
```

**Go Format**
```bash
go run ./internal/gofmtcheck
```

**Benchmark Validation**
N/A — test-only addition covering adapter selection boundary.

- [x] Unit tests pass (`go test ./...`)
- [x] Go format passes (`go run ./internal/gofmtcheck`)
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`)
- [x] Manually tested locally

---

## ✅ Contributor Checklist

- [x] PR is linked to an issue with `status:approved`
- [x] PR stays within 400 changed lines, or I have requested/obtained maintainer-applied `size:exception` with rationale documented
- [x] I have added the appropriate `type:*` label to this PR
- [x] Unit tests pass (`go test ./...`)
- [x] Go format passes (`go run ./internal/gofmtcheck`)
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`)
- [x] Benchmark validation completed, or this change is not applicable to the benchmark (explain why in the Test Plan).
- [ ] I have updated documentation if necessary
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] I understand, reviewed, and take responsibility for the complete submission
- [x] I selected exactly one AI-assistance option and, if material assistance was used, completed all applicable declaration fields
- [x] My commits do not include `Co-Authored-By` trailers

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded coverage for reviewer-provider selection across supported and unsupported runtimes.
  * Added validation coverage to ensure incompatible review contracts are rejected before execution.
  * Improved confidence in clear error handling when provider adapters are unavailable or unsupported.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->