### PR TITLE
fix(review): keep the product's public identifiers out of defect-report redaction

### DIFF
--- a/internal/cli/review_defect_report.go
+++ b/internal/cli/review_defect_report.go
@@ -11,6 +11,7 @@ import (
 	"runtime"
 	"runtime/debug"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 
@@ -119,7 +120,24 @@ var (
 	// reviewDefectReportEnvAssignmentRegexp matches a KEY=VALUE token shaped
 	// like an environment variable assignment.
 	reviewDefectReportEnvAssignmentRegexp = regexp.MustCompile(`\b[A-Z][A-Z0-9_]{2,}=\S+`)
+	// reviewDefectReportPublicIdentifierRegexp matches the product's own
+	// public identifiers: contract and schema ids such as
+	// gentle-ai.review-integration/v2, gentle-ai.review-integration.status/v7,
+	// or gentle-pi.review-relay/v1, plus the one exact relay handshake
+	// assignment. None of them describe a filesystem or a secret, and a
+	// report that hides them tells the reader to run a command that does not
+	// exist (#3443). Every other KEY=VALUE token and every path still redact.
+	reviewDefectReportPublicIdentifierRegexp = regexp.MustCompile(
+		regexp.QuoteMeta(reviewPiHostRelayContractEnvironment+"="+reviewPiHostRelayContract) +
+			`|gentle-(?:ai|pi)\.[A-Za-z0-9.-]+/v[0-9]+`)
 )
+
+// reviewDefectReportPlaceholder is the shape a protected public identifier
+// takes while the redactions run: no slash, no `=`, no `@`, so no redaction
+// rule can match it, and NUL never appears in a rendered field.
+func reviewDefectReportPlaceholder(index int) string {
+	return "\x00" + strconv.Itoa(index) + "\x00"
+}
 
 // reviewScrubDefectReportField is the field-level privacy gate: every string
 // that reaches a rendered report passes through this exact function first.
@@ -133,9 +151,17 @@ func reviewScrubDefectReportField(value string) string {
 	if newline := strings.IndexByte(value, '\n'); newline >= 0 {
 		value = value[:newline]
 	}
+	var protected []string
+	value = reviewDefectReportPublicIdentifierRegexp.ReplaceAllStringFunc(value, func(match string) string {
+		protected = append(protected, match)
+		return reviewDefectReportPlaceholder(len(protected) - 1)
+	})
 	value = reviewDefectReportEnvAssignmentRegexp.ReplaceAllString(value, reviewDefectReportRedactionMarker)
 	value = reviewDefectReportEmailRegexp.ReplaceAllString(value, reviewDefectReportRedactionMarker)
 	value = reviewDefectReportAbsolutePathRegexp.ReplaceAllString(value, reviewDefectReportRedactionMarker)
+	for index, identifier := range protected {
+		value = strings.ReplaceAll(value, reviewDefectReportPlaceholder(index), identifier)
+	}
 	return strings.TrimSpace(value)
 }
 

--- a/internal/cli/review_defect_report_scrub_test.go
+++ b/internal/cli/review_defect_report_scrub_test.go
@@ -1,0 +1,30 @@
+package cli
+
+import "testing"
+
+// The field-level privacy gate keeps the product's own public identifiers
+// (contract ids, schema ids, the exact relay handshake) and still redacts
+// everything that describes a machine: absolute and $HOME-rooted paths,
+// file URLs, emails, and every other environment assignment (#3443).
+func TestReviewScrubDefectReportFieldKeepsPublicIdentifiersAndRedactsTheRest(t *testing.T) {
+	cases := []struct{ name, in, want string }{
+		{"contract id survives", "run gentle-ai review status --contract gentle-ai.review-integration/v2 --agent pi", "run gentle-ai review status --contract gentle-ai.review-integration/v2 --agent pi"},
+		{"schema id survives", "schema gentle-ai.review-integration.status/v7 required", "schema gentle-ai.review-integration.status/v7 required"},
+		{"relay contract survives", "declares gentle-pi.review-relay/v1 exactly", "declares gentle-pi.review-relay/v1 exactly"},
+		{"exact relay handshake survives", "export GENTLE_PI_REVIEW_RELAY_CONTRACT=gentle-pi.review-relay/v1 and re-run", "export GENTLE_PI_REVIEW_RELAY_CONTRACT=gentle-pi.review-relay/v1 and re-run"},
+		{"other assignments still redact", "export GENTLE_PI_REVIEW_RELAY_CONTRACT=gentle-pi.review-relay/v9 and GITHUB_TOKEN=abc", "export <redacted> and <redacted>"},
+		{"absolute path still redacts", "repo at /Users/alan/work/gentle-pi failed", "repo at <redacted> failed"},
+		{"home-rooted path still redacts", "read ~/.pi/agent/settings.json first", "read ~<redacted> first"},
+		{"file url still redacts", "see file:///Users/alan/x", "see fil<redacted>"},
+		{"windows path still redacts", `path C:\Users\alan\repo\x.go missing`, "path <redacted> missing"},
+		{"email still redacts", "by alan@example.com", "by <redacted>"},
+		{"identifier next to a path keeps only the identifier", "gentle-ai.review-integration/v2 at /tmp/x", "gentle-ai.review-integration/v2 at <redacted>"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := reviewScrubDefectReportField(tc.in); got != tc.want {
+				t.Fatalf("reviewScrubDefectReportField(%q)\n got %q\nwant %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/cli/review_pi_handshake_refusal_test.go
+++ b/internal/cli/review_pi_handshake_refusal_test.go
@@ -23,8 +23,8 @@ import (
 // message and concluded v2.4.0 had dropped Pi support, when the fix was one
 // exported variable.
 const piRelayHandshakeRefusalCause = "the active runtime is not eligible for immutable receipt review; " +
-	"pi is eligible only while GENTLE_PI_REVIEW_RELAY_CONTRACT declares the exact relay contract this binary admits, " +
-	"which the gentle-pi host exports on every invocation it relays; export it in this shell and re-run"
+	"pi is eligible only while GENTLE_PI_REVIEW_RELAY_CONTRACT=gentle-pi.review-relay/v1 is exported, " +
+	"which the gentle-pi host does on every invocation it relays; export it in this shell and re-run"
 
 // TestPiTransportRefusalNamesTheHandshakeNotTheKillSwitch runs the exact
 // documented shell entry point both ways round: the identical command must

--- a/internal/cli/review_pi_handshake_refusal_test.go
+++ b/internal/cli/review_pi_handshake_refusal_test.go
@@ -79,35 +79,21 @@ func TestPiTransportRefusalNamesTheHandshakeNotTheKillSwitch(t *testing.T) {
 	})
 }
 
-// TestPiRelayHandshakeGuidanceSurvivesTheFailureCausePrivacyGate is the guard
-// the first draft of this fix needed, and the reason the cause names the
-// variable without its value.
-//
-// This prose reaches the operator only as the negotiated envelope's `cause`,
-// and every refusal crosses reviewScrubDefectReportField to get there. That
-// gate rewrites any `KEY=VALUE` token to `<redacted>` in full, and any
-// `/`-rooted run to `<redacted>` from the slash onward. A cause that spells
-// the handshake out therefore arrives as advice to export `<redacted>`:
-// strictly worse than the misleading message it replaced.
+// TestPiRelayHandshakeGuidanceSurvivesTheFailureCausePrivacyGate pins the
+// exit the operator reads: the cause spells the exact handshake out, and the
+// privacy gate every refusal crosses keeps it byte for byte, because the
+// product's own public identifiers are not secrets (#3443, #3440).
 func TestPiRelayHandshakeGuidanceSurvivesTheFailureCausePrivacyGate(t *testing.T) {
 	guidance := reviewPiRelayHandshakeGuidance()
 	if scrubbed := reviewScrubDefectReportField(guidance); scrubbed != guidance {
 		t.Fatalf("the privacy gate rewrites the pi guidance before the operator reads it:\n\tguidance %q\n\tscrubbed %q", guidance, scrubbed)
 	}
-	if !strings.Contains(guidance, reviewPiHostRelayContractEnvironment) {
-		t.Fatalf("the pi guidance no longer names the missing condition: %q", guidance)
-	}
-
-	// The tripwire for the half of #3440 this change cannot deliver. While
-	// the gate still destroys the spelled-out handshake, the omission is a
-	// constraint. The day it stops, this fails and the cause owes the
-	// operator the exact value.
 	spelled := reviewPiHostRelayContractEnvironment + "=" + reviewPiHostRelayContract
-	if scrubbed := reviewScrubDefectReportField("export " + spelled + " and re-run"); scrubbed != "export "+reviewDefectReportRedactionMarker+" and re-run" {
-		t.Fatalf("the privacy gate no longer destroys %q (it now renders %q); the pi cause can carry the exact handshake and should", spelled, scrubbed)
+	if !strings.Contains(guidance, spelled) {
+		t.Fatalf("the pi guidance no longer names the exact handshake %q: %q", spelled, guidance)
 	}
-	if scrubbed := reviewScrubDefectReportField("the value " + reviewPiHostRelayContract); scrubbed != "the value gentle-pi.review-relay"+reviewDefectReportRedactionMarker {
-		t.Fatalf("the privacy gate no longer truncates the bare contract value (it now renders %q); the pi cause can carry it and should", scrubbed)
+	if scrubbed := reviewScrubDefectReportField("the value " + reviewPiHostRelayContract); scrubbed != "the value "+reviewPiHostRelayContract {
+		t.Fatalf("the privacy gate truncates the bare contract value (renders %q)", scrubbed)
 	}
 }
 

--- a/internal/cli/review_transport_capability.go
+++ b/internal/cli/review_transport_capability.go
@@ -146,22 +146,16 @@ func reviewPiRelayHandshakeIsSoleMissingCondition(agent model.AgentID) bool {
 // declared contract away from eligible, and a reader who follows it concludes
 // the runtime was dropped.
 //
-// The guidance names the variable but NOT its value, and that is deliberate
-// rather than an oversight. This prose reaches the operator only as the
-// negotiated envelope's `cause`, which every refusal crosses
-// reviewScrubDefectReportField to reach: that gate rewrites any `KEY=VALUE`
-// token to `<redacted>` in full, and any `/`-rooted run to `<redacted>` from
-// the slash onward. The exact handshake collides with both rules, so
-// `GENTLE_PI_REVIEW_RELAY_CONTRACT=gentle-pi.review-relay/v1` renders as
-// `<redacted>` and `gentle-pi.review-relay/v1` renders as
-// `gentle-pi.review-relay<redacted>`. Naming the variable alone survives the
-// gate byte for byte (pinned by
-// TestPiRelayHandshakeGuidanceSurvivesTheFailureCausePrivacyGate), so it is
-// the most actionable cause that can actually reach the operator without
-// relaxing a privacy boundary from a diagnostics change.
+// The guidance spells the exact handshake out. This prose reaches the
+// operator only as the negotiated envelope's `cause`, which every refusal
+// crosses reviewScrubDefectReportField to reach; that gate now keeps the
+// product's own public identifiers (pinned by
+// TestPiRelayHandshakeGuidanceSurvivesTheFailureCausePrivacyGate), so the
+// cause can name the runnable exit instead of a variable whose value the
+// reader had to find in gentle-pi's source.
 func reviewPiRelayHandshakeGuidance() string {
-	return "; pi is eligible only while " + reviewPiHostRelayContractEnvironment +
-		" declares the exact relay contract this binary admits, which the gentle-pi host exports on every invocation it relays; export it in this shell and re-run"
+	return "; pi is eligible only while " + reviewPiHostRelayContractEnvironment + "=" + reviewPiHostRelayContract +
+		" is exported, which the gentle-pi host does on every invocation it relays; export it in this shell and re-run"
 }
 
 // reviewTransportRefusalGuidanceFor selects the guidance the refused runtime


### PR DESCRIPTION
Closes #3443

## PR type

- [x] Bug fix
- [ ] New feature
- [ ] Documentation only
- [ ] Code refactoring
- [ ] Maintenance/tooling
- [ ] Breaking change

## Summary

- Reproduced on main: refusal causes rendered the product's own identifiers as `gentle-ai.review-integration<redacted>` inside the command they told the reader to run, and the Pi handshake guidance could only name `GENTLE_PI_REVIEW_RELAY_CONTRACT`, never its value (root of #3645, #3746, #4162 and gentle-pi#550: every "pi is not eligible" report traces to that missing value).
- The gate now protects contract and schema ids (`gentle-(ai|pi).<name>/vN`) and the one exact relay handshake assignment before the redactions run and restores them after. Every other `KEY=VALUE`, absolute and `$HOME`-rooted paths, file URLs, and emails redact exactly as before: the path regex is untouched.
- The Pi refusal cause now spells out `GENTLE_PI_REVIEW_RELAY_CONTRACT=gentle-pi.review-relay/v1`; the pinned privacy-gate test flips from "the gate destroys the handshake" to "the gate keeps it".

Relation to #3456: that PR attacks the same root by anchoring the path regex, but the anchored form stops redacting `~/.pi/agent/settings.json` and `file:///Users/x` (verified with a Go regex harness against the current regex); this change keeps the broad path rule and allowlists only the product's identifiers.

## Evidence

Scratch repo, `review status --agent pi --next-transition` without the variable:
- main: `pi is eligible only while GENTLE_PI_REVIEW_RELAY_CONTRACT declares the exact relay contract this binary admits …`
- this branch: `pi is eligible only while GENTLE_PI_REVIEW_RELAY_CONTRACT=gentle-pi.review-relay/v1 is exported …`

## Changes

| File | Change |
|------|--------|
| `internal/cli/review_defect_report.go` | Protect public identifiers with placeholders around the existing redactions |
| `internal/cli/review_transport_capability.go` | Pi handshake guidance names the exact assignment |
| `internal/cli/review_defect_report_scrub_test.go` | Keep/redact matrix incl. `~/`, `file://`, other assignments |
| `internal/cli/review_pi_handshake_refusal_test.go` | Privacy-gate pin now asserts the spelled-out handshake survives |

## Test plan

- [x] `go test ./internal/cli/ -skip TestReviewCaptureRefuterExecuteDeadline` (ok)
- [x] gofmt clean, `go build ./...`

https://claude.ai/code/session_01SYqbaaqyJcAv1FYtSJXx6M

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Defect reports now preserve recognized public Gentle AI and PI protocol identifiers while continuing to redact sensitive paths, email addresses, environment variables, and other machine-specific details.
  - PI relay handshake failure guidance now includes the exact environment variable and contract value needed to configure the relay.
  - Privacy filtering preserves this configuration guidance so it remains actionable in reported errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->