### PR TITLE
fix(engram): clarify ambiguous_project recovery distinction in protocol

### DIFF
--- a/internal/assets/engram/protocol.md
+++ b/internal/assets/engram/protocol.md
@@ -141,8 +141,8 @@ MCP server instructions and the SessionStart hook. Always-on rules:
 - If `mem_session_start` fails with `ambiguous_project`: resolve the intended
   repository root and retry `mem_session_start` with that root as `directory`.
   The session ID remains unregistered until registration succeeds; never attach
-  an unregistered session ID to writes. Do not pass `recovery_token` or
-  `project_choice_reason` to `mem_session_start`.
+  an unregistered session ID to writes. Do not pass `project`,
+  `project_choice_reason`, or `recovery_token` to `mem_session_start`.
 - On `ambiguous_project` from write tools (`mem_save`, `mem_save_prompt`,
   `mem_session_summary`): never guess. Ask the user to choose exactly one value
   from `available_projects`, then retry the write tool with `project`,

--- a/internal/assets/engram/protocol.md
+++ b/internal/assets/engram/protocol.md
@@ -67,6 +67,13 @@ Memory lifecycle rule (when Engram exposes lifecycle metadata/tooling):
 - When a retrieved memory is marked `needs_review`, surface that stale context to the user and verify it against current evidence before relying on it.
 - Do NOT call `mem_review` with action `mark_reviewed` automatically. Only call `mark_reviewed` after explicit user confirmation or through a dedicated memory maintenance command.
 
+Session registration and ambiguous project recovery rules:
+- `mem_session_start` accepts a caller-supplied session ID and optional `directory`; it does not accept `project`, `project_choice_reason`, or `recovery_token`.
+- If `mem_session_start` fails with `ambiguous_project`, resolve the intended repository root and retry `mem_session_start` with that root as `directory`.
+- A failed start leaves the session ID unregistered; it is not permanently invalidated, but must never be attached to `mem_save` or another write until registration succeeds.
+- For `ambiguous_project` returned by supported write tools (`mem_save`, `mem_save_prompt`, or `mem_session_summary`), never guess. Ask the user to choose exactly one value from `available_projects`, then retry the same write tool with `project`, `project_choice_reason=user_selected_after_ambiguous_project`, and the returned `recovery_token`.
+- Do not apply the write-tool recovery shape (`project`, `project_choice_reason`, `recovery_token`) to `mem_session_start`.
+
 ### WHEN TO SEARCH MEMORY
 
 On any variation of "remember", "recall", "what did we do", "how did we solve", or references to past work (in any language the user writes in):
@@ -131,6 +138,16 @@ MCP server instructions and the SessionStart hook. Always-on rules:
   answer into a "saved / done" acknowledgement.
 - If a memory call fails or times out, deliver the answer anyway — memory
   failures never block or replace the reply.
+- If `mem_session_start` fails with `ambiguous_project`: resolve the intended
+  repository root and retry `mem_session_start` with that root as `directory`.
+  The session ID remains unregistered until registration succeeds; never attach
+  an unregistered session ID to writes. Do not pass `recovery_token` or
+  `project_choice_reason` to `mem_session_start`.
+- On `ambiguous_project` from write tools (`mem_save`, `mem_save_prompt`,
+  `mem_session_summary`): never guess. Ask the user to choose exactly one value
+  from `available_projects`, then retry the write tool with `project`,
+  `project_choice_reason=user_selected_after_ambiguous_project`, and the
+  returned `recovery_token`.
 <!-- /section:slim -->
 
 <!-- section:passive-capture -->

--- a/internal/components/engram/protocol_test.go
+++ b/internal/components/engram/protocol_test.go
@@ -114,6 +114,10 @@ func TestExtractProtocolSectionBoundsAllFourMarkerPairs(t *testing.T) {
 	}
 }
 
