### PR TITLE
fix(sdd): keep rules.apply in the model-small sdd-apply tier

### DIFF
--- a/internal/assets/skills/sdd-apply/SKILL.md
+++ b/internal/assets/skills/sdd-apply/SKILL.md
@@ -306,6 +306,7 @@ You are an IMPLEMENTER sub-agent. You receive specific tasks and implement them 
 - Read max 3 files at a time — if you need more to understand a task, stop and report `needs-explore`
 - Keep edits minimal and localized to task files
 - Consume structured status when provided; stop on `blocked`, `all_done`, or unsafe `actionContext`
+- Apply any `rules.apply` from `openspec/config.yaml` before implementing a task
 - If workload forecast says >400 lines or `Chained PRs recommended`, STOP and return `blocked: workload-decision-required`
 - If previous apply-progress exists, read it via mem_search + mem_get_observation and MERGE before saving
 - Focused remediation is the sole `all_done` exception and must bind evidence to the exact failed_evidence_revision from native status

--- a/internal/components/sdd/review_foundations_test.go
+++ b/internal/components/sdd/review_foundations_test.go
@@ -70,8 +70,10 @@ func TestSDDApplyModelSectionsPreserveRulesApplyContract(t *testing.T) {
 		if section == content {
 			t.Fatalf("sdd-apply has no model-%s section marker", capability)
 		}
-		if !strings.Contains(section, "rules.apply") {
-			t.Fatalf("sdd-apply model-%s section omits the openspec/config.yaml rules.apply instruction", capability)
+		for _, want := range []string{"rules.apply", "openspec/config.yaml"} {
+			if !strings.Contains(section, want) {
+				t.Fatalf("sdd-apply model-%s section omits %q from the rules.apply instruction", capability, want)
+			}
 		}
 	}
 }

--- a/internal/components/sdd/review_foundations_test.go
+++ b/internal/components/sdd/review_foundations_test.go
@@ -63,6 +63,19 @@ func TestSDDApplyRoutesToIndependentVerifyBeforeOptionalReview(t *testing.T) {
 	}
 }
 
+func TestSDDApplyModelSectionsPreserveRulesApplyContract(t *testing.T) {
+	content := assets.MustRead("skills/sdd-apply/SKILL.md")
+	for _, capability := range []string{"capable", "small"} {
+		section := extractModelSection(content, capability)
+		if section == content {
+			t.Fatalf("sdd-apply has no model-%s section marker", capability)
+		}
+		if !strings.Contains(section, "rules.apply") {
+			t.Fatalf("sdd-apply model-%s section omits the openspec/config.yaml rules.apply instruction", capability)
+		}
+	}
+}
+
 func TestSDDVerifyRunsWithoutReviewArtifacts(t *testing.T) {
 	content := assets.MustRead("skills/sdd-verify/SKILL.md")
 	for _, want := range []string{


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #4118

---

## 🏷️ PR Type

- [x] `type:bug` — Bug fix (non-breaking change that fixes an issue)

---

## 📝 Summary

- The `model-capable` section of `sdd-apply/SKILL.md` instructs applying any `rules.apply` from `openspec/config.yaml`; the `model-small` section had no equivalent, so an apply rendered for a small-model profile was never required to apply the project's phase-specific apply rules.
- Adds the rule to the model-small `Rules` list, phrased in that tier's terse register.
- Pins the parity with a test that extracts both sections exactly the way the product does (`extractModelSection`) and requires each to carry the `rules.apply` instruction — the parity cannot silently regress per tier again.

---

## 📂 Changes

| File / Area | What Changed |
|-------------|--------------|
| `internal/assets/skills/sdd-apply/SKILL.md` | One rule added to the `model-small` section's Rules list |
| `internal/components/sdd/review_foundations_test.go` | `TestSDDApplyModelSectionsPreserveRulesApplyContract` — RED-first: fails on the unmodified asset, passes with the rule |

---

## 🤖 AI Assistance

- [x] **Material assistance used**
  - **Tool/model:** Pi (gentle-ai harness) with an LLM agent
  - **Material scope:** diagnosis of the section gap, RED-first test authoring, fix implementation, verification, PR authoring
  - **Verification performed:** RED→GREEN on the new test; `go test ./internal/components/sdd/ ./internal/assets/ ./internal/cli/` green; full `e2e/docker-test.sh` matrix green on the branch

---

## 🧪 Test Plan

**Unit Tests**
```bash
go test ./internal/components/sdd/ ./internal/assets/ ./internal/cli/
```

**Go Format**
```bash
go run ./internal/gofmtcheck
```

**E2E Tests** (Docker required)
```bash
cd e2e && ./docker-test.sh
```

**Benchmark Validation:** N/A — skill asset prose parity; no review-lifecycle, gate, recovery, delivery, or benchmark implementation/corpus/classifier change.

- [x] Unit tests pass
- [x] Go format passes (`go run ./internal/gofmtcheck`)
- [x] E2E tests pass (`cd e2e && ./docker-test.sh`) — ubuntu/arch/fedora all green
- [x] Manually tested locally (RED reproduced the omission on main; GREEN with the rule)

---

## ✅ Contributor Checklist

- [x] PR is linked to an issue with `status:approved` (#4118)
- [x] PR stays within 400 changed lines (+17/−1)
- [x] I have added the appropriate `type:bug` label to this PR — maintainer gate: I cannot apply labels on this repository; please add `type:bug`
- [x] Unit tests pass (`go test ./...`)
- [x] Go format passes (`go run ./internal/gofmtcheck`)
- [x] E2E tests pass (`cd e2e && ./docker-test.sh`)
- [x] Benchmark validation N/A (explained in the Test Plan)
- [x] I have updated documentation if necessary (the skill asset is the documented contract; no docs/ page mirrors it)
- [x] My commits follow Conventional Commits format
- [x] I understand, reviewed, and take responsibility for the complete submission
- [x] I selected exactly one AI-assistance option and completed all applicable declaration fields
- [x] My commits do not include `Co-Authored-By` trailers

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated task guidance for smaller models to require applying the configured implementation rules before beginning work.

- **Tests**
  - Added coverage to verify that both supported model guidance sections retain the required implementation-rules instruction and remain aligned with the documented workflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->