### PR TITLE
fix(review): name the mandated transition in the v2 status root action

### DIFF
--- a/contracts/review-integration/v2/schemas/status-v7.schema.json
+++ b/contracts/review-integration/v2/schemas/status-v7.schema.json
@@ -11,7 +11,7 @@
     "schema": {"const": "gentle-ai.review-integration.status/v7"},
     "contract": {"$ref": "status-v5.schema.json#/properties/contract"}, "operation": {"$ref": "status-v5.schema.json#/properties/operation"},
     "applicability": {"$ref": "status-v5.schema.json#/properties/applicability"}, "authority": {"$ref": "status-v5.schema.json#/properties/authority"},
-    "action": {"$ref": "status-v5.schema.json#/properties/action"}, "action_disposition": {"$ref": "status-v5.schema.json#/properties/action_disposition"},
+    "action": {"enum": ["start", "validate", "recover", "maintainer_action", "select_lineage", "repair_authority", "stop", "collect", "execute"]}, "action_disposition": {"$ref": "status-v5.schema.json#/properties/action_disposition"},
     "replayability": {"$ref": "status-v5.schema.json#/properties/replayability"}, "frozen": {"$ref": "status-v5.schema.json#/properties/frozen"},
     "target_identity": {"$ref": "status-v5.schema.json#/properties/target_identity"}, "authority_target_identity": {"$ref": "status-v5.schema.json#/properties/authority_target_identity"},
     "projection": {"$ref": "status-v5.schema.json#/properties/projection"}, "repair": {"$ref": "status-v5.schema.json#/properties/repair"},

--- a/internal/cli/review_facade.go
+++ b/internal/cli/review_facade.go
@@ -1239,6 +1239,10 @@ func runReviewStatus(ctx context.Context, args []string, stdout io.Writer) error
 			transition := reviewIntendedUntrackedCollection(result, intendedScope, runtime)
 			result.NextTransition = &transition
 		}
