### PR TITLE
docs: point the version advisory at stable v2.6.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -451,7 +451,7 @@ If reviewers find severe findings caused by the candidate itself, RDD permits on
 
 ### Approval waits to be acknowledged
 
-> **In stable `v2.5.0`, a review does not end when it is approved.** It ends when your agent confirms it received that approval.
+> **In stable `v2.6.0`, a review does not end when it is approved.** It ends when your agent confirms it received that approval.
 
 Why this exists: previously, approval destroyed its own authority and returned a response. If that response never reached the host — a crash, a dropped connection — the review was over and nothing said so.
 
@@ -466,7 +466,7 @@ If a host decodes the acknowledgement but never runs it, the review stays approv
 
 Re-entering a frozen review used to be described in prose, which could drift from what the CLI accepted.
 
-**Stable `v2.5.0` carries that knowledge in the protocol instead of prose.** A negotiated START returns a `gentle-ai.review-integration.start/v4` envelope whose `next_transition` contains the complete command that re-enters the transaction. Your agent runs it verbatim rather than reconstructing it.
+**Stable `v2.6.0` carries that knowledge in the protocol instead of prose.** A negotiated START returns a `gentle-ai.review-integration.start/v4` envelope whose `next_transition` contains the complete command that re-enters the transaction. Your agent runs it verbatim rather than reconstructing it.
 
 The practical rule, and the one worth knowing even if you never read an envelope: **the agent should run the command the provider returned, never one assembled from a description of it.** You can check which protocol version your build speaks with:
 
