### PR TITLE
docs(vscode): correct Copilot delegation claims to solo-agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,7 +213,6 @@ Gentle-AI configures each agent using that agent's own native features, so capab
 | **Kilo Code** | Multi-mode overlay | OpenCode-compatible config in `~/.config/kilo` |
 | **Gemini CLI** | Experimental | Custom agents in `~/.gemini/agents/` |
 | **Cursor** | Native subagents | 10 SDD agents in `~/.cursor/agents/` |
-| **VS Code Copilot** | runSubagent | Parallel execution |
 | **Codex** | Native multi-agent | CLI-native TOML config; enabled by default with solo-agent fallback |
 | **Antigravity** | Dynamic subagents | Mission Control uses `define_subagent` + `invoke_subagent` for SDD phases |
 | **Kimi Code** | Native custom agents | Modular prompt templates in `~/.kimi` |
@@ -229,6 +228,7 @@ Gentle-AI configures each agent using that agent's own native features, so capab
 | **Windsurf** | Plan Mode, Code Mode, native workflows |
 | **OpenClaw** | Workspace-first `AGENTS.md` / `SOUL.md` with global MCP config |
 | **Trae** | Desktop app by ByteDance; `~/.trae/skills/` + OS-specific rules |
+| **VS Code Copilot** | Desktop IDE with GitHub Copilot; inline SDD orchestrator via instructions, `~/.copilot/skills/`, and MCP |
 
 > **Hermes must be installed manually first.** Gentle-AI detects and configures the existing runtime; it does not install Hermes.
 

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -13,7 +13,7 @@
 | Kilo Code       | `kilocode`       | Yes          | Yes | Full (multi-mode overlay)        | No            | Yes            | `~/.config/kilo`                    |
 | Gemini CLI      | `gemini-cli`     | Yes          | Yes | Full (experimental)              | No            | No             | `~/.gemini`                         |
 | Cursor          | `cursor`         | Yes          | Yes | Full (native subagents)          | No            | No             | `~/.cursor`                         |
-| VS Code Copilot | `vscode-copilot` | Yes          | Yes | Full (runSubagent)               | No            | No             | `~/.copilot` + VS Code User profile |
+| VS Code Copilot | `vscode-copilot` | Yes          | Yes | Solo-agent                       | No            | No             | `~/.copilot` + VS Code User profile |
 | Codex           | `codex`          | Yes          | Yes | Native multi-agent (default; solo fallback) | No            | No             | `~/.codex`                          |
 | Windsurf        | `windsurf`       | Yes (native) | Yes | Solo-agent                       | No            | No             | `~/.codeium/windsurf`               |
 | Antigravity     | `antigravity`    | Yes (native) | Yes | Solo-agent + Mission Control     | No            | No             | `~/.gemini/antigravity`             |
@@ -37,10 +37,10 @@ Most agents receive the **full SDD orchestrator** policy, plus skill files writt
 
 | Model                 | How It Works                                                                                                                                                                                       | Agents                                                                                                    |
 | --------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------- |
-| **Full (sub-agents)** | Each SDD phase runs in an isolated context window via native sub-agent delegation, package-managed subagents, or an OpenCode-compatible overlay. The orchestrator coordinates; sub-agents execute. | Claude Code, OpenCode, Kilo Code, Gemini CLI, Cursor, VS Code Copilot, Kimi Code, Kiro IDE, Qwen Code, Pi |
+| **Full (sub-agents)** | Each SDD phase runs in an isolated context window via native sub-agent delegation, package-managed subagents, or an OpenCode-compatible overlay. The orchestrator coordinates; sub-agents execute. | Claude Code, OpenCode, Kilo Code, Gemini CLI, Cursor, Kimi Code, Kiro IDE, Qwen Code, Pi |
 | **Full (delegate_task)** | The orchestrator uses Hermes's native `delegate_task` primitive to spawn ephemeral workers in fresh context windows. Workers receive only a self-contained mission; the parent receives only their final summary. Toolsets, MCP, and skills must be passed explicitly (not inherited by default). | Hermes |
 | **Native multi-agent** | The orchestrator delegates through the agent's native collaboration tools when configured and available, with inline execution as a graceful fallback. | Codex |
