### PR TITLE
fix(review): harden the Windows git process tree launch and gate it in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -227,6 +227,21 @@ jobs:
           go test -v ./internal/components/filemerge -count=1 -run $selector
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
+      # Every Windows git launch goes through the suspended-start / job-object
+      # / resume sequence; the crashes in #4081, #4128 and #4152 were a Go
+      # runtime fault on that path at roughly one launch in four, so the lane
+      # bursts real launches instead of trusting a single green run.
+      - name: Run native Windows git process tree tests
+        shell: pwsh
+        timeout-minutes: 6
+        run: |
+          $selector = '^(TestStartGitProcessTreeSurvivesRepeatedLaunches|TestStartGitProcessTreeKillsUnboundChildOnFailure)$'
+          $selected = @(go test ./internal/reviewtransaction -list $selector | Where-Object { $_ -match '^Test' })
+          if ($LASTEXITCODE -ne 0) { throw 'Could not list native Windows git process tree tests' }
+          if ($selected.Count -ne 2) { throw "Missing native Windows git process tree tests: $($selected -join ', ')" }
+          go test -v ./internal/reviewtransaction -count=1 -run $selector
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+
       - name: Build native test binary
         shell: pwsh
         run: go build -trimpath -ldflags="-s -w -X main.version=ci" -o "$env:RUNNER_TEMP\gentle-ai.exe" ./cmd/gentle-ai

--- a/internal/reviewtransaction/git_process_windows.go
+++ b/internal/reviewtransaction/git_process_windows.go
@@ -5,12 +5,25 @@ package reviewtransaction
 import (
 	"golang.org/x/sys/windows"
 	"os/exec"
+	"runtime"
 	"syscall"
 	"unsafe"
 )
 
 var ntResumeProcess = windows.NewLazySystemDLL("ntdll.dll").NewProc("NtResumeProcess")
 
+// assignGitProcessToJob is the bind step; tests swap it to force a failure
+// after the child exists and prove the suspended child is killed.
+var assignGitProcessToJob = windows.AssignProcessToJobObject
+
+// startGitProcessTree starts the git command suspended, binds it to a job
+// object that kills the whole tree when the job closes, then resumes it.
+//
+// Every Windows git launch funnels through here, so it has to be exact about
+// object lifetimes: the job limit structure stays a named local kept alive
+// across the raw pointer hand-off, handles are closed only when they were
+// opened, and a child that could not be bound is killed instead of being left
+// suspended forever (#4081, #4128, #4152).
 func startGitProcessTree(command *exec.Cmd) (func() error, error) {
 	command.SysProcAttr = &syscall.SysProcAttr{CreationFlags: windows.CREATE_SUSPENDED}
 	if err := command.Start(); err != nil {
@@ -18,17 +31,39 @@ func startGitProcessTree(command *exec.Cmd) (func() error, error) {
 	}
 	job, err := windows.CreateJobObject(nil, nil)
 	if err != nil {
+		_ = command.Process.Kill()
 		return nil, err
 	}
 	release := func() error { _ = windows.TerminateJobObject(job, 1); return windows.CloseHandle(job) }
-	var process windows.Handle
-	if _, err = windows.SetInformationJobObject(job, windows.JobObjectExtendedLimitInformation, uintptr(unsafe.Pointer(&windows.JOBOBJECT_EXTENDED_LIMIT_INFORMATION{BasicLimitInformation: windows.JOBOBJECT_BASIC_LIMIT_INFORMATION{LimitFlags: windows.JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE}})), uint32(unsafe.Sizeof(windows.JOBOBJECT_EXTENDED_LIMIT_INFORMATION{}))); err != nil {
-	} else if process, err = windows.OpenProcess(windows.PROCESS_SET_QUOTA|windows.PROCESS_TERMINATE|windows.PROCESS_SUSPEND_RESUME, false, uint32(command.Process.Pid)); err != nil {
-	} else if err = windows.AssignProcessToJobObject(job, process); err != nil {
-	} else if err = ntResumeProcess.Find(); err != nil {
-	} else if status, _, _ := ntResumeProcess.Call(uintptr(process)); status != 0 {
-		err = windows.NTStatus(status)
+	limits := windows.JOBOBJECT_EXTENDED_LIMIT_INFORMATION{
+		BasicLimitInformation: windows.JOBOBJECT_BASIC_LIMIT_INFORMATION{LimitFlags: windows.JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE},
 	}
-	_ = windows.CloseHandle(process)
-	return release, err
+	_, err = windows.SetInformationJobObject(job, windows.JobObjectExtendedLimitInformation, uintptr(unsafe.Pointer(&limits)), uint32(unsafe.Sizeof(limits)))
+	runtime.KeepAlive(&limits)
+	var process windows.Handle
+	if err == nil {
+		process, err = windows.OpenProcess(windows.PROCESS_SET_QUOTA|windows.PROCESS_TERMINATE|windows.PROCESS_SUSPEND_RESUME, false, uint32(command.Process.Pid))
+	}
+	if err == nil {
+		err = assignGitProcessToJob(job, process)
+	}
+	if err == nil {
+		err = ntResumeProcess.Find()
+	}
+	if err == nil {
+		if status, _, _ := ntResumeProcess.Call(uintptr(process)); status != 0 {
+			err = windows.NTStatus(status)
+		}
+	}
+	if process != 0 {
+		_ = windows.CloseHandle(process)
+	}
+	if err != nil {
+		// The child is still suspended; releasing the job kills it when it was
+		// bound, and the direct kill covers the case where binding failed.
+		_ = release()
+		_ = command.Process.Kill()
+		return nil, err
+	}
+	return release, nil
 }

--- a/internal/reviewtransaction/git_process_windows_test.go
+++ b/internal/reviewtransaction/git_process_windows_test.go
@@ -1,0 +1,74 @@
+//go:build windows
+
+package reviewtransaction
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"os/exec"
+	"testing"
+	"time"
+
+	"golang.org/x/sys/windows"
+)
+
+// TestStartGitProcessTreeSurvivesRepeatedLaunches exercises the real
+// suspended-start / job-object / resume sequence many times in one process.
+// The Windows crashes in #4081, #4128 and #4152 were a Go runtime
+// "unknown caller pc" fault surfacing at roughly one launch in four, so a
+// single successful launch proves nothing; a burst of launches under the
+// garbage collector does.
+func TestStartGitProcessTreeSurvivesRepeatedLaunches(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git is not installed")
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 4*time.Minute)
+	defer cancel()
+	for i := 0; i < 120; i++ {
+		command := exec.CommandContext(ctx, "git", "--version")
+		var output bytes.Buffer
+		command.Stdout = &output
+		release, err := startGitProcessTree(command)
+		if err != nil {
+			t.Fatalf("launch %d: startGitProcessTree: %v", i, err)
+		}
+		if err := command.Wait(); err != nil {
+			t.Fatalf("launch %d: git --version: %v", i, err)
+		}
+		if err := release(); err != nil {
+			t.Fatalf("launch %d: release: %v", i, err)
+		}
+		if !bytes.Contains(output.Bytes(), []byte("git version")) {
+			t.Fatalf("launch %d: unexpected output %q", i, output.String())
+		}
+	}
+}
+
+// A launch whose child exists but cannot be bound to its job must not leave
+// that child suspended forever: the bind error is returned, no release is
+// handed out, and the child has already exited when Wait returns.
+func TestStartGitProcessTreeKillsUnboundChildOnFailure(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git is not installed")
+	}
+	bindErr := errors.New("job binding refused for the test")
+	previous := assignGitProcessToJob
+	assignGitProcessToJob = func(windows.Handle, windows.Handle) error { return bindErr }
+	t.Cleanup(func() { assignGitProcessToJob = previous })
+	command := exec.Command("git", "--version")
+	release, err := startGitProcessTree(command)
+	if !errors.Is(err, bindErr) || release != nil {
+		t.Fatalf("startGitProcessTree = (release %t, %v), want the bind error and no release", release != nil, err)
+	}
+	waited := make(chan error, 1)
+	go func() { waited <- command.Wait() }()
+	select {
+	case err := <-waited:
+		if err == nil {
+			t.Fatal("a killed suspended child must not report success")
+		}
+	case <-time.After(30 * time.Second):
+		t.Fatal("the unbound child was left suspended instead of being killed")
+	}
+}