@@ -567,6 +567,12 @@ gentle-ai sync
 > [!IMPORTANT]
 > `sync` is not optional after an upgrade. If you replace the `gentle-ai` binary by any means, run `gentle-ai sync` to refresh the managed assets it writes into your agents. See the [sync and upgrade reference](docs/usage.md#sync).
 
+**What `sync` writes in `v2.6.0`:**
+
+- **Claude Code review hooks.** `Stop` and `SessionStart` entries are written into `~/.claude/settings.json` as managed entries. They remind the agent to preflight a review once per session candidate, and stay silent when review mode is off or the worktree is clean. `uninstall` removes them and preserves every hook it does not own.
+- **Pi system prompt cleanup.** Stale managed blocks left by older builds are stripped from `~/.pi/agent/APPEND_SYSTEM.md`. The file is preserved; only the blocks Gentle-AI wrote are removed.
+- **Only the agents you selected.** `sync` derives its agent set from the agents recorded at install time, not from what it finds on disk. If you relied on `sync` writing into an agent you never selected, run `gentle-ai` and select it first.
+
 ### Backups
 
 Every install, sync and upgrade automatically snapshots your config files. Backups are **compressed** (tar.gz), **deduplicated** (identical configs are not re-backed up) and **auto-pruned** (the 5 most recent are kept). Pin important backups via the TUI (<kbd>p</kbd> key) to protect them from pruning.
@@ -588,7 +594,7 @@ There are two current channels. Install `@latest` unless you are deliberately te
 
 | Channel | Current | Install |
 | --- | --- | --- |
-| **Stable** | [`v2.5.0`](https://github.com/Gentleman-Programming/gentle-ai/releases/tag/v2.5.0) | `go install github.com/gentleman-programming/gentle-ai/v2/cmd/gentle-ai@latest` |
+| **Stable** | [`v2.6.0`](https://github.com/Gentleman-Programming/gentle-ai/releases/tag/v2.6.0) | `go install github.com/gentleman-programming/gentle-ai/v2/cmd/gentle-ai@latest` |
 | **Development** | `main` | `go install github.com/gentleman-programming/gentle-ai/v2/cmd/gentle-ai@main` |
 
 Verify with `gentle-ai version` after any of them.
@@ -597,7 +603,7 @@ Use `@main` only to test changes that are not part of a release. The managed ins
 
 **About the `/v2` suffix:** Go requires it for major version 2 and above. Releases before `v2.0.0` use the unsuffixed import path.
 
-**Stable `v2.5.0` publishes six archives under a signed checksum manifest:** four platform `.tar.gz` archives for macOS and Linux (amd64 and arm64), the provider-contract archive, and the release-provenance archive. `checksums.txt` covers all six and is authenticated by `checksums.txt.minisig`.
+**Stable `v2.6.0` publishes six archives under a signed checksum manifest:** four platform `.tar.gz` archives for macOS and Linux (amd64 and arm64), the provider-contract archive, and the release-provenance archive. `checksums.txt` covers all six and is authenticated by `checksums.txt.minisig`.
 
 Receipt-Driven Development became the supported stable path in `v2.2.0`; the negotiated public review contract was published in `v2.1.6`.
 
@@ -670,7 +676,7 @@ Workspace scope covers agent-scoped files — system prompts, skills, SDD agents
 
 <br/>
 
-**Stable channel — Minisign.** Stable `v2.5.0` publishes six archives: four macOS/Linux platform archives, the provider-contract archive, and the release-provenance archive. All six are covered by an authenticated `checksums.txt`. The built-in upgrader verifies its Minisign signature, its exact `Gentleman-Programming/gentle-ai` + release-tag binding, and the selected platform archive checksum **before** replacing the installed binary. Release archives are capped at **128 MiB**, including chunked or unknown-length responses. Missing, oversized, malformed, untrusted or placeholder key material fails closed without changing the installed binary.
+**Stable channel — Minisign.** Stable `v2.6.0` publishes six archives: four macOS/Linux platform archives, the provider-contract archive, and the release-provenance archive. All six are covered by an authenticated `checksums.txt`. The built-in upgrader verifies its Minisign signature, its exact `Gentleman-Programming/gentle-ai` + release-tag binding, and the selected platform archive checksum **before** replacing the installed binary. Release archives are capped at **128 MiB**, including chunked or unknown-length responses. Missing, oversized, malformed, untrusted or placeholder key material fails closed without changing the installed binary.
 
 To verify yourself, obtain the production public-key payload and fingerprint from a maintainer-controlled channel, then download `checksums.txt` and `checksums.txt.minisig` from the same release:
 
@@ -682,7 +688,7 @@ sha256sum --check --strict --ignore-missing checksums.txt
 
 Do not bootstrap trust from a public key downloaded only beside the artifacts it verifies. See [Release signing and key rotation](docs/release-signing.md).
 
-**Provider contract bundle.** Stable `v2.5.0` publishes `gentle-ai-review-provider-contract-1.1.0.tar.gz`. Verify and inspect it from the tagged source:
+**Provider contract bundle.** Stable `v2.6.0` publishes `gentle-ai-review-provider-contract-1.2.0.tar.gz`. Verify and inspect it from the tagged source:
 
 ```bash
 go run ./internal/providercontractbundlecmd verify --archive <bundle>

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -51,33 +51,23 @@
   [restoration gate](release-signing.md#windows-distribution-restoration-gate).
 
 ```powershell
-# Stable channel (`@latest`, currently v2.3.0)
+# Stable channel (`@latest`, currently v2.6.0)
 go install github.com/gentleman-programming/gentle-ai/v2/cmd/gentle-ai@latest
-
-# Opt-in prerelease (v2.4.0-rc.1)
-go install github.com/gentleman-programming/gentle-ai/v2/cmd/gentle-ai@v2.4.0-rc.1
 ```
 
-Both commands use the `/v2` module path. Go requires that suffix for major
+This command uses the `/v2` module path. Go requires that suffix for major
 version 2 and above.
 
 ## Version Policy
 
 Receipt-Driven Development (RDD) began in `v1.47.0` on 2026-07-10, and `v2.2.0` made it the supported stable path. Those are historical milestones. The negotiated public review contract was published in `v2.1.6`.
 
-The current stable release is [`v2.3.0`](https://github.com/Gentleman-Programming/gentle-ai/releases/tag/v2.3.0). `@latest` explicitly tracks this stable channel. The current opt-in prerelease is [`v2.4.0-rc.1`](https://github.com/Gentleman-Programming/gentle-ai/releases/tag/v2.4.0-rc.1). `@main` installs unreleased development changes.
+The current stable release is [`v2.6.0`](https://github.com/Gentleman-Programming/gentle-ai/releases/tag/v2.6.0). `@latest` explicitly tracks this stable channel. No prerelease is ahead of stable. `@main` installs unreleased development changes.
 
 ### Install the stable channel
 
 ```bash
 go install github.com/gentleman-programming/gentle-ai/v2/cmd/gentle-ai@latest
-gentle-ai version
-```
-
-### Install the opt-in prerelease
-
-```bash
-go install github.com/gentleman-programming/gentle-ai/v2/cmd/gentle-ai@v2.4.0-rc.1
 gentle-ai version
 ```
 

--- a/docs/testing/organic-rdd-testing-guide.md
+++ b/docs/testing/organic-rdd-testing-guide.md
@@ -4,7 +4,7 @@
 > **Current closure and delivery semantics.** A zero-lens START, or the final admitted lens, refuter, or validation capture, closes and burns a review. Delivery always follows ordinary repository policy; review closure is informational.
 
 > [!WARNING]
-> **Historical and superseded guide.** This document preserves the candidate-specific validation procedure for `v2.2.0-rc.1` and PR [#1801](https://github.com/Gentleman-Programming/gentle-ai/pull/1801). It is not current installation or validation guidance for stable [`v2.3.0`](https://github.com/Gentleman-Programming/gentle-ai/releases/tag/v2.3.0), prerelease [`v2.4.0-rc.1`](https://github.com/Gentleman-Programming/gentle-ai/releases/tag/v2.4.0-rc.1), or unreleased `main`. Use the [Quickstart version policy](../quickstart.md#version-policy) for current installation channels and validation entry points.
+> **Historical and superseded guide.** This document preserves the candidate-specific validation procedure for `v2.2.0-rc.1` and PR [#1801](https://github.com/Gentleman-Programming/gentle-ai/pull/1801). It is not current installation or validation guidance for stable [`v2.6.0`](https://github.com/Gentleman-Programming/gentle-ai/releases/tag/v2.6.0) or unreleased `main`. Use the [Quickstart version policy](../quickstart.md#version-policy) for current installation channels and validation entry points.
 >
 > Community testing guide for the candidate built from PR [#1801](https://github.com/Gentleman-Programming/gentle-ai/pull/1801). Every **Expected** here was validated against real output before publication. The guide uses a throwaway HOME precisely so it does not touch your real config — do not skip the setup.
 
@@ -665,7 +665,7 @@ echo "exit=$?"
 
 ## Historical reporting instructions
 
-This section is retained to explain the original candidate procedure. Do not open a current issue or comment on PR [#1801](https://github.com/Gentleman-Programming/gentle-ai/pull/1801) for results from `v2.2.0-rc.1`; that candidate process is complete. For a current concern, first reproduce it against stable [`v2.3.0`](https://github.com/Gentleman-Programming/gentle-ai/releases/tag/v2.3.0) or the opt-in prerelease [`v2.4.0-rc.1`](https://github.com/Gentleman-Programming/gentle-ai/releases/tag/v2.4.0-rc.1), then use the repository's current contribution and issue workflow.
+This section is retained to explain the original candidate procedure. Do not open a current issue or comment on PR [#1801](https://github.com/Gentleman-Programming/gentle-ai/pull/1801) for results from `v2.2.0-rc.1`; that candidate process is complete. For a current concern, first reproduce it against stable [`v2.6.0`](https://github.com/Gentleman-Programming/gentle-ai/releases/tag/v2.6.0), then use the repository's current contribution and issue workflow.
 
 ## What is NOT a bug
 

--- a/docs/trigger-rules.md
+++ b/docs/trigger-rules.md
@@ -84,7 +84,7 @@ user's behalf. Review context may remain visible when available, but it never
 authorizes or blocks commit, push, PR, release, or archive. Native delivery gates
 report `disabled/unmanaged` when no exact receipt applies and never fabricate approval.
 
-In stable [`v2.3.0`](https://github.com/Gentleman-Programming/gentle-ai/releases/tag/v2.3.0), prerelease [`v2.4.0-rc.1`](https://github.com/Gentleman-Programming/gentle-ai/releases/tag/v2.4.0-rc.1), and unreleased `main`, disabled SDD status skips review authority and leaves `reviewGate` structurally absent. Pre-verify continues without routing to review. When visible, `reviewGate` is informational only; SDD requirements, tasks, and verification determine archive readiness, while ordinary repository policy owns delivery. Native compatibility commands may report `disabled/unmanaged` review context, but no receipt state or validation result governs delivery. See the [SDD status contract](../internal/assets/skills/_shared/sdd-status-contract.md).
+In stable [`v2.6.0`](https://github.com/Gentleman-Programming/gentle-ai/releases/tag/v2.6.0) and unreleased `main`, disabled SDD status skips review authority and leaves `reviewGate` structurally absent. Pre-verify continues without routing to review. When visible, `reviewGate` is informational only; SDD requirements, tasks, and verification determine archive readiness, while ordinary repository policy owns delivery. Native compatibility commands may report `disabled/unmanaged` review context, but no receipt state or validation result governs delivery. See the [SDD status contract](../internal/assets/skills/_shared/sdd-status-contract.md).
 
 ## Review store reset
 


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #3424

This also resolves #3213, which covers the same drift with narrower scope: after this change, `git grep -n -F 'v2.4.0-rc.1' -- README.md docs` returns zero results.

---

## 🏷️ PR Type

- [ ] `type:bug` — Bug fix (non-breaking change that fixes an issue)
- [ ] `type:feature` — New feature (non-breaking change that adds functionality)
- [x] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring (no functional changes)
- [ ] `type:chore` — Build, CI, or tooling changes
- [ ] `type:breaking-change` — Breaking change (fix or feature that changes existing behavior)

---

## 📝 Summary

`v2.6.0` shipped, so the version advisory drifted again. The drift had also split: the onboarding restructure moved `README.md` forward, but the guides were left behind, still naming `v2.3.0` as current stable and `v2.4.0-rc.1` as the current opt-in prerelease.

- **The install path was handing newcomers superseded code.** `docs/quickstart.md` carried two runnable `go install ...@v2.4.0-rc.1` commands. That release candidate is three stable releases behind `v2.6.0`, so anyone following the documented prerelease path installed something older than stable. Both commands and the prerelease section are removed, since no prerelease is ahead of `v2.6.0`.
- **The provider contract bundle version was wrong, not just stale.** `README.md` advertised `gentle-ai-review-provider-contract-1.1.0.tar.gz`; `v2.6.0` bumped it additively to `1.2.0` to ship `orchestration/pi.md`.
- **`v2.6.0` changed what `sync` writes, and that was undocumented.** The README now covers the managed Claude Code `Stop`/`SessionStart` review hooks, the stale Pi `APPEND_SYSTEM.md` managed-block cleanup, and `sync` deriving its agent set from `installed_agents` rather than filesystem discovery — the last of which is a behavior change users can be bitten by after an upgrade.

Historical version references are deliberately preserved: `v1.47.0`, `v2.2.0`, `v2.1.6`, `v2.2.0-rc.1` and the PR #1801 links record when behavior landed, not which release is current.

---

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| `README.md` | Version advisory `v2.5.0` → `v2.6.0` (RDD acknowledgement note, `next_transition` note, release-channel table and tag link, signed-archives claim, Minisign section); provider contract bundle `1.1.0` → `1.2.0`; new "What `sync` writes in `v2.6.0`" section |
| `docs/quickstart.md` | Stable `v2.3.0` → `v2.6.0`; removed both runnable `@v2.4.0-rc.1` install commands and the "Install the opt-in prerelease" section; advisory now states no prerelease is ahead of stable; corrected the now-dangling "Both commands" sentence |
| `docs/trigger-rules.md` | Version-scoped behavior sentence now names stable `v2.6.0` and drops the superseded prerelease clause |
| `docs/testing/organic-rdd-testing-guide.md` | Superseded-guide banner and historical reporting guidance now point at stable `v2.6.0` |

---

## 🤖 AI Assistance

- [ ] **None** — No material AI assistance was used.
- [x] **Material assistance used** — Complete all applicable declaration fields below.

**Tool/model (if known):** Claude Opus 5, via Claude Code.

**Material scope:** Auditing the `v2.6.0` release notes against `README.md` and `docs/`, locating the drifted references, drafting the replacement prose (including the new `sync` section and the reworded version-policy sentence), and drafting the commit messages and this PR body.

**Verification performed:** Every line number and claim was verified against `origin/main` rather than taken from the assistant's own summary — the affected lines in the issue descriptions no longer matched `main` and were re-derived with `git show origin/main:<path>`. The `sync` claims added to the README were checked against the installed binary (`gentle-ai review stop-hook --help`) and against the managed `Stop`/`SessionStart` entries actually present in `~/.claude/settings.json`, not just against the release notes. The removal of the "Both commands" sentence was caught by re-reading the rendered section after the edit. Final state confirmed with `git grep -n -F 'v2.4.0-rc.1' -- README.md docs` returning zero results.

---

## 🧪 Test Plan

This PR changes only Markdown files — `git diff --name-only origin/main..HEAD` returns no non-`.md` paths — so no Go behavior is exercised by it.

**Benchmark Validation:** `N/A`. This change touches no review-lifecycle, gate, recovery, delivery, benchmark implementation, corpus, classifier, or benchmark-claim code or content. It only corrects version literals and install guidance in prose.

- [ ] Unit tests pass (`go test ./...`) — see the note below; not claimed as passing locally
- [x] Go format passes (`go run ./internal/gofmtcheck`)
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`) — not run locally; Docker-based suite, and this PR touches no code path it exercises. Deferred to CI.
- [x] Manually tested locally

**On `go test ./...`:** it was run and it is red on this machine, with failures that predate this PR and are unrelated to it. I am reporting that rather than checking the box.

- `internal/update` — `TestReleaseSecurityScriptsAreSyntacticallyValidAndFailClosed` and `TestCanonicalReleasePublicKeysControlRealLinkerBuild` fail because the local `bash` is macOS system bash `3.2.57`, which has neither `[[ -v VAR ]]` (bash 4.2+) nor `declare -A` (bash 4.0+). Linux CI runs a modern bash, so these are environment-only.
- `internal/reviewtransaction` — `TestStoreRejectsFreshLegacyShapedBoundedGenesis` and `TestStoreLoadChainBindsGenesisHeadAndOrderedIdentity` fail deterministically in 0.016s with `review store lock could not be acquired: not a directory`, from `filepath.Join(store.Dir, "LOCK")` in `store_lock.go`. Reproduces in isolation.

Why these cannot be caused by this PR: `git diff --name-only origin/main..HEAD` returns four `.md` paths and nothing else. Every test that does read documentation (`internal/components/golden_test.go`, `internal/providercontractbundle/bundle_test.go`, `internal/reviewtransaction/verification_contract_test.go`, and the other doc-referencing suites) passed on this exact candidate.

Manual verification:

```bash
git grep -n -F 'v2.4.0-rc.1' -- README.md docs   # zero results
rg -n 'v2\.3\.0|v2\.5\.0' README.md docs          # only historical milestones remain
```

---

## ✅ Contributor Checklist

- [x] PR is linked to an issue with `status:approved`
- [x] PR stays within 400 changed lines, or I have requested/obtained maintainer-applied `size:exception` with rationale documented
- [x] I have added the appropriate `type:*` label to this PR
- [ ] Unit tests pass (`go test ./...`) — see Test Plan; red locally for pre-existing, unrelated reasons
- [x] Go format passes (`go run ./internal/gofmtcheck`)
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`) — see Test Plan; deferred to CI
- [x] Benchmark validation completed, or this change is not applicable to the benchmark (explain why in the Test Plan).
- [x] I have updated documentation if necessary
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] I understand, reviewed, and take responsibility for the complete submission
- [x] I selected exactly one AI-assistance option and, if material assistance was used, completed all applicable declaration fields
- [x] My commits do not include `Co-Authored-By` trailers

---

## 💬 Notes for Reviewers

**One judgment call worth checking.** `docs/trigger-rules.md` is classified differently by the two issues: #3213 lists it as intentional version-specific evidence to preserve, while #3424 lists it as affected. I treated it as current guidance and updated it, because the sentence reads as a statement about current channels ("In stable X ... disabled SDD status skips review authority"), not as a record of a past defect. If you consider it historical evidence, that single line is easy to revert without affecting the rest.

Related: `docs/architecture/organic-rdd.md:170` is named in #3213's preserve list, but it no longer contains any `v2.4.0-rc.1` reference on `main`, so that half of the preserve list is already moot.

**This is the third instance of the same drift**, and PR #3288 was superseded by a stable release before it could merge. A fourth value bump will be superseded by `v2.7.0` the same way. The durable fix is to stop hardcoding the current release in prose, or to add a release-gated check that fails when current-guidance docs name a version that is not the latest published release. I have deliberately kept that out of this PR: #3213 was approved with an explicit "this is a documentation-only correction, do not add release machinery" directive, and re-litigating that inside a docs fix would be the wrong place. Happy to open it as a separate issue if maintainers want it pursued.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated release references to stable version 2.6.0 across the README and guides.
  * Added documentation for synchronization behavior, including review hooks, prompt cleanup, and installation-selected agents.
  * Clarified quickstart guidance for stable, prerelease, and development installations.
  * Updated testing and trigger-rule guidance to reference the current stable release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->