### PR TITLE
fix(tui): resolve model assignments per phase in Configure Models

### DIFF
--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -150,6 +150,112 @@ func sanitizeKnownModelEfforts(assignments map[string]model.ModelAssignment, sdd
 	return sanitized
 }
 
+func cloneModelAssignments(m map[string]model.ModelAssignment) map[string]model.ModelAssignment {
+	if m == nil {
+		return nil
+	}
+	cloned := make(map[string]model.ModelAssignment, len(m))
+	for k, v := range m {
+		cloned[k] = v
+	}
+	return cloned
+}
+
+func (m *Model) recordSessionModelAssignment(key string, assignment model.ModelAssignment) {
+	if m.sessionModelAssignments == nil {
+		m.sessionModelAssignments = make(map[string]model.ModelAssignment)
+	}
+	delete(m.sessionModelTombstones, key)
+	m.sessionModelAssignments[key] = assignment
+}
+
+func (m *Model) recordSessionModelTombstone(key string) {
+	if m.sessionModelTombstones == nil {
+		m.sessionModelTombstones = make(map[string]bool)
+	}
+	delete(m.sessionModelAssignments, key)
+	m.sessionModelTombstones[key] = true
+}
+
+func agentsForPickerRow(row screens.ModelPickerRow, customAgents []string) []string {
+	switch row.Kind {
+	case screens.ModelPickerRowKindSetAllSDD:
+		return opencode.SDDPhases()
+	case screens.ModelPickerRowKindSetAllCustom:
+		return customAgents
+	case screens.ModelPickerRowKindAgent:
+		if row.AgentID != "" {
+			return []string{row.AgentID}
+		}
+	}
+	return nil
+}
+
+func (m *Model) recordSessionModelNavUpdate(updated map[string]model.ModelAssignment) {
+	m.Selection.ModelAssignments = updated
+	if m.ModelPicker.Mode != screens.ModePhaseList {
+		return
+	}
+	if selectedRow, ok := screens.ModelPickerRowAt(m.ModelPicker, m.ModelPicker.SelectedPhaseIdx); ok {
+		for _, agent := range agentsForPickerRow(selectedRow, m.ModelPicker.CustomAgents) {
+			if asg, has := updated[agent]; has {
+				m.recordSessionModelAssignment(agent, asg)
+			}
+		}
+	}
+}
+
+func (m *Model) clearModelPickerAssignmentForSelectedRow() {
+	if selectedRow, ok := screens.ModelPickerRowAt(m.ModelPicker, m.ModelPicker.SelectedPhaseIdx); ok {
+		for _, agent := range agentsForPickerRow(selectedRow, m.ModelPicker.CustomAgents) {
+			m.recordSessionModelTombstone(agent)
+		}
+	}
+	m.Selection.ModelAssignments = screens.ClearModelPickerAssignment(&m.ModelPicker, m.Selection.ModelAssignments)
+}
+
+func (m *Model) resolveOpenCodeModelAssignments() {
+	var effectiveConfig map[string]model.ModelAssignment
+	if current, err := readCurrentAssignmentsFn(currentOpenCodeSettingsPath()); err == nil {
+		effectiveConfig = current
+	}
+
+	if m.sessionModelAssignments == nil {
+		m.sessionModelAssignments = make(map[string]model.ModelAssignment)
+		for k, v := range m.Selection.ModelAssignments {
+			if m.persistedModelAssignments == nil || m.persistedModelAssignments[k] != v {
+				m.sessionModelAssignments[k] = v
+			}
+		}
+	}
+	if m.sessionModelTombstones == nil {
+		m.sessionModelTombstones = make(map[string]bool)
+	}
+
+	result := make(map[string]model.ModelAssignment)
+	for k, v := range m.persistedModelAssignments {
+		result[k] = v
+	}
+	for k, v := range effectiveConfig {
+		result[k] = v
+	}
+	for k, isTombstone := range m.sessionModelTombstones {
+		if isTombstone {
+			delete(result, k)
+		}
+	}
+	for k, v := range m.sessionModelAssignments {
+		result[k] = v
+	}
+
+	sanitized := sanitizeKnownModelEfforts(result, m.ModelPicker.SDDModels)
+	if len(sanitized) == 0 {
+		m.Selection.ModelAssignments = nil
+	} else {
+		m.Selection.ModelAssignments = sanitized
+	}
+}
+
 func sanitizeKnownModelEffort(assignment model.ModelAssignment, sddModels map[string][]opencode.Model) model.ModelAssignment {
 	if assignment.Effort == "" {
 		return assignment
@@ -823,6 +929,14 @@ type Model struct {
 	CommunityToolStatusErr     error
 	CommunityToolResults       []communitytool.Result
 	CommunityToolErr           error
+
+	// OpenCode model assignment precedence state:
+	// persistedModelAssignments captures persisted Gentle AI state (Tier 3 fallback).
+	// sessionModelAssignments and sessionModelTombstones track explicit assignments and
+	// explicit clears made in the current TUI session (Tier 1 precedence).
+	persistedModelAssignments map[string]model.ModelAssignment
+	sessionModelAssignments   map[string]model.ModelAssignment
+	sessionModelTombstones    map[string]bool
 }
 
 // NewModel constructs the initial TUI model for the given detection result.
@@ -841,6 +955,8 @@ func NewModel(detection system.DetectionResult, version string, installState ...
 		components = piOnlyComponents()
 	}
 
+	persistedModelAssignments := installStateModelAssignments(s.ModelAssignments)
+
 	selection := model.Selection{
 		Agents:                 agents,
 		Persona:                model.PersonaGentleman,
@@ -849,22 +965,23 @@ func NewModel(detection system.DetectionResult, version string, installState ...
 		ClaudeModelAssignments: installStateClaudeAssignments(s.ClaudeModelAssignments),
 		ClaudePhaseAssignments: installStateClaudePhaseAssignments(s.ClaudePhaseAssignments),
 		KiroModelAssignments:   installStateKiroAssignments(s.KiroModelAssignments),
-		ModelAssignments:       installStateModelAssignments(s.ModelAssignments),
+		ModelAssignments:       cloneModelAssignments(persistedModelAssignments),
 	}
 
 	return Model{
-		Screen:                ScreenWelcome,
-		Version:               version,
-		Selection:             selection,
-		Detection:             detection,
-		BackgroundIntent:      s.BackgroundIntent,
-		PiBackgroundIntent:    s.PiBackgroundIntent,
-		UninstallAgents:       agents,
-		UninstallComponents:   defaultUninstallComponents(),
-		UninstallEngramScope:  model.EngramUninstallScopeGlobal,
-		ReviewModeCwdFn:       os.Getwd,
-		ReviewModeStatusFn:    cli.ReviewModeStatus,
-		ReviewModeSetGlobalFn: cli.SetGlobalReviewMode,
+		Screen:                    ScreenWelcome,
+		Version:                   version,
+		Selection:                 selection,
+		Detection:                 detection,
+		BackgroundIntent:          s.BackgroundIntent,
+		PiBackgroundIntent:        s.PiBackgroundIntent,
+		UninstallAgents:           agents,
+		UninstallComponents:       defaultUninstallComponents(),
+		UninstallEngramScope:      model.EngramUninstallScopeGlobal,
+		ReviewModeCwdFn:           os.Getwd,
+		ReviewModeStatusFn:        cli.ReviewModeStatus,
+		ReviewModeSetGlobalFn:     cli.SetGlobalReviewMode,
+		persistedModelAssignments: persistedModelAssignments,
 		Progress: NewProgressState([]string{
 			"Install dependencies",
 			"Configure selected agents",
@@ -1568,7 +1685,7 @@ func (m Model) handleKeyPress(key tea.KeyMsg) (tea.Model, tea.Cmd) {
 	if m.Screen == ScreenModelPicker && m.ModelPicker.Mode != screens.ModePhaseList {
 		handled, updated := screens.HandleModelPickerNav(keyStr, &m.ModelPicker, m.Selection.ModelAssignments)
 		if handled {
-			m.Selection.ModelAssignments = updated
+			m.recordSessionModelNavUpdate(updated)
 			return m, nil
 		}
 	}
@@ -1583,14 +1700,21 @@ func (m Model) handleKeyPress(key tea.KeyMsg) (tea.Model, tea.Cmd) {
 		}
 	}
 
-	if m.Screen == ScreenProfileCreate && m.ProfileCreateStep == 1 &&
+	if (m.Screen == ScreenModelPicker || (m.Screen == ScreenProfileCreate && m.ProfileCreateStep == 1)) &&
 		m.ModelPicker.Mode == screens.ModePhaseList && keyStr == "backspace" &&
 		len(m.ModelPicker.AvailableIDs) > 0 {
-		rows := screens.ModelPickerRowsForProfile()
+		rows := screens.ModelPickerRowsForState(m.ModelPicker)
+		if m.Screen == ScreenProfileCreate {
+			rows = screens.ModelPickerRowsForProfile()
+		}
 		row, ok := screens.ModelPickerRowAt(m.ModelPicker, m.Cursor)
 		if m.Cursor < len(rows) && ok && row.Kind != screens.ModelPickerRowKindSeparator {
 			m.ModelPicker.SelectedPhaseIdx = m.Cursor
-			m.Selection.ModelAssignments = screens.ClearModelPickerAssignment(&m.ModelPicker, m.Selection.ModelAssignments)
+			if m.Screen == ScreenModelPicker {
+				m.clearModelPickerAssignmentForSelectedRow()
+			} else {
+				m.Selection.ModelAssignments = screens.ClearModelPickerAssignment(&m.ModelPicker, m.Selection.ModelAssignments)
+			}
 			return m, nil
 		}
 	}
@@ -2338,20 +2462,7 @@ func (m Model) confirmSelection() (tea.Model, tea.Cmd) {
 		case 1: // Configure OpenCode models
 			m.ModelConfigMode = true
 			discoveryCmd := m.initializeModelPicker()
-			// Pre-populate with existing assignments from opencode.json.
-			// Only when there are no in-session assignments yet — the nil guard
-			// ensures we don't overwrite changes the user already made this session.
-			if m.Selection.ModelAssignments == nil {
-				settingsPath := currentOpenCodeSettingsPath()
-				if current, err := readCurrentAssignmentsFn(settingsPath); err == nil && len(current) > 0 {
-					// Sanitize loaded assignments: clear any stale effort values for
-					// models that no longer report variants (e.g. provider refreshed
-					// their catalog since the user last synced). Without this, a stale
-					// effort would be preserved in the picker and re-injected on the
-					// next sync even if the model no longer supports that effort level.
-					m.Selection.ModelAssignments = sanitizeKnownModelEfforts(current, m.ModelPicker.SDDModels)
-				}
-			}
+			m.resolveOpenCodeModelAssignments()
 			m.setScreen(ScreenModelPicker)
 			return m, discoveryCmd
 		case 2: // Configure Kiro models

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -4937,6 +4937,221 @@ func TestModelConfigOpenCodeNoPrePopulationWhenFileEmpty(t *testing.T) {
 	}
 }
 
+// ─── Issue #2771: Per-phase 4-tier model assignment precedence ────────────────
+
+func TestModelConfigOpenCodePerPhasePrecedence(t *testing.T) {
+	deepseekExplore := model.ModelAssignment{ProviderID: "deepseek", ModelID: "deepseek-v4-pro"}
+	deepseekApply := model.ModelAssignment{ProviderID: "deepseek", ModelID: "deepseek-v4-pro"}
+	openaiReview := model.ModelAssignment{ProviderID: "openai", ModelID: "gpt-5"}
+	openaiArchive := model.ModelAssignment{ProviderID: "openai", ModelID: "gpt-4o"}
+	anthropicExplore := model.ModelAssignment{ProviderID: "anthropic", ModelID: "claude-sonnet-4-20250514"}
+
+	openModelPicker := func(persisted ...state.InstallState) Model {
+		m := NewModel(system.DetectionResult{}, "dev", persisted...)
+		m.Screen, m.Cursor = ScreenModelConfig, 1
+		updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+		return updated.(Model)
+	}
+
+	t.Run("unrelated in-state agent does not suppress SDD phases from config (Issue #2771)", func(t *testing.T) {
+		orig := readCurrentAssignmentsFn
+		readCurrentAssignmentsFn = func(_ string) (map[string]model.ModelAssignment, error) {
+			return map[string]model.ModelAssignment{"sdd-explore": deepseekExplore, "sdd-apply": deepseekApply}, nil
+		}
+		t.Cleanup(func() { readCurrentAssignmentsFn = orig })
+
+		st := openModelPicker(state.InstallState{
+			ModelAssignments: map[string]state.ModelAssignmentState{"review-refuter": {ProviderID: "openai", ModelID: "gpt-5"}},
+		})
+
+		if st.Screen != ScreenModelPicker {
+			t.Fatalf("screen = %v, want ScreenModelPicker", st.Screen)
+		}
+		if got := st.Selection.ModelAssignments["sdd-explore"]; got != deepseekExplore {
+			t.Errorf("sdd-explore = %+v, want %+v", got, deepseekExplore)
+		}
+		if got := st.Selection.ModelAssignments["sdd-apply"]; got != deepseekApply {
+			t.Errorf("sdd-apply = %+v, want %+v", got, deepseekApply)
+		}
+		if got := st.Selection.ModelAssignments["review-refuter"]; got != openaiReview {
+			t.Errorf("review-refuter = %+v, want %+v", got, openaiReview)
+		}
+		if _, exists := st.Selection.ModelAssignments["sdd-design"]; exists {
+			t.Errorf("sdd-design should be unassigned/default")
+		}
+	})
+
+	t.Run("effective config beats stale persisted state", func(t *testing.T) {
+		orig := readCurrentAssignmentsFn
+		readCurrentAssignmentsFn = func(_ string) (map[string]model.ModelAssignment, error) {
+			return map[string]model.ModelAssignment{"sdd-explore": deepseekExplore}, nil
+		}
+		t.Cleanup(func() { readCurrentAssignmentsFn = orig })
+
+		st := openModelPicker(state.InstallState{
+			ModelAssignments: map[string]state.ModelAssignmentState{"sdd-explore": {ProviderID: "anthropic", ModelID: "claude-sonnet-4-20250514"}},
+		})
+		if got := st.Selection.ModelAssignments["sdd-explore"]; got != deepseekExplore {
+			t.Errorf("sdd-explore = %+v, want config %+v", got, deepseekExplore)
+		}
+	})
+
+	t.Run("persisted state fallback when config silent", func(t *testing.T) {
+		orig := readCurrentAssignmentsFn
+		readCurrentAssignmentsFn = func(_ string) (map[string]model.ModelAssignment, error) {
+			return map[string]model.ModelAssignment{"sdd-explore": deepseekExplore}, nil
+		}
+		t.Cleanup(func() { readCurrentAssignmentsFn = orig })
+
+		st := openModelPicker(state.InstallState{
+			ModelAssignments: map[string]state.ModelAssignmentState{"sdd-archive": {ProviderID: "openai", ModelID: "gpt-4o"}},
+		})
+		if got := st.Selection.ModelAssignments["sdd-archive"]; got != openaiArchive {
+			t.Errorf("sdd-archive = %+v, want persisted fallback %+v", got, openaiArchive)
+		}
+	})
+
+	t.Run("session edit preserved across screen re-entry", func(t *testing.T) {
+		orig := readCurrentAssignmentsFn
+		readCurrentAssignmentsFn = func(_ string) (map[string]model.ModelAssignment, error) {
+			return map[string]model.ModelAssignment{"sdd-explore": deepseekExplore, "sdd-apply": deepseekApply}, nil
+		}
+		t.Cleanup(func() { readCurrentAssignmentsFn = orig })
+
+		st := openModelPicker()
+		st.recordSessionModelAssignment("sdd-explore", anthropicExplore)
+		st.Selection.ModelAssignments["sdd-explore"] = anthropicExplore
+
+		escaped, _ := st.Update(tea.KeyMsg{Type: tea.KeyEsc})
+		stEsc := escaped.(Model)
+		stEsc.Cursor = 1
+		reentered, _ := stEsc.Update(tea.KeyMsg{Type: tea.KeyEnter})
+		stRe := reentered.(Model)
+
+		if got := stRe.Selection.ModelAssignments["sdd-explore"]; got != anthropicExplore {
+			t.Errorf("sdd-explore = %+v, want session edit %+v", got, anthropicExplore)
+		}
+		if got := stRe.Selection.ModelAssignments["sdd-apply"]; got != deepseekApply {
+			t.Errorf("sdd-apply = %+v, want config %+v", got, deepseekApply)
+		}
+	})
+
+	t.Run("session tombstone prevents repopulation across re-entry", func(t *testing.T) {
+		orig := readCurrentAssignmentsFn
+		readCurrentAssignmentsFn = func(_ string) (map[string]model.ModelAssignment, error) {
+			return map[string]model.ModelAssignment{"sdd-explore": deepseekExplore, "sdd-apply": deepseekApply}, nil
+		}
+		t.Cleanup(func() { readCurrentAssignmentsFn = orig })
+
+		st := openModelPicker(state.InstallState{
+			ModelAssignments: map[string]state.ModelAssignmentState{"sdd-explore": {ProviderID: "openai", ModelID: "gpt-4o"}},
+		})
+		st.ModelPicker.AvailableIDs = []string{"anthropic", "deepseek"}
+		st.Cursor = findRowIndex(st.ModelPicker, func(r screens.ModelPickerRow) bool { return r.AgentID == "sdd-explore" })
+
+		cleared, _ := st.Update(tea.KeyMsg{Type: tea.KeyBackspace})
+		stCl := cleared.(Model)
+
+		escaped, _ := stCl.Update(tea.KeyMsg{Type: tea.KeyEsc})
+		stEsc := escaped.(Model)
+		stEsc.Cursor = 1
+		reentered, _ := stEsc.Update(tea.KeyMsg{Type: tea.KeyEnter})
+		stRe := reentered.(Model)
+
+		if got, exists := stRe.Selection.ModelAssignments["sdd-explore"]; exists {
+			t.Errorf("sdd-explore should remain cleared, got %+v", got)
+		}
+		if got := stRe.Selection.ModelAssignments["sdd-apply"]; got != deepseekApply {
+			t.Errorf("sdd-apply = %+v, want config %+v", got, deepseekApply)
+		}
+	})
+
+	t.Run("bulk clear all SDD phases creates tombstones across re-entry", func(t *testing.T) {
+		orig := readCurrentAssignmentsFn
+		readCurrentAssignmentsFn = func(_ string) (map[string]model.ModelAssignment, error) {
+			return map[string]model.ModelAssignment{"sdd-explore": deepseekExplore, "sdd-apply": deepseekApply}, nil
+		}
+		t.Cleanup(func() { readCurrentAssignmentsFn = orig })
+
+		st := openModelPicker()
+		st.ModelPicker.AvailableIDs = []string{"anthropic", "deepseek"}
+		st.Cursor = findRowIndex(st.ModelPicker, func(r screens.ModelPickerRow) bool { return r.Kind == screens.ModelPickerRowKindSetAllSDD })
+
+		cleared, _ := st.Update(tea.KeyMsg{Type: tea.KeyBackspace})
+		stCl := cleared.(Model)
+
+		escaped, _ := stCl.Update(tea.KeyMsg{Type: tea.KeyEsc})
+		stEsc := escaped.(Model)
+		stEsc.Cursor = 1
+		reentered, _ := stEsc.Update(tea.KeyMsg{Type: tea.KeyEnter})
+		stRe := reentered.(Model)
+
+		for _, phase := range opencode.SDDPhases() {
+			if got, exists := stRe.Selection.ModelAssignments[phase]; exists {
+				t.Errorf("phase %q should remain cleared, got %+v", phase, got)
+			}
+		}
+	})
+
+	t.Run("reassigning after clear removes tombstone and preserves new model", func(t *testing.T) {
+		orig := readCurrentAssignmentsFn
+		readCurrentAssignmentsFn = func(_ string) (map[string]model.ModelAssignment, error) {
+			return map[string]model.ModelAssignment{"sdd-explore": deepseekExplore}, nil
+		}
+		t.Cleanup(func() { readCurrentAssignmentsFn = orig })
+
+		st := openModelPicker()
+		st.ModelPicker.AvailableIDs = []string{"anthropic", "openai", "deepseek"}
+		st.Cursor = findRowIndex(st.ModelPicker, func(r screens.ModelPickerRow) bool { return r.AgentID == "sdd-explore" })
+
+		cleared, _ := st.Update(tea.KeyMsg{Type: tea.KeyBackspace})
+		stCl := cleared.(Model)
+
+		newAsg := model.ModelAssignment{ProviderID: "openai", ModelID: "gpt-4o"}
+		stCl.recordSessionModelAssignment("sdd-explore", newAsg)
+		if stCl.Selection.ModelAssignments == nil {
+			stCl.Selection.ModelAssignments = make(map[string]model.ModelAssignment)
+		}
+		stCl.Selection.ModelAssignments["sdd-explore"] = newAsg
+
+		escaped, _ := stCl.Update(tea.KeyMsg{Type: tea.KeyEsc})
+		stEsc := escaped.(Model)
+		stEsc.Cursor = 1
+		reentered, _ := stEsc.Update(tea.KeyMsg{Type: tea.KeyEnter})
+		stRe := reentered.(Model)
+
+		if got := stRe.Selection.ModelAssignments["sdd-explore"]; got != newAsg {
+			t.Errorf("sdd-explore = %+v, want reassigned %+v", got, newAsg)
+		}
+	})
+
+	t.Run("screen entry remains read-only without sync or pending overrides", func(t *testing.T) {
+		orig := readCurrentAssignmentsFn
+		readCurrentAssignmentsFn = func(_ string) (map[string]model.ModelAssignment, error) {
+			return map[string]model.ModelAssignment{"sdd-explore": deepseekExplore}, nil
+		}
+		t.Cleanup(func() { readCurrentAssignmentsFn = orig })
+
+		st := openModelPicker()
+
+		if st.Screen != ScreenModelPicker {
+			t.Fatalf("screen = %v, want ScreenModelPicker", st.Screen)
+		}
+		if st.PendingSyncOverrides != nil || st.OperationRunning || st.OperationMode != "" {
+			t.Errorf("entry must be read-only; overrides=%v, running=%v, mode=%q", st.PendingSyncOverrides, st.OperationRunning, st.OperationMode)
+		}
+	})
+}
+
+func findRowIndex(state screens.ModelPickerState, predicate func(screens.ModelPickerRow) bool) int {
+	for idx, r := range screens.ModelPickerRowsForStateWithIdentity(state) {
+		if predicate(r) {
+			return idx
+		}
+	}
+	return -1
+}
+
 // TestCustomSkillPickerBackGoesToStrictTDD verifies that in the custom preset,
 // with OpenCode + SDD + Skills, pressing Back on ScreenSkillPicker goes to ScreenStrictTDD
 // and NOT directly to ScreenSDDMode. StrictTDD must come before SDDMode in the back chain.


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #2771

## 🏷️ PR Type

- [x] `type:bug` — Bug fix (non-breaking change that fixes an issue)
- [ ] `type:feature` — New feature (non-breaking change that adds functionality)
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring (no functional changes)
- [ ] `type:chore` — Build, CI, or tooling changes
- [ ] `type:breaking-change` — Breaking change

## 📝 Summary

Replaces the whole-map nil guard (`if m.Selection.ModelAssignments == nil`) in Configure OpenCode Models screen with an independent, per-phase 4-tier precedence resolver:

1. Explicit assignment or explicit clear (tombstone) from current TUI session
2. Effective OpenCode configuration (`opencode.json` / `opencode.jsonc`)
3. Persisted Gentle AI state (`state.json`) as legacy fallback
4. Default/unassigned

Previously, when `state.json` already contained any prior in-state assignment for unrelated agents (such as `review-refuter`), the nil guard prevented reading `opencode.json`, causing all SDD phases to render as `[default]`.

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/tui/model.go` | Added per-phase precedence resolver, session edit/tombstone tracking, and row-level clear handler for `ScreenModelPicker`. |
| `internal/tui/model_test.go` | Added comprehensive tests covering per-phase resolution, mixed sources, stale state fallback, session edits, tombstones across re-entry, and read-only entry. |

## 🧪 Test Plan

**Focused Unit Tests**
```bash
go test -v -count=1 -timeout 100s -run 'TestModelConfigOpenCode' ./internal/tui
```
Result: 11 tests PASS (0.28s)

**Format and Vet Checks**
```bash
gofmt -l internal/tui internal/components/sdd
go vet ./internal/tui ./internal/components/sdd
```
Result: Clean (no errors, no warnings)

- [x] Unit tests pass (`go test ./internal/tui/...`)
- [x] Go format passes (`gofmt -l`)
- [x] Manually tested locally

## ✅ Contributor Checklist

- [x] PR is linked to an issue with `status:approved` (#2771)
- [x] PR stays within 400 changed lines (388 lines total)
- [ ] API read-back confirms exactly one appropriate `type:*` label on this PR (pending workflow action)
- [x] Unit tests pass
- [x] My commits follow Conventional Commits format
- [x] My commits do not include `Co-Authored-By` trailers

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved OpenCode model selection so session changes and cleared assignments are preserved when revisiting the picker.
  * Configuration values now take precedence appropriately, with saved assignments used as fallback when configuration is unavailable.
  * Clearing model assignments now works consistently across model picker and profile creation screens.
  * Reassigning a model after clearing it correctly restores the new selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->