### PR TITLE
fix(review): resume a committed-only lineage from its frozen selector after HEAD moves

### DIFF
--- a/internal/cli/review_frozen_status_test.go
+++ b/internal/cli/review_frozen_status_test.go
@@ -347,6 +347,38 @@ func createFrozenReviewingStatusRecord(t *testing.T, repo, lineage string, targe
 	return store, started.Record
 }
 
+// A bound STATUS for a committed-only lineage carries `--base-ref` and
+// `--committed-only`, which bind a base-diff target instead of the default
+// current-changes one. When HEAD moves after START (the correction was
+// committed before its plan was captured), that bound STATUS must resume the
+// named lineage from its frozen selector exactly like the workspace path does,
+// not offer a fresh START that abandons the reviewing lineage.
+func TestExplicitFrozenReviewingBaseDiffStatusResumesAfterCommittedDrift(t *testing.T) {
+	reviewEnabledHome(t)
+	repo, _, record := frozenReviewingStatusFixture(t, reviewtransaction.TargetBaseDiff, nil)
+	base := strings.TrimSpace(runReviewCLIGit(t, repo, "rev-parse", "HEAD~1"))
+	writeReviewStartCandidate(t, repo, "service-token.ts", "export const token = 'committed drift'\n", 0o644)
+	runReviewCLIGit(t, repo, "commit", "-qam", "correction committed before its plan")
+
+	var output bytes.Buffer
+	args := []string{"status", "--contract", ReviewIntegrationContractV2, "--next-transition", "--cwd", repo,
+		"--lineage", record.State.LineageID, "--base-ref", base, "--committed-only"}
+	if err := RunReview(args, &output); err != nil {
+		t.Fatalf("bound base-diff STATUS after committed drift: %v\n%s", err, output.String())
+	}
+	var status ReviewTargetStatusResult
+	decodeStrictReviewJSON(t, output.Bytes(), &status)
+	if err := status.Validate(); err != nil {
+		t.Fatal(err)
+	}
+	if status.Applicability != reviewtransaction.TargetApplicabilityCurrent || status.Authority == nil ||
+		status.Authority.LineageID != record.State.LineageID || status.TargetIdentity != record.State.InitialSnapshot.Identity ||
+		status.NextTransition == nil || status.NextTransition.Kind != reviewNextTransitionCollect ||
+		status.NextTransition.ReasonCode != "reviewer_results_required" {
+		t.Fatalf("bound base-diff status after committed drift = %#v", status)
+	}
+}
+
 func explicitFrozenReviewingStatus(t *testing.T, repo, lineage string) ReviewTargetStatusResult {
 	t.Helper()
 	var output bytes.Buffer

--- a/internal/reviewtransaction/target_status.go
+++ b/internal/reviewtransaction/target_status.go
@@ -226,8 +226,14 @@ func assessTargetStatusSnapshot(ctx context.Context, repo string, request Target
 			compactHistoricalFailedValidator(state) && compactEscalatedRecoveryTargetChanged(state.CurrentSnapshot, live)) {
 			continue
 		}
-		if request.LineageID != "" && request.Target.Kind == TargetCurrentChanges && request.Target.Projection != ProjectionStaged &&
-			!compactLiveTargetMatchesValidatedSnapshot(state, live, true) {
+		// An explicitly named reviewing lineage whose live candidate drifted is
+		// resumed or recovered from its frozen selector, whether the caller
+		// bound a current-changes target or the committed base-diff one a
+		// `--base-ref --committed-only` STATUS carries; the frozen record
+		// already knows its own kind, so a base-diff request must not fall
+		// through to a fresh START that silently abandons the lineage.
+		if request.LineageID != "" && (request.Target.Kind == TargetCurrentChanges || request.Target.Kind == TargetBaseDiff) &&
+			request.Target.Projection != ProjectionStaged && !compactLiveTargetMatchesValidatedSnapshot(state, live, true) {
 			eligible, pendingSlots, eligibilityErr := explicitReviewingCompactCandidate(ctx, repo, candidate)
 			if eligibilityErr != nil {
 				return targetStatusFailure(base, eligibilityErr)


### PR DESCRIPTION
Closes #4212

Reproducible half of #4094 (defect A) and #3904.

## Summary
- A bound STATUS with `--base-ref --committed-only` after HEAD moved (the correction was committed before its plan) now resumes the named lineage from its frozen selector instead of offering a fresh START with a new lineage.
- The eligibility guard in `target_status.go` admits base-diff requests next to current-changes ones; `frozenReviewingCandidateDrifted` already rebuilt base-diff selectors, so no other path changes.

| File | Change |
|------|--------|
| `internal/reviewtransaction/target_status.go` | widen the explicit-lineage drift guard to `TargetBaseDiff` |
| `internal/cli/review_frozen_status_test.go` | bound base-diff STATUS after a committed drift resumes the lineage (failed before the change) |

## Test plan
- [x] New test fails on main, passes with the change
- [x] `go test ./internal/cli/ -run 'Frozen|Drift|Recover|BaseDiff|Committed|NegotiatedStatus'` passes
- [x] Native review approved and acknowledged (lineage review-8a405b3eda51a0cd, four lenses, no correction)

https://claude.ai/code/session_01SYqbaaqyJcAv1FYtSJXx6M

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed `status` requests using committed base-diff targets so they correctly resume an existing frozen review lineage after committed changes.
  - Prevented these requests from incorrectly starting a new review and losing the active lineage.
  - The resumed status now preserves the applicable target and offers the expected collection transition when reviewer results are required.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->