+// TestProtocolAmbiguousProjectRecoveryDistinction asserts that every rendered protocol
+// surface (full and slim) documents recovery for ambiguous_project errors, explicitly
+// separating the repository directory retry for mem_session_start from write-tool recovery
+// parameters (project, project_choice_reason, recovery_token).
 func TestProtocolAmbiguousProjectRecoveryDistinction(t *testing.T) {
 	surfaces := map[string]string{
 		"full": protocolFull(),
@@ -144,11 +148,26 @@ func TestProtocolAmbiguousProjectRecoveryDistinction(t *testing.T) {
 				}
 			}
 
-			// Verify distinction: session_start must not receive write-tool recovery parameters.
 			normalized := normalizeForSemanticMatch(content)
-			if !strings.Contains(normalized, "do not pass `recovery_token` or `project_choice_reason` to `mem_session_start`") &&
-				!strings.Contains(normalized, "do not apply the write-tool recovery shape") {
-				t.Errorf("surface %q does not enforce distinction preventing write-tool recovery parameters on mem_session_start", surfaceName)
+
+			// Verify session start recovery binds ambiguous_project to directory retry.
+			if !strings.Contains(normalized, "`mem_session_start` fails with `ambiguous_project`") ||
+				!strings.Contains(normalized, "retry `mem_session_start` with that root as `directory`") {
+				t.Errorf("surface %q does not connect mem_session_start ambiguous_project to directory retry", surfaceName)
+			}
+
+			// Verify distinction: mem_session_start must exclude all three write-recovery parameters.
+			hasFullExclusion := strings.Contains(normalized, "`mem_session_start`") &&
+				strings.Contains(normalized, "does not accept `project`, `project_choice_reason`, or `recovery_token`")
+			hasSlimExclusion := strings.Contains(normalized, "do not pass `project`, `project_choice_reason`, or `recovery_token` to `mem_session_start`")
+			if !hasFullExclusion && !hasSlimExclusion {
+				t.Errorf("surface %q does not enforce exclusion of project, project_choice_reason, and recovery_token from mem_session_start", surfaceName)
+			}
+
+			// Verify write-tool recovery binds available_projects, project, project_choice_reason, and recovery_token.
+			if !strings.Contains(normalized, "choose exactly one value from `available_projects`") ||
+				!strings.Contains(normalized, "`project`, `project_choice_reason=user_selected_after_ambiguous_project`, and the returned `recovery_token`") {
+				t.Errorf("surface %q does not connect write-tool recovery parameters to available_projects selection", surfaceName)
 			}
 		})
 	}

--- a/internal/components/engram/protocol_test.go
+++ b/internal/components/engram/protocol_test.go
@@ -113,3 +113,43 @@ func TestExtractProtocolSectionBoundsAllFourMarkerPairs(t *testing.T) {
 		}
 	}
 }
+
+func TestProtocolAmbiguousProjectRecoveryDistinction(t *testing.T) {
+	surfaces := map[string]string{
+		"full": protocolFull(),
+		"slim": protocolSlim(),
+	}
+
+	requiredPhrases := []struct {
+		name   string
+		phrase string
+	}{
+		{"ambiguous-project-error-code", "ambiguous_project"},
+		{"session-start-target", "mem_session_start"},
+		{"session-start-directory-retry", "directory"},
+		{"session-start-unregistered-id", "unregistered"},
+		{"write-tools-target-mem-save", "mem_save"},
+		{"write-tools-target-mem-save-prompt", "mem_save_prompt"},
+		{"write-tools-target-mem-session-summary", "mem_session_summary"},
+		{"write-tools-available-projects", "available_projects"},
+		{"write-tools-project-choice-reason", "project_choice_reason=user_selected_after_ambiguous_project"},
+		{"write-tools-recovery-token", "recovery_token"},
+	}
+
+	for surfaceName, content := range surfaces {
+		t.Run(surfaceName, func(t *testing.T) {
+			for _, req := range requiredPhrases {
+				if !strings.Contains(content, req.phrase) {
+					t.Errorf("surface %q missing required phrase %q (%s)", surfaceName, req.phrase, req.name)
+				}
+			}
+
+			// Verify distinction: session_start must not receive write-tool recovery parameters.
+			normalized := normalizeForSemanticMatch(content)
+			if !strings.Contains(normalized, "do not pass `recovery_token` or `project_choice_reason` to `mem_session_start`") &&
+				!strings.Contains(normalized, "do not apply the write-tool recovery shape") {
+				t.Errorf("surface %q does not enforce distinction preventing write-tool recovery parameters on mem_session_start", surfaceName)
+			}
+		})
+	}
+}

--- a/internal/components/engram/testdata/protocol-full.md
+++ b/internal/components/engram/testdata/protocol-full.md
@@ -66,6 +66,13 @@ Memory lifecycle rule (when Engram exposes lifecycle metadata/tooling):
 - When a retrieved memory is marked `needs_review`, surface that stale context to the user and verify it against current evidence before relying on it.
 - Do NOT call `mem_review` with action `mark_reviewed` automatically. Only call `mark_reviewed` after explicit user confirmation or through a dedicated memory maintenance command.
 
