### PR TITLE
test(update): build the cooldown candidate binary with the .exe suffix on Windows

### DIFF
--- a/internal/update/cooldown_concurrency_test.go
+++ b/internal/update/cooldown_concurrency_test.go
@@ -210,7 +210,11 @@ func awaitSignal(t *testing.T, ctx context.Context, signal <-chan struct{}, mess
 
 func buildCandidateBinary(t *testing.T) string {
 	t.Helper()
-	binary := filepath.Join(t.TempDir(), "gentle-ai")
+	binaryName := "gentle-ai"
+	if runtime.GOOS == "windows" {
+		binaryName += ".exe"
+	}
+	binary := filepath.Join(t.TempDir(), binaryName)
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 	command := exec.CommandContext(ctx, "go", "build", "-o", binary, "./cmd/gentle-ai")


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #4168

---

## 🏷️ PR Type

- [x] `type:bug` — Bug fix (non-breaking change that fixes an issue)
- [ ] `type:feature` — New feature (non-breaking change that adds functionality)
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring (no functional changes)
- [ ] `type:chore` — Build, CI, or tooling changes
- [ ] `type:breaking-change` — Breaking change (fix or feature that changes existing behavior)

---

## 📝 Summary

- The Windows Full Suite lane has been red on `main` since #4083 (`59a742a5`). Its two cooldown concurrency tests build a candidate `gentle-ai` binary into `t.TempDir()` and exec it, but the output was always named `gentle-ai`, which Windows refuses to execute without an extension.
- `buildCandidateBinary` now appends `.exe` when `runtime.GOOS == "windows"`, matching the pattern already used in `internal/update/upgrade/go_install_destination_test.go`.
- Test-only change. No production code is touched.

---

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/update/cooldown_concurrency_test.go` | `buildCandidateBinary` names the output `gentle-ai.exe` on Windows |

---

## 🤖 AI Assistance

- [ ] **None** — No material AI assistance was used.
- [x] **Material assistance used** — Complete all applicable declaration fields below.

**Tool/model (if known):** Claude Code (Claude)

**Material scope:** Diagnosed the Windows lane failure from the CI log, wrote the one-line helper fix, and drafted the issue and this PR body.

**Verification performed:** Ran the two affected tests locally on macOS (pass) and cross-compiled the test package with `GOOS=windows GOARCH=amd64 go test -c ./internal/update/` (compiles). The Windows Full Suite run on this PR is the real proof.

---

## 🧪 Test Plan

**Unit Tests**
```bash
go test ./internal/update/ -run 'TestCheckAllWithCooldown_ConcurrentReviewModeDisablePreservesMode|TestCheckAllWithCooldown_ContendedPersistenceRejectsReviewModeDisable' -count=1
GOOS=windows GOARCH=amd64 go test -c -o /dev/null ./internal/update/
```

Benchmark validation: N/A. This changes a test helper's output filename only; no review-lifecycle, gate, recovery, delivery, or benchmark code is involved.

- [x] Unit tests pass (`go test ./...`) — affected package locally; full suite runs in CI
- [x] Go format passes (`go run ./internal/gofmtcheck`)
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`) — runs in CI
- [x] Manually tested locally

---

## ✅ Contributor Checklist

- [x] PR is linked to an issue with `status:approved`
- [x] PR stays within 400 changed lines, or I have requested/obtained maintainer-applied `size:exception` with rationale documented
- [x] I have added the appropriate `type:*` label to this PR
- [x] Unit tests pass (`go test ./...`)
- [x] Go format passes (`go run ./internal/gofmtcheck`)
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`) — runs in CI
- [x] Benchmark validation completed, or this change is not applicable to the benchmark (explain why in the Test Plan).
- [x] I have updated documentation if necessary
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] I understand, reviewed, and take responsibility for the complete submission
- [x] I selected exactly one AI-assistance option and, if material assistance was used, completed all applicable declaration fields
- [x] My commits do not include `Co-Authored-By` trailers

---

## 💬 Notes for Reviewers

This unblocks the next stable release: `release.yml` preflight requires the Windows lane green on the tagged `main` head, and it has been red since `59a742a5` (last green `b57a77be`).

https://claude.ai/code/session_01Tryq31uBK9Kto7EPGTGKf3


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed test binary naming on Windows so candidate binaries use the correct executable format and path.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->