### PR TITLE
fix(persona): drop Windows-incompatible tool mandate from Claude persona rules

### DIFF
--- a/internal/assets/claude/persona-gentleman.md
+++ b/internal/assets/claude/persona-gentleman.md
@@ -1,7 +1,7 @@
 ## Rules
 
 - Never add "Co-Authored-By" or AI attribution to commits. Use conventional commits only.
-- Never use cat/grep/find/sed/ls. Use bat/rg/fd/sd/eza instead. Install via brew if missing.
+- Prefer the agent's native file-reading, search, and editing tools. When shell commands are necessary, use tools available on the current platform; do not require a specific package manager.
 - Response-length contract: default to short answers. Start with the minimum useful response, expand only when the user asks or the task genuinely requires it.
 - Ask at most one question at a time. After asking it, STOP and wait.
 - Do not present option menus, exhaustive lists, or multiple approaches unless there is a real fork with meaningful tradeoffs.

--- a/testdata/golden/combined-claude-claudemd.golden
+++ b/testdata/golden/combined-claude-claudemd.golden
@@ -2,7 +2,7 @@
 ## Rules
 
 - Never add "Co-Authored-By" or AI attribution to commits. Use conventional commits only.
-- Never use cat/grep/find/sed/ls. Use bat/rg/fd/sd/eza instead. Install via brew if missing.
+- Prefer the agent's native file-reading, search, and editing tools. When shell commands are necessary, use tools available on the current platform; do not require a specific package manager.
 - Response-length contract: default to short answers. Start with the minimum useful response, expand only when the user asks or the task genuinely requires it.
 - Ask at most one question at a time. After asking it, STOP and wait.
 - Do not present option menus, exhaustive lists, or multiple approaches unless there is a real fork with meaningful tradeoffs.

--- a/testdata/golden/persona-claude-gentleman.golden
+++ b/testdata/golden/persona-claude-gentleman.golden
@@ -2,7 +2,7 @@
 ## Rules
 
 - Never add "Co-Authored-By" or AI attribution to commits. Use conventional commits only.
-- Never use cat/grep/find/sed/ls. Use bat/rg/fd/sd/eza instead. Install via brew if missing.
+- Prefer the agent's native file-reading, search, and editing tools. When shell commands are necessary, use tools available on the current platform; do not require a specific package manager.
 - Response-length contract: default to short answers. Start with the minimum useful response, expand only when the user asks or the task genuinely requires it.
 - Ask at most one question at a time. After asking it, STOP and wait.
 - Do not present option menus, exhaustive lists, or multiple approaches unless there is a real fork with meaningful tradeoffs.


### PR DESCRIPTION
<!-- ⚠️ READ BEFORE SUBMITTING
  Every PR must be linked to an issue that has the "status:approved" label.
  PRs without a linked approved issue will be automatically rejected by CI.
  See CONTRIBUTING.md for the full contribution workflow.
-->

## 🔗 Linked Issue

Closes #2597

---

## 🏷️ PR Type

What kind of change does this PR introduce?

- [x] `type:bug` — Bug fix (non-breaking change that fixes an issue)
- [ ] `type:feature` — New feature (non-breaking change that adds functionality)
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring (no functional changes)
- [ ] `type:chore` — Build, CI, or tooling changes
- [ ] `type:breaking-change` — Breaking change (fix or feature that changes existing behavior)

---

## 📝 Summary

`internal/assets/claude/persona-gentleman.md` told the agent to "Never use cat/grep/find/sed/ls. Use bat/rg/fd/sd/eza instead. Install via brew if missing." This asset is injected into every Claude Code session's `CLAUDE.md`, but bat/fd/sd/eza and brew are not reliably available on Windows, and brew isn't a Windows package manager at all — so the stated remedy can't be followed there, and the file can't be fixed locally because it's regenerated on every gentle-ai sync.

Per the maintainer direction on the issue thread, this replaces the blanket tool/package-manager mandate with a platform-neutral outcome statement, without adding platform-detection plumbing or install documentation:

> Prefer the agent's native file-reading, search, and editing tools. When shell commands are necessary, use tools available on the current platform; do not require a specific package manager.