+		// v1 envelopes keep their pinned schema; only v2 projects the root action.
+		if *contract == ReviewIntegrationContractV2 {
+			result.Action = reviewRootActionForTransition(result.Action, result.NextTransition)
+		}
 		if *contract == ReviewIntegrationContractV2 && result.NextTransition != nil {
 			// The forecast is structural only: it rides the v2 envelope's
 			// `forecast` field and is never narrated to stderr, because a

--- a/internal/cli/review_next_transition.go
+++ b/internal/cli/review_next_transition.go
@@ -421,6 +421,25 @@ func reviewProviderHostRelayRoleInput(binding ReviewTransitionBinding, role revi
 	return input, nil
 }
 
+// reviewRootActionForTransition keeps the envelope's root `action` in
+// agreement with `next_transition`: a stop that still mandates a collect or
+// an execute is not a stop (#3928). Every other action is left as native
+// status decided it, so preflight (`start`), recovery, repair, and genuine
+// terminal stops are untouched.
+func reviewRootActionForTransition(action reviewtransaction.TargetStatusAction, transition *ReviewNextTransition) reviewtransaction.TargetStatusAction {
+	if action != reviewtransaction.TargetStatusActionStop || transition == nil {
+		return action
+	}
+	switch transition.Kind {
+	case reviewNextTransitionCollect:
+		return reviewtransaction.TargetStatusActionCollect
+	case reviewNextTransitionExecute:
+		return reviewtransaction.TargetStatusActionExecute
+	default:
+		return action
+	}
+}
+
 func reviewMissingCaptureTransition(binding ReviewTransitionBinding, selectedLenses []string, artifacts []ReviewTransitionArtifact, context *reviewCaptureContext, runtime ...model.AgentID) ReviewNextTransition {
 	providerRuntime := model.AgentID("")
 	if len(runtime) > 0 && (reviewProviderCaptureRuntime(runtime[0]) || reviewProviderHostRelayMaterializeRuntime(runtime[0])) {

--- a/internal/cli/review_provider_artifact_contract_test.go
+++ b/internal/cli/review_provider_artifact_contract_test.go
@@ -218,7 +218,10 @@ func TestReviewProviderArtifactConformanceSchemasArePinned(t *testing.T) {
 func TestReviewProviderArtifactStatusV7ContractsArePinned(t *testing.T) {
 	root := filepath.Join("..", "..", "contracts", "review-integration", "v2")
 	want := map[string]string{
-		"schemas/status-v7.schema.json":         "5a5e4a7052689f97767d02625ad7572628cc4d5a62677497f569fb2d78608aa2",
+		// issue #3928: the root action enum gained "collect" and "execute", the
+		// v7 envelope's projection of a live transaction whose next_transition
+		// is mandatory. Deliberate, not drift.
+		"schemas/status-v7.schema.json":         "c856784a603601e14103c26adb484cb0331db1ab29ed14b208f45f435a61cea6",
 		"schemas/capabilities-v2.5.schema.json": "9fcdb1717a54bcd4f73d4dee1283d9ec2f27cccbb5d54804ee8b40a6ed2db553",
 	}
 	for name, expected := range want {

--- a/internal/cli/review_root_action_test.go
+++ b/internal/cli/review_root_action_test.go
@@ -1,0 +1,36 @@
+package cli
+
+import (
+	"testing"
+
+	"github.com/gentleman-programming/gentle-ai/v2/internal/reviewtransaction"
+)
+
+// The root `action` of a negotiated STATUS envelope must agree with its
+// `next_transition`: while a live transaction mandates a collect or an
+// execute, "stop" is not an honest root action (#3928).
+func TestReviewRootActionFollowsMandatedTransition(t *testing.T) {
+	collect := &ReviewNextTransition{Kind: reviewNextTransitionCollect, ReasonCode: "reviewer_results_required"}
+	execute := &ReviewNextTransition{Kind: reviewNextTransitionExecute, ReasonCode: "approved_acknowledgement_required"}
+	stop := &ReviewNextTransition{Kind: reviewNextTransitionStop, ReasonCode: "native_stop_required"}
+	cases := []struct {
+		name       string
+		action     reviewtransaction.TargetStatusAction
+		transition *ReviewNextTransition
+		want       reviewtransaction.TargetStatusAction
+	}{
+		{"reviewing lineage awaiting captures", reviewtransaction.TargetStatusActionStop, collect, reviewtransaction.TargetStatusActionCollect},
+		{"approved lineage awaiting acknowledgement", reviewtransaction.TargetStatusActionStop, execute, reviewtransaction.TargetStatusActionExecute},
+		{"genuine terminal stop", reviewtransaction.TargetStatusActionStop, stop, reviewtransaction.TargetStatusActionStop},
+		{"no transition computed", reviewtransaction.TargetStatusActionStop, nil, reviewtransaction.TargetStatusActionStop},
+		{"preflight start stays start", reviewtransaction.TargetStatusActionStart, execute, reviewtransaction.TargetStatusActionStart},
+		{"recovery stays recover", reviewtransaction.TargetStatusActionRecover, execute, reviewtransaction.TargetStatusActionRecover},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := reviewRootActionForTransition(tc.action, tc.transition); got != tc.want {
+				t.Fatalf("reviewRootActionForTransition(%q, %v) = %q, want %q", tc.action, tc.transition, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/reviewtransaction/target_status.go
+++ b/internal/reviewtransaction/target_status.go
@@ -25,6 +25,12 @@ const (
 	TargetStatusActionSelectLineage   TargetStatusAction = "select_lineage"
 	TargetStatusActionRepairAuthority TargetStatusAction = "repair_authority"
 	TargetStatusActionStop            TargetStatusAction = "stop"
+	// Envelope-only projections: native status keeps "stop" while a compact
+	// review is in flight (only the adapter can project its next capture), and
+	// the public envelope names the mandated transition kind instead, so the
+	// root action never reads as terminal while next_transition is required.
+	TargetStatusActionCollect TargetStatusAction = "collect"
+	TargetStatusActionExecute TargetStatusAction = "execute"
 )
 
 type Replayability string


### PR DESCRIPTION
Closes #3928

## PR type

- [x] Bug fix
- [ ] New feature
- [ ] Documentation only
- [ ] Code refactoring
- [ ] Maintenance/tooling
- [ ] Breaking change

## Summary

- Reproduced on main: a bound STATUS on a reviewing lineage answered `action: "stop"` while `next_transition` mandated `collect` (and `execute` once approved).
- The v2 envelope now projects the root `action` to the mandated transition kind (`collect` / `execute`) whenever native status says `stop` but a transition is required. Native `TargetStatusAction` is unchanged: the core keeps `stop` in flight by design and only the adapter projects captures.
- v1 envelopes and their digest-pinned schemas are untouched; `status-v7.schema.json` now defines the `action` enum with the two new values and its pin was updated deliberately (same precedent as #2659).
- gentle-pi mirror (strict enum decoder) lands in Gentleman-Programming/gentle-pi alongside this PR.

## Changes

| File | Change |
|------|--------|
| `internal/cli/review_next_transition.go` | `reviewRootActionForTransition` |
| `internal/cli/review_facade.go` | Apply the projection for contract v2 after the transition is final |
| `internal/reviewtransaction/target_status.go` | `TargetStatusActionCollect` / `TargetStatusActionExecute` (envelope-only values) |
| `contracts/review-integration/v2/schemas/status-v7.schema.json` | `action` enum gains `collect`, `execute` |
| `internal/cli/review_provider_artifact_contract_test.go` | Deliberate v7 digest update |
| `internal/cli/review_root_action_test.go` | Table test for the projection |

## Evidence

Bound STATUS on the same reviewing lineage, before: `action: stop | next: collect reviewer_results_required`; after: `action: collect | next: collect reviewer_results_required`.

## Test plan

- [x] `go test ./internal/cli/ -skip TestReviewCaptureRefuterExecuteDeadline` (ok, 575s)
- [x] `go test ./internal/reviewtransaction/`: two store-lock tests fail identically on untouched main in this environment (`review store lock could not be acquired: not a directory`); unrelated to this change
- [x] gofmt clean, `go build ./...`

https://claude.ai/code/session_01SYqbaaqyJcAv1FYtSJXx6M

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Review status responses now expose `collect` or `execute` as the root action when the corresponding next transition is required.
  - Status contracts now explicitly support nine valid root actions, including `collect` and `execute`.

- **Bug Fixes**
  - Prevented in-progress reviews requiring a follow-up transition from being incorrectly represented as terminal `stop` actions.
  - Terminal stops and unaffected actions continue to be reported as before.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->