### PR TITLE
fix(kilocode): resolve config target using 5-candidate precedence

### DIFF
--- a/internal/agents/kilocode/adapter.go
+++ b/internal/agents/kilocode/adapter.go
@@ -96,7 +96,7 @@ func (a *Adapter) SkillsDir(homeDir string) string {
 }
 
 func (a *Adapter) SettingsPath(homeDir string) string {
-	return filepath.Join(homeDir, ".config", "kilo", "opencode.json")
+	return ResolveConfigPath(homeDir)
 }
 
 // --- Config strategies ---
@@ -111,10 +111,10 @@ func (a *Adapter) MCPStrategy() model.MCPStrategy {
 
 // --- MCP ---
 
-func (a *Adapter) MCPConfigPath(homeDir string, serverName string) string {
-	// Kilocode merges into opencode.json, but this provides the path
+func (a *Adapter) MCPConfigPath(homeDir string, _ string) string {
+	// Kilocode merges into its global config file, but this provides the path
 	// for components that use the separate-file strategy fallback.
-	return filepath.Join(homeDir, ".config", "kilo", "opencode.json")
+	return ResolveConfigPath(homeDir)
 }
 
 // --- Optional capabilities ---

--- a/internal/agents/kilocode/adapter_test.go
+++ b/internal/agents/kilocode/adapter_test.go
@@ -1,13 +1,16 @@
 package kilocode
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"os"
 	"path/filepath"
 	"reflect"
+	"strings"
 	"testing"
 
+	"github.com/gentleman-programming/gentle-ai/v2/internal/components/filemerge"
 	"github.com/gentleman-programming/gentle-ai/v2/internal/model"
 	"github.com/gentleman-programming/gentle-ai/v2/internal/system"
 )
@@ -132,7 +135,7 @@ func TestSkillsDir(t *testing.T) {
 
 func TestSettingsPath(t *testing.T) {
 	a := NewAdapter()
-	want := filepath.Join("/home/user", ".config", "kilo", "opencode.json")
+	want := filepath.Join("/home/user", ".config", "kilo", "kilo.jsonc")
 	if got := a.SettingsPath("/home/user"); got != want {
 		t.Fatalf("SettingsPath() = %q, want %q", got, want)
 	}
@@ -184,9 +187,271 @@ func TestCommandsDir(t *testing.T) {
 
 func TestMCPConfigPath(t *testing.T) {
 	a := NewAdapter()
-	want := filepath.Join("/home/user", ".config", "kilo", "opencode.json")
+	want := filepath.Join("/home/user", ".config", "kilo", "kilo.jsonc")
 	if got := a.MCPConfigPath("/home/user", "test-server"); got != want {
 		t.Fatalf("MCPConfigPath() = %q, want %q", got, want)
+	}
+}
+
+func TestResolveConfigPathCandidates(t *testing.T) {
+	candidates := []string{
+		"kilo.jsonc",
+		"kilo.json",
+		"opencode.jsonc",
+		"opencode.json",
+		"config.json",
+	}
+
+	for _, candidate := range candidates {
+		t.Run("isolated candidate "+candidate, func(t *testing.T) {
+			home := t.TempDir()
+			configDir := filepath.Join(home, ".config", "kilo")
+			if err := os.MkdirAll(configDir, 0o755); err != nil {
+				t.Fatalf("MkdirAll() error = %v", err)
+			}
+			targetFile := filepath.Join(configDir, candidate)
+			if err := os.WriteFile(targetFile, []byte("{}"), 0o644); err != nil {
+				t.Fatalf("WriteFile() error = %v", err)
+			}
+
+			if got := ResolveConfigPath(home); got != targetFile {
+				t.Fatalf("ResolveConfigPath() = %q, want %q", got, targetFile)
+			}
+		})
+	}
+
+	t.Run("default when no candidate exists", func(t *testing.T) {
+		home := t.TempDir()
+		want := filepath.Join(home, ".config", "kilo", "kilo.jsonc")
+		if got := ResolveConfigPath(home); got != want {
+			t.Fatalf("ResolveConfigPath() = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("skip directory matching candidate name", func(t *testing.T) {
+		home := t.TempDir()
+		configDir := filepath.Join(home, ".config", "kilo")
+		if err := os.MkdirAll(filepath.Join(configDir, "kilo.jsonc"), 0o755); err != nil {
+			t.Fatalf("MkdirAll() error = %v", err)
+		}
+		opencodeJSON := filepath.Join(configDir, "opencode.json")
+		if err := os.WriteFile(opencodeJSON, []byte("{}"), 0o644); err != nil {
+			t.Fatalf("WriteFile() error = %v", err)
+		}
+
+		if got := ResolveConfigPath(home); got != opencodeJSON {
+			t.Fatalf("ResolveConfigPath() = %q, want regular file %q", got, opencodeJSON)
+		}
+	})
+}
+
+func TestResolveConfigPathPrecedence(t *testing.T) {
+	tests := []struct {
+		name       string
+		staged     []string
+		wantChosen string
+	}{
+		{
+			name:       "all candidates staged chooses kilo.jsonc",
+			staged:     []string{"kilo.jsonc", "kilo.json", "opencode.jsonc", "opencode.json", "config.json"},
+			wantChosen: "kilo.jsonc",
+		},
+		{
+			name:       "kilo.json beats opencode and config candidates",
+			staged:     []string{"kilo.json", "opencode.jsonc", "opencode.json", "config.json"},
+			wantChosen: "kilo.json",
+		},
+		{
+			name:       "opencode.jsonc beats opencode.json and config.json",
+			staged:     []string{"opencode.jsonc", "opencode.json", "config.json"},
+			wantChosen: "opencode.jsonc",
+		},
+		{
+			name:       "opencode.json beats config.json",
+			staged:     []string{"opencode.json", "config.json"},
+			wantChosen: "opencode.json",
+		},
+		{
+			name:       "config.json matches when alone",
+			staged:     []string{"config.json"},
+			wantChosen: "config.json",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			home := t.TempDir()
+			configDir := filepath.Join(home, ".config", "kilo")
+			if err := os.MkdirAll(configDir, 0o755); err != nil {
+				t.Fatalf("MkdirAll() error = %v", err)
+			}
+			for _, file := range tt.staged {
+				if err := os.WriteFile(filepath.Join(configDir, file), []byte("{}"), 0o644); err != nil {
+					t.Fatalf("WriteFile(%q) error = %v", file, err)
+				}
+			}
+
+			wantPath := filepath.Join(configDir, tt.wantChosen)
+			if got := ResolveConfigPath(home); got != wantPath {
+				t.Fatalf("ResolveConfigPath() = %q, want %q", got, wantPath)
+			}
+		})
+	}
+}
+
+func TestSettingsPathAndMCPConfigPathIdentical(t *testing.T) {
+	adapter := NewAdapter()
+	candidates := []string{
+		"kilo.jsonc",
+		"kilo.json",
+		"opencode.jsonc",
+		"opencode.json",
+		"config.json",
+		"", // no file
+	}
+
+	for _, candidate := range candidates {
+		t.Run("identical target for candidate "+candidate, func(t *testing.T) {
+			home := t.TempDir()
+			configDir := filepath.Join(home, ".config", "kilo")
+			if candidate != "" {
+				if err := os.MkdirAll(configDir, 0o755); err != nil {
+					t.Fatalf("MkdirAll() error = %v", err)
+				}
+				if err := os.WriteFile(filepath.Join(configDir, candidate), []byte("{}"), 0o644); err != nil {
+					t.Fatalf("WriteFile() error = %v", err)
+				}
+			}
+
+			settings := adapter.SettingsPath(home)
+			mcp := adapter.MCPConfigPath(home, "context7")
+
+			if settings != mcp {
+				t.Fatalf("SettingsPath() = %q != MCPConfigPath() = %q", settings, mcp)
+			}
+		})
+	}
+}
+
+func TestKilocodeJSONCCommentPreservationAndIdempotency(t *testing.T) {
+	home := t.TempDir()
+	configDir := filepath.Join(home, ".config", "kilo")
+	if err := os.MkdirAll(configDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+
+	originalJSONC := []byte(`{
+  // User comments for Kilocode settings
+  "theme": "dark",
+  // Existing MCP server note
+  "mcp": {
+    "custom-server": {
+      "command": "custom-mcp"
+    }
+  },
+  "agent": {
+    "my-agent": {
+      "model": "anthropic/claude-3-5-sonnet"
+    }
+  }
+}
+`)
+
+	jsoncPath := filepath.Join(configDir, "kilo.jsonc")
+	if err := os.WriteFile(jsoncPath, originalJSONC, 0o644); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+
+	adapter := NewAdapter()
+	selectedPath := adapter.SettingsPath(home)
+	if selectedPath != jsoncPath {
+		t.Fatalf("SettingsPath() = %q, want %q", selectedPath, jsoncPath)
+	}
+
+	overlay := []byte(`{
+  "mcp": {
+    "context7": {
+      "command": "npx",
+      "args": ["-y", "@upstash/context7-mcp"]
+    }
+  },
+  "agent": {
+    "sdd-orchestrator": {
+      "model": "anthropic/claude-3-7-sonnet"
+    }
+  }
+}`)
+
+	firstMerge, err := filemerge.MergeJSONObjectsForPath(selectedPath, originalJSONC, overlay)
+	if err != nil {
+		t.Fatalf("MergeJSONObjectsForPath() error = %v", err)
+	}
+
+	firstStr := string(firstMerge)
+	if !strings.Contains(firstStr, "// User comments for Kilocode settings") {
+		t.Fatal("lost top comment in kilo.jsonc")
+	}
+	if !strings.Contains(firstStr, "// Existing MCP server note") {
+		t.Fatal("lost existing server note comment in kilo.jsonc")
+	}
+	if !strings.Contains(firstStr, "custom-server") {
+		t.Fatal("lost existing custom MCP server")
+	}
+	if !strings.Contains(firstStr, "my-agent") {
+		t.Fatal("lost existing custom agent")
+	}
+	if !strings.Contains(firstStr, "context7") {
+		t.Fatal("missing injected context7 MCP server")
+	}
+	if !strings.Contains(firstStr, "sdd-orchestrator") {
+		t.Fatal("missing injected sdd-orchestrator agent")
+	}
+
+	// Test idempotency: re-merging the same overlay on the merged output yields identical result
+	secondMerge, err := filemerge.MergeJSONObjectsForPath(selectedPath, firstMerge, overlay)
+	if err != nil {
+		t.Fatalf("second MergeJSONObjectsForPath() error = %v", err)
+	}
+
+	if !bytes.Equal(firstMerge, secondMerge) {
+		t.Fatalf("idempotency violation:\nFirst:\n%s\nSecond:\n%s", string(firstMerge), string(secondMerge))
+	}
+}
+
+func TestKilocodeNoParallelFileCreated(t *testing.T) {
+	home := t.TempDir()
+	configDir := filepath.Join(home, ".config", "kilo")
+	if err := os.MkdirAll(configDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+
+	existingFile := filepath.Join(configDir, "opencode.json")
+	if err := os.WriteFile(existingFile, []byte(`{"theme":"light"}`), 0o644); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+
+	adapter := NewAdapter()
+	selected := adapter.SettingsPath(home)
+	if selected != existingFile {
+		t.Fatalf("SettingsPath() = %q, want existing %q", selected, existingFile)
+	}
+
+	overlay := []byte(`{"mcp":{"context7":{"command":"context7"}}}`)
+	merged, err := filemerge.MergeJSONObjectsForPath(selected, []byte(`{"theme":"light"}`), overlay)
+	if err != nil {
+		t.Fatalf("MergeJSONObjectsForPath() error = %v", err)
+	}
+
+	if _, err := filemerge.WriteFileAtomic(selected, merged, 0o644); err != nil {
+		t.Fatalf("WriteFileAtomic() error = %v", err)
+	}
+
+	// Verify no parallel kilo.jsonc or other candidate was created
+	for _, candidate := range []string{"kilo.jsonc", "kilo.json", "opencode.jsonc", "config.json"} {
+		parallel := filepath.Join(configDir, candidate)
+		if _, err := os.Stat(parallel); !os.IsNotExist(err) {
+			t.Fatalf("parallel file %q should not exist", parallel)
+		}
 	}
 }
 

--- a/internal/agents/kilocode/paths.go
+++ b/internal/agents/kilocode/paths.go
@@ -1,7 +1,39 @@
 package kilocode
 
-import "path/filepath"
+import (
+	"os"
+	"path/filepath"
+)
+
+var candidateConfigFiles = []string{
+	"kilo.jsonc",
+	"kilo.json",
+	"opencode.jsonc",
+	"opencode.json",
+	"config.json",
+}
+
+const defaultConfigFile = "kilo.jsonc"
 
 func ConfigPath(homeDir string) string {
 	return filepath.Join(homeDir, ".config", "kilo")
+}
+
+// ResolveConfigPath locates the effective global configuration file for Kilocode.
+// It selects the first existing regular file in candidateConfigFiles precedence order,
+// defaulting to kilo.jsonc if none exists.
+func ResolveConfigPath(homeDir string) string {
+	configDir := ConfigPath(homeDir)
+	for _, candidate := range candidateConfigFiles {
+		candidatePath := filepath.Join(configDir, candidate)
+		if regularFileExists(candidatePath) {
+			return candidatePath
+		}
+	}
+	return filepath.Join(configDir, defaultConfigFile)
+}
+
+func regularFileExists(path string) bool {
+	info, err := os.Stat(path)
+	return err == nil && info.Mode().IsRegular()
 }

--- a/internal/cli/run_component_paths_test.go
+++ b/internal/cli/run_component_paths_test.go
@@ -1006,7 +1006,7 @@ func TestRoutingGuidancePathsWorkspaceScopeReportOrchestratorPromptAgentsAtHome(
 
 	for _, want := range []string{
 		filepath.Join(home, ".config", "opencode", "opencode.json"),
-		filepath.Join(home, ".config", "kilo", "opencode.json"),
+		filepath.Join(home, ".config", "kilo", "kilo.jsonc"),
 	} {
 		if !containsPath(paths, want) {
 			t.Fatalf("routingGuidancePaths(workspace) missing home settings path %q\npaths=%v", want, paths)
@@ -1014,7 +1014,7 @@ func TestRoutingGuidancePathsWorkspaceScopeReportOrchestratorPromptAgentsAtHome(
 	}
 	for _, unwanted := range []string{
 		filepath.Join(workspace, ".config", "opencode", "opencode.json"),
-		filepath.Join(workspace, ".config", "kilo", "opencode.json"),
+		filepath.Join(workspace, ".config", "kilo", "kilo.jsonc"),
 	} {
 		if containsPath(paths, unwanted) {
 			t.Fatalf("routingGuidancePaths(workspace) reported %q, a path the agent never loads\npaths=%v", unwanted, paths)

--- a/internal/components/agentguidance/inject_test.go
+++ b/internal/components/agentguidance/inject_test.go
@@ -580,7 +580,7 @@ func markdownSectionAgents(t *testing.T) []model.AgentID {
 func deliveredGuidance(t *testing.T, path string) string {
 	t.Helper()
 
-	if strings.HasSuffix(path, ".json") {
+	if strings.HasSuffix(path, ".json") || strings.HasSuffix(path, ".jsonc") {
 		return orchestratorPrompt(t, path)
 	}
 	return readFile(t, path)

--- a/internal/components/mcp/inject_test.go
+++ b/internal/components/mcp/inject_test.go
@@ -371,14 +371,15 @@ func TestInjectOpenCodeAndKilocodePreserveContext7Headers(t *testing.T) {
 
 func TestInjectOpenCodeAndKilocodeRecoverMalformedSettingsAndDiscardInvalidHeaders(t *testing.T) {
 	tests := []struct {
-		name     string
-		adapter  agents.Adapter
-		existing string
+		name        string
+		adapter     agents.Adapter
+		settingsRel string
+		existing    string
 	}{
 		{name: "OpenCode malformed settings", adapter: opencodeAdapter(), existing: `{malformed`},
-		{name: "KiloCode malformed settings", adapter: kilocodeAdapter(), existing: `{malformed`},
+		{name: "KiloCode malformed JSON settings", adapter: kilocodeAdapter(), settingsRel: filepath.Join(".config", "kilo", "opencode.json"), existing: `{malformed`},
 		{name: "OpenCode malformed headers", adapter: opencodeAdapter(), existing: `{"mcp":{"context7":{"headers":`},
-		{name: "KiloCode malformed headers", adapter: kilocodeAdapter(), existing: `{"mcp":{"context7":{"headers":`},
+		{name: "KiloCode malformed JSON headers", adapter: kilocodeAdapter(), settingsRel: filepath.Join(".config", "kilo", "opencode.json"), existing: `{"mcp":{"context7":{"headers":`},
 		{name: "OpenCode non-object headers", adapter: opencodeAdapter(), existing: `{"mcp":{"context7":{"headers":["secret"]}}}`},
 		{name: "KiloCode non-object headers", adapter: kilocodeAdapter(), existing: `{"mcp":{"context7":{"headers":"secret"}}}`},
 	}
@@ -386,12 +387,17 @@ func TestInjectOpenCodeAndKilocodeRecoverMalformedSettingsAndDiscardInvalidHeade
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			home := t.TempDir()
-			configPath := tt.adapter.SettingsPath(home)
+			var configPath string
+			if tt.settingsRel != "" {
+				configPath = filepath.Join(home, tt.settingsRel)
+			} else {
+				configPath = tt.adapter.SettingsPath(home)
+			}
 			if err := os.MkdirAll(filepath.Dir(configPath), 0o755); err != nil {
 				t.Fatalf("MkdirAll error = %v", err)
 			}
 			if err := os.WriteFile(configPath, []byte(tt.existing), 0o644); err != nil {
-				t.Fatalf("WriteFile(opencode.json) error = %v", err)
+				t.Fatalf("WriteFile(settings) error = %v", err)
 			}
 
 			first, err := Inject(home, home, tt.adapter)
@@ -419,27 +425,39 @@ func TestInjectOpenCodeAndKilocodeRecoverMalformedSettingsAndDiscardInvalidHeade
 	}
 }
 
-func TestInjectOpenCodeRejectsMalformedJSONCSettingsWithoutReplacingBytes(t *testing.T) {
-	home := t.TempDir()
-	adapter := opencodeAdapter()
-	settingsPath := filepath.Join(home, ".config", "opencode", "opencode.jsonc")
-	original := []byte("// interrupted user edit\n{\n  \"mcp\": {\n")
-	if err := os.MkdirAll(filepath.Dir(settingsPath), 0o755); err != nil {
-		t.Fatalf("MkdirAll(settings dir) error = %v", err)
-	}
-	if err := os.WriteFile(settingsPath, original, 0o644); err != nil {
-		t.Fatalf("WriteFile(opencode.jsonc) error = %v", err)
+func TestInjectOpenCodeAndKilocodeRejectMalformedJSONCSettingsWithoutReplacingBytes(t *testing.T) {
+	tests := []struct {
+		name        string
+		adapter     agents.Adapter
+		settingsRel string
+	}{
+		{name: "OpenCode", adapter: opencodeAdapter(), settingsRel: filepath.Join(".config", "opencode", "opencode.jsonc")},
+		{name: "KiloCode", adapter: kilocodeAdapter(), settingsRel: filepath.Join(".config", "kilo", "kilo.jsonc")},
 	}
 
-	if _, err := Inject(home, home, adapter); err == nil {
-		t.Fatal("Inject() error = nil, want refusal for malformed opencode.jsonc")
-	}
-	after, err := os.ReadFile(settingsPath)
-	if err != nil {
-		t.Fatalf("ReadFile(opencode.jsonc) error = %v", err)
-	}
-	if !bytes.Equal(after, original) {
-		t.Fatalf("malformed opencode.jsonc was replaced:\n got: %q\nwant: %q", after, original)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			home := t.TempDir()
+			settingsPath := filepath.Join(home, tt.settingsRel)
+			original := []byte("// interrupted user edit\n{\n  \"mcp\": {\n")
+			if err := os.MkdirAll(filepath.Dir(settingsPath), 0o755); err != nil {
+				t.Fatalf("MkdirAll(settings dir) error = %v", err)
+			}
+			if err := os.WriteFile(settingsPath, original, 0o644); err != nil {
+				t.Fatalf("WriteFile(%s) error = %v", tt.settingsRel, err)
+			}
+
+			if _, err := Inject(home, home, tt.adapter); err == nil {
+				t.Fatalf("Inject() error = nil, want refusal for malformed %s", tt.settingsRel)
+			}
+			after, err := os.ReadFile(settingsPath)
+			if err != nil {
+				t.Fatalf("ReadFile(%s) error = %v", tt.settingsRel, err)
+			}
+			if !bytes.Equal(after, original) {
+				t.Fatalf("malformed %s was replaced:\n got: %q\nwant: %q", tt.settingsRel, after, original)
+			}
+		})
 	}
 }
 

--- a/internal/components/persona/inject_test.go
+++ b/internal/components/persona/inject_test.go
@@ -1964,19 +1964,20 @@ func TestInjectOpenCode_SwitchGentlemanToNeutral_CleansAgentOverlay(t *testing.T
 
 func TestInjectKilocode_SwitchGentlemanToNeutral_CleansAgentOverlay(t *testing.T) {
 	home := t.TempDir()
+	adapter := kilocodeAdapter()
 
-	_, err := Inject(home, kilocodeAdapter(), model.PersonaGentleman)
+	_, err := Inject(home, adapter, model.PersonaGentleman)
 	if err != nil {
 		t.Fatalf("Inject(gentleman) error = %v", err)
 	}
 
-	settingsPath := filepath.Join(home, ".config", "kilo", "opencode.json")
+	settingsPath := adapter.SettingsPath(home)
 	data, _ := os.ReadFile(settingsPath)
 	if !strings.Contains(string(data), `"gentleman"`) {
-		t.Fatal("precondition: kilo/opencode.json should have gentleman agent after Gentleman install")
+		t.Fatal("precondition: kilo config should have gentleman agent after Gentleman install")
 	}
 
-	result, err := Inject(home, kilocodeAdapter(), model.PersonaNeutral)
+	result, err := Inject(home, adapter, model.PersonaNeutral)
 	if err != nil {
 		t.Fatalf("Inject(neutral) error = %v", err)
 	}
@@ -1986,10 +1987,10 @@ func TestInjectKilocode_SwitchGentlemanToNeutral_CleansAgentOverlay(t *testing.T
 
 	data, err = os.ReadFile(settingsPath)
 	if err != nil {
-		t.Fatalf("ReadFile kilo/opencode.json error = %v", err)
+		t.Fatalf("ReadFile kilo config error = %v", err)
 	}
 	if strings.Contains(string(data), `"gentleman"`) {
-		t.Fatal("kilo/opencode.json must not have gentleman agent key after switching to Neutral")
+		t.Fatal("kilo config must not have gentleman agent key after switching to Neutral")
 	}
 }
 

--- a/internal/components/sdd/inject_test.go
+++ b/internal/components/sdd/inject_test.go
@@ -4839,12 +4839,12 @@ func TestInjectKilocodeKeepsLegacyBackgroundAgentsPluginAndRemovesOpenCodeReview
 	if _, err := os.Stat(reviewPluginPath); !os.IsNotExist(err) {
 		t.Fatalf("OpenCode-only review plugin remains installed for Kilo: %v", err)
 	}
-	settings, err := os.ReadFile(filepath.Join(home, ".config", "kilo", "opencode.json"))
+	settings, err := os.ReadFile(kilocodeAdapter().SettingsPath(home))
 	if err != nil {
 		t.Fatalf("ReadFile(Kilocode settings) error = %v", err)
 	}
-	var root map[string]any
-	if err := json.Unmarshal(settings, &root); err != nil {
+	root, err := filemerge.UnmarshalJSONObject(settings)
+	if err != nil {
 		t.Fatalf("Unmarshal(Kilocode settings) error = %v", err)
 	}
 	agentMap, ok := root["agent"].(map[string]any)
@@ -5797,8 +5797,8 @@ func TestKilocodeSharedLegacyMigrationsPreserveTools(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	root := map[string]any{}
-	if err := json.Unmarshal(payload, &root); err != nil {
+	root, err := filemerge.UnmarshalJSONObject(payload)
+	if err != nil {
 		t.Fatal(err)
 	}
 	if _, exists := root["agents"]; exists {

--- a/internal/components/sdd/review_ledger_contract_test.go
+++ b/internal/components/sdd/review_ledger_contract_test.go
@@ -351,7 +351,7 @@ func TestKilocodeReviewSettingsMatchCurrentMainBaseline(t *testing.T) {
 	if _, err := os.Stat(filepath.Join(home, ".config", "kilo", "plugins", "review-result-artifacts.ts")); !os.IsNotExist(err) {
 		t.Fatalf("Kilo installed OpenCode-only review plugin: %v", err)
 	}
-	settings, err := os.ReadFile(filepath.Join(home, ".config", "kilo", "opencode.json"))
+	settings, err := os.ReadFile(kilocodeAdapter().SettingsPath(home))
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #3505

## 🏷️ PR Type

- [x] `type:bug` — Bug fix (non-breaking change that fixes an issue)

## 📝 Summary

Implements the 5-candidate config resolver for Kilocode to support upstream Kilo configuration files (`kilo.jsonc` -> `kilo.json` -> `opencode.jsonc` -> `opencode.json` -> `config.json`), defaulting to `kilo.jsonc` when no candidate file exists. Both `SettingsPath` and `MCPConfigPath` share this resolver, preserving JSONC comments, preventing parallel file creation when supported configs exist, and maintaining merge/settings idempotency.

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/agents/kilocode/paths.go` | Added `ResolveConfigPath` with 5-candidate precedence (`kilo.jsonc` -> `kilo.json` -> `opencode.jsonc` -> `opencode.json` -> `config.json`) defaulting to `kilo.jsonc` |
| `internal/agents/kilocode/adapter.go` | Routed `SettingsPath` and `MCPConfigPath` through `ResolveConfigPath` |
| `internal/agents/kilocode/adapter_test.go` | Added tests for candidate isolation, precedence order, no-file default, directory skip, identical path selection, JSONC comment preservation, and parallel file avoidance |
| `internal/cli/run_component_paths_test.go` | Updated expected default Kilo path in routing guidance tests |
| `internal/components/sdd/inject_test.go` | Updated test helper to use adapter-resolved config path and JSONC-aware unmarshaling |
| `internal/components/sdd/review_ledger_contract_test.go` | Updated review baseline test to read adapter-resolved config path |

## 🧪 Test Plan

**Unit Tests**
```bash
go test -count=1 -timeout 100s -v ./internal/agents/kilocode/...
go test -count=1 -timeout 100s -run 'TestRoutingGuidancePathsWorkspaceScopeReportOrchestratorPromptAgentsAtHome' ./internal/cli
go test -count=1 -timeout 100s -run 'TestKilocode' ./internal/components/sdd/...
```

**Go Format & Vet**
```bash
gofmt -l internal/agents/kilocode/adapter.go internal/agents/kilocode/adapter_test.go internal/agents/kilocode/paths.go internal/cli/run_component_paths_test.go internal/components/sdd/inject_test.go internal/components/sdd/review_ledger_contract_test.go
go vet ./internal/agents/kilocode ./internal/cli ./internal/components/sdd
```

- [x] Unit tests pass
- [x] Go format passes
- [x] Manually tested locally

## ✅ Contributor Checklist

- [x] PR is linked to an issue with `status:approved`
- [x] PR stays within 400 changed lines, or the `size:exception` rationale and verified policy authority are documented
- [ ] API read-back confirms exactly one appropriate `type:*` label on this PR
- [x] Unit tests pass
- [x] I have updated documentation if necessary
- [x] My commits follow Conventional Commits format
- [x] My commits do not include `Co-Authored-By` trailers

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Kilocode now automatically selects the appropriate existing configuration file, with support for JSONC formatting.
  * New installations use `kilo.jsonc` as the default configuration file.

* **Bug Fixes**
  * Corrected Kilocode workspace routing and settings paths to use the proper configuration location.
  * Preserved comments and prevented duplicate configuration files during settings updates.
  * Improved handling of configuration files with malformed JSONC, preventing partial or unintended changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->