### PR TITLE
fix(review): fail closed when a bound STATUS re-enters a lineage from a sibling worktree

### DIFF
--- a/internal/cli/review_facade.go
+++ b/internal/cli/review_facade.go
@@ -889,6 +889,20 @@ func runReviewStatus(ctx context.Context, args []string, stdout io.Writer) error
 			if !requestedLineageOccupied {
 				return reviewPreflightError(fmt.Errorf("review lineage %q is not held by repository %s; rerun the same command from the repository that owns the lineage, or name it: `gentle-ai review status --cwd <repository> --contract %s --next-transition --lineage %s --repository-context %s`", requestedLineage, root, *contract, requestedLineage, requestedContext))
 			}
+			// Issue #4023: the authority store above is scoped to the Git
+			// common dir, so a linked worktree of the same repository also
+			// reports the lineage occupied. Occupancy alone is not proof this
+			// process cwd is the worktree that froze it, so a mismatch must
+			// fail closed the same way the #3932 guard above does instead of
+			// letting the occupied branch evaluate the wrong working tree as
+			// a fresh target for someone else's lineage.
+			foreignWorktree, err := reviewtransaction.ExactReviewLineageForeignWorktree(ctx, root, requestedLineage)
+			if err != nil {
+				return fmt.Errorf("inspect negotiated START lineage worktree binding: %w", err)
+			}
+			if foreignWorktree {
+				return reviewPreflightError(fmt.Errorf("review lineage %q is held by a different worktree of repository %s (expected worktree %s); rerun the same command from the worktree that started the lineage, or name it: `gentle-ai review status --cwd <repository> --contract %s --next-transition --lineage %s --repository-context %s`", requestedLineage, root, reviewDefectReportRedactionMarker, *contract, requestedLineage, requestedContext))
+			}
 		}
 		if *nextTransition && (requestedLineage == "" || !requestedLineageOccupied) {
 			// A free exact selector starts independently. Freeze its target without

--- a/internal/cli/review_wrong_exits_test.go
+++ b/internal/cli/review_wrong_exits_test.go
@@ -146,3 +146,62 @@ func TestNegotiatedStatusWithUnknownLineageFailsClosedFromForeignRepository(t *t
 		t.Fatalf("owning-repository continuation authority = %#v, want lineage %q reviewing", status.Authority, started.LineageID)
 	}
 }
+
+// TestNegotiatedStatusWithOccupiedLineageFailsClosedFromSiblingWorktree is
+// issue #4023: a linked worktree shares its owning repository's git common
+// dir, so ExactReviewLineageOccupied (scoped to that shared authority store)
+// reports the lineage occupied from the sibling too. Before this fix, that let
+// the #3932 foreign-repository guard pass, and the bound STATUS continuation
+// then silently froze a fresh target from the sibling's own working tree
+// instead of failing closed. An explicitly named lineage must only be
+// evaluated from the exact worktree that froze it.
+func TestNegotiatedStatusWithOccupiedLineageFailsClosedFromSiblingWorktree(t *testing.T) {
+	reviewEnabledHome(t)
+	owner := initReviewCLIRepo(t)
+	writeReviewStartCandidate(t, owner, "candidate.go", "package candidate\n\nfunc Candidate() int { return 7 }\n", 0o644)
+	started := runNegotiatedReviewStart(t, owner, "continuation-sibling-worktree")
+	execution := startStatusContinuationExecution(t, started, []ReviewTransitionArgument{
+		{Name: "projection", Value: string(reviewtransaction.ProjectionWorkspace)},
+	})
+	if binding := execution.Arguments[3]; binding.Name != "repository-context" || started.RepositoryContext == nil || binding.Value != started.RepositoryContext.Handle {
+		t.Fatalf("START continuation binding row = %#v, want the published repository context handle", execution.Arguments)
+	}
+	fields := strings.Fields(execution.Command)
+
+	sibling := canonicalReviewCLITempDir(t)
+	runReviewCLIGit(t, owner, "worktree", "add", sibling, "-b", "sibling-branch")
+	previous, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chdir(sibling); err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = os.Chdir(previous) }()
+	var siblingOutput bytes.Buffer
+	err = RunReview(fields[2:], &siblingOutput)
+	if err == nil {
+		t.Fatalf("continuation from a sibling worktree succeeded instead of failing closed:\n%s", siblingOutput.String())
+	}
+	failure := decodeReviewIntegrationFailure(t, siblingOutput.Bytes())
+	if failure.Operation != "review.status" || failure.Code != reviewIntegrationInvalidRequestCode || failure.NextAction != "correct_request" ||
+		!strings.Contains(failure.Cause, started.LineageID) || !strings.Contains(failure.Cause, "worktree") {
+		t.Fatalf("sibling-worktree continuation failure = %#v, want invalid_request naming the lineage and the worktree mismatch", failure)
+	}
+	if strings.Contains(failure.Cause, sibling) || strings.Contains(failure.Cause, owner) {
+		t.Fatalf("sibling-worktree continuation cause leaked an absolute worktree path: %q", failure.Cause)
+	}
+
+	if err := os.Chdir(owner); err != nil {
+		t.Fatal(err)
+	}
+	var ownerOutput bytes.Buffer
+	if err := RunReview(fields[2:], &ownerOutput); err != nil {
+		t.Fatalf("continuation from the original worktree: %v\n%s", err, ownerOutput.String())
+	}
+	var status ReviewTargetStatusResult
+	decodeStrictReviewJSON(t, ownerOutput.Bytes(), &status)
+	if status.Authority == nil || status.Authority.LineageID != started.LineageID || status.Authority.State != reviewtransaction.StateReviewing {
+		t.Fatalf("original-worktree continuation authority = %#v, want lineage %q reviewing", status.Authority, started.LineageID)
+	}
+}