### PR DESCRIPTION
Closes #4081
Closes #4128
Closes #4152

## Summary
- All three reports carry the same Go runtime fault (`unknown caller pc`, roughly one launch in four, argument-independent); the only Windows-only raw-syscall path every git launch shares is `startGitProcessTree`.
- The job limit structure is a named local kept alive across the `unsafe.Pointer` hand-off, the process handle is closed only when it was opened, and a child that cannot be bound or resumed is killed instead of staying suspended forever.
- Two Windows-only tests: a 120-launch burst under the GC, and a seam-driven test proving an unbound child is killed. Both are hard-required in the `windows-runtime` CI job, so the lane no longer trusts a single green launch.
- Cannot be reproduced on macOS; the CI lane is the proof. If the fault persists on the Windows lane after this lands, the next step is a GOTRACEBACK=crash capture there.

| File | Change |
|------|--------|
| `internal/reviewtransaction/git_process_windows.go` | lifetime, handle, and cleanup hardening; `assignGitProcessToJob` seam |
| `internal/reviewtransaction/git_process_windows_test.go` | burst launch test; unbound-child kill test (native correction R2/R3) |
| `.github/workflows/ci.yml` | windows-runtime requires both tests |

## Test plan
- [x] `GOOS=windows go vet ./internal/reviewtransaction/` and `GOOS=windows go build ./...` clean
- [ ] Windows Runtime CI job on this PR runs both new tests (the proof for this change)
- [x] Native review approved and acknowledged (lineage review-ed60cd7296422f0d, one bounded correction)

https://claude.ai/code/session_01SYqbaaqyJcAv1FYtSJXx6M

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Windows Git process startup reliability during repeated launches.
  * Ensured child processes are terminated cleanly when job binding or startup fails.
  * Prevented failed launches from leaving suspended processes running.

* **Tests**
  * Added Windows coverage for repeated Git launches and startup failure handling.
  * Added automated CI execution for the Windows process-tree tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->