-| **Solo-agent**        | All SDD phases run inline in the same conversation. The orchestrator IS the executor. Engram™ provides cross-phase persistence.                                                                     | Windsurf, Antigravity, OpenClaw, Trae                                                                     |
+| **Solo-agent**        | All SDD phases run inline in the same conversation. The orchestrator IS the executor. Engram™ provides cross-phase persistence.                                                                     | Windsurf, Antigravity, VS Code Copilot, OpenClaw, Trae                                                                     |
 
 ### Cursor Native Subagents
 
@@ -138,7 +138,7 @@ Kiro uses native custom agents in `~/.kiro/agents/`. `gentle-ai` writes phase ag
 
 ### VS Code Copilot
 
-- Uses the `runSubagent` tool with support for parallel execution
+- Solo-agent SDD execution (all phases run inline in the conversation)
 - Skills at `~/.copilot/skills/`
 - System prompt at `Code/User/prompts/gentle-ai.instructions.md`
 - MCP config at `Code/User/mcp.json`

--- a/docs/intended-usage.md
+++ b/docs/intended-usage.md
@@ -105,9 +105,9 @@ This pattern works today in several delegation models:
 
 | Model | Agents | How it runs |
 | ----- | ------ | ----------- |
-| **Full sub-agents** | Claude Code, OpenCode, Kilo Code, Gemini CLI, Cursor, VS Code Copilot, Kimi Code, Kiro IDE, Qwen Code, Pi | Each SDD phase can run in a focused context through native delegation, package-managed subagents, or an OpenCode-compatible overlay |
+| **Full sub-agents** | Claude Code, OpenCode, Kilo Code, Gemini CLI, Cursor, Kimi Code, Kiro IDE, Qwen Code, Pi | Each SDD phase can run in a focused context through native delegation, package-managed subagents, or an OpenCode-compatible overlay |
 | **Hermes delegate_task** | Hermes | The orchestrator spawns ephemeral workers with self-contained missions and verifies their summaries before reporting success |
-| **Solo-agent** | Codex, Windsurf, Antigravity, OpenClaw, Trae | SDD phases run inline in one conversation; Engram still provides cross-phase persistence when available |
+| **Solo-agent** | Codex, Windsurf, Antigravity, VS Code Copilot, OpenClaw, Trae | SDD phases run inline in one conversation; Engram still provides cross-phase persistence when available |
 
 You don't need to configure any of this. The installer sets up the right model for your agent, and the orchestrator manages delegation automatically.
 

--- a/internal/agents/vscode/adapter_test.go
+++ b/internal/agents/vscode/adapter_test.go
@@ -157,3 +157,39 @@ func TestMCPConfigPathUsesVSCodeUserProfile(t *testing.T) {
 		}
 	}
 }
+
+func TestCapabilities(t *testing.T) {
+	a := NewAdapter()
+	home := "/tmp/home"
+
+	if !a.SupportsSkills() {
+		t.Fatal("SupportsSkills() = false, want true")
+	}
+	if !a.SupportsSystemPrompt() {
+		t.Fatal("SupportsSystemPrompt() = false, want true")
+	}
+	if !a.SupportsMCP() {
+		t.Fatal("SupportsMCP() = false, want true")
+	}
+	if a.SupportsSubAgents() {
+		t.Fatal("SupportsSubAgents() = true, want false (VS Code Copilot runs inline solo-agent)")
+	}
+	if a.SupportsSlashCommands() {
+		t.Fatal("SupportsSlashCommands() = true, want false")
+	}
+	if a.SupportsOutputStyles() {
+		t.Fatal("SupportsOutputStyles() = true, want false")
+	}
+	if got := a.SubAgentsDir(home); got != "" {
+		t.Fatalf("SubAgentsDir() = %q, want empty", got)
+	}
+	if got := a.EmbeddedSubAgentsDir(); got != "" {
+		t.Fatalf("EmbeddedSubAgentsDir() = %q, want empty", got)
+	}
+	if got := a.CommandsDir(home); got != "" {
+		t.Fatalf("CommandsDir() = %q, want empty", got)
+	}
+	if got := a.OutputStyleDir(home); got != "" {
+		t.Fatalf("OutputStyleDir() = %q, want empty", got)
+	}
+}


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #4136

