### PR TITLE
fix(review): stop counting member calls named exec as process boundaries

### DIFF
--- a/internal/reviewtransaction/risk.go
+++ b/internal/reviewtransaction/risk.go
@@ -572,6 +572,17 @@ func treeBlobSizes(ctx context.Context, repo, tree string, paths []string) ([]tr
 	return blobs, nil
 }
 
+// processBoundaryPattern is the case-insensitive extended regular expression
+// the frozen-tree scan hands to git grep. A bare spawn word (`subprocess`,
+// `child_process`, `execute_process`, `exec` as in `os/exec` or `exec "$@"`)
+// counts only when it is not a member of another value: `db.Exec(`,
+// `stmt.Exec(`, and `/re/.exec(` are database statements and regular
+// expressions, not process boundaries (#2542). Spawn calls that only exist in
+// member form are named explicitly instead.
+const processBoundaryPattern = `(^#!)` +
+	`|((^|[^[:alnum:]_.])(subprocess|child_process|execute_process|exec)([^[:alnum:]_]|$))` +
+	`|(getRuntime\(\)\.exec\(|ProcessBuilder|os\.system\(|os\.exec[lv]p?e?\(|posix_spawn|proc_open\(|shell_exec\(|passthru\(|popen\(|Process\.Start\()`
+
 func (builder SnapshotBuilder) processBoundaryRiskReasons(ctx context.Context, snapshot Snapshot, stats []DiffStat) ([]RiskReason, error) {
 	repo, err := builder.repositoryRoot(ctx)
 	if err != nil {
@@ -608,7 +619,7 @@ func (builder SnapshotBuilder) processBoundaryRiskReasons(ctx context.Context, s
 		// same bounded pass looks for either inside the frozen bytes.
 		fixedArgs := []string{
 			"grep", "-I", "-l", "-z", "-i", "-E",
-			`(^#!)|((^|[^[:alnum:]_])(subprocess|execute_process|exec)([^[:alnum:]_]|$))`, tree, "--",
+			processBoundaryPattern, tree, "--",
 		}
 		prefixLength := gitArgvPrefixLength(repo, fixedArgs...)
 		for _, batch := range batchLiteralPathspecs(treePaths, prefixLength) {

--- a/internal/reviewtransaction/risk_test.go
+++ b/internal/reviewtransaction/risk_test.go
@@ -691,6 +691,36 @@ func TestTierIsClassifiedByContentNotExtension(t *testing.T) {
 			files: []candidateFile{{path: "README-install.sh", content: "#!/bin/sh\nexec \"$@\"\n"}},
 			want:  RiskHigh,
 		},
+		{
+			name:  "database Exec method is not a spawn construct",
+			files: []candidateFile{{path: "internal/storage/repository.go", content: "package storage\n\nimport \"database/sql\"\n\nfunc insert(db *sql.DB, text string) error {\n\t_, err := db.Exec(\"INSERT INTO verses(text) VALUES (?)\", text)\n\treturn err\n}\n"}},
+			want:  RiskMedium,
+		},
+		{
+			name:  "RegExp exec method is not a spawn construct",
+			files: []candidateFile{{path: "src/parse.js", content: "const match = /^(\\d+)/.exec(input);\n"}},
+			want:  RiskMedium,
+		},
+		{
+			name:  "Go source proving a spawn construct",
+			files: []candidateFile{{path: "internal/tools/run.go", content: "package tools\n\nimport \"os/exec\"\n\nfunc run() error { return exec.Command(\"git\", \"status\").Run() }\n"}},
+			want:  RiskHigh,
+		},
+		{
+			name:  "Node source proving a spawn construct",
+			files: []candidateFile{{path: "src/run.js", content: "const { execFile } = require(\"child_process\");\n"}},
+			want:  RiskHigh,
+		},
+		{
+			name:  "Java source proving a spawn construct",
+			files: []candidateFile{{path: "src/Run.java", content: "class Run { void go() throws Exception { Runtime.getRuntime().exec(\"ls\"); } }\n"}},
+			want:  RiskHigh,
+		},
+		{
+			name:  "Python source proving a spawn construct",
+			files: []candidateFile{{path: "tools/run.py", content: "import os\nos.system(\"ls\")\n"}},
+			want:  RiskHigh,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
Closes #2542

## Summary
- `db.Exec(...)`, `stmt.Exec(...)`, and `/re/.exec(input)` no longer count as code that starts other processes; the bare-word `exec` match now skips members of another value.
- Spawn calls that only exist in member form are named explicitly (`Runtime.getRuntime().exec`, `ProcessBuilder`, `os.system`, `os.execv*`, `posix_spawn`, `proc_open`, `shell_exec`, `passthru`, `popen`, `Process.Start`); `os/exec`, `exec.Command`, `subprocess`, `child_process`, `execute_process`, and a shell `exec` still escalate.
- Reproduced on main with a `database/sql` repository file: consent said `risk_level: high` for process execution; with this change the same candidate is `medium` with the plain executable-change reason.

| File | Change |
|------|--------|
| `internal/reviewtransaction/risk.go` | `processBoundaryPattern` constant with the narrowed word match and the explicit member-form spawns |
| `internal/reviewtransaction/risk_test.go` | database Exec and RegExp exec stay medium; Go, Node, Java, Python spawn constructs stay high |

## Test plan
- [x] `go test ./internal/reviewtransaction/ -run 'TestTierIsClassifiedByContentNotExtension|TestTierTwoAlwaysNamesItsEvidence'` passes (the new cases failed before the change)
- [x] Live comparison main vs candidate binary on the reproduction repo
- [x] Native review approved and acknowledged (lineage review-aa0a437d375841c2, four lenses, no correction)

https://claude.ai/code/session_01SYqbaaqyJcAv1FYtSJXx6M

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved risk classification for code that launches external processes across multiple languages and APIs.
  - Added detection for shebangs and common process-spawning patterns, including Node.js, Java, Go, and Python.
  - Reduced false positives by distinguishing database methods and regular-expression methods from process execution calls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->