### PR TITLE
fix(review): keep binary image assets passive in risk classification

### DIFF
--- a/internal/reviewtransaction/risk.go
+++ b/internal/reviewtransaction/risk.go
@@ -446,6 +446,9 @@ func catFileBatchRecordBytes(oid string, size int64) int64 {
 // Extensions only nominate a candidate; an interpreter directive, runtime MDX
 // syntax, or bytes that are not decodable text all withdraw the nomination.
 func isPassiveDocumentContent(logicalPath string, content []byte) bool {
+	if isPassiveImageExtension(logicalPath) {
+		return hasPassiveImageSignature(content)
+	}
 	if bytes.IndexByte(content, 0) >= 0 || !utf8.Valid(content) {
 		return false
 	}
@@ -977,11 +980,39 @@ func isPassiveContentCandidatePath(logicalPath string) bool {
 	return true
 }
 
+// isPassiveImageExtension names the binary image formats a reviewer can never
+// read as prose or execute: their bytes carry no authored behavior, so a
+// binary blob under one of them stays passive instead of failing closed into a
+// lens that could not inspect it anyway (#4185).
+func isPassiveImageExtension(logicalPath string) bool {
+	switch strings.ToLower(path.Ext(logicalPath)) {
+	case ".png", ".jpg", ".jpeg", ".gif":
+		return true
+	default:
+		return false
+	}
+}
+
+// hasPassiveImageSignature requires the bytes to open with the PNG, JPEG, or
+// GIF signature: an image extension alone never admits a blob as passive.
+func hasPassiveImageSignature(content []byte) bool {
+	for _, magic := range [][]byte{[]byte("\x89PNG\r\n\x1a\n"), {0xff, 0xd8, 0xff}, []byte("GIF87a"), []byte("GIF89a")} {
+		if bytes.HasPrefix(content, magic) {
+			return true
+		}
+	}
+	return false
+}
+
 // isPassiveContentCandidateStat adds the mode half of the tier-0 nomination: a
-// binary blob, a symlink, a gitlink, a mode-only entry, or an executable bit
-// cannot be reviewed as prose whatever its extension claims.
+// symlink, a gitlink, a mode-only entry, or an executable bit cannot be
+// reviewed as prose whatever its extension claims, and a binary blob only
+// qualifies under a passive image extension.
 func isPassiveContentCandidateStat(stat DiffStat) bool {
-	if stat.Binary || stat.ModeOnly || !isPassiveContentCandidatePath(stat.Path) {
+	if stat.Binary && !isPassiveImageExtension(stat.Path) {
+		return false
+	}
+	if stat.ModeOnly || !isPassiveContentCandidatePath(stat.Path) {
 		return false
 	}
 	return isRegularNonExecutableGitMode(stat.OldMode) && isRegularNonExecutableGitMode(stat.NewMode)

--- a/internal/reviewtransaction/risk_test.go
+++ b/internal/reviewtransaction/risk_test.go
@@ -274,6 +274,9 @@ func TestLowRiskReviewPathPolicyUsesCanonicalPOSIXOperationalBoundaries(t *testi
 		{name: "MDX", stat: DiffStat{Path: "docs/guide.mdx", Additions: 1, NewMode: "100644"}, want: true},
 		{name: "source comment", stat: DiffStat{Path: "internal/view.go", Additions: 1, NewMode: "100644"}},
 		{name: "binary Markdown", stat: DiffStat{Path: "docs/guide.md", Binary: true, NewMode: "100644"}},
+		{name: "binary image asset", stat: DiffStat{Path: "assets/logo.png", Binary: true, NewMode: "100644"}, want: true},
+		{name: "binary image under agents", stat: DiffStat{Path: ".claude/agents/logo.png", Binary: true, NewMode: "100644"}},
+		{name: "executable image", stat: DiffStat{Path: "assets/logo.png", Binary: true, NewMode: "100755"}},
 		{name: "symlink Markdown", stat: DiffStat{Path: "docs/guide.md", Additions: 1, NewMode: "120000"}},
 		{name: "gitlink Markdown", stat: DiffStat{Path: "docs/guide.md", Additions: 1, NewMode: "160000"}},
 		{name: "executable Markdown", stat: DiffStat{Path: "docs/guide.md", Additions: 1, NewMode: "100755"}},
@@ -719,6 +722,10 @@ func TestPassiveDocumentContentFailsClosedUpward(t *testing.T) {
 		{name: "interpreter directive", path: "docs/guide.md", content: "#!/bin/sh\necho hi\n"},
 		{name: "embedded NUL byte", path: "docs/guide.md", content: "prose\x00more\n"},
 		{name: "invalid UTF-8", path: "docs/guide.md", content: "prose \xff\xfe\n"},
+		{name: "binary image bytes", path: "assets/logo.png", content: "\x89PNG\r\n\x1a\n\x00\x00", want: true},
+		{name: "image wearing a shebang", path: "assets/logo.png", content: "#!/bin/sh\necho hi\n"},
+		{name: "text wearing an image extension", path: "assets/logo.png", content: "prose\n"},
+		{name: "archive wearing an image extension", path: "assets/logo.jpg", content: "PK\x03\x04payload"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
Closes #4185

## Summary
- A candidate whose only binary change is a `.png`/`.jpg`/`.jpeg`/`.gif` asset no longer escalates out of the passive tier into a lens that cannot read the bytes.
- The blob must open with the PNG, JPEG, or GIF signature; the extension alone never admits it (native review correction R1 on this candidate).
- A shebang, plain text, or an archive wearing an image extension still withdraws the nomination, as before.

| File | Change |
|------|--------|
| `internal/reviewtransaction/risk.go` | `isPassiveImageExtension`, `hasPassiveImageSignature`; stat gate admits Binary only under an image extension; content gate requires the signature |
| `internal/reviewtransaction/risk_test.go` | stat-policy and content fail-closed cases for image assets |

## Test plan
- [x] `go test ./internal/reviewtransaction/ -run 'TestPassiveDocumentContentFailsClosedUpward|TestLowRiskReviewPathPolicy'` passes
- [x] Live: a png-only candidate now preflights as low tier / `non_executable_only`
- [x] Native review: approved and acknowledged (lineage review-e7038eff559b6f27, one bounded correction)

https://claude.ai/code/session_01SYqbaaqyJcAv1FYtSJXx6M

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of image files during content safety reviews.
  * Genuine PNG, JPEG, and GIF files are now recognized correctly when their contents match the file type.
  * Files that only use an image extension but contain scripts, text, archives, or other data are no longer treated as passive images.
  * Image files in restricted paths or with executable permissions continue to receive additional scrutiny.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->