## 🏷️ PR Type

- [x] `type:docs` — Documentation only

## 📝 Summary

Updates documentation across `README.md`, `docs/agents.md`, and `docs/intended-usage.md` to accurately reflect the real runtime surface of the VS Code Copilot adapter (`internal/agents/vscode/adapter.go`), which operates as a solo-agent with inline SDD orchestration (wiring Skills, SystemPrompt, and MCP) rather than full `runSubagent` sub-agent delegation.

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| `README.md` | Move VS Code Copilot from "Full delegation" (`runSubagent`) to "Solo-agent" table |
| `docs/agents.md` | Update Agent Matrix, Delegation Models table, and Agent Notes section to list VS Code Copilot as Solo-agent |
| `docs/intended-usage.md` | Update Sub-Agents table to list VS Code Copilot under Solo-agent |
| `internal/agents/vscode/adapter_test.go` | Add `TestCapabilities` unit test verifying adapter capability claims |

### Runtime Claim Audit Table

| Claim | Status | Evidence |
|---|:---:|---|
| VS Code Copilot supports Skills (`~/.copilot/skills/`) | True | `internal/agents/vscode/adapter.go:90-93`, `internal/agents/capabilitymanifest/manifest.go:335` |
| VS Code Copilot supports SystemPrompt (`gentle-ai.instructions.md`) | True | `internal/agents/vscode/adapter.go:82-88`, `internal/agents/capabilitymanifest/manifest.go:335` |
| VS Code Copilot supports MCP (`Code/User/mcp.json`) | True | `internal/agents/vscode/adapter.go:111-113`, `internal/agents/capabilitymanifest/manifest.go:335` |
| VS Code Copilot supports full `runSubagent` delegation | False | `internal/agents/vscode/adapter.go:164-174` (`SupportsSubAgents() == false`, `SubAgentsDir() == ""`, `EmbeddedSubAgentsDir() == ""`) |

## 🧪 Test Plan

**Claim Grep Verification**
```bash
grep -rn "runSubagent" --include="*.go" --include="*.md" .
# Output: zero matches across the entire repository
```

**Unit Tests**
```bash
go test -count=1 -v ./internal/agents/vscode/...
# Output: PASS (all 7 tests pass including TestCapabilities)
go test -count=1 -v ./internal/agents/capabilitymanifest/...
# Output: PASS (all tests pass)
```

**Go Format**
```bash
go run ./internal/gofmtcheck
# Output: clean (exit code 0)
```

- [x] Unit tests pass (`go test -count=1 -v ./internal/agents/vscode/...`)
- [x] Go format passes (`go run ./internal/gofmtcheck`)
- [x] Claim grep verified (`grep -rn "runSubagent"`)
- [x] Manually tested locally

## ✅ Contributor Checklist

- [x] PR is linked to an issue with `status:approved`
- [x] PR stays within 400 changed lines, or the `size:exception` rationale and verified policy authority are documented
- [ ] API read-back confirms exactly one appropriate `type:*` label on this PR
- [x] Unit tests pass (`go test ./...`)
- [x] I have updated documentation if necessary
- [x] My commits follow Conventional Commits format
- [x] My commits do not include `Co-Authored-By` trailers

## 💬 Notes for Reviewers

- Pure docs-first fix (no new production machinery or runtime wrappers added).
- Line delta: +43, -7 (total 50 lines, well within the 400-line budget).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated agent support tables and guidance for VS Code Copilot.
  - Clarified Copilot’s inline SDD orchestration, including support for skills, system prompts, and MCP.
  - Revised delegation model documentation and updated the listed support for OpenClaw and Trae.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->