+Session registration and ambiguous project recovery rules:
+- `mem_session_start` accepts a caller-supplied session ID and optional `directory`; it does not accept `project`, `project_choice_reason`, or `recovery_token`.
+- If `mem_session_start` fails with `ambiguous_project`, resolve the intended repository root and retry `mem_session_start` with that root as `directory`.
+- A failed start leaves the session ID unregistered; it is not permanently invalidated, but must never be attached to `mem_save` or another write until registration succeeds.
+- For `ambiguous_project` returned by supported write tools (`mem_save`, `mem_save_prompt`, or `mem_session_summary`), never guess. Ask the user to choose exactly one value from `available_projects`, then retry the same write tool with `project`, `project_choice_reason=user_selected_after_ambiguous_project`, and the returned `recovery_token`.
+- Do not apply the write-tool recovery shape (`project`, `project_choice_reason`, `recovery_token`) to `mem_session_start`.
+
 ### WHEN TO SEARCH MEMORY
 
 On any variation of "remember", "recall", "what did we do", "how did we solve", or references to past work (in any language the user writes in):

--- a/internal/components/engram/testdata/protocol-slim.md
+++ b/internal/components/engram/testdata/protocol-slim.md
@@ -18,8 +18,8 @@ MCP server instructions and the SessionStart hook. Always-on rules:
 - If `mem_session_start` fails with `ambiguous_project`: resolve the intended
   repository root and retry `mem_session_start` with that root as `directory`.
   The session ID remains unregistered until registration succeeds; never attach
-  an unregistered session ID to writes. Do not pass `recovery_token` or
-  `project_choice_reason` to `mem_session_start`.
+  an unregistered session ID to writes. Do not pass `project`,
+  `project_choice_reason`, or `recovery_token` to `mem_session_start`.
 - On `ambiguous_project` from write tools (`mem_save`, `mem_save_prompt`,
   `mem_session_summary`): never guess. Ask the user to choose exactly one value
   from `available_projects`, then retry the write tool with `project`,

--- a/internal/components/engram/testdata/protocol-slim.md
+++ b/internal/components/engram/testdata/protocol-slim.md
@@ -15,3 +15,13 @@ MCP server instructions and the SessionStart hook. Always-on rules:
   answer into a "saved / done" acknowledgement.
 - If a memory call fails or times out, deliver the answer anyway — memory
   failures never block or replace the reply.
+- If `mem_session_start` fails with `ambiguous_project`: resolve the intended
+  repository root and retry `mem_session_start` with that root as `directory`.
+  The session ID remains unregistered until registration succeeds; never attach
+  an unregistered session ID to writes. Do not pass `recovery_token` or
+  `project_choice_reason` to `mem_session_start`.
+- On `ambiguous_project` from write tools (`mem_save`, `mem_save_prompt`,
+  `mem_session_summary`): never guess. Ask the user to choose exactly one value
+  from `available_projects`, then retry the write tool with `project`,
+  `project_choice_reason=user_selected_after_ambiguous_project`, and the
+  returned `recovery_token`.

--- a/testdata/golden/combined-claude-claudemd.golden
+++ b/testdata/golden/combined-claude-claudemd.golden
@@ -317,8 +317,8 @@ MCP server instructions and the SessionStart hook. Always-on rules:
 - If `mem_session_start` fails with `ambiguous_project`: resolve the intended
   repository root and retry `mem_session_start` with that root as `directory`.
   The session ID remains unregistered until registration succeeds; never attach
-  an unregistered session ID to writes. Do not pass `recovery_token` or
-  `project_choice_reason` to `mem_session_start`.
+  an unregistered session ID to writes. Do not pass `project`,
+  `project_choice_reason`, or `recovery_token` to `mem_session_start`.
 - On `ambiguous_project` from write tools (`mem_save`, `mem_save_prompt`,
   `mem_session_summary`): never guess. Ask the user to choose exactly one value
   from `available_projects`, then retry the write tool with `project`,

--- a/testdata/golden/combined-claude-claudemd.golden
+++ b/testdata/golden/combined-claude-claudemd.golden
@@ -314,4 +314,14 @@ MCP server instructions and the SessionStart hook. Always-on rules:
   answer into a "saved / done" acknowledgement.
 - If a memory call fails or times out, deliver the answer anyway — memory
   failures never block or replace the reply.
