### PR TITLE
fix(review): name the findings surface after collection and preflight the validator budget

### DIFF
--- a/internal/cli/review_capture_validation_budget_preflight_test.go
+++ b/internal/cli/review_capture_validation_budget_preflight_test.go
@@ -1,0 +1,175 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/gentleman-programming/gentle-ai/v2/internal/model"
+	"github.com/gentleman-programming/gentle-ai/v2/internal/reviewerprovider"
+	"github.com/gentleman-programming/gentle-ai/v2/internal/reviewtransaction"
+)
+
+// providerCorrectionReadyOverBudget freezes a one-lens correction whose
+// accepted forecast (the full frozen budget) fits, but whose actual applied
+// fix changes every remaining line -- well past that same budget. It mirrors
+// providerCorrectionReadyWithoutVerificationEvidence's fixture shape, tuned so
+// the returned request's actual correction size exceeds CorrectionBudget.
+func providerCorrectionReadyOverBudget(t *testing.T) (string, string, reviewtransaction.TargetedValidationRequest) {
+	t.Helper()
+	repo := initReviewCLIRepo(t)
+	if err := os.WriteFile(filepath.Join(repo, "tracked.txt"), []byte("base\none\ntwo\nthree\nfour\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	started := runNegotiatedReviewStartWith(t, repo, "provider-targeted-validator-over-budget")
+	legacyStarted := ReviewFacadeStartResult{
+		LineageID: started.LineageID, TargetIdentity: started.RepositoryContext.TargetIdentity,
+		SelectedLenses: started.SelectedLenses,
+	}
+	args := cliReviewerCaptureArgs(t, repo, legacyStarted, 0, []facadeFinding{{
+		Location: "tracked.txt:5", Severity: "CRITICAL", Claim: "terminal value is incorrect",
+		ProofRefs: []string{"tracked.txt:5 changed hunk"}, EvidenceClass: reviewtransaction.EvidenceDeterministic,
+		CausalDisposition: reviewtransaction.CausalIntroduced,
+	}})
+	if err := RunReviewCaptureResult(args, &bytes.Buffer{}); err != nil {
+		t.Fatal(err)
+	}
+	store, err := reviewtransaction.CompactAuthoritativeStore(context.Background(), repo, started.LineageID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	record, err := store.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	plan, err := reviewtransaction.BuildCorrectionPlanRequest(record.State, record.State.CapturePhaseRevision)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Forecast the full frozen budget: accepted because a forecast is never
+	// compared to anything (issue #4080's contributing factor), even though
+	// the actual fix below spends far more than it.
+	if err := RunReviewCaptureCorrectionPlan([]string{
+		"--cwd", repo, "--lineage", started.LineageID, "--target", plan.TargetIdentity,
+		"--expected-revision", record.State.CapturePhaseRevision, "--request-hash", plan.RequestHash,
+		"--correction-lines", strconv.Itoa(record.State.CorrectionBudget),
+	}, &bytes.Buffer{}); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(repo, "tracked.txt"), []byte("base\nONE\nTWO\nTHREE\nFOUR\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	store, err = reviewtransaction.CompactAuthoritativeStore(context.Background(), repo, started.LineageID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	record, err = store.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	request, err := reviewtransaction.BuildTargetedValidationRequest(context.Background(), repo, record.State, record.State.CapturePhaseRevision)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return repo, started.LineageID, request
+}
+
+// TestOverBudgetPassedValidatorRefusesBeforeAdmittingAnyRole is issue #4080:
+// a targeted validator that reports "passed" on a correction whose actual
+// changed lines exceed the frozen budget must be refused before its admission
+// is durably written, leaving zero admitted validator roles behind -- not
+// admitted first and refused on a later, separate write, which used to spend
+// the sixth admitted-role slot on a result the budget then rejected and wedge
+// the lineage on retry.
+func TestOverBudgetPassedValidatorRefusesBeforeAdmittingAnyRole(t *testing.T) {
+	reviewEnabledHome(t)
+	repo, lineage, request := providerCorrectionReadyOverBudget(t)
+	store, err := reviewtransaction.CompactAuthoritativeStore(context.Background(), repo, lineage)
+	if err != nil {
+		t.Fatal(err)
+	}
+	record, err := store.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	beforeAdmitted := len(record.State.AdmittedRoleResults)
+
+	previous := reviewProviderAdapterFor
+	reviewProviderAdapterFor = func(_ reviewerprovider.Contract, agent model.AgentID) (reviewerprovider.Adapter, error) {
+		if agent != model.AgentClaudeCode {
+			return nil, errors.New("unexpected runtime")
+		}
+		return providerTestAdapter{raw: providerTargetedValidationPayload(t, request)}, nil
+	}
+	t.Cleanup(func() { reviewProviderAdapterFor = previous })
+
+	var output bytes.Buffer
+	err = RunReviewCaptureValidation([]string{
+		"--cwd", repo, "--lineage", lineage, "--target", request.CorrectionTargetIdentity,
+		"--expected-revision", record.State.CapturePhaseRevision, "--request-hash", request.RequestHash,
+		"--agent", string(model.AgentClaudeCode), "--execute=true",
+	}, &output)
+	if err == nil {
+		t.Fatalf("over-budget passed validator capture succeeded, want a refused not_started preflight; output=%s", output.String())
+	}
+	if !strings.Contains(err.Error(), "exceeding the frozen budget") {
+		t.Fatalf("over-budget passed validator capture error = %v, want the budget-exceeded refusal", err)
+	}
+
+	afterRecord, err := store.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(afterRecord.State.AdmittedRoleResults) != beforeAdmitted {
+		t.Fatalf("admitted role results after refused over-budget capture = %d, want unchanged %d (zero admitted validator roles)",
+			len(afterRecord.State.AdmittedRoleResults), beforeAdmitted)
+	}
+	if _, found := afterRecord.State.AdmittedRoleResult(reviewtransaction.CompactRoleTargetedValidator,
+		afterRecord.State.CapturePhaseRevision, request.CorrectionTargetIdentity, request.RequestHash); found {
+		t.Fatal("over-budget passed validator was admitted despite the budget refusal")
+	}
+
+	// Shrinking the correction back within budget and retrying succeeds: the
+	// refused attempt above consumed neither the correction attempt nor an
+	// admitted-role slot.
+	if err := os.WriteFile(filepath.Join(repo, "tracked.txt"), []byte("base\none\ntwo\nthree\nfixed\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	store, err = reviewtransaction.CompactAuthoritativeStore(context.Background(), repo, lineage)
+	if err != nil {
+		t.Fatal(err)
+	}
+	record, err = store.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	retryRequest, err := reviewtransaction.BuildTargetedValidationRequest(context.Background(), repo, record.State, record.State.CapturePhaseRevision)
+	if err != nil {
+		t.Fatal(err)
+	}
+	reviewProviderAdapterFor = func(_ reviewerprovider.Contract, agent model.AgentID) (reviewerprovider.Adapter, error) {
+		if agent != model.AgentClaudeCode {
+			return nil, errors.New("unexpected runtime")
+		}
+		return providerTestAdapter{raw: providerTargetedValidationPayload(t, retryRequest)}, nil
+	}
+	var retryOutput bytes.Buffer
+	if err := RunReviewCaptureValidation([]string{
+		"--cwd", repo, "--lineage", lineage, "--target", retryRequest.CorrectionTargetIdentity,
+		"--expected-revision", record.State.CapturePhaseRevision, "--request-hash", retryRequest.RequestHash,
+		"--agent", string(model.AgentClaudeCode), "--execute=true",
+	}, &retryOutput); err != nil {
+		t.Fatalf("in-budget retry after over-budget refusal failed: %v\n%s", err, retryOutput.String())
+	}
+	var terminal reviewLastEventClosureResult
+	decodeStrictReviewJSON(t, retryOutput.Bytes(), &terminal)
+	if terminal.State != reviewtransaction.StateApproved {
+		t.Fatalf("in-budget retry terminal state = %q, want approved", terminal.State)
+	}
+	assertApprovedCompactAuthorityBurned(t, store, lineage)
+}

--- a/internal/cli/review_lens_context.go
+++ b/internal/cli/review_lens_context.go
@@ -104,6 +104,14 @@ const (
 	reviewLensContextConflictAction = "this frozen lens slot already recorded a reviewer context produced by a different mechanism, and audit history is never rewritten; " +
 		"produce this lens context by the same mechanism that already recorded one, or start a review for a fresh candidate by running " +
 		reviewNextTransitionRefreshCommandV21
+	// reviewLensContextCollectionClosedAction is issue #4019's fix: once
+	// collection closes (correction_required, validating, escalated, approved,
+	// ...), no next_transition ever re-offers lens-context tokens again, so the
+	// generic "refresh the transition, then run this operation again" hint is
+	// unfollowable. The admitted findings that closed collection are readable
+	// through review status's own provider-owned surface instead.
+	reviewLensContextCollectionClosedAction = "reviewer lens context is produced only while its capture is still open; a capture already closed to correction, validation, escalation, or approval has no lens-context tokens to refresh -- run " +
+		reviewNextTransitionRefreshCommandV21 + " and read the admitted findings from its next_transition.correction_request.findings instead of retrying lens-context"
 )
 
 // RunReviewLensContext emits the finished reviewer lens context for one
@@ -377,8 +385,13 @@ func resolveReviewLensAuthority(ctx context.Context, deps reviewLensContextDeps,
 		return reviewLensAuthority{}, reviewLensContextRefusal("lens_context_authority_unavailable", reviewLensContextRefreshAction)
 	}
 	state := record.State
-	if state.State != reviewtransaction.StateReviewing || state.InitialSnapshot.Identity != binding.TargetIdentity ||
-		state.CapturePhaseRevision != binding.Revision {
+	if state.InitialSnapshot.Identity != binding.TargetIdentity {
+		return reviewLensAuthority{}, reviewLensContextRefusal("lens_context_binding_stale", reviewLensContextRefreshAction)
+	}
+	if state.State != reviewtransaction.StateReviewing {
+		return reviewLensAuthority{}, reviewLensContextRefusal("lens_context_unavailable_after_collection", reviewLensContextCollectionClosedAction)
+	}
+	if state.CapturePhaseRevision != binding.Revision {
 		return reviewLensAuthority{}, reviewLensContextRefusal("lens_context_binding_stale", reviewLensContextRefreshAction)
 	}
 	order, err := reviewLensContextSelectedOrder(state.SelectedLenses, lens)

--- a/internal/cli/review_lens_context_test.go
+++ b/internal/cli/review_lens_context_test.go
@@ -408,6 +408,70 @@ func TestReviewLensContextRecoveryGuidanceRefreshesThenExecutesNextTransition(t 
 	}
 }
 
+// TestReviewLensContextAfterCollectionClosesNamesTheFindingsSurface is issue
+// #4019: once the last lens capture closes collection to correction_required,
+// the CURRENT repository-context handle is genuinely bound to the live
+// authority, yet no next_transition ever re-offers lens-context tokens for it
+// again -- so the generic "refresh the transition, then run this operation
+// again" hint can never be followed. lens-context must instead name the
+// provider-owned surface that actually carries the admitted findings a
+// correction must target: review status's own
+// next_transition.correction_request.findings (added by issue #4087).
+func TestReviewLensContextAfterCollectionClosesNamesTheFindingsSurface(t *testing.T) {
+	reviewEnabledHome(t)
+	repo := initReviewCLIRepo(t)
+	started := startHighRiskCLIReview(t, repo)
+	for order := 0; order < len(started.SelectedLenses)-1; order++ {
+		captureCleanCLIReviewerResult(t, repo, started, order, &bytes.Buffer{})
+	}
+	captureCLIReviewerResultWithFindings(t, repo, started, len(started.SelectedLenses)-1, []facadeFinding{{
+		ID: "R3-001", Location: "internal/auth/session.go:4", Severity: "CRITICAL",
+		Claim:         "the candidate introduces an observable authentication failure",
+		ProofRefs:     []string{"the changed line deterministically causes the reproduced failure"},
+		EvidenceClass: reviewtransaction.EvidenceDeterministic, CausalDisposition: reviewtransaction.CausalIntroduced,
+	}}, &bytes.Buffer{})
+
+	store, err := reviewtransaction.CompactAuthoritativeStore(context.Background(), repo, started.LineageID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	record, err := store.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if record.State.State != reviewtransaction.StateCorrectionRequired {
+		t.Fatalf("fixture state = %q, want correction_required", record.State.State)
+	}
+
+	// The current bound handle: exactly the tokens a fresh next_transition
+	// would carry for this live authority, not a stale one from before
+	// collection closed.
+	handle, err := reviewtransaction.DeriveReviewRepositoryContextHandle(context.Background(), repo, reviewtransaction.ReviewRepositoryContextBinding{
+		LineageID: started.LineageID, TargetIdentity: started.TargetIdentity, Revision: record.State.CapturePhaseRevision,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var output bytes.Buffer
+	err = RunReview([]string{
+		"lens-context", "--cwd", repo, "--repository-context", handle,
+		"--lineage", started.LineageID, "--target", started.TargetIdentity,
+		"--expected-revision", record.State.CapturePhaseRevision, "--lens", started.SelectedLenses[0],
+	}, &output)
+	if err == nil {
+		t.Fatal("lens-context with the current bound handle after collection closed succeeded, want a followable refusal")
+	}
+	var refusal *reviewLensContextError
+	if !errors.As(err, &refusal) || refusal.Code != "lens_context_unavailable_after_collection" {
+		t.Fatalf("lens-context after collection closed error = %v, want lens_context_unavailable_after_collection", err)
+	}
+	if !strings.Contains(refusal.Action, "next_transition.correction_request.findings") ||
+		!strings.Contains(refusal.Action, reviewNextTransitionRefreshCommandV21) {
+		t.Fatalf("lens-context after collection closed action = %q, want it to name the findings surface", refusal.Action)
+	}
+}
+
 func TestReviewLensContextCleanupClassifiesCleanupFailureIndependentlyOfOperationContext(t *testing.T) {
 	canceled, cancel := context.WithCancel(context.Background())
 	cancel()

--- a/internal/cli/review_provider_roles.go
+++ b/internal/cli/review_provider_roles.go
@@ -597,7 +597,7 @@ func reviewProviderCaptureAdmittedTargetedValidatorResult(ctx context.Context, r
 			return nil, err
 		}
 		if remaining := state.CorrectionBudget - state.CumulativeCorrectionLines; actual < 0 || actual > remaining {
-			return nil, fmt.Errorf("actual correction is %d changed lines, exceeding the frozen budget of %d", actual, state.CorrectionBudget)
+			return nil, fmt.Errorf("actual correction is %d changed lines, exceeding the frozen budget of %d; shrink the correction to at most %d changed lines and rerun `gentle-ai review capture-validation` with the exact tokens STATUS reoffers", actual, state.CorrectionBudget, remaining)
 		}
 	}
 	if outcome == "failed" {

--- a/internal/cli/review_provider_roles.go
+++ b/internal/cli/review_provider_roles.go
@@ -580,7 +580,27 @@ func reviewProviderCaptureAdmittedTargetedValidatorResult(ctx context.Context, r
 	capture := reviewtransaction.CompactAdmittedTargetedValidatorResultRequest{
 		ExpectedRequest: request.ValidationRequest, Payload: payload, Evidence: &evidence, Validation: &native,
 	}
-	if reviewProviderTargetedValidatorOutcome(native) == "failed" {
+	outcome := reviewProviderTargetedValidatorOutcome(native)
+	if outcome == "passed" {
+		// Issue #4080: the correction-budget preflight must run before the
+		// validator admission is durably written. A passed verdict used to be
+		// admitted first, with the budget check only running afterward inside
+		// closeCorrectionOnCapturedValidator's own, later write -- so an
+		// over-budget correction still consumed the sixth admitted-role slot
+		// before being refused, and the prescribed shrink-and-retry then hit the
+		// fixed six-admitted-roles cap and wedged the lineage. Checking here,
+		// before any write, keeps an over-budget correction from ever being
+		// admitted, matching the "failed" branch below which already gates its
+		// own completion atomically with the write.
+		actual, err := (reviewtransaction.SnapshotBuilder{Repo: repo}).ChangedLines(ctx, correction)
+		if err != nil {
+			return nil, err
+		}
+		if remaining := state.CorrectionBudget - state.CumulativeCorrectionLines; actual < 0 || actual > remaining {
+			return nil, fmt.Errorf("actual correction is %d changed lines, exceeding the frozen budget of %d", actual, state.CorrectionBudget)
+		}
+	}
+	if outcome == "failed" {
 		actual, err := (reviewtransaction.SnapshotBuilder{Repo: repo}).ChangedLines(ctx, correction)
 		if err != nil {
 			return nil, err
@@ -600,7 +620,7 @@ func reviewProviderCaptureAdmittedTargetedValidatorResult(ctx context.Context, r
 	if err != nil {
 		return nil, err
 	}
-	if reviewProviderTargetedValidatorOutcome(native) == "passed" {
+	if outcome == "passed" {
 		return closeCorrectionOnCapturedValidator(ctx, repo, store, current, correction, request.ValidationRequest, native)
 	}
 	return newCorrectionCapturedValidatorClosure(repo, current.State, current.Revision, request.ValidationRequest)


### PR DESCRIPTION
Closes #4019
Closes #4080

## Summary
- `review lens-context` after collection closes now refuses with `lens_context_unavailable_after_collection` and names the surface that exists (`review status --next-transition` → `next_transition.correction_request.findings`, from #4087) instead of a stale-binding hint whose remediation is never offered again.
- A passed targeted validator is no longer admitted as the sixth role before the correction budget is checked: the budget preflight runs first, an over-budget correction is refused with nothing persisted, and the refusal names the shrink-and-retry route; a shrunk retry proceeds to approval.

| File | Change |
|------|--------|
| `internal/cli/review_lens_context.go` | state-aware refusal naming the findings surface |
| `internal/cli/review_provider_roles.go` | budget preflight before the admission write; resolution named in the refusal |
| `internal/cli/review_lens_context_test.go`, `review_capture_validation_budget_preflight_test.go` | regression tests (both failed before the change) |

## Test plan
- [x] `go test ./internal/cli/ -run 'LensContext|TargetedValidator|Validation|Correction|LastEventClosure' -count=1 -timeout 30m`
- [x] `go test ./internal/reviewtransaction/ -run 'Correction|Validator|Admit' -count=1`
- [x] Refusal ratchet passes
- [x] Native review approved and acknowledged on both commits (lineages review-d076ecd369a06748, review-6c4a5088d4c11d51)

https://claude.ai/code/session_01SYqbaaqyJcAv1FYtSJXx6M

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented validation results from being accepted when a correction exceeds its remaining line budget.
  - Ensured over-budget validations are refused before role admission or correction-attempt consumption.
  - Improved lens-context errors when collection has closed, directing users to the available correction findings.
  - Added distinct handling for stale bindings and unavailable review states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->