### PR TITLE
fix(tui): disable reset review store outside Git repository

### DIFF
--- a/internal/cli/review_store_reset.go
+++ b/internal/cli/review_store_reset.go
@@ -17,6 +17,7 @@ const ReviewStoreResetSchema = "gentle-ai.review-store-reset-result/v1"
 
 // ErrReviewStoreResetRequiresGitRepository reports that review store-reset
 // was attempted outside a Git repository.
+// refusal:by-design operator-knowledge: review store-reset requires a Git repository; only the operator knows where the Git repository checkout is located
 var ErrReviewStoreResetRequiresGitRepository = errors.New("review store-reset requires a Git repository")
 
 // ReviewStoreResetRepositoryRequiredError represents a typed failure when
@@ -28,6 +29,7 @@ type ReviewStoreResetRepositoryRequiredError struct {
 func (err *ReviewStoreResetRepositoryRequiredError) Unwrap() error { return err.Cause }
 
 func (err *ReviewStoreResetRepositoryRequiredError) Error() string {
+	// refusal:by-design operator-knowledge: running store-reset requires an existing Git repository; only the operator knows where the repository checkout is located
 	return "review store-reset requires a Git repository; rerun the command from inside a Git repository, or rerun with --cwd pointing at one"
 }
 

--- a/internal/cli/review_store_reset.go
+++ b/internal/cli/review_store_reset.go
@@ -15,6 +15,40 @@ import (
 // ReviewStoreResetSchema identifies the user-facing store reset projection.
 const ReviewStoreResetSchema = "gentle-ai.review-store-reset-result/v1"
 
+// ErrReviewStoreResetRequiresGitRepository reports that review store-reset
+// was attempted outside a Git repository.
+var ErrReviewStoreResetRequiresGitRepository = errors.New("review store-reset requires a Git repository")
+
+// ReviewStoreResetRepositoryRequiredError represents a typed failure when
+// store-reset is executed outside a Git repository, providing actionable guidance.
+type ReviewStoreResetRepositoryRequiredError struct {
+	Cause error
+}
+
+func (err *ReviewStoreResetRepositoryRequiredError) Unwrap() error { return err.Cause }
+
+func (err *ReviewStoreResetRepositoryRequiredError) Error() string {
+	return "review store-reset requires a Git repository; rerun the command from inside a Git repository, or rerun with --cwd pointing at one"
+}
+
+func (err *ReviewStoreResetRepositoryRequiredError) Is(target error) bool {
+	return target == ErrReviewStoreResetRequiresGitRepository
+}
+
+func reviewStoreResetRepositoryRequiredRefusal(err error) error {
+	if err == nil {
+		return nil
+	}
+	var typed *reviewtransaction.StoreResetRepositoryRequiredError
+	if errors.As(err, &typed) {
+		return &ReviewStoreResetRepositoryRequiredError{Cause: err}
+	}
+	if reviewtransaction.ReviewRootResolutionReportsNoRepository(err) {
+		return &ReviewStoreResetRepositoryRequiredError{Cause: err}
+	}
+	return nil
+}
+
 // ReviewStoreResetResult is the command's machine-readable output.
 type ReviewStoreResetResult struct {
 	Schema    string                             `json:"schema"`
@@ -81,6 +115,9 @@ func RunReviewStoreReset(args []string, stdout io.Writer) error {
 		if emitErr := emitReviewStoreReset(stdout, report, attempted, *confirm, *emitJSON); emitErr != nil && err == nil {
 			return emitErr
 		}
+	}
+	if refusal := reviewStoreResetRepositoryRequiredRefusal(err); refusal != nil {
+		return refusal
 	}
 	return err
 }

--- a/internal/cli/review_store_reset_test.go
+++ b/internal/cli/review_store_reset_test.go
@@ -409,3 +409,32 @@ func TestReviewStoreResetSparesTheAdapterReviewStoreByDefault(t *testing.T) {
 		t.Fatalf("the override did not remove the adapter review store: %v", err)
 	}
 }
+
+// TestReviewStoreResetRefusesNonGitRepositoryAndNamesTheContinuation proves that
+// running store-reset outside a Git repository returns a typed error containing
+// actionable guidance rather than exposing raw git rev-parse subprocess stderr.
+func TestReviewStoreResetRefusesNonGitRepositoryAndNamesTheContinuation(t *testing.T) {
+	nonGitDir := t.TempDir()
+	var output bytes.Buffer
+	err := RunReview([]string{"store-reset", "--cwd", nonGitDir}, &output)
+	if err == nil {
+		t.Fatalf("expected error running store-reset outside a Git repository; got nil, output: %s", output.String())
+	}
+	var nonGit *ReviewStoreResetRepositoryRequiredError
+	if !errors.As(err, &nonGit) {
+		t.Fatalf("error = %T %v, want *ReviewStoreResetRepositoryRequiredError", err, err)
+	}
+	if !errors.Is(err, ErrReviewStoreResetRequiresGitRepository) {
+		t.Fatalf("errors.Is(err, ErrReviewStoreResetRequiresGitRepository) = false for %v", err)
+	}
+	message := err.Error()
+	if !strings.Contains(message, "review store-reset requires a Git repository") {
+		t.Fatalf("error missing requirement statement: %q", message)
+	}
+	if !strings.Contains(message, "--cwd") {
+		t.Fatalf("error missing actionable continuation: %q", message)
+	}
+	if strings.Contains(message, "exit code 128") || strings.Contains(message, "rev-parse") {
+		t.Fatalf("error exposes raw git subprocess details: %q", message)
+	}
+}

--- a/internal/reviewtransaction/store_reset.go
+++ b/internal/reviewtransaction/store_reset.go
@@ -321,6 +321,24 @@ func (err *StoreResetIncompleteError) Error() string {
 	return message
 }
 
+// ErrStoreResetRequiresGitRepository reports that review store reset was attempted outside a Git repository.
+var ErrStoreResetRequiresGitRepository = errors.New("review store-reset requires a Git repository")
+
+// StoreResetRepositoryRequiredError represents a failure when store reset is executed outside a Git repository.
+type StoreResetRepositoryRequiredError struct {
+	Cause error
+}
+
+func (err *StoreResetRepositoryRequiredError) Unwrap() error { return err.Cause }
+
+func (err *StoreResetRepositoryRequiredError) Error() string {
+	return "review store-reset requires a Git repository; rerun the command from inside a Git repository, or rerun with --cwd pointing at one"
+}
+
+func (err *StoreResetRepositoryRequiredError) Is(target error) bool {
+	return target == ErrStoreResetRequiresGitRepository
+}
+
 // storeResetRoot resolves <git-common-dir>/gentle-ai for one clone.
 //
 // It deliberately does not apply the receipt-driven-development gate. The kill
@@ -332,6 +350,9 @@ func (err *StoreResetIncompleteError) Error() string {
 func storeResetRoot(ctx context.Context, repo string) (root, repository string, err error) {
 	lease, err := OpenRepositoryIdentityLease(ctx, repo)
 	if err != nil {
+		if ReviewRootResolutionReportsNoRepository(err) {
+			return "", "", &StoreResetRepositoryRequiredError{Cause: err}
+		}
 		return "", "", err
 	}
 	identity := lease.Identity()
@@ -613,6 +634,9 @@ func ResetReviewStore(ctx context.Context, repo string, request StoreResetReques
 	defer cancel()
 	lock, err := storeResetAcquireLease(lockCtx, repo)
 	if err != nil {
+		if ReviewRootResolutionReportsNoRepository(err) {
+			return StoreResetReport{}, &StoreResetRepositoryRequiredError{Cause: err}
+		}
 		// No report is returned with this. Nothing was read under the lease, so
 		// there is no classification this command is entitled to state, and a
 		// report rendered from an unleased read is the same stale picture the

--- a/internal/reviewtransaction/store_reset.go
+++ b/internal/reviewtransaction/store_reset.go
@@ -322,6 +322,7 @@ func (err *StoreResetIncompleteError) Error() string {
 }
 
 // ErrStoreResetRequiresGitRepository reports that review store reset was attempted outside a Git repository.
+// refusal:by-design operator-knowledge: review store-reset requires a Git repository; only the operator knows where the Git repository checkout is located
 var ErrStoreResetRequiresGitRepository = errors.New("review store-reset requires a Git repository")
 
 // StoreResetRepositoryRequiredError represents a failure when store reset is executed outside a Git repository.
@@ -332,6 +333,7 @@ type StoreResetRepositoryRequiredError struct {
 func (err *StoreResetRepositoryRequiredError) Unwrap() error { return err.Cause }
 
 func (err *StoreResetRepositoryRequiredError) Error() string {
+	// refusal:by-design operator-knowledge: running store-reset requires an existing Git repository; only the operator knows where the repository checkout is located
 	return "review store-reset requires a Git repository; rerun the command from inside a Git repository, or rerun with --cwd pointing at one"
 }
 

--- a/internal/reviewtransaction/store_reset_test.go
+++ b/internal/reviewtransaction/store_reset_test.go
@@ -1075,3 +1075,44 @@ func TestReviewStoreResetFreedBytesNeverGoesNegative(t *testing.T) {
 		})
 	}
 }
+
+// TestSurveyReviewStoreOutsideGitReturnsTypedError proves survey on a non-git
+// directory produces the typed StoreResetRepositoryRequiredError rather than
+// raw subprocess stderr.
+func TestSurveyReviewStoreOutsideGitReturnsTypedError(t *testing.T) {
+	nonGitDir := t.TempDir()
+	_, err := SurveyReviewStore(context.Background(), nonGitDir, StoreResetRequest{})
+	if err == nil {
+		t.Fatal("survey on non-git directory succeeded, want error")
+	}
+	var typed *StoreResetRepositoryRequiredError
+	if !errors.As(err, &typed) {
+		t.Fatalf("survey error = %T %v, want *StoreResetRepositoryRequiredError", err, err)
+	}
+	if !errors.Is(err, ErrStoreResetRequiresGitRepository) {
+		t.Fatalf("errors.Is(err, ErrStoreResetRequiresGitRepository) = false for %v", err)
+	}
+	if strings.Contains(err.Error(), "exit code 128") {
+		t.Fatalf("error message exposes raw git exit code: %v", err)
+	}
+}
+
+// TestResetReviewStoreOutsideGitReturnsTypedError proves reset on a non-git
+// directory produces the typed StoreResetRepositoryRequiredError.
+func TestResetReviewStoreOutsideGitReturnsTypedError(t *testing.T) {
+	nonGitDir := t.TempDir()
+	_, err := ResetReviewStore(context.Background(), nonGitDir, StoreResetRequest{})
+	if err == nil {
+		t.Fatal("reset on non-git directory succeeded, want error")
+	}
+	var typed *StoreResetRepositoryRequiredError
+	if !errors.As(err, &typed) {
+		t.Fatalf("reset error = %T %v, want *StoreResetRepositoryRequiredError", err, err)
+	}
+	if !errors.Is(err, ErrStoreResetRequiresGitRepository) {
+		t.Fatalf("errors.Is(err, ErrStoreResetRequiresGitRepository) = false for %v", err)
+	}
+	if strings.Contains(err.Error(), "exit code 128") {
+		t.Fatalf("error message exposes raw git exit code: %v", err)
+	}
+}

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -780,6 +780,9 @@ type Model struct {
 	ReviewStoreResetSurveyErr error
 	// ReviewStoreResetErr records the outcome of an applied reset.
 	ReviewStoreResetErr error
+	// ReviewStoreResetHasGitFn reports whether the current workspace resolves
+	// to a usable Git repository for review store operations. Injected for tests.
+	ReviewStoreResetHasGitFn func() bool
 	// ReviewModeCwdFn, ReviewModeStatusFn, and ReviewModeSetGlobalFn are injected
 	// so the screen can be tested without filesystem state or CLI process calls.
 	ReviewModeCwdFn       func() (string, error)
@@ -1402,6 +1405,7 @@ func (m Model) View() string {
 		return screens.RenderWelcomeWithAdvisory(
 			m.Cursor, m.Version, banner, m.UpdateResults, m.UpdateCheckDone,
 			m.hasDetectedOpenCode(), len(m.ProfileList), m.hasAgentBuilderEngines(),
+			m.hasGitRepository(),
 			m.Width, m.Height,
 			screens.WelcomeAdvisory{Message: m.AdvisoryMessage, URL: m.AdvisoryURL, Scroll: m.AdvisoryScroll},
 		)
@@ -2054,6 +2058,9 @@ func (m Model) confirmSelection() (tea.Model, tea.Cmd) {
 			next++
 
 			if m.Cursor == next {
+				if !m.hasGitRepository() {
+					return m, nil
+				}
 				return m.startReviewStoreResetSurvey()
 			}
 			next++
@@ -4050,7 +4057,7 @@ func (m Model) optionCount() int {
 	}
 	switch m.Screen {
 	case ScreenWelcome:
-		return len(screens.WelcomeOptions(m.UpdateResults, m.UpdateCheckDone, m.hasDetectedOpenCode(), len(m.ProfileList), m.hasAgentBuilderEngines()))
+		return len(screens.WelcomeOptions(m.UpdateResults, m.UpdateCheckDone, m.hasDetectedOpenCode(), len(m.ProfileList), m.hasAgentBuilderEngines(), m.hasGitRepository()))
 	case ScreenUpgrade:
 		if m.UpgradeReport != nil || m.UpgradeErr != nil {
 			return 0
@@ -5248,6 +5255,22 @@ func (m Model) detectAgentBuilderEngines() []model.AgentID {
 // hasAgentBuilderEngines reports whether any supported AI agent binary is installed.
 func (m Model) hasAgentBuilderEngines() bool {
 	return len(m.detectAgentBuilderEngines()) > 0
+}
+
+// hasGitRepository reports whether the current workspace resolves to a usable
+// Git repository without reading or mutating review store state.
+func (m Model) hasGitRepository() bool {
+	if m.ReviewStoreResetHasGitFn != nil {
+		return m.ReviewStoreResetHasGitFn()
+	}
+	repo := "."
+	if m.ReviewModeCwdFn != nil {
+		if dir, err := m.ReviewModeCwdFn(); err == nil && dir != "" {
+			repo = dir
+		}
+	}
+	_, err := (reviewtransaction.SnapshotBuilder{Repo: repo}).ResolveRepositoryRoot(context.Background())
+	return err == nil
 }
 
 // agentBuilderInstallTargets returns the list of install target paths for the preview screen.

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -2025,12 +2025,12 @@ func TestWelcomeMenu_UninstallNavigation_WithProfiles(t *testing.T) {
 func TestWelcomeMenu_OptionCount(t *testing.T) {
 	m := NewModel(system.DetectionResult{}, "dev")
 	// Without OpenCode detected: 14 options, including the review-mode entry.
-	opts := screens.WelcomeOptions(m.UpdateResults, m.UpdateCheckDone, false, 0, true)
+	opts := screens.WelcomeOptions(m.UpdateResults, m.UpdateCheckDone, false, 0, true, true)
 	if len(opts) != 14 {
 		t.Fatalf("WelcomeOptions(showProfiles=false) len = %d, want 14; got %v", len(opts), opts)
 	}
 	// With OpenCode detected: 15 options (adds "OpenCode SDD Profiles").
-	optsWithProfiles := screens.WelcomeOptions(m.UpdateResults, m.UpdateCheckDone, true, 0, true)
+	optsWithProfiles := screens.WelcomeOptions(m.UpdateResults, m.UpdateCheckDone, true, 0, true, true)
 	if len(optsWithProfiles) != 15 {
 		t.Fatalf("WelcomeOptions(showProfiles=true) len = %d, want 15; got %v", len(optsWithProfiles), optsWithProfiles)
 	}

--- a/internal/tui/review_mode_test.go
+++ b/internal/tui/review_mode_test.go
@@ -38,7 +38,7 @@ func TestReviewModeTUI(t *testing.T) {
 		return current, nil
 	}
 	open := func(model Model) Model {
-		model.Cursor = len(screens.WelcomeOptions(model.UpdateResults, model.UpdateCheckDone, false, 0, true)) - 4
+		model.Cursor = len(screens.WelcomeOptions(model.UpdateResults, model.UpdateCheckDone, false, 0, true, true)) - 4
 		updated, cmd := model.Update(tea.KeyMsg{Type: tea.KeyEnter})
 		return settleReviewMode(t, updated.(Model), cmd)
 	}

--- a/internal/tui/review_store_reset_test.go
+++ b/internal/tui/review_store_reset_test.go
@@ -15,6 +15,7 @@ import (
 func reviewStoreResetModel(t *testing.T) Model {
 	t.Helper()
 	m := NewModel(system.DetectionResult{}, "dev")
+	m.ReviewStoreResetHasGitFn = func() bool { return true }
 	m.Screen = ScreenReviewStoreResetConfirm
 	m.Cursor = 0
 	return m
@@ -38,7 +39,7 @@ func settledStoreResetReport() reviewtransaction.StoreResetReport {
 // the TUI at all, and that it sits in the maintenance cluster at the bottom
 // rather than among the everyday entries.
 func TestWelcomeMenuOffersTheReviewStoreReset(t *testing.T) {
-	options := screens.WelcomeOptions(nil, true, false, 0, true)
+	options := screens.WelcomeOptions(nil, true, false, 0, true, true)
 	reset, backups, uninstall := -1, -1, -1
 	for index, option := range options {
 		switch option {
@@ -58,11 +59,63 @@ func TestWelcomeMenuOffersTheReviewStoreReset(t *testing.T) {
 	}
 }
 
+// TestWelcomeMenuShowsDisabledResetReviewStoreOutsideGit proves that outside a
+// Git repository, the welcome menu renders the row with the requires-git precondition.
+func TestWelcomeMenuShowsDisabledResetReviewStoreOutsideGit(t *testing.T) {
+	options := screens.WelcomeOptions(nil, true, false, 0, true, false)
+	found := false
+	for _, option := range options {
+		if option == "Reset review store (requires a Git repository)" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("welcome menu outside git does not show disabled option: %#v", options)
+	}
+}
+
+// TestWelcomeSelectionOutsideGitIsNoOp proves that pressing Enter on the
+// disabled reset row outside a Git repository is a no-op and never triggers the survey.
+func TestWelcomeSelectionOutsideGitIsNoOp(t *testing.T) {
+	m := NewModel(system.DetectionResult{}, "dev")
+	m.Screen = ScreenWelcome
+	m.ReviewStoreResetHasGitFn = func() bool { return false }
+	surveyed := false
+	m.ReviewStoreResetSurveyFn = func() (reviewtransaction.StoreResetReport, error) {
+		surveyed = true
+		return settledStoreResetReport(), nil
+	}
+	m.ReviewStoreResetFn = func() (reviewtransaction.StoreResetReport, error) {
+		t.Fatal("selecting the disabled menu entry applied a reset")
+		return reviewtransaction.StoreResetReport{}, nil
+	}
+	options := screens.WelcomeOptions(m.UpdateResults, m.UpdateCheckDone, m.hasDetectedOpenCode(), len(m.ProfileList), m.hasAgentBuilderEngines(), false)
+	for index, option := range options {
+		if strings.HasPrefix(option, "Reset review store") {
+			m.Cursor = index
+		}
+	}
+
+	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	state := updated.(Model)
+	if state.Screen != ScreenWelcome {
+		t.Fatalf("screen = %v, want ScreenWelcome (no-op)", state.Screen)
+	}
+	if cmd != nil {
+		t.Fatalf("cmd = %v, want nil", cmd)
+	}
+	if surveyed {
+		t.Fatal("the survey function was called when selecting disabled reset row")
+	}
+}
+
 // TestWelcomeSelectionEntersTheSurvey proves the menu entry runs the read-only
 // survey and lands on the confirmation screen, never straight into a removal.
 func TestWelcomeSelectionEntersTheSurvey(t *testing.T) {
 	m := NewModel(system.DetectionResult{}, "dev")
 	m.Screen = ScreenWelcome
+	m.ReviewStoreResetHasGitFn = func() bool { return true }
 	surveyed := false
 	m.ReviewStoreResetSurveyFn = func() (reviewtransaction.StoreResetReport, error) {
 		surveyed = true
@@ -72,7 +125,7 @@ func TestWelcomeSelectionEntersTheSurvey(t *testing.T) {
 		t.Fatal("selecting the menu entry applied a reset")
 		return reviewtransaction.StoreResetReport{}, nil
 	}
-	options := screens.WelcomeOptions(m.UpdateResults, m.UpdateCheckDone, m.hasDetectedOpenCode(), len(m.ProfileList), m.hasAgentBuilderEngines())
+	options := screens.WelcomeOptions(m.UpdateResults, m.UpdateCheckDone, m.hasDetectedOpenCode(), len(m.ProfileList), m.hasAgentBuilderEngines(), true)
 	for index, option := range options {
 		if option == "Reset review store" {
 			m.Cursor = index
@@ -317,6 +370,7 @@ func TestReviewStoreResetResultIsNeverDropped(t *testing.T) {
 func TestReviewStoreResetConfirmStartsOnCancel(t *testing.T) {
 	m := NewModel(system.DetectionResult{}, "dev")
 	m.Screen = ScreenWelcome
+	m.ReviewStoreResetHasGitFn = func() bool { return true }
 	m.ReviewStoreResetSurveyFn = func() (reviewtransaction.StoreResetReport, error) {
 		return settledStoreResetReport(), nil
 	}
@@ -324,7 +378,7 @@ func TestReviewStoreResetConfirmStartsOnCancel(t *testing.T) {
 		t.Fatal("the second Enter after entering the screen destroyed the store")
 		return reviewtransaction.StoreResetReport{}, nil
 	}
-	options := screens.WelcomeOptions(m.UpdateResults, m.UpdateCheckDone, m.hasDetectedOpenCode(), len(m.ProfileList), m.hasAgentBuilderEngines())
+	options := screens.WelcomeOptions(m.UpdateResults, m.UpdateCheckDone, m.hasDetectedOpenCode(), len(m.ProfileList), m.hasAgentBuilderEngines(), true)
 	for index, option := range options {
 		if option == "Reset review store" {
 			m.Cursor = index

--- a/internal/tui/screens/welcome.go
+++ b/internal/tui/screens/welcome.go
@@ -28,7 +28,10 @@ type WelcomeAdvisory struct {
 // profileCount is used to show a badge with the current profile count.
 // When hasEngines is false, "Create your own Agent" is shown as disabled
 // (labelled "(no agents)") to signal that no supported AI engine is installed.
-func WelcomeOptions(updateResults []update.UpdateResult, updateCheckDone bool, showProfiles bool, profileCount int, hasEngines bool) []string {
+// When hasGit is false, "Reset review store" is shown as disabled
+// (labelled "Reset review store (requires a Git repository)") to signal that
+// repository-scoped store operations require a Git repository.
+func WelcomeOptions(updateResults []update.UpdateResult, updateCheckDone bool, showProfiles bool, profileCount int, hasEngines bool, hasGit bool) []string {
 	upgradeLabel := "Upgrade tools"
 	if updateCheckDone && update.HasUpdates(updateResults) {
 		upgradeLabel = "Upgrade tools ★"
@@ -65,7 +68,11 @@ func WelcomeOptions(updateResults []update.UpdateResult, updateCheckDone bool, s
 	}
 
 	opts = append(opts, "Manage backups")
-	opts = append(opts, "Reset review store")
+	resetLabel := "Reset review store"
+	if !hasGit {
+		resetLabel = "Reset review store (requires a Git repository)"
+	}
+	opts = append(opts, resetLabel)
 	opts = append(opts, "Receipt-Driven Development")
 	opts = append(opts, "Managed uninstall")
 	opts = append(opts, "Community Tools/Plugins")
@@ -74,15 +81,15 @@ func WelcomeOptions(updateResults []update.UpdateResult, updateCheckDone bool, s
 	return opts
 }
 
-func RenderWelcome(cursor int, version string, updateBanner string, updateResults []update.UpdateResult, updateCheckDone bool, showProfiles bool, profileCount int, hasEngines bool) string {
-	return RenderWelcomeWithWidth(cursor, version, updateBanner, updateResults, updateCheckDone, showProfiles, profileCount, hasEngines, 0)
+func RenderWelcome(cursor int, version string, updateBanner string, updateResults []update.UpdateResult, updateCheckDone bool, showProfiles bool, profileCount int, hasEngines bool, hasGit bool) string {
+	return RenderWelcomeWithWidth(cursor, version, updateBanner, updateResults, updateCheckDone, showProfiles, profileCount, hasEngines, hasGit, 0)
 }
 
-func RenderWelcomeWithWidth(cursor int, version string, updateBanner string, updateResults []update.UpdateResult, updateCheckDone bool, showProfiles bool, profileCount int, hasEngines bool, width int) string {
-	return RenderWelcomeWithAdvisory(cursor, version, updateBanner, updateResults, updateCheckDone, showProfiles, profileCount, hasEngines, width, 0, WelcomeAdvisory{})
+func RenderWelcomeWithWidth(cursor int, version string, updateBanner string, updateResults []update.UpdateResult, updateCheckDone bool, showProfiles bool, profileCount int, hasEngines bool, hasGit bool, width int) string {
+	return RenderWelcomeWithAdvisory(cursor, version, updateBanner, updateResults, updateCheckDone, showProfiles, profileCount, hasEngines, hasGit, width, 0, WelcomeAdvisory{})
 }
 
-func RenderWelcomeWithAdvisory(cursor int, version string, updateBanner string, updateResults []update.UpdateResult, updateCheckDone bool, showProfiles bool, profileCount int, hasEngines bool, width int, height int, advisory WelcomeAdvisory) string {
+func RenderWelcomeWithAdvisory(cursor int, version string, updateBanner string, updateResults []update.UpdateResult, updateCheckDone bool, showProfiles bool, profileCount int, hasEngines bool, hasGit bool, width int, height int, advisory WelcomeAdvisory) string {
 	render := func(includeLogo, includeOptional, compact bool) string {
 		var b strings.Builder
 
@@ -119,7 +126,7 @@ func RenderWelcomeWithAdvisory(cursor int, version string, updateBanner string, 
 		} else {
 			b.WriteString("\n\n")
 		}
-		options := WelcomeOptions(updateResults, updateCheckDone, showProfiles, profileCount, hasEngines)
+		options := WelcomeOptions(updateResults, updateCheckDone, showProfiles, profileCount, hasEngines, hasGit)
 		if compact {
 			b.WriteString(renderWelcomeOptions(options, cursor, width))
 		} else {

--- a/internal/tui/screens/welcome_internal_test.go
+++ b/internal/tui/screens/welcome_internal_test.go
@@ -91,7 +91,7 @@ func TestRenderWelcome_StaysWithinViewport(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			view := RenderWelcomeWithAdvisory(0, "dev", tc.updateBanner, nil, true, false, 0, true, tc.width, tc.height, tc.advisory)
+			view := RenderWelcomeWithAdvisory(0, "dev", tc.updateBanner, nil, true, false, 0, true, true, tc.width, tc.height, tc.advisory)
 
 			if got := lipgloss.Width(view); got > tc.width {
 				t.Fatalf("welcome width = %d, want <= %d\nview:\n%s", got, tc.width, view)

--- a/internal/tui/screens/welcome_test.go
+++ b/internal/tui/screens/welcome_test.go
@@ -12,7 +12,7 @@ import (
 // TestWelcomeOptions_WithoutProfiles verifies that when showProfiles is false,
 // the "OpenCode SDD Profiles" option is NOT present.
 func TestWelcomeOptions_WithoutProfiles(t *testing.T) {
-	opts := screens.WelcomeOptions(nil, true, false, 0, true)
+	opts := screens.WelcomeOptions(nil, true, false, 0, true, true)
 	if !containsOption(opts, "OpenCode Community Plugins") {
 		t.Fatalf("expected dedicated OpenCode Community Plugins option; got: %v", opts)
 	}
@@ -26,7 +26,7 @@ func TestWelcomeOptions_WithoutProfiles(t *testing.T) {
 
 // TestWelcomeOptions_WithProfiles_ZeroCount shows "OpenCode SDD Profiles" without a badge.
 func TestWelcomeOptions_WithProfiles_ZeroCount(t *testing.T) {
-	opts := screens.WelcomeOptions(nil, true, true, 0, true)
+	opts := screens.WelcomeOptions(nil, true, true, 0, true, true)
 	found := false
 	for _, opt := range opts {
 		if opt == "OpenCode SDD Profiles" {
@@ -43,7 +43,7 @@ func TestWelcomeOptions_WithProfiles_ZeroCount(t *testing.T) {
 
 // TestWelcomeOptions_WithProfiles_CountTwo shows "OpenCode SDD Profiles (2)".
 func TestWelcomeOptions_WithProfiles_CountTwo(t *testing.T) {
-	opts := screens.WelcomeOptions(nil, true, true, 2, true)
+	opts := screens.WelcomeOptions(nil, true, true, 2, true, true)
 	found := false
 	for _, opt := range opts {
 		if opt == "OpenCode SDD Profiles (2)" {
@@ -57,7 +57,7 @@ func TestWelcomeOptions_WithProfiles_CountTwo(t *testing.T) {
 
 // TestWelcomeOptions_WithProfiles_CountOne shows "OpenCode SDD Profiles (1)".
 func TestWelcomeOptions_WithProfiles_CountOne(t *testing.T) {
-	opts := screens.WelcomeOptions(nil, true, true, 1, true)
+	opts := screens.WelcomeOptions(nil, true, true, 1, true, true)
 	found := false
 	for _, opt := range opts {
 		if opt == "OpenCode SDD Profiles (1)" {
@@ -72,7 +72,7 @@ func TestWelcomeOptions_WithProfiles_CountOne(t *testing.T) {
 // TestWelcomeOptions_OptionCount_WithoutProfiles verifies 14 options when showProfiles=false
 // and hasEngines=true.
 func TestWelcomeOptions_OptionCount_WithoutProfiles(t *testing.T) {
-	opts := screens.WelcomeOptions(nil, true, false, 0, true)
+	opts := screens.WelcomeOptions(nil, true, false, 0, true, true)
 	// Includes the Receipt-Driven Development entry.
 	want := 14
 	if len(opts) != want {
@@ -83,7 +83,7 @@ func TestWelcomeOptions_OptionCount_WithoutProfiles(t *testing.T) {
 // TestWelcomeOptions_OptionCount_WithProfiles verifies 15 options when showProfiles=true
 // and hasEngines=true.
 func TestWelcomeOptions_OptionCount_WithProfiles(t *testing.T) {
-	opts := screens.WelcomeOptions(nil, true, true, 2, true)
+	opts := screens.WelcomeOptions(nil, true, true, 2, true, true)
 	// Includes the Receipt-Driven Development entry.
 	want := 15
 	if len(opts) != want {
@@ -94,7 +94,7 @@ func TestWelcomeOptions_OptionCount_WithProfiles(t *testing.T) {
 // TestWelcomeOptions_NoEngines_ShowsDisabledLabel verifies that when hasEngines=false,
 // the agent option is labelled "(no agents)" to signal unavailability.
 func TestWelcomeOptions_NoEngines_ShowsDisabledLabel(t *testing.T) {
-	opts := screens.WelcomeOptions(nil, true, false, 0, false)
+	opts := screens.WelcomeOptions(nil, true, false, 0, false, true)
 	found := false
 	for _, opt := range opts {
 		if strings.Contains(opt, "no agents") {
@@ -106,12 +106,28 @@ func TestWelcomeOptions_NoEngines_ShowsDisabledLabel(t *testing.T) {
 	}
 }
 
+// TestWelcomeOptions_NoGit_ShowsDisabledLabel verifies that when hasGit=false,
+// the reset review store option is labelled with the requires git precondition.
+func TestWelcomeOptions_NoGit_ShowsDisabledLabel(t *testing.T) {
+	opts := screens.WelcomeOptions(nil, true, false, 0, true, false)
+	found := false
+	for _, opt := range opts {
+		if opt == "Reset review store (requires a Git repository)" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected 'Reset review store (requires a Git repository)' label when hasGit=false; got: %v", opts)
+	}
+}
+
 // TestWelcomeOptions_ProfilesInsertedBeforeManageBackups verifies the ordering:
 // profiles option sits between "OpenCode Community Plugins" / "Uninstall OpenCode
 // Plugin" and "Manage backups". Slice 3b inserts the uninstall shortcut between
 // the plugins entry and the profiles entry.
 func TestWelcomeOptions_ProfilesInsertedBeforeManageBackups(t *testing.T) {
-	opts := screens.WelcomeOptions(nil, true, true, 1, true)
+	opts := screens.WelcomeOptions(nil, true, true, 1, true, true)
 
 	agentIdx := -1
 	pluginsIdx := -1
@@ -180,7 +196,7 @@ func containsOption(opts []string, want string) bool {
 }
 
 func TestWelcomeOptions_IncludesManagedUninstall(t *testing.T) {
-	opts := screens.WelcomeOptions(nil, true, false, 0, true)
+	opts := screens.WelcomeOptions(nil, true, false, 0, true, true)
 
 	found := false
 	for _, opt := range opts {
@@ -199,7 +215,7 @@ func TestWelcomeOptions_IncludesManagedUninstall(t *testing.T) {
 
 // TestRenderWelcome_WithoutProfiles verifies no "OpenCode SDD Profiles" in output.
 func TestRenderWelcome_WithoutProfiles(t *testing.T) {
-	output := screens.RenderWelcome(0, "1.0.0", "", nil, true, false, 0, true)
+	output := screens.RenderWelcome(0, "1.0.0", "", nil, true, false, 0, true, true)
 	if strings.Contains(output, "OpenCode SDD Profiles") {
 		snippet := output
 		if len(snippet) > 200 {
@@ -211,7 +227,7 @@ func TestRenderWelcome_WithoutProfiles(t *testing.T) {
 
 // TestRenderWelcome_WithProfiles_ZeroCount contains "OpenCode SDD Profiles" but no badge.
 func TestRenderWelcome_WithProfiles_ZeroCount(t *testing.T) {
-	output := screens.RenderWelcome(0, "1.0.0", "", nil, true, true, 0, true)
+	output := screens.RenderWelcome(0, "1.0.0", "", nil, true, true, 0, true, true)
 	if !strings.Contains(output, "OpenCode SDD Profiles") {
 		t.Errorf("RenderWelcome(showProfiles=true, count=0) missing 'OpenCode SDD Profiles'")
 	}
@@ -222,7 +238,7 @@ func TestRenderWelcome_WithProfiles_ZeroCount(t *testing.T) {
 
 // TestRenderWelcome_WithProfiles_CountTwo contains "OpenCode SDD Profiles (2)".
 func TestRenderWelcome_WithProfiles_CountTwo(t *testing.T) {
-	output := screens.RenderWelcome(0, "1.0.0", "", nil, true, true, 2, true)
+	output := screens.RenderWelcome(0, "1.0.0", "", nil, true, true, 2, true, true)
 	if !strings.Contains(output, "OpenCode SDD Profiles (2)") {
 		t.Errorf("RenderWelcome(showProfiles=true, count=2) missing 'OpenCode SDD Profiles (2)'")
 	}
@@ -230,7 +246,7 @@ func TestRenderWelcome_WithProfiles_CountTwo(t *testing.T) {
 
 // TestRenderWelcome_WithProfiles_CountOne contains "OpenCode SDD Profiles (1)".
 func TestRenderWelcome_WithProfiles_CountOne(t *testing.T) {
-	output := screens.RenderWelcome(0, "1.0.0", "", nil, true, true, 1, true)
+	output := screens.RenderWelcome(0, "1.0.0", "", nil, true, true, 1, true, true)
 	if !strings.Contains(output, "OpenCode SDD Profiles (1)") {
 		t.Errorf("RenderWelcome(showProfiles=true, count=1) missing 'OpenCode SDD Profiles (1)'")
 	}


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #3558

## 🏷️ PR Type

- [x] `type:bug` — Bug fix (non-breaking change that fixes an issue)

## 📝 Summary

Renders the "Reset review store" option as disabled (`Reset review store (requires a Git repository)`) in the welcome menu when running outside a Git repository, prevents Enter on that disabled option from executing a survey or reset, and returns a typed `ReviewStoreResetRepositoryRequiredError` with actionable continuation guidance on the direct CLI path (`gentle-ai review store-reset --cwd ...`) instead of leaking raw `git rev-parse` exit-128 subprocess stderr.

## 📂 Changes

| File / Area | What Changed |
|-------------|--------------|
| `internal/reviewtransaction/store_reset.go` | Added `StoreResetRepositoryRequiredError` and typed error returns in `storeResetRoot` and `ResetReviewStore` |
| `internal/reviewtransaction/store_reset_test.go` | Added tests asserting typed error on non-Git directories |
| `internal/cli/review_store_reset.go` | Added `ReviewStoreResetRepositoryRequiredError` and refusal helper with runnable continuation |
| `internal/cli/review_store_reset_test.go` | Added test asserting typed continuation error for `review store-reset` outside Git |
| `internal/tui/screens/welcome.go` | Updated `WelcomeOptions` and renderers to display disabled label when `hasGit` is false |
| `internal/tui/screens/welcome_test.go` | Updated test options and added disabled label test |
| `internal/tui/screens/welcome_internal_test.go` | Updated test render call |
| `internal/tui/model.go` | Added `ReviewStoreResetHasGitFn`, `hasGitRepository()`, and no-op Enter handling when outside Git |
| `internal/tui/model_test.go` | Updated test calls to `WelcomeOptions` |
| `internal/tui/review_mode_test.go` | Updated test call to `WelcomeOptions` |
| `internal/tui/review_store_reset_test.go` | Added tests verifying disabled row outside Git and no-op on Enter |

## 🧪 Test Plan

**Focused Unit Tests**
```bash
go test -v ./internal/reviewtransaction -run 'Test(Survey|Reset)ReviewStore|TestReviewStoreReset'
go test -v ./internal/cli -run 'TestReviewStoreReset|TestEveryNamedReviewContinuationIsStructurallyReal'
go test -v ./internal/tui/screens -run 'TestWelcome'
go test -v ./internal/tui -run 'TestWelcome|TestReviewStoreReset'
```

**Go Format & Vet**
```bash
go run ./internal/gofmtcheck
go vet ./internal/reviewtransaction ./internal/cli ./internal/tui ./internal/tui/screens
```

- [x] Unit tests pass
- [x] Go format passes (`go run ./internal/gofmtcheck`)
- [x] Manually tested locally

## ✅ Contributor Checklist

- [x] PR is linked to an issue with `status:approved`
- [x] PR stays within 400 changed lines
- [ ] API read-back confirms exactly one appropriate `type:*` label on this PR (pending maintainer or CI workflow)
- [x] Unit tests pass
- [x] I have updated documentation if necessary
- [x] My commits follow Conventional Commits format
- [x] My commits do not include `Co-Authored-By` trailers

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - The Review Store Reset option is disabled when the current workspace is not a Git repository.
  - The disabled option explains that a Git repository is required.
  - Selecting the unavailable option has no effect.

- **Bug Fixes**
  - Review Store Reset now provides clear, actionable guidance to use `--cwd` when run outside a Git repository.
  - Raw Git subprocess details, including exit codes, are no longer shown.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->