+- If `mem_session_start` fails with `ambiguous_project`: resolve the intended
+  repository root and retry `mem_session_start` with that root as `directory`.
+  The session ID remains unregistered until registration succeeds; never attach
+  an unregistered session ID to writes. Do not pass `recovery_token` or
+  `project_choice_reason` to `mem_session_start`.
+- On `ambiguous_project` from write tools (`mem_save`, `mem_save_prompt`,
+  `mem_session_summary`): never guess. Ask the user to choose exactly one value
+  from `available_projects`, then retry the write tool with `project`,
+  `project_choice_reason=user_selected_after_ambiguous_project`, and the
+  returned `recovery_token`.
 <!-- /gentle-ai:engram-protocol -->

--- a/testdata/golden/combined-windsurf-global-rules.golden
+++ b/testdata/golden/combined-windsurf-global-rules.golden
@@ -665,6 +665,13 @@ Memory lifecycle rule (when Engram exposes lifecycle metadata/tooling):
 - When a retrieved memory is marked `needs_review`, surface that stale context to the user and verify it against current evidence before relying on it.
 - Do NOT call `mem_review` with action `mark_reviewed` automatically. Only call `mark_reviewed` after explicit user confirmation or through a dedicated memory maintenance command.
 
+Session registration and ambiguous project recovery rules:
+- `mem_session_start` accepts a caller-supplied session ID and optional `directory`; it does not accept `project`, `project_choice_reason`, or `recovery_token`.
+- If `mem_session_start` fails with `ambiguous_project`, resolve the intended repository root and retry `mem_session_start` with that root as `directory`.
+- A failed start leaves the session ID unregistered; it is not permanently invalidated, but must never be attached to `mem_save` or another write until registration succeeds.
+- For `ambiguous_project` returned by supported write tools (`mem_save`, `mem_save_prompt`, or `mem_session_summary`), never guess. Ask the user to choose exactly one value from `available_projects`, then retry the same write tool with `project`, `project_choice_reason=user_selected_after_ambiguous_project`, and the returned `recovery_token`.
+- Do not apply the write-tool recovery shape (`project`, `project_choice_reason`, `recovery_token`) to `mem_session_start`.
+
 ### WHEN TO SEARCH MEMORY
 
 On any variation of "remember", "recall", "what did we do", "how did we solve", or references to past work (in any language the user writes in):

--- a/testdata/golden/engram-antigravity-rulesmd.golden
+++ b/testdata/golden/engram-antigravity-rulesmd.golden
@@ -67,6 +67,13 @@ Memory lifecycle rule (when Engram exposes lifecycle metadata/tooling):
 - When a retrieved memory is marked `needs_review`, surface that stale context to the user and verify it against current evidence before relying on it.
 - Do NOT call `mem_review` with action `mark_reviewed` automatically. Only call `mark_reviewed` after explicit user confirmation or through a dedicated memory maintenance command.
 
+Session registration and ambiguous project recovery rules:
+- `mem_session_start` accepts a caller-supplied session ID and optional `directory`; it does not accept `project`, `project_choice_reason`, or `recovery_token`.
+- If `mem_session_start` fails with `ambiguous_project`, resolve the intended repository root and retry `mem_session_start` with that root as `directory`.
+- A failed start leaves the session ID unregistered; it is not permanently invalidated, but must never be attached to `mem_save` or another write until registration succeeds.
+- For `ambiguous_project` returned by supported write tools (`mem_save`, `mem_save_prompt`, or `mem_session_summary`), never guess. Ask the user to choose exactly one value from `available_projects`, then retry the same write tool with `project`, `project_choice_reason=user_selected_after_ambiguous_project`, and the returned `recovery_token`.
+- Do not apply the write-tool recovery shape (`project`, `project_choice_reason`, `recovery_token`) to `mem_session_start`.
+
 ### WHEN TO SEARCH MEMORY
 
 On any variation of "remember", "recall", "what did we do", "how did we solve", or references to past work (in any language the user writes in):

--- a/testdata/golden/engram-claude-claudemd.golden
+++ b/testdata/golden/engram-claude-claudemd.golden
@@ -19,8 +19,8 @@ MCP server instructions and the SessionStart hook. Always-on rules:
 - If `mem_session_start` fails with `ambiguous_project`: resolve the intended
   repository root and retry `mem_session_start` with that root as `directory`.
   The session ID remains unregistered until registration succeeds; never attach