---

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/assets/claude/persona-gentleman.md` | Replaced the cat/grep/find/sed/ls-prohibition + brew-install bullet with a platform-neutral outcome statement |
| `testdata/golden/persona-claude-gentleman.golden` | Regenerated to match the updated asset |
| `testdata/golden/combined-claude-claudemd.golden` | Regenerated to match the updated asset |

---

## 🤖 AI Assistance

Select exactly one option. Do not check both options.

- [ ] **None** — No material AI assistance was used.
- [x] **Material assistance used** — Complete all applicable declaration fields below.

**Tool/model (if known):** Claude (Claude Code)

**Material scope:** Diagnosed the target rule text and its two golden fixtures from the issue and the maintainer's scoped direction, wrote the replacement sentence (verbatim per maintainer direction), regenerated the goldens, and wrote this PR description.

**Verification performed:** Inspected the full diff (3 files, 3 lines) and confirmed it is confined to the maintainer-specified bounded scope; ran the build, format check, targeted and full test suites (see Test Plan); confirmed the two pre-existing test-suite failure areas are unrelated to this change by stashing it and reproducing the identical failures against the unmodified base; searched the repo for any other file embedding the old rule text to rule out stale goldens elsewhere.

---

## 🧪 Test Plan

**Unit Tests**
```bash
go test ./...
```
Passed except for two pre-existing, environment-caused failure areas confirmed unrelated to this change (reproduced identically with the change stashed out, against the unmodified base):
- `internal/reviewtransaction` and `internal/update`: this macOS box's bash 3.2 lacks `[[ -v ]]`/`declare -A` used by some release scripts under test, and a `/var`-symlink lock-path check fails locally — both pre-existing/environmental.
- `internal/components/engram`: one flaky signal-permission test (`operation not permitted`) from this sandbox, also reproduces unchanged against the unmodified base.

The change's own targeted tests pass cleanly:
```bash
go test ./internal/components/ -run 'TestGoldenPersona_Claude_Gentleman|TestGoldenCombined_Claude' -v
go test ./internal/components/...
```

**Go Format**
```bash
go run ./internal/gofmtcheck
```
Passes (exit 0, no output).

**E2E Tests** (Docker required)
```bash
cd e2e && ./docker-test.sh
```
Not run — Docker is not installed in this environment. This is a text-only asset and golden-fixture change with no install/sync code path touched, so it is not expected to affect e2e behavior, but that could not be verified directly here. Flagging as a known gap for reviewers/CI rather than silently skipping.

**Benchmark Validation**

N/A — this change only edits a persona-rules text asset and its golden fixtures; it does not touch review-lifecycle, gates, recovery, delivery, or benchmark surfaces.

- [x] Unit tests pass (`go test ./...`) — see caveats above (pre-existing/unrelated failures)
- [x] Go format passes (`go run ./internal/gofmtcheck`)
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`) — not run, Docker unavailable locally
- [x] Manually tested locally (golden output inspected byte-for-byte)

Base branch (`main`) CI was confirmed green before starting (`gh run list --repo Gentleman-Programming/gentle-ai --branch main --limit 5`), so none of the above are inherited base failures.

---

## 🤖 Automated Checks

The following checks run automatically on this PR:

| Check | Status | Description |
|-------|--------|-------------|
| Check PR Cognitive Load | ⏳ | PR should stay within 400 changed lines (`additions + deletions`) or use `size:exception` |
| Check Issue Reference | ⏳ | PR body must contain `Closes/Fixes/Resolves #N` |
| Check Issue Has `status:approved` | ⏳ | Linked issue must have been approved before work began |
| Check PR Has `type:*` Label | ⏳ | Exactly one `type:*` label must be applied |
| Unit Tests | ⏳ | `go test ./...` must pass |
| Go Format | ⏳ | `go run ./internal/gofmtcheck` must pass |
| E2E Tests | ⏳ | `cd e2e && ./docker-test.sh` must pass |

---

## ✅ Contributor Checklist

- [x] PR is linked to an issue with `status:approved`
- [x] The PR is at or below 400 changed lines, or I have requested/obtained maintainer-applied `size:exception` with rationale documented
- [x] I have added the appropriate `type:*` label to this PR
- [x] Unit tests pass (`go test ./...`)
- [x] Go format passes (`go run ./internal/gofmtcheck`)
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`) — not run, Docker unavailable in this environment
- [x] Benchmark validation completed, or this change is not applicable to the benchmark (explain why in the Test Plan).
- [ ] I have updated documentation if necessary — not applicable, no docs reference this rule text
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] I understand, reviewed, and take responsibility for the complete submission
- [x] I selected exactly one AI-assistance option and, if material assistance was used, completed all applicable declaration fields
- [x] My commits do not include `Co-Authored-By` trailers

---

## 💬 Notes for Reviewers

This change is scoped exactly to what the maintainer specified on the issue thread: the one rule bullet in `internal/assets/claude/persona-gentleman.md`, plus its two golden fixtures. No platform-detection logic or installation documentation was added, per that same direction. I verified no other persona asset (kimi, opencode, kiro, hermes, generic) contains this rule text, and no other golden fixture in the repo embeds it (only an archived historical design doc references the old wording in prose, which is not a test artifact).

E2E (`docker-test.sh`) could not be run locally because Docker isn't installed in this environment — flagging this explicitly rather than silently skipping it, since it's a required checklist item. Happy to address anything CI surfaces there.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated tooling guidance to prioritize native file-reading, search, and editing capabilities.
  * Clarified that shell commands should use tools available on the current platform without requiring a specific package manager.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->