### PR TITLE
chore(pi): retire rpiv-todo now that gentle-pi ships Gentle Todo

### DIFF
--- a/docs/agents.md
+++ b/docs/agents.md
@@ -249,7 +249,6 @@ For the full Pi command and package reference, see [Pi Agent](pi.md).
   - `pi install npm:pi-subagents-j0k3r`
   - `pi install npm:@juicesharp/rpiv-ask-user-question`
   - `pi install npm:pi-web-access`
-  - `pi install npm:@juicesharp/rpiv-todo`
   - `pi install npm:pi-btw`
 - **`gentle-pi` package**: adds the Gentleman harness for Pi: SDD/OpenSpec workflow, strict TDD guidance, safety defaults, `/gentle-ai:*` commands, skill assets, prompts, SDD agents, and SDD chains. On normal `session_start`, it copies project assets into `.pi/agents/`, `.pi/chains/`, and `.pi/gentle-ai/support/` without overwriting local files unless the Pi recovery command uses `--force`. Starting Pi with `pi -ns` skips startup skill loading/hooks, so that automatic refresh does not run in that mode.
 - **Package metadata**: latest verified `gentle-pi` version is `0.2.6`; npm lists `alan_buscaglia` as maintainer, with source at [Gentleman-Programming/gentle-pi](https://github.com/Gentleman-Programming/gentle-pi) and package docs at [npm: gentle-pi](https://www.npmjs.com/package/gentle-pi).
@@ -262,7 +261,7 @@ For the full Pi command and package reference, see [Pi Agent](pi.md).
 - CLI precedence is flag, non-empty environment, prior managed state, then `auto`; `auto` never enables by itself, unresolved non-interactive `auto` stays foreground, and the interactive Pi installer prompts only when that preference is unresolved.
 - The resolved on/off policy is projected to `~/.pi/gentle-ai/background-subagents.json` as `{"schema":"gentle-pi.background-subagents/v1","policy":"on"|"off"}` (the base directory honors `GENTLE_PI_CONFIG_HOME`); `off` rewrites the policy instead of deleting files, and a file at that path without the managed schema marker is never overwritten.
 - **`@juicesharp/rpiv-ask-user-question` package**: lets Pi child agents ask the active user session for clarification when they need human input.
-- **Pi companion packages**: `pi-web-access`, `@juicesharp/rpiv-todo`, and `pi-btw` add web access, todo tracking, and companion workflow support.
+- **Pi companion packages**: `pi-web-access` and `pi-btw` add web access and companion workflow support. Todo tracking ships inside `gentle-pi` (Gentle Todo); an existing `@juicesharp/rpiv-todo` entry is dropped from `settings.json` on the next install or update, and Pi uninstalls it on its next package sync.
 - **Pi-only flow**: when Pi is the only selected agent, gentle-ai skips persona, ecosystem component selection, and Strict TDD prompts because those behaviors are provided by `gentle-pi`.
 
 ### Hermes Ephemeral Delegation

--- a/docs/pi.md
+++ b/docs/pi.md
@@ -33,7 +33,6 @@ npm exec --yes --package gentle-engram@latest -- pi-engram init
 pi install npm:pi-subagents-j0k3r
 pi install npm:@juicesharp/rpiv-ask-user-question
 pi install npm:pi-web-access
-pi install npm:@juicesharp/rpiv-todo
 pi install npm:pi-btw
 ```
 
@@ -46,7 +45,6 @@ pi install npm:pi-btw
 | `pi-subagents-j0k3r`                                      | Runs SDD agents discovered from `.pi/agents/`; installed from the published Pi package `npm:pi-subagents-j0k3r`.                 |
 | `@juicesharp/rpiv-ask-user-question`                     | Lets Pi child agents ask the active user session for clarification when they need human input.                            |
 | `pi-web-access`                                          | Adds web access tools for Pi.                                                                                             |
-| `@juicesharp/rpiv-todo`                                  | Adds todo/task tracking support for Pi sessions.                                                                          |
 | `pi-btw`                                                 | Adds BTW companion workflow support for Pi.                                                                               |
 
 `gentle-pi` owns Pi's runtime behavior. Its current harness enforces parent-only delegation triggers: delegate exploration after 4+ files, use one writer for multi-file changes, require fresh review before PRs, run fresh audits after incidents, and pause long monolithic sessions before they drift.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -159,7 +159,7 @@ When checks pass, installer reports:
 
 If something looks wrong after install, run `gentle-ai doctor` for a read-only health check. It verifies tool binaries, `state.json` validity, Engram™ MCP reachability, and disk space — each check reports pass/warn/fail with a remedy hint.
 
-For a Pi-only install, the plan shows the Pi package stack instead of Gentle AI components. It installs `gentle-pi`, `gentle-engram`, and `pi-mcp-adapter`, runs `pi-engram init` through the pinned `gentle-engram` package, then installs `pi-subagents-j0k3r`, `@juicesharp/rpiv-ask-user-question`, `pi-web-access`, `@juicesharp/rpiv-todo`, and `pi-btw`.
+For a Pi-only install, the plan shows the Pi package stack instead of Gentle AI components. It installs `gentle-pi`, `gentle-engram`, and `pi-mcp-adapter`, runs `pi-engram init` through the pinned `gentle-engram` package, then installs `pi-subagents-j0k3r`, `@juicesharp/rpiv-ask-user-question`, `pi-web-access`, and `pi-btw`.
 
 ## Hardening recommendations for users
 

--- a/internal/agents/pi/adapter.go
+++ b/internal/agents/pi/adapter.go
@@ -37,6 +37,13 @@ var legacyPiSubagentPackageIdentities = map[string]struct{}{
 	"vendor/pi-subagents-fixed": {},
 }
 
+// Retired Pi companion packages: their replacement ships inside gentle-pi,
+// so every install or update drops them from the user's settings and Pi
+// uninstalls them on its next package sync.
+var retiredPiPackageIdentities = map[string]struct{}{
+	"npm:@juicesharp/rpiv-todo": {},
+}
+
 var piWalkDir = filepath.WalkDir
 
 func piSubagentsInstallCommand(system.PlatformProfile) []string {
@@ -246,7 +253,6 @@ func (a *Adapter) InstallCommand(profile system.PlatformProfile) ([][]string, er
 		piSubagentsInstallCommand(profile),
 		{"pi", "install", "npm:@juicesharp/rpiv-ask-user-question"},
 		{"pi", "install", "npm:pi-web-access"},
-		{"pi", "install", "npm:@juicesharp/rpiv-todo"},
 		{"pi", "install", "npm:pi-btw"},
 	}, nil
 }
@@ -395,7 +401,7 @@ func appendPiPackage(existing any, desired string) []any {
 	filtered := make([]any, 0, len(packages)+1)
 	for _, pkg := range packages {
 		identity := piPackageIdentity(pkg)
-		if identity == piMCPAdapterPackage || isLegacyPiSubagentPackage(identity) {
+		if identity == piMCPAdapterPackage || isLegacyPiSubagentPackage(identity) || isRetiredPiPackage(identity) {
 			continue
 		}
 		filtered = append(filtered, pkg)
@@ -446,11 +452,21 @@ func piPackageIdentity(pkg any) string {
 			return legacy
 		}
 	}
+	for retired := range retiredPiPackageIdentities {
+		if source == retired || strings.HasPrefix(source, retired+"@") {
+			return retired
+		}
+	}
 	return source
 }
 
 func isLegacyPiSubagentPackage(identity string) bool {
 	_, ok := legacyPiSubagentPackageIdentities[identity]
+	return ok
+}
+
+func isRetiredPiPackage(identity string) bool {
+	_, ok := retiredPiPackageIdentities[identity]
 	return ok
 }
 

--- a/internal/agents/pi/adapter_test.go
+++ b/internal/agents/pi/adapter_test.go
@@ -277,7 +277,6 @@ func TestAdapterInstallCommandSequenceUsesNpmWhenPnpmIsUnavailable(t *testing.T)
 		piSubagentsInstallCommand(system.PlatformProfile{}),
 		{"pi", "install", "npm:@juicesharp/rpiv-ask-user-question"},
 		{"pi", "install", "npm:pi-web-access"},
-		{"pi", "install", "npm:@juicesharp/rpiv-todo"},
 		{"pi", "install", "npm:pi-btw"},
 	}
 	if !reflect.DeepEqual(commands, want) {
@@ -324,6 +323,43 @@ func TestAdapterInstallCommandSequenceUsesNpmForEngramInitWhenPnpmIsAvailable(t 
 	want := []string{"npm", "exec", "--yes", "--package", "gentle-engram@latest", "--", "pi-engram", "init"}
 	if !reflect.DeepEqual(commands[3], want) {
 		t.Fatalf("InstallCommand()[3] = %#v, want %#v", commands[3], want)
+	}
+}
+
+func TestMergePiSettingsFileRemovesRetiredCompanionPackages(t *testing.T) {
+	home := t.TempDir()
+	settingsPath := filepath.Join(home, ".pi", "agent", "settings.json")
+	if err := os.MkdirAll(filepath.Dir(settingsPath), 0o755); err != nil {
+		t.Fatalf("MkdirAll(settings dir) error = %v", err)
+	}
+	initial := `{
+  "packages": [
+    "npm:@juicesharp/rpiv-todo",
+    "npm:@juicesharp/rpiv-todo@2.9.0",
+    "npm:@juicesharp/rpiv-ask-user-question",
+    "npm:other@1.0.0"
+  ]
+}`
+	if err := os.WriteFile(settingsPath, []byte(initial), 0o644); err != nil {
+		t.Fatalf("WriteFile(settings) error = %v", err)
+	}
+
+	if _, err := mergePiSettingsFile(settingsPath); err != nil {
+		t.Fatalf("mergePiSettingsFile() error = %v", err)
+	}
+
+	var settings struct {
+		Packages []string `json:"packages"`
+	}
+	data, err := os.ReadFile(settingsPath)
+	if err != nil {
+		t.Fatalf("ReadFile(settings) error = %v", err)
+	}
+	if err := json.Unmarshal(data, &settings); err != nil {
+		t.Fatalf("Unmarshal(settings) error = %v", err)
+	}
+	if !reflect.DeepEqual(settings.Packages, []string{"npm:@juicesharp/rpiv-ask-user-question", "npm:other@1.0.0", "npm:pi-mcp-adapter"}) {
+		t.Fatalf("packages = %#v, want the retired todo package gone and the rest untouched", settings.Packages)
 	}
 }
 

--- a/internal/cli/run_integration_test.go
+++ b/internal/cli/run_integration_test.go
@@ -238,7 +238,7 @@ func TestPiAgentInstallProgressUsesAdapterCommandNames(t *testing.T) {
 		t.Fatalf("agentInstallStep.Run() error = %v", err)
 	}
 
-	wantPackages := []string{"pi install npm:gentle-pi", "pi install npm:gentle-engram", "pi install npm:pi-mcp-adapter", engramInitCommandForTest, "pi install npm:pi-subagents-j0k3r", "pi install npm:@juicesharp/rpiv-ask-user-question", "pi install npm:pi-web-access", "pi install npm:@juicesharp/rpiv-todo", "pi install npm:pi-btw"}
+	wantPackages := []string{"pi install npm:gentle-pi", "pi install npm:gentle-engram", "pi install npm:pi-mcp-adapter", engramInitCommandForTest, "pi install npm:pi-subagents-j0k3r", "pi install npm:@juicesharp/rpiv-ask-user-question", "pi install npm:pi-web-access", "pi install npm:pi-btw"}
 	if len(events) != len(wantPackages)*2 {
 		t.Fatalf("progress events = %d, want %d: %v", len(events), len(wantPackages)*2, events)
 	}
@@ -338,7 +338,6 @@ func TestPiAgentInstallRunsPackageCommandsWhenPiAlreadyInstalled(t *testing.T) {
 		"pi install npm:pi-subagents-j0k3r",
 		"pi install npm:@juicesharp/rpiv-ask-user-question",
 		"pi install npm:pi-web-access",
-		"pi install npm:@juicesharp/rpiv-todo",
 		"pi install npm:pi-btw",
 	} {
 		if !stringSliceContains(commands, want) {

--- a/internal/tui/screens/dependency_tree.go
+++ b/internal/tui/screens/dependency_tree.go
@@ -102,7 +102,6 @@ func piInstallCommands() []string {
 		"pi install npm:pi-subagents-j0k3r",
 		"pi install npm:@juicesharp/rpiv-ask-user-question",
 		"pi install npm:pi-web-access",
-		"pi install npm:@juicesharp/rpiv-todo",
 		"pi install npm:pi-btw",
 	}
 }

--- a/internal/tui/screens/dependency_tree_test.go
+++ b/internal/tui/screens/dependency_tree_test.go
@@ -35,7 +35,6 @@ func TestRenderDependencyTreePiOnlyEngramPlanShowsComponentAndPiInstallCopy(t *t
 		"pi install npm:pi-subagents-j0k3r",
 		"pi install npm:@juicesharp/rpiv-ask-user-question",
 		"pi install npm:pi-web-access",
-		"pi install npm:@juicesharp/rpiv-todo",
 		"pi install npm:pi-btw",
 	} {
 		if !strings.Contains(out, want) {
@@ -78,7 +77,6 @@ func TestRenderDependencyTreeMixedPiEmptyPlanShowsPiInstallCopy(t *testing.T) {
 		"pi install npm:pi-subagents-j0k3r",
 		"pi install npm:@juicesharp/rpiv-ask-user-question",
 		"pi install npm:pi-web-access",
-		"pi install npm:@juicesharp/rpiv-todo",
 		"pi install npm:pi-btw",
 	} {
 		if !strings.Contains(out, want) {


### PR DESCRIPTION
Closes #4190

## PR type

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation only
- [ ] Code refactoring
- [x] Maintenance/tooling
- [ ] Breaking change

## Summary

- Stops installing `@juicesharp/rpiv-todo` in the Pi install plan, the dependency tree, and the docs; gentle-pi now ships Gentle Todo.
- Every install or update drops an existing `@juicesharp/rpiv-todo` entry (with or without a version) from the user's `settings.json`, so Pi uninstalls it on its next package sync, mirroring the retired subagent packages.

## Changes

| File | Change |
|------|--------|
| `internal/agents/pi/adapter.go` | Remove the install command; add the retired package set and drop it in the settings merge |
| `internal/agents/pi/adapter_test.go` | Install plan expectation; new test for the settings removal |
| `internal/tui/screens/dependency_tree.go` (+ test) | Dependency tree no longer lists the package |
| `internal/cli/run_integration_test.go` | Expected Pi package list |
| `docs/agents.md`, `docs/pi.md`, `docs/quickstart.md` | Docs updated; migration note |

## Test plan

- [x] `go test ./internal/agents/pi/... ./internal/tui/screens/...` pass
- [x] `go test ./internal/cli/ -run 'TestPiAgentInstall'` pass (the package's full run also fails on `main` in `TestReviewCaptureRefuterExecuteDeadlineFailsClosedWithoutCapture`, unrelated to this change)
- [x] `gofmt -l` clean

## Contributor checklist

- [x] Linked an approved issue
- [x] Added exactly one `type:*` label
- [x] No shell scripts modified
- [x] Docs updated
- [x] Conventional commit format
- [x] No `Co-Authored-By` trailers

https://claude.ai/code/session_01SYqbaaqyJcAv1FYtSJXx6M

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Changes**
  - Retired the `@juicesharp/rpiv-todo` Pi companion package from installation and synchronization.
  - Existing installations will remove the retired package during the next package sync.
  - Updated Pi installation, quickstart, and package reference documentation to reflect the current package list.
- **Tests**
  - Updated installation and dependency-tree checks for the revised package list.
  - Added coverage confirming retired package entries are removed while other packages remain intact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->