--- a/internal/reviewtransaction/lineage_occupancy.go
+++ b/internal/reviewtransaction/lineage_occupancy.go
@@ -33,3 +33,38 @@ func ExactReviewLineageOccupied(ctx context.Context, repo, lineageID string) (bo
 	}
 	return false, nil
 }
+
+// ExactReviewLineageForeignWorktree reports whether one exact occupied lineage
+// froze its compact authority from a worktree other than repo. Issue #4023:
+// the shared authority store lives under the Git common dir, so a linked
+// worktree of the same repository sees the lineage as occupied even though it
+// never froze it. ExactReviewLineageOccupied only proves occupancy, never
+// which worktree owns it, so a caller resuming an explicitly named lineage
+// must additionally confirm this before treating a bound STATUS as a resume
+// instead of a fresh preflight of the wrong working tree.
+//
+// A record written before the worktree-bound atomic START binding existed
+// carries no InitialAtomicStart and cannot be compared; it is never reported
+// foreign, preserving today's behavior for historical authority.
+func ExactReviewLineageForeignWorktree(ctx context.Context, repo, lineageID string) (bool, error) {
+	store, err := CompactAuthoritativeStore(ctx, repo, lineageID)
+	if err != nil {
+		return false, err
+	}
+	record, err := store.LoadContext(ctx)
+	if err != nil {
+		if IsCompactAuthorityOperationalFailure(err) {
+			return false, err
+		}
+		return false, nil
+	}
+	binding := record.State.InitialAtomicStart
+	if binding == nil {
+		return false, nil
+	}
+	lease, err := OpenRepositoryIdentityLease(ctx, repo)
+	if err != nil {
+		return false, err
+	}
+	return binding.WorktreeIdentity != lease.Identity().RepositoryRef, nil
+}


### PR DESCRIPTION
Closes #4023

## Summary
- A bound STATUS run from a linked worktree that shares the git common dir no longer evaluates that worktree's live tree as a fresh target for another worktree's lineage; it refuses with the same typed `invalid_request` shape as the foreign-repository guard from #3932, with the worktree path redacted.
- Uses the worktree binding START already records (`InitialAtomicStart.WorktreeIdentity`); records without it keep the current behaviour.
- Reproduced on main today with two linked worktrees (replay in the session's `repro/worktrees/run.sh`).

| File | Change |
|------|--------|
| `internal/reviewtransaction/lineage_occupancy.go` | `ExactReviewLineageForeignWorktree` compares the record's worktree identity with the requester |
| `internal/cli/review_facade.go` | bound-STATUS guard fails closed on a sibling worktree |
| `internal/cli/review_wrong_exits_test.go` | sibling worktree fails closed, original worktree still resumes (failed before the change) |

## Test plan
- [x] `go test ./internal/cli/ -run 'Foreign|Worktree|Occupied|WrongExit|NegotiatedStatus'` passes
- [x] `go test ./internal/reviewtransaction/ -run 'Compact|Start|Worktree'` (one pre-existing environmental lock failure on this tmp path, reproduces without the change)
- [x] Native review approved and acknowledged (lineage review-ab37f3b87094623a, four lenses, no correction)

https://claude.ai/code/session_01SYqbaaqyJcAv1FYtSJXx6M

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Review status continuations now fail clearly when run from a linked worktree different from the one where the review lineage began.
  * Error messages provide corrective guidance without exposing absolute worktree paths.
  * Continuations continue to work from the original worktree, preserving the expected review state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->