### PR TITLE
fix(install): keep shared GGA config while another installed agent still uses it

### DIFF
--- a/internal/components/uninstall/service.go
+++ b/internal/components/uninstall/service.go
@@ -239,23 +239,7 @@ func (s *Service) PartialUninstall(agentIDs []model.AgentID, componentIDs []mode
 	s.profileSelectionScoped = false
 	s.engramUninstallScope = model.EngramUninstallScopeGlobal
 
-	if len(agentIDs) == 0 {
-		return Result{}, fmt.Errorf("partial uninstall requires at least one agent")
-	}
-
-	components := componentIDs
-	if len(components) == 0 {
-		components = slices.Clone(allManagedComponents)
-	}
-	components = expandVisualPolishUninstallComponents(components)
-
-	plan, err := s.buildPlan(agentIDs, components)
-	if err != nil {
-		return Result{}, err
-	}
-
-	stateRemovals := stateAgentsToRemove(agentIDs, components)
-	return s.executePlan(plan, stateRemovals)
+	return s.partialUninstall(agentIDs, componentIDs)
 }
 
 func (s *Service) PartialUninstallWithProfiles(agentIDs []model.AgentID, componentIDs []model.ComponentID, profileNames []string, engramScope model.EngramUninstallScope) (Result, error) {
@@ -267,9 +251,23 @@ func (s *Service) PartialUninstallWithProfiles(agentIDs []model.AgentID, compone
 		s.engramUninstallScope = model.EngramUninstallScopeGlobal
 	}()
 
+	return s.partialUninstall(agentIDs, componentIDs)
+}
+
+// partialUninstall is the shared body of PartialUninstall and
+// PartialUninstallWithProfiles. It resolves the requested components,
+// downgrades any that are still shared with an agent this run is not
+// removing (see reconcileSharedComponents), and executes the resulting plan.
+func (s *Service) partialUninstall(agentIDs []model.AgentID, componentIDs []model.ComponentID) (Result, error) {
 	if len(agentIDs) == 0 {
 		return Result{}, fmt.Errorf("partial uninstall requires at least one agent")
 	}
+
+	// explicitGGA tracks whether the caller itself named "gga" (as opposed to
+	// it only being present because the component list defaulted to
+	// allManagedComponents). It decides whether an unreadable install state
+	// fails the whole command or is merely downgraded to a kept-GGA note.
+	explicitGGA := slices.Contains(componentIDs, model.ComponentGGA)
 
 	components := componentIDs
 	if len(components) == 0 {
@@ -277,13 +275,115 @@ func (s *Service) PartialUninstallWithProfiles(agentIDs []model.AgentID, compone
 	}
 	components = expandVisualPolishUninstallComponents(components)
 
+	components, sharedNote, err := s.reconcileSharedComponents(agentIDs, components, explicitGGA)
+	if err != nil {
+		return Result{}, err
+	}
+
 	plan, err := s.buildPlan(agentIDs, components)
 	if err != nil {
 		return Result{}, err
 	}
 
 	stateRemovals := stateAgentsToRemove(agentIDs, components)
-	return s.executePlan(plan, stateRemovals)
+	result, err := s.executePlan(plan, stateRemovals)
+	if err != nil {
+		return result, err
+	}
+	if sharedNote != "" {
+		result.ManualActions = append(result.ManualActions, sharedNote)
+	}
+	return result, nil
+}
+
+// reconcileSharedComponents downgrades components that are shared across all
+// installed agents (currently just GGA's global config) when at least one
+// agent outside agentIDs is still installed. Ownership is derived from the
+// persisted install state (state.json's InstalledAgents) rather than probing
+// disk, so it stays correct even when files were hand-edited (#3534).
+//
+// A missing state file is treated as "no other agent is recorded", matching
+// the pre-existing behavior of an install predating state.json. Any other
+// read failure (corrupt JSON, permission error, ...) fails closed toward
+// preservation: GGA is kept and a note explains why, and the rest of the
+// uninstall still proceeds — unless the caller explicitly asked for
+// "--components gga", in which case there is nothing safe left to do for
+// that explicit request and the error is returned instead.
+func (s *Service) reconcileSharedComponents(agentIDs []model.AgentID, componentIDs []model.ComponentID, explicitGGA bool) ([]model.ComponentID, string, error) {
+	if !slices.Contains(componentIDs, model.ComponentGGA) {
+		return componentIDs, "", nil
+	}
+
+	remaining, err := otherInstalledAgents(s.homeDir, agentIDs)
+	if err != nil {
+		if explicitGGA {
+			return nil, "", fmt.Errorf("check remaining installed agents for shared GGA config: %w", err)
+		}
+		note := fmt.Sprintf(
+			"No action needed: kept the shared GGA config (%s) because the install state could not be read (%v), so it is unclear whether another installed agent still depends on it.",
+			gga.ConfigPath(s.homeDir), err,
+		)
+		return withoutComponent(componentIDs, model.ComponentGGA), note, nil
+	}
+	if len(remaining) == 0 {
+		return componentIDs, "", nil
+	}
+
+	note := fmt.Sprintf(
+		"No action needed: kept the shared GGA config (%s) because installed agent(s) still use it: %s. It is removed automatically once those agents are also uninstalled.",
+		gga.ConfigPath(s.homeDir), strings.Join(remaining, ", "),
+	)
+	return withoutComponent(componentIDs, model.ComponentGGA), note, nil
+}
+
+// withoutComponent returns componentIDs with every occurrence of excluded
+// removed, preserving order.
+func withoutComponent(componentIDs []model.ComponentID, excluded model.ComponentID) []model.ComponentID {
+	kept := make([]model.ComponentID, 0, len(componentIDs))
+	for _, componentID := range componentIDs {
+		if componentID != excluded {
+			kept = append(kept, componentID)
+		}
+	}
+	return kept
+}
+
+// isStateNotFound reports whether err indicates the install state file does
+// not exist. It uses errors.Is against fs.ErrNotExist (rather than
+// os.IsNotExist) so a caller that wraps state.Read's error — e.g. via
+// fmt.Errorf's %w — is still classified correctly instead of falling through
+// to the "unreadable state" path.
+func isStateNotFound(err error) bool {
+	return errors.Is(err, fs.ErrNotExist)
+}
+
+// otherInstalledAgents returns the sorted IDs of agents recorded as installed
+// in state.json that are not in agentIDs. It answers "which agents remain
+// installed after this uninstall" for components shared across every
+// installed agent.
+func otherInstalledAgents(homeDir string, agentIDs []model.AgentID) ([]string, error) {
+	current, err := state.Read(homeDir)
+	if err != nil {
+		if isStateNotFound(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+
+	removing := make(map[string]struct{}, len(agentIDs))
+	for _, agentID := range agentIDs {
+		removing[string(agentID)] = struct{}{}
+	}
+
+	remaining := make([]string, 0, len(current.InstalledAgents))
+	for _, installed := range current.InstalledAgents {
+		if _, ok := removing[installed]; ok {
+			continue
+		}
+		remaining = append(remaining, installed)
+	}
+	slices.Sort(remaining)
+	return remaining, nil
 }
 
 func expandVisualPolishUninstallComponents(components []model.ComponentID) []model.ComponentID {

--- a/internal/components/uninstall/service_test.go
+++ b/internal/components/uninstall/service_test.go
@@ -2,6 +2,8 @@ package uninstall
 
 import (
 	"encoding/json"
+	"fmt"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -17,6 +19,7 @@ import (
 	"github.com/gentleman-programming/gentle-ai/v2/internal/backup"
 	"github.com/gentleman-programming/gentle-ai/v2/internal/components/communitytool"
 	"github.com/gentleman-programming/gentle-ai/v2/internal/components/engram"
+	"github.com/gentleman-programming/gentle-ai/v2/internal/components/gga"
 	"github.com/gentleman-programming/gentle-ai/v2/internal/components/sdd"
 	"github.com/gentleman-programming/gentle-ai/v2/internal/model"
 	opencodeactivation "github.com/gentleman-programming/gentle-ai/v2/internal/opencode"
@@ -89,6 +92,226 @@ func TestUninstallOpenCodeClearsBackgroundIntent(t *testing.T) {
 	if got.BackgroundIntent != "" || len(got.InstalledAgents) != 0 {
 		t.Fatalf("state after uninstall = %#v, want no OpenCode intent or installed agent", got)
 	}
+}
+
+// TestPartialUninstallKeepsSharedGGAWhileOtherAgentInstalled covers #3534:
+// uninstalling one agent must not wipe the shared GGA config that another
+// still-installed agent depends on, while agent-scoped assets (here,
+// OpenCode's gentle-logo TUI plugin) are still removed as before.
+func TestPartialUninstallKeepsSharedGGAWhileOtherAgentInstalled(t *testing.T) {
+	homeDir := t.TempDir()
+	if err := state.Write(homeDir, state.InstallState{
+		InstalledAgents: []string{"claude-code", "opencode"},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	configPath := gga.ConfigPath(homeDir)
+	if err := os.MkdirAll(filepath.Dir(configPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(configPath, []byte("shared gga config"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	logoPath := filepath.Join(homeDir, ".config", "opencode", "tui-plugins", "gentle-logo.tsx")
+	if err := os.MkdirAll(filepath.Dir(logoPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(logoPath, []byte("logo"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	svc, err := NewService(homeDir, t.TempDir(), "dev")
+	if err != nil {
+		t.Fatal(err)
+	}
+	svc.snapshotter = stubSnapshotter{}
+
+	result, err := svc.PartialUninstall([]model.AgentID{model.AgentOpenCode}, allManagedComponents)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := os.Stat(configPath); err != nil {
+		t.Fatalf("shared GGA config = %v, want it to survive because claude-code is still installed", err)
+	}
+	if _, err := os.Stat(logoPath); !os.IsNotExist(err) {
+		t.Fatalf("opencode gentle-logo stat error = %v, want removed", err)
+	}
+	if !slices.Contains(result.RemovedFiles, logoPath) {
+		t.Fatalf("removed files = %v, want %q", result.RemovedFiles, logoPath)
+	}
+
+	foundNote := false
+	for _, action := range result.ManualActions {
+		if strings.Contains(action, "GGA") && strings.Contains(action, "claude-code") {
+			foundNote = true
+		}
+	}
+	if !foundNote {
+		t.Fatalf("manual actions = %v, want a note explaining the kept shared GGA config", result.ManualActions)
+	}
+
+	got, err := state.Read(homeDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !slices.Equal(got.InstalledAgents, []string{"claude-code"}) {
+		t.Fatalf("installed agents after uninstall = %v, want [claude-code]", got.InstalledAgents)
+	}
+}
+
+// TestPartialUninstallRemovesSharedGGAOnLastAgent covers the other half of
+// #3534: once the last agent that depends on GGA is uninstalled, the shared
+// config is removed like any other managed component.
+func TestPartialUninstallRemovesSharedGGAOnLastAgent(t *testing.T) {
+	homeDir := t.TempDir()
+	if err := state.Write(homeDir, state.InstallState{
+		InstalledAgents: []string{"opencode"},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	configPath := gga.ConfigPath(homeDir)
+	if err := os.MkdirAll(filepath.Dir(configPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(configPath, []byte("shared gga config"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	svc, err := NewService(homeDir, t.TempDir(), "dev")
+	if err != nil {
+		t.Fatal(err)
+	}
+	svc.snapshotter = stubSnapshotter{}
+
+	result, err := svc.PartialUninstall([]model.AgentID{model.AgentOpenCode}, allManagedComponents)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := os.Stat(configPath); !os.IsNotExist(err) {
+		t.Fatalf("shared GGA config stat error = %v, want removed once no agent needs it", err)
+	}
+	if !slices.Contains(result.RemovedFiles, configPath) {
+		t.Fatalf("removed files = %v, want %q", result.RemovedFiles, configPath)
+	}
+	for _, action := range result.ManualActions {
+		if strings.Contains(action, "GGA") {
+			t.Fatalf("manual actions = %v, want no kept-GGA note on last-agent removal", result.ManualActions)
+		}
+	}
+}
+
+// TestPartialUninstallExplicitGGARequestSkippedWhileSharedWithAnotherAgent
+// covers requesting `--components gga` explicitly for one agent while
+// another installed agent still relies on it: the safer behavior is to skip
+// the shared removal (rather than fail the whole command) and say why,
+// instead of silently deleting a config another agent still needs.
+func TestPartialUninstallExplicitGGARequestSkippedWhileSharedWithAnotherAgent(t *testing.T) {
+	homeDir := t.TempDir()
+	if err := state.Write(homeDir, state.InstallState{
+		InstalledAgents: []string{"claude-code", "opencode"},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	configPath := gga.ConfigPath(homeDir)
+	if err := os.MkdirAll(filepath.Dir(configPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(configPath, []byte("shared gga config"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	svc, err := NewService(homeDir, t.TempDir(), "dev")
+	if err != nil {
+		t.Fatal(err)
+	}
+	svc.snapshotter = stubSnapshotter{}
+
+	result, err := svc.PartialUninstall([]model.AgentID{model.AgentOpenCode}, []model.ComponentID{model.ComponentGGA})
+	if err != nil {
+		t.Fatalf("explicit --components gga while shared should be skipped, not fail: %v", err)
+	}
+
+	if _, err := os.Stat(configPath); err != nil {
+		t.Fatalf("shared GGA config = %v, want it to survive an explicit but unsafe removal request", err)
+	}
+	foundNote := false
+	for _, action := range result.ManualActions {
+		if strings.Contains(action, "GGA") && strings.Contains(action, "claude-code") {
+			foundNote = true
+		}
+	}
+	if !foundNote {
+		t.Fatalf("manual actions = %v, want a note explaining why the explicit gga removal was skipped", result.ManualActions)
+	}
+}
+
+// TestIsStateNotFoundUnwrapsWrappedError guards the classification used by
+// otherInstalledAgents: it must follow the error-wrap chain (via errors.Is)
+// rather than only recognizing a bare *fs.PathError the way os.IsNotExist
+// effectively does for a caller that wraps state.Read's error further.
+func TestIsStateNotFoundUnwrapsWrappedError(t *testing.T) {
+	wrapped := fmt.Errorf("read install state: %w", fs.ErrNotExist)
+	if !isStateNotFound(wrapped) {
+		t.Fatalf("isStateNotFound(%v) = false, want true for a wrapped not-exist error", wrapped)
+	}
+
+	other := fmt.Errorf("read install state: %w", os.ErrPermission)
+	if isStateNotFound(other) {
+		t.Fatalf("isStateNotFound(%v) = true, want false for a non-not-exist error", other)
+	}
+}
+
+// TestReconcileSharedComponentsWithUnreadableState covers a corrupt
+// state.json: reconcileSharedComponents cannot tell whether another agent
+// still needs GGA, so it fails closed toward preservation — GGA is dropped
+// from the returned component set and a note explains why — instead of
+// aborting the caller's partial uninstall, unless the caller explicitly
+// requested "--components gga", where there is nothing safe left to do for
+// that explicit request and the error is returned instead.
+func TestReconcileSharedComponentsWithUnreadableState(t *testing.T) {
+	homeDir := t.TempDir()
+	if err := os.MkdirAll(filepath.Dir(state.Path(homeDir)), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(state.Path(homeDir), []byte("{not valid json"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	svc, err := NewService(homeDir, t.TempDir(), "dev")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Run("default components keep GGA and continue", func(t *testing.T) {
+		components, note, err := svc.reconcileSharedComponents(
+			[]model.AgentID{model.AgentOpenCode}, slices.Clone(allManagedComponents), false)
+		if err != nil {
+			t.Fatalf("reconcileSharedComponents() error = %v, want nil (fail closed, don't abort)", err)
+		}
+		if slices.Contains(components, model.ComponentGGA) {
+			t.Fatalf("components = %v, want GGA dropped when state cannot be read", components)
+		}
+		if !slices.Contains(components, model.ComponentTheme) {
+			t.Fatalf("components = %v, want unrelated components preserved so the rest of the uninstall proceeds", components)
+		}
+		if !strings.Contains(note, "GGA") || !strings.Contains(note, "could not be read") {
+			t.Fatalf("note = %q, want it to explain the state could not be read", note)
+		}
+	})
+
+	t.Run("explicit gga request fails instead of silently skipping", func(t *testing.T) {
+		_, _, err := svc.reconcileSharedComponents(
+			[]model.AgentID{model.AgentOpenCode}, []model.ComponentID{model.ComponentGGA}, true)
+		if err == nil {
+			t.Fatal("reconcileSharedComponents() error = nil, want an error for an explicit --components gga request when state is unreadable")
+		}
+	})
 }
 
 func TestBuildPlanSnapshotsPiManifestAndOwnedOverlay(t *testing.T) {


### PR DESCRIPTION
Closes #3534

## Summary
- `gentle-ai uninstall --agent X` no longer deletes the shared GGA config while another agent is still recorded as installed in state.json; it is removed when the last agent goes. Agent-scoped assets (opencode-gentle-logo) are removed as before.
- Explicit `--components gga` while shared is skipped with a manual-action note rather than failing a scripted `--yes` run.
- State read failures: a wrapped not-exist counts as no other agent; any other failure keeps GGA and continues with a note, unless GGA was requested explicitly (native review follow-up on the first lineage).
- Reproduced live on main with an isolated HOME and confirmed fixed on a binary from this branch.

| File | Change |
|------|--------|
| `internal/components/uninstall/service.go` | shared-component reconciliation from persisted state; unwrapped not-exist classification; scoped state-read failure handling |
| `internal/components/uninstall/service_test.go` | two agents keep GGA, last agent removes it, explicit request skipped, wrapped not-exist, unreadable state |

Note: the issue also mentions opencode-gentle-logo being removed by an unrelated agent's uninstall; that is a separate path (`componentOperations` never checks the agent) and is left for its own fix.

## Test plan
- [x] `go test ./internal/components/uninstall/ -count=1`
- [x] `go test ./internal/cli/ -run Uninstall -count=1`
- [x] Refusal ratchet passes
- [x] Native review approved and acknowledged (lineage review-f4c2db0c102fc65b)

https://claude.ai/code/session_01SYqbaaqyJcAv1FYtSJXx6M

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Partial uninstall now preserves shared GGA configuration when other installed agents still depend on it.
  * GGA configuration is removed when uninstalling the last dependent agent.
  * Explicit GGA uninstall requests are skipped when shared configuration must be retained.
  * Unreadable installation state is handled safely, with manual follow-up guidance provided when needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->