### PR TITLE
fix(sdd): drop discarded intended-untracked paths when reconciling a historical selection

### DIFF
--- a/internal/reviewtransaction/snapshot.go
+++ b/internal/reviewtransaction/snapshot.go
@@ -788,9 +788,20 @@ func (builder SnapshotBuilder) StillUntrackedIntended(ctx context.Context, inten
 	tracked := nulSeparatedPathSet(trackedOutput)
 	remaining := make([]string, 0, len(intended))
 	for _, path := range intended {
-		if _, isTracked := tracked[path]; !isTracked {
-			remaining = append(remaining, path)
+		if _, isTracked := tracked[path]; isTracked {
+			continue
 		}
+		// A recorded path that no longer exists in the working tree has left
+		// the candidate just as surely as one that became tracked: carrying it
+		// forward would make every later capture fail on the missing file
+		// instead of classifying the discard as drift (#4055).
+		if _, err := os.Lstat(filepath.Join(root, filepath.FromSlash(path))); err != nil {
+			if errors.Is(err, os.ErrNotExist) {
+				continue
+			}
+			return nil, fmt.Errorf("intended-untracked path %q: %w", path, err)
+		}
+		remaining = append(remaining, path)
 	}
 	return remaining, nil
 }

--- a/internal/reviewtransaction/snapshot_still_untracked_test.go
+++ b/internal/reviewtransaction/snapshot_still_untracked_test.go
@@ -27,6 +27,17 @@ func TestSnapshotBuilderStillUntrackedIntendedReconcilesTrackedPaths(t *testing.
 		t.Fatalf("StillUntrackedIntended() = %v, want %v", got, want)
 	}
 
+	// Issue #4055: a recorded path that was discarded from the working tree
+	// drops out like a tracked one instead of surfacing as a raw lstat error
+	// from the next candidate capture.
+	discarded, err := builder.StillUntrackedIntended(context.Background(), []string{"keep-a.txt", "vanished.txt"})
+	if err != nil {
+		t.Fatalf("StillUntrackedIntended over a discarded selection: %v", err)
+	}
+	if want := []string{"keep-a.txt"}; !reflect.DeepEqual(discarded, want) {
+		t.Fatalf("StillUntrackedIntended() = %v, want %v", discarded, want)
+	}
+
 	landed, err := builder.StillUntrackedIntended(context.Background(), []string{"tracked.txt", "deleted.txt"})
 	if err != nil {
 		t.Fatalf("StillUntrackedIntended over a fully-landed selection: %v", err)


### PR DESCRIPTION
Closes #4055
Closes #3996

## Summary
- `sdd-attempt reset` (and rescope) no longer fails with `lstat ...: no such file or directory` when an admitted intended-untracked path was discarded from the working tree after an interrupted settlement.
- `StillUntrackedIntended` now drops a recorded path that vanished, mirroring the existing became-tracked rule; any other lstat failure still surfaces.
- Reproduced on main with the replay script from today's triage (acquire → settle interrupted with one selected untracked file → delete it → reset).

| File | Change |
|------|--------|
| `internal/reviewtransaction/snapshot.go` | vanished paths leave the replayed selection |
| `internal/reviewtransaction/snapshot_still_untracked_test.go` | discarded path drops out, still-present path survives |

## Test plan
- [x] `go test ./internal/reviewtransaction/ -run StillUntracked` (new case failed before the change)
- [x] `go test ./internal/reviewtransaction/ -run 'Snapshot|Intended|Untracked'` and `go test ./internal/cli/ -run 'Untracked|Intended|SddAttempt'` pass
- [x] Native review approved and acknowledged (lineage review-dfd07b302fdd428e, four lenses, no correction)

https://claude.ai/code/session_01SYqbaaqyJcAv1FYtSJXx6M

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Historical untracked paths that no longer exist are now excluded from review results.
  - Remaining valid untracked paths continue to be retained.
  - Unexpected file-system errors are still reported.

- **Tests**
  - Added coverage for handling vanished paths without producing errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->