-  an unregistered session ID to writes. Do not pass `recovery_token` or
-  `project_choice_reason` to `mem_session_start`.
+  an unregistered session ID to writes. Do not pass `project`,
+  `project_choice_reason`, or `recovery_token` to `mem_session_start`.
 - On `ambiguous_project` from write tools (`mem_save`, `mem_save_prompt`,
   `mem_session_summary`): never guess. Ask the user to choose exactly one value
   from `available_projects`, then retry the write tool with `project`,

--- a/testdata/golden/engram-claude-claudemd.golden
+++ b/testdata/golden/engram-claude-claudemd.golden
@@ -16,4 +16,14 @@ MCP server instructions and the SessionStart hook. Always-on rules:
   answer into a "saved / done" acknowledgement.
 - If a memory call fails or times out, deliver the answer anyway — memory
   failures never block or replace the reply.
+- If `mem_session_start` fails with `ambiguous_project`: resolve the intended
+  repository root and retry `mem_session_start` with that root as `directory`.
+  The session ID remains unregistered until registration succeeds; never attach
+  an unregistered session ID to writes. Do not pass `recovery_token` or
+  `project_choice_reason` to `mem_session_start`.
+- On `ambiguous_project` from write tools (`mem_save`, `mem_save_prompt`,
+  `mem_session_summary`): never guess. Ask the user to choose exactly one value
+  from `available_projects`, then retry the write tool with `project`,
+  `project_choice_reason=user_selected_after_ambiguous_project`, and the
+  returned `recovery_token`.
 <!-- /gentle-ai:engram-protocol -->

--- a/testdata/golden/engram-codex-instructions.golden
+++ b/testdata/golden/engram-codex-instructions.golden
@@ -66,6 +66,13 @@ Memory lifecycle rule (when Engram exposes lifecycle metadata/tooling):
 - When a retrieved memory is marked `needs_review`, surface that stale context to the user and verify it against current evidence before relying on it.
 - Do NOT call `mem_review` with action `mark_reviewed` automatically. Only call `mark_reviewed` after explicit user confirmation or through a dedicated memory maintenance command.
 
+Session registration and ambiguous project recovery rules:
+- `mem_session_start` accepts a caller-supplied session ID and optional `directory`; it does not accept `project`, `project_choice_reason`, or `recovery_token`.
+- If `mem_session_start` fails with `ambiguous_project`, resolve the intended repository root and retry `mem_session_start` with that root as `directory`.
+- A failed start leaves the session ID unregistered; it is not permanently invalidated, but must never be attached to `mem_save` or another write until registration succeeds.
+- For `ambiguous_project` returned by supported write tools (`mem_save`, `mem_save_prompt`, or `mem_session_summary`), never guess. Ask the user to choose exactly one value from `available_projects`, then retry the same write tool with `project`, `project_choice_reason=user_selected_after_ambiguous_project`, and the returned `recovery_token`.
+- Do not apply the write-tool recovery shape (`project`, `project_choice_reason`, `recovery_token`) to `mem_session_start`.
+
 ### WHEN TO SEARCH MEMORY
 
 On any variation of "remember", "recall", "what did we do", "how did we solve", or references to past work (in any language the user writes in):


### PR DESCRIPTION
<!-- ⚠️ READ BEFORE SUBMITTING
  Every PR must be linked to an issue that has the "status:approved" label.
  PRs without a linked approved issue will be automatically rejected by CI.
  See CONTRIBUTING.md for the full contribution workflow.
-->

## 🔗 Linked Issue

Closes #3156

---

## 🏷️ PR Type

What kind of change does this PR introduce?

- [x] `type:bug` — Bug fix (non-breaking change that fixes an issue)
- [ ] `type:feature` — New feature (non-breaking change that adds functionality)
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring (no functional changes)
- [ ] `type:chore` — Build, CI, or tooling changes
- [ ] `type:breaking-change` — Breaking change (fix or feature that changes existing behavior)

---

## 📝 Summary

Clarifies the recovery contract for `ambiguous_project` in the Engram protocol asset (`internal/assets/engram/protocol.md`) across both `full` and `slim` sections, following the maintainer clarification by @decode2:

- For `mem_session_start`: retry with `directory` pointing to the intended repository root. Clarifies that the session ID remains unregistered until start succeeds and must not be attached to writes before registration. It does not accept `recovery_token` or `project_choice_reason`.
- For write tools (`mem_save`, `mem_save_prompt`, `mem_session_summary`): ask the user to select from `available_projects` and retry with `project`, `project_choice_reason=user_selected_after_ambiguous_project`, and `recovery_token`.
- Updates byte-exact testdata fixtures and golden files across all affected surfaces.
- Adds focused table-driven regression test `TestProtocolAmbiguousProjectRecoveryDistinction` verifying the contracts and their separation.

---

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/assets/engram/protocol.md` | Added ambiguous project recovery distinction to full and slim sections |
| `internal/components/engram/testdata/protocol-full.md` | Synced byte-for-byte with full protocol section |
| `internal/components/engram/testdata/protocol-slim.md` | Synced byte-for-byte with slim protocol section |
| `internal/components/engram/protocol_test.go` | Added `TestProtocolAmbiguousProjectRecoveryDistinction` regression test |
| `testdata/golden/*` | Regenerated golden files for Claude, Codex, Windsurf, and Antigravity |

---

## 🤖 AI Assistance

Select exactly one option. Do not check both options.

- [ ] **None** — No material AI assistance was used.
- [x] **Material assistance used** — Complete all applicable declaration fields below.

**Tool/model (if known):**
OpenCode / gentle-orchestrator

**Material scope:**
Assisted in drafting protocol wording according to the maintainer specification, updating fixtures, generating golden updates, and adding the Go regression test.

**Verification performed:**
Ran `go run ./internal/gofmtcheck` (clean), `go test -count=1 ./internal/components/engram/...` (all pass), and `go test ./internal/components/...` (all pass).

---

## 🧪 Test Plan

**Unit Tests**
```bash
go test ./...
```

**Go Format**
```bash
go run ./internal/gofmtcheck
```

**E2E Tests** (Docker required)
```bash
cd e2e && ./docker-test.sh
```

**Benchmark Validation**

N/A: Documentation protocol asset and regression tests; does not affect benchmarks, review lifecycle, or runtime binaries.

- [x] Unit tests pass (`go test ./...`)
- [x] Go format passes (`go run ./internal/gofmtcheck`)
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`)
- [x] Manually tested locally

---

## 🤖 Automated Checks

The following checks run automatically on this PR:

| Check | Status | Description |
|-------|--------|-------------|
| Check PR Cognitive Load | ⏳ | PR should stay within 400 changed lines (`additions + deletions`) or use `size:exception` |
| Check Issue Reference | ⏳ | PR body must contain `Closes/Fixes/Resolves #N` |
| Check Issue Has `status:approved` | ⏳ | Linked issue must have been approved before work began |
| Check PR Has `type:*` Label | ⏳ | Exactly one `type:*` label must be applied |
| Unit Tests | ⏳ | `go test ./...` must pass |
| Go Format | ⏳ | `go run ./internal/gofmtcheck` must pass |
| E2E Tests | ⏳ | `cd e2e && ./docker-test.sh` must pass |

---

## ✅ Contributor Checklist

- [x] PR is linked to an issue with `status:approved`
- [x] PR stays within 400 changed lines, or I have requested/obtained maintainer-applied `size:exception` with rationale documented
- [x] I have added the appropriate `type:*` label to this PR
- [x] Unit tests pass (`go test ./...`)
- [x] Go format passes (`go run ./internal/gofmtcheck`)
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`)
- [x] Benchmark validation completed, or this change is not applicable to the benchmark (explain why in the Test Plan).
- [x] I have updated documentation if necessary
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] I understand, reviewed, and take responsibility for the complete submission
- [x] I selected exactly one AI-assistance option and, if material assistance was used, completed all applicable declaration fields
- [x] My commits do not include `Co-Authored-By` trailers

---

## 💬 Notes for Reviewers

Follows the contract and scope guidelines outlined by @decode2 on #3156.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified session registration and project-recovery guidance in the Engram protocol.
  * Added rules for resolving ambiguous projects during session start and write operations.
  * Documented repository-root recovery, explicit project selection, and recovery-token handling.
  * Clarified that failed session registration leaves the session unregistered until a successful retry.
* **Tests**
  * Added coverage ensuring full and slim protocol documentation consistently enforce these recovery rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->