### PR TITLE
fix(install): keep the apply error when rollback also fails and stop forcing sdd onto skills

### DIFF
--- a/e2e/e2e_test.sh
+++ b/e2e/e2e_test.sh
@@ -637,12 +637,15 @@ test_cc_skills_minimal() {
     log_test "Claude Code: skills injection (minimal preset = SDD skills only)"
     cleanup_test_env
 
-    if $BINARY install --agent claude-code --component skills --preset minimal --persona custom 2>&1; then
+    # #3554: skills no longer hard-depends on sdd, so the SDD orchestrator
+    # skills must be requested explicitly via --component skills,sdd. The SDD
+    # component writes all 12 (11 phases + judgment-day) regardless of preset.
+    if $BINARY install --agent claude-code --component skills,sdd --preset minimal --persona custom 2>&1; then
         local skills_dir="$HOME/.claude/skills"
         assert_dir_exists "$skills_dir" "Claude skills directory"
 
-        # Minimal preset = 12 files: 11 SDD phases + judgment-day. _shared is support-only.
-        assert_file_count "$skills_dir" "SKILL.md" 12 "Minimal preset: 12 skill files"
+        # 12 files: 11 SDD phases + judgment-day. _shared is support-only.
+        assert_file_count "$skills_dir" "SKILL.md" 12 "SDD selected: 12 skill files"
 
         # Verify specific SDD skills exist
         assert_file_exists "$skills_dir/sdd-init/SKILL.md" "sdd-init SKILL.md"
@@ -672,8 +675,11 @@ test_cc_skills_full() {
         local skills_dir="$HOME/.claude/skills"
         assert_dir_exists "$skills_dir" "Claude skills directory"
 
-        # Full preset = 25 files: 11 SDD phases + judgment-day + 13 foundation. _shared is support-only.
-        assert_file_count "$skills_dir" "SKILL.md" 25 "Full preset: 25 skill files"
+        # #3554: skills alone no longer pulls sdd. Full preset's skill catalog
+        # is 13 foundation + judgment-day = 14 files; the 11 sdd-* phase
+        # skills come only from the SDD component (not selected here).
+        assert_file_count "$skills_dir" "SKILL.md" 14 "Full preset (skills alone): 14 skill files"
+        assert_file_not_exists "$skills_dir/sdd-init/SKILL.md" "sdd-init NOT installed by skills alone"
 
         # Verify foundation skills exist
         assert_file_exists "$skills_dir/go-testing/SKILL.md" "go-testing SKILL.md"
@@ -701,11 +707,11 @@ test_cc_skills_ecosystem() {
         local skills_dir="$HOME/.claude/skills"
         assert_dir_exists "$skills_dir" "Claude skills directory"
 
-        # ecosystem-only = 25 files: 11 SDD phases + judgment-day + 13 foundation. _shared is support-only.
-        assert_file_count "$skills_dir" "SKILL.md" 25 "Ecosystem preset: 25 skill files"
-
-        # SDD skills present
-        assert_file_exists "$skills_dir/sdd-init/SKILL.md" "SDD skills present"
+        # #3554: skills alone no longer pulls sdd. 13 foundation + judgment-day
+        # = 14 files; the 11 sdd-* phase skills need the SDD component too.
+        assert_file_count "$skills_dir" "SKILL.md" 14 "Ecosystem preset (skills alone): 14 skill files"
+        # SDD skills NOT present (skills has no hard dependency on sdd)
+        assert_file_not_exists "$skills_dir/sdd-init/SKILL.md" "sdd-init NOT installed by skills alone"
         # Foundation skills present
         assert_file_exists "$skills_dir/go-testing/SKILL.md" "Foundation skills present"
         assert_file_exists "$skills_dir/skill-creator/SKILL.md" "skill-creator present"
@@ -734,30 +740,31 @@ test_cc_custom_skills_with_flag() {
         assert_file_exists "$skills_dir/go-testing/SKILL.md" "go-testing SKILL.md"
         assert_file_exists "$skills_dir/branch-pr/SKILL.md" "branch-pr SKILL.md"
 
-        # Note: --component skills auto-resolves sdd (graph dep), which installs 12 SDD/orchestration skills.
-        # Total = 12 SDD/orchestration skills + 2 explicit skills = 14 SKILL.md files.
-        assert_file_count "$skills_dir" "SKILL.md" 14 "Custom + explicit skills: 12 SDD/orchestration + 2 explicit = 14 files"
+        # #3554: skills has no hard dependency on sdd anymore. Total = just
+        # the 2 explicitly requested skills.
+        assert_file_count "$skills_dir" "SKILL.md" 2 "Custom + explicit skills: 2 files, no sdd"
 
-        # SDD skills ARE present (from the sdd dependency)
-        assert_file_exists "$skills_dir/sdd-init/SKILL.md" "sdd-init SKILL.md (from sdd dep)"
+        # SDD skills are NOT present (no auto-dependency)
+        assert_file_not_exists "$skills_dir/sdd-init/SKILL.md" "sdd-init NOT installed (skills has no sdd dependency)"
     else
         log_fail "custom + skills flag install command failed"
     fi
 }
 
 test_cc_custom_no_skills_flag_installs_nothing() {
-    log_test "Claude Code: custom preset + skills component without --skills flag installs only SDD skills (from dep)"
+    log_test "Claude Code: custom preset + skills component without --skills flag installs nothing"
     cleanup_test_env
 
     if $BINARY install --agent claude-code --preset custom --component skills --persona neutral 2>&1; then
         local skills_dir="$HOME/.claude/skills"
-        # --component skills auto-resolves sdd as a hard dependency (graph: skills → sdd → engram).
-        # The SDD component always installs its 12 SDD/orchestration skills.
-        # The skills component itself is a no-op (SkillsForPreset(custom) returns nil, no --skills flag).
-        # Result: exactly 12 SKILL.md files from the SDD dependency. _shared is support-only.
-        assert_dir_exists "$skills_dir" "Skills directory created by sdd dependency"
-        assert_file_count "$skills_dir" "SKILL.md" 12 "12 skill files from the SDD dependency"
-        assert_file_exists "$skills_dir/sdd-init/SKILL.md" "sdd-init installed by sdd dependency"
+        # #3554: skills has no hard dependency on sdd anymore. SkillsForPreset
+        # (custom) returns nil and no --skills flag was given, so the skills
+        # component is a true no-op: no directory, no files at all.
+        if [ -d "$skills_dir" ]; then
+            log_fail "Skills directory should NOT be created: skills alone has nothing to install"
+        else
+            log_pass "No skills directory created (skills alone, no --skills flag, no sdd dependency)"
+        fi
     else
         log_fail "custom + skills component (no flag) install command failed"
     fi
@@ -771,15 +778,19 @@ test_cc_custom_sdd_plus_skills() {
         local skills_dir="$HOME/.claude/skills"
         assert_dir_exists "$skills_dir" "Claude skills directory"
 
-        # SDD component installs its own skills (sdd-init, sdd-explore, etc.)
+        # #3554 regression guard: skills and sdd are independent components
+        # now (no hard dependency either way). When both are explicitly
+        # selected, SDD writes its own 12 skills exactly once (the skills
+        # injector skips sdd-* IDs to avoid a duplicate write) and the skills
+        # component writes only the explicitly requested ones — no clobbering.
         assert_file_exists "$skills_dir/sdd-init/SKILL.md" "sdd-init SKILL.md (from SDD component)"
 
         # Skills component installs only the explicitly requested ones
         assert_file_exists "$skills_dir/go-testing/SKILL.md" "go-testing SKILL.md (from --skills flag)"
         assert_file_exists "$skills_dir/branch-pr/SKILL.md" "branch-pr SKILL.md (from --skills flag)"
 
-        # Total: 12 SDD/orchestration skills + 2 explicit skills = 14.
-        assert_file_count "$skills_dir" "SKILL.md" 14 "SDD + explicit skills: 14 skill files total"
+        # Total: 12 SDD/orchestration skills + 2 explicit skills = 14, written once each.
+        assert_file_count "$skills_dir" "SKILL.md" 14 "SDD + explicit skills: 14 skill files total, no duplicates"
     else
         log_fail "custom + SDD + skills install command failed"
     fi
@@ -920,10 +931,12 @@ test_oc_skills_minimal() {
     log_test "OpenCode: skills injection (minimal)"
     cleanup_test_env
 
-    if $BINARY install --agent opencode --component skills --preset minimal --persona custom 2>&1; then
+    # #3554: skills no longer hard-depends on sdd; request sdd explicitly
+    # to still exercise the full 12-file SDD orchestrator skill set.
+    if $BINARY install --agent opencode --component skills,sdd --preset minimal --persona custom 2>&1; then
         local skill_dir="$HOME/.config/opencode/skills"
         assert_dir_exists "$skill_dir" "OpenCode skill directory"
-        assert_file_count "$skill_dir" "SKILL.md" 12 "Minimal preset: 12 skill files"
+        assert_file_count "$skill_dir" "SKILL.md" 12 "SDD selected: 12 skill files"
         assert_file_exists "$skill_dir/sdd-init/SKILL.md" "sdd-init SKILL.md"
         assert_file_size_min "$skill_dir/sdd-init/SKILL.md" 100 "sdd-init skill has real content"
     else
@@ -935,10 +948,12 @@ test_oc_skills_full() {
     log_test "OpenCode: skills injection (full-gentleman = 13 foundation skills)"
     cleanup_test_env
 
+    # #3554: skills alone no longer pulls sdd. 13 foundation + judgment-day = 14.
     if $BINARY install --agent opencode --component skills --preset full-gentleman --persona neutral 2>&1; then
         local skill_dir="$HOME/.config/opencode/skills"
         assert_dir_exists "$skill_dir" "OpenCode skill directory"
-        assert_file_count "$skill_dir" "SKILL.md" 25 "Full preset: 25 skill files"
+        assert_file_count "$skill_dir" "SKILL.md" 14 "Full preset (skills alone): 14 skill files"
+        assert_file_not_exists "$skill_dir/sdd-init/SKILL.md" "sdd-init NOT installed by skills alone"
         assert_file_exists "$skill_dir/go-testing/SKILL.md" "go-testing skill"
         assert_file_exists "$skill_dir/skill-creator/SKILL.md" "skill-creator skill"
         assert_file_exists "$skill_dir/branch-pr/SKILL.md" "branch-pr skill"

--- a/internal/cli/run_integration_test.go
+++ b/internal/cli/run_integration_test.go
@@ -2047,17 +2047,16 @@ func TestRunInstallCustomPresetExplicitSkillsFlagPopulatesSelection(t *testing.T
 		t.Fatalf("expected branch-pr skill file %q: %v", branchPRPath, err)
 	}
 
-	// Note: the graph defines skills → sdd → engram as a hard dependency chain.
-	// Selecting --component skills auto-resolves sdd (and engram) as dependencies.
-	// The SDD component installs its own 10 SDD+orchestration skills during injection,
-	// regardless of the --skills flag. So sdd-init and other SDD skills ARE installed.
+	// Regression guard for #3554: `skills` no longer has a hard dependency on
+	// `sdd` in the planner graph, so selecting only the skills component must
+	// NOT auto-resolve SDD (or Engram). sdd-init and the rest of the SDD
+	// orchestrator suite are installed only by the SDD component itself.
 	sddInitPath := filepath.Join(home, ".claude", "skills", "sdd-init", "SKILL.md")
-	if _, err := os.Stat(sddInitPath); err != nil {
-		t.Fatalf("sdd-init skill should be installed (sdd is auto-resolved as dep of skills): %v", err)
+	if _, err := os.Stat(sddInitPath); !os.IsNotExist(err) {
+		t.Fatalf("sdd-init skill should NOT be installed (skills has no hard dependency on sdd): err=%v", err)
 	}
 
-	// The --skills flag controls what the skills COMPONENT adds on top of SDD skills.
-	// Total = 10 SDD skills + 2 explicit skills = 12 SKILL.md files.
+	// Total = 2 explicitly requested skills only.
 	skillsDir := filepath.Join(home, ".claude", "skills")
 	entries, err := os.ReadDir(skillsDir)
 	if err != nil {
@@ -2074,9 +2073,8 @@ func TestRunInstallCustomPresetExplicitSkillsFlagPopulatesSelection(t *testing.T
 			skillCount++
 		}
 	}
-	// 12 SDD skills + 2 explicit skills = 14. _shared is support-only.
-	if skillCount != 14 {
-		t.Fatalf("expected 14 skill files (12 SDD + 2 explicit), got %d", skillCount)
+	if skillCount != 2 {
+		t.Fatalf("expected 2 skill files (go-testing + branch-pr only, no SDD), got %d", skillCount)
 	}
 }
 
@@ -2113,12 +2111,10 @@ func TestRunInstallCustomPresetSkillsNoFlagInstallsNothing(t *testing.T) {
 		t.Fatalf("verification ready = false, report = %#v", result.Verify)
 	}
 
-	// The graph defines skills → sdd → engram as hard dependencies.
-	// Selecting --component skills auto-resolves sdd (and engram).
-	// The SDD component ALWAYS installs its 10 SDD+orchestration skills during injection.
-	// Without --skills flag, selectedSkillIDs() returns nil for custom preset,
-	// so the skills COMPONENT is a no-op — but the sdd DEPENDENCY still runs and
-	// installs its 10 skills.
+	// Regression guard for #3554: skills has no hard dependency on sdd, so
+	// selecting only --component skills without --skills (which leaves
+	// selectedSkillIDs() empty for the custom preset) truly installs nothing —
+	// sdd is not auto-resolved and its skills are not written.
 	skillsDir := filepath.Join(home, ".claude", "skills")
 	// Count SKILL.md files (one per skill, excluding _shared and other non-skill dirs).
 	var skillCount int
@@ -2133,9 +2129,50 @@ func TestRunInstallCustomPresetSkillsNoFlagInstallsNothing(t *testing.T) {
 			}
 		}
 	}
-	// Expect 12 files: 11 SDD phases + judgment-day. _shared is support-only.
-	if skillCount != 12 {
-		t.Fatalf("expected 12 SDD skill files installed by the sdd dependency, got %d", skillCount)
+	if skillCount != 0 {
+		t.Fatalf("expected 0 skill files (skills has no hard dependency on sdd), got %d", skillCount)
+	}
+}
+
+// TestRunInstallSkillsAndSDDBothSelectedNoDuplicateSkillFiles guards #3554
+// review finding: skills+sdd together must write every sdd-* skill exactly
+// once plus the requested standalone skill — no duplicates, no clobbering.
+func TestRunInstallSkillsAndSDDBothSelectedNoDuplicateSkillFiles(t *testing.T) {
+	home := t.TempDir()
+	restoreHome, restoreCommand, restoreLookPath := osUserHomeDir, runCommand, cmdLookPath
+	t.Cleanup(func() {
+		osUserHomeDir, runCommand, cmdLookPath = restoreHome, restoreCommand, restoreLookPath
+	})
+	osUserHomeDir = func() (string, error) { return home, nil }
+	runCommand = func(string, ...string) error { return nil }
+	cmdLookPath = func(name string) (string, error) { return "/usr/local/bin/" + name, nil }
+
+	result, err := RunInstall([]string{
+		"--agent", "claude-code", "--preset", "custom",
+		"--component", "skills,sdd", "--skills", "go-testing",
+	}, system.DetectionResult{})
+	if err != nil || !result.Verify.Ready {
+		t.Fatalf("RunInstall() error = %v, verify = %#v", err, result.Verify)
+	}
+
+	skillsDir := filepath.Join(home, ".claude", "skills")
+	entries, err := os.ReadDir(skillsDir)
+	if err != nil {
+		t.Fatalf("ReadDir(%q) error = %v", skillsDir, err)
+	}
+	var skillCount int
+	for _, entry := range entries {
+		if _, statErr := os.Stat(filepath.Join(skillsDir, entry.Name(), "SKILL.md")); statErr == nil {
+			skillCount++
+		}
+	}
+	if skillCount != 13 {
+		t.Fatalf("expected 13 skill files (12 SDD + go-testing, no duplicates), got %d", skillCount)
+	}
+	for _, id := range []string{"sdd-init", "go-testing"} {
+		if _, err := os.Stat(filepath.Join(skillsDir, id, "SKILL.md")); err != nil {
+			t.Fatalf("expected %s skill file: %v", id, err)
+		}
 	}
 }
 

--- a/internal/pipeline/orchestrator.go
+++ b/internal/pipeline/orchestrator.go
@@ -1,5 +1,7 @@
 package pipeline
 
+import "errors"
+
 // OrchestratorOption configures the orchestrator.
 type OrchestratorOption func(*Orchestrator)
 
@@ -56,7 +58,7 @@ func (o *Orchestrator) Execute(plan StagePlan) ExecutionResult {
 	if o.policy.ShouldRollback(StageApply, applyResult.Err) {
 		result.Rollback = ExecuteRollback(applyResult.Steps, o.stepByID)
 		if !result.Rollback.Success {
-			result.Err = result.Rollback.Err
+			result.Err = errors.Join(result.Err, result.Rollback.Err)
 		}
 	}
 

--- a/internal/pipeline/orchestrator_test.go
+++ b/internal/pipeline/orchestrator_test.go
@@ -291,6 +291,39 @@ func TestExecuteRollbackAttemptsEveryStepAfterFailures(t *testing.T) {
 	}
 }
 
+// TestOrchestratorJoinsApplyAndRollbackErrors verifies that when apply fails
+// and the subsequent rollback also fails, Execute reports both errors instead
+// of letting the rollback error overwrite the original apply error.
+func TestOrchestratorJoinsApplyAndRollbackErrors(t *testing.T) {
+	order := []string{}
+	applyErr := errors.New("apply boom")
+	rollbackErr := errors.New("restore failed")
+	orchestrator := NewOrchestrator(DefaultRollbackPolicy())
+
+	result := orchestrator.Execute(StagePlan{
+		Apply: []Step{
+			&testStep{id: "apply-1", order: &order, rollErr: rollbackErr},
+			&testStep{id: "apply-2", order: &order, runErr: applyErr},
+		},
+	})
+
+	if result.Err == nil {
+		t.Fatalf("Execute() expected an error")
+	}
+	if !errors.Is(result.Err, applyErr) {
+		t.Fatalf("Execute() err = %v, want it to wrap apply error %v", result.Err, applyErr)
+	}
+	if !errors.Is(result.Err, rollbackErr) {
+		t.Fatalf("Execute() err = %v, want it to wrap rollback error %v", result.Err, rollbackErr)
+	}
+	if result.Rollback.Success {
+		t.Fatalf("Rollback.Success = true, want false")
+	}
+	if result.Rollback.Err == nil || !errors.Is(result.Rollback.Err, rollbackErr) {
+		t.Fatalf("Rollback.Err = %v, want it to wrap %v", result.Rollback.Err, rollbackErr)
+	}
+}
+
 func TestOrchestratorWithProgressFunc(t *testing.T) {
 	order := []string{}
 	events := []ProgressEvent{}

--- a/internal/planner/graph.go
+++ b/internal/planner/graph.go
@@ -35,9 +35,13 @@ func (g Graph) DependenciesOf(component model.ComponentID) []model.ComponentID {
 
 func MVPGraph() Graph {
 	return NewGraph(map[model.ComponentID][]model.ComponentID{
-		model.ComponentEngram:             nil,
-		model.ComponentSDD:                {model.ComponentEngram},
-		model.ComponentSkills:             {model.ComponentSDD},
+		model.ComponentEngram: nil,
+		model.ComponentSDD:    {model.ComponentEngram},
+		// Skills has no hard dependency on SDD: standalone skill files (e.g.
+		// go-testing, judgment-day) install fine without it. The SDD-authored
+		// skills (sdd-*) are written by the SDD component itself — see
+		// internal/components/skills.IsSDDSkill and internal/components/sdd.
+		model.ComponentSkills:             nil,
 		model.ComponentContext7:           nil,
 		model.ComponentPersona:            nil,
 		model.ComponentPermission:         nil,

--- a/internal/planner/resolver_test.go
+++ b/internal/planner/resolver_test.go
@@ -7,7 +7,15 @@ import (
 	"github.com/gentleman-programming/gentle-ai/v2/internal/model"
 )
 
-func TestResolverAddsMissingDependenciesInOrder(t *testing.T) {
+// TestResolverSkillsAloneResolvesWithoutSDDOrEngram guards #3554: selecting
+// only the Skills component must not force-install SDD (and transitively
+// Engram). Standalone skill files have no hard dependency on SDD; the
+// SDD-authored skills are installed by the SDD component itself.
+//
+// This test replaces the old TestResolverAddsMissingDependenciesInOrder,
+// which encoded the previous (buggy) expansion of Skills into
+// [Engram, SDD, Skills].
+func TestResolverSkillsAloneResolvesWithoutSDDOrEngram(t *testing.T) {
 	resolver := NewResolver(MVPGraph())
 
 	selection := model.Selection{
@@ -24,12 +32,55 @@ func TestResolverAddsMissingDependenciesInOrder(t *testing.T) {
 		t.Fatalf("Resolve() agents = %v", plan.Agents)
 	}
 
-	if !reflect.DeepEqual(plan.OrderedComponents, []model.ComponentID{model.ComponentEngram, model.ComponentSDD, model.ComponentSkills}) {
-		t.Fatalf("Resolve() ordered components = %v", plan.OrderedComponents)
+	if !reflect.DeepEqual(plan.OrderedComponents, []model.ComponentID{model.ComponentSkills}) {
+		t.Fatalf("Resolve() ordered components = %v, want [skills] only", plan.OrderedComponents)
 	}
 
-	if !reflect.DeepEqual(plan.AddedDependencies, []model.ComponentID{model.ComponentEngram, model.ComponentSDD}) {
-		t.Fatalf("Resolve() added dependencies = %v", plan.AddedDependencies)
+	if len(plan.AddedDependencies) != 0 {
+		t.Fatalf("Resolve() added dependencies = %v, want none", plan.AddedDependencies)
+	}
+}
+
+// TestResolverSDDAloneStillPullsEngram guards that removing Skills' hard
+// dependency on SDD did not weaken SDD's own dependency on Engram.
+func TestResolverSDDAloneStillPullsEngram(t *testing.T) {
+	resolver := NewResolver(MVPGraph())
+
+	selection := model.Selection{
+		Components: []model.ComponentID{model.ComponentSDD},
+	}
+
+	plan, err := resolver.Resolve(selection)
+	if err != nil {
+		t.Fatalf("Resolve() returned error: %v", err)
+	}
+
+	if !reflect.DeepEqual(plan.OrderedComponents, []model.ComponentID{model.ComponentEngram, model.ComponentSDD}) {
+		t.Fatalf("Resolve() ordered components = %v, want [engram, sdd]", plan.OrderedComponents)
+	}
+
+	if !reflect.DeepEqual(plan.AddedDependencies, []model.ComponentID{model.ComponentEngram}) {
+		t.Fatalf("Resolve() added dependencies = %v, want [engram]", plan.AddedDependencies)
+	}
+}
+
+// TestResolverSkillsAndSDDBothSelectedDeterministicOrderNoDuplicates guards a
+// #3554 review finding: dropping Skills' hard dependency on SDD must not
+// regress selecting both together — order stays deterministic, once each.
+func TestResolverSkillsAndSDDBothSelectedDeterministicOrderNoDuplicates(t *testing.T) {
+	resolver := NewResolver(MVPGraph())
+	selection := model.Selection{
+		Components: []model.ComponentID{model.ComponentSkills, model.ComponentSDD},
+	}
+
+	plan, err := resolver.Resolve(selection)
+	if err != nil {
+		t.Fatalf("Resolve() returned error: %v", err)
+	}
+
+	want := []model.ComponentID{model.ComponentEngram, model.ComponentSDD, model.ComponentSkills}
+	if !reflect.DeepEqual(plan.OrderedComponents, want) {
+		t.Fatalf("Resolve() ordered components = %v, want %v (sdd before skills, no duplicates)", plan.OrderedComponents, want)
 	}
 }
 


### PR DESCRIPTION
Closes #3995
Closes #3554

## Summary
- `pipeline.Orchestrator.Execute` joins the apply and rollback errors instead of overwriting the apply error, matching the `errors.Join` already used in run/sync.
- `install --components skills` no longer auto-adds `sdd` (and `engram`): the hard planner edge is gone; SDD-authored skills stay owned by the SDD component and the skills injector already skips them. Selecting both resolves to `[engram, sdd, skills]` deterministically with no duplicate files (native review correction R3 added that coverage).
- Two integration goldens that had encoded the forced expansion were updated deliberately.

| File | Change |
|------|--------|
| `internal/pipeline/orchestrator.go` | join apply + rollback errors |
| `internal/planner/graph.go` | skills has no hard dependency on sdd |
| `internal/pipeline/orchestrator_test.go`, `internal/planner/resolver_test.go`, `internal/cli/run_integration_test.go` | both errors survive; skills alone; sdd alone; both selected; no duplicate skill files |

## Test plan
- [x] `go test ./internal/pipeline/ ./internal/planner/ -count=1`
- [x] `go test ./internal/cli/ -run 'Install|Plan|Components' -count=1 -timeout 30m`
- [x] `go test ./internal/components/... -count=1` (one pre-existing sandbox signal failure in engram, reproduces on main)
- [x] Native review approved and acknowledged (lineage review-45ddc57db02aa9e2, one bounded correction)

https://claude.ai/code/session_01SYqbaaqyJcAv1FYtSJXx6M

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Skills can now be installed independently without automatically installing SDD or Engram.
  - Selecting Skills and SDD together remains supported without duplicate skill files.
  - SDD installations continue to include Engram when required.

- **Bug Fixes**
  - Installation errors now preserve both the original apply failure and any rollback failure, improving troubleshooting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->