### PR TITLE
fix(sdd): keep rules.apply and rules.verify across model tiers and name the evidence_revision format

### DIFF
--- a/internal/assets/sdd_phase_rules_tier_parity_test.go
+++ b/internal/assets/sdd_phase_rules_tier_parity_test.go
@@ -1,0 +1,117 @@
+package assets
+
+import (
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// rulesConfigTokenPattern matches a phase-scoped openspec/config.yaml rules
+// reference such as `rules.apply` or `rules.verify`.
+var rulesConfigTokenPattern = regexp.MustCompile(`rules\.[a-zA-Z0-9_]+`)
+
+// sddPhaseSkillIDs enumerates every sdd-<phase> skill directory under
+// internal/assets/skills. Kept as a literal list (rather than a directory
+// walk) so a newly added phase must be added here deliberately.
+var sddPhaseSkillIDs = []string{
+	"sdd-apply",
+	"sdd-archive",
+	"sdd-design",
+	"sdd-explore",
+	"sdd-init",
+	"sdd-onboard",
+	"sdd-propose",
+	"sdd-research",
+	"sdd-spec",
+	"sdd-tasks",
+	"sdd-verify",
+}
+
+// extractModelSectionForTest mirrors
+// internal/components/filemerge.ExtractHTMLCommentSection's marker semantics
+// without importing that package from assets' test suite. When a matching
+// section marker pair is absent, the whole content is returned unchanged —
+// which is how a single-tier skill (no model-capable/model-small split)
+// naturally short-circuits the drift check below.
+func extractModelSectionForTest(content, tier string) string {
+	openMarker := "<!-- section:model-" + tier + " -->"
+	closeMarker := "<!-- /section:model-" + tier + " -->"
+	start := strings.Index(content, openMarker)
+	end := strings.Index(content, closeMarker)
+	if start == -1 || end == -1 || end <= start {
+		return content
+	}
+	return content[start+len(openMarker) : end]
+}
+
+// #4114/#4118: sdd-apply and sdd-verify render two model tiers
+// (model-capable and model-small) from one SKILL.md. Whenever any tier
+// mentions reading a `rules.<phase>` key from openspec/config.yaml, every
+// other rendered tier of that same skill must carry the same instruction —
+// otherwise a smaller model silently skips the project's configured phase
+// rules while the capable tier still applies them.
+func TestSDDPhaseSkillsKeepRulesConfigInstructionAcrossModelTiers(t *testing.T) {
+	for _, phase := range sddPhaseSkillIDs {
+		t.Run(phase, func(t *testing.T) {
+			path := "skills/" + phase + "/SKILL.md"
+			content := MustRead(path)
+
+			tokens := rulesConfigTokenPattern.FindAllString(content, -1)
+			if len(tokens) == 0 {
+				t.Skipf("%s does not reference an openspec/config.yaml rules key", path)
+			}
+
+			capable := extractModelSectionForTest(content, "capable")
+			small := extractModelSectionForTest(content, "small")
+			if capable == content && small == content {
+				// No model-capable/model-small marker pair found: this skill
+				// renders a single tier, so there is nothing to drift.
+				return
+			}
+
+			seen := map[string]bool{}
+			for _, token := range tokens {
+				if seen[token] {
+					continue
+				}
+				seen[token] = true
+
+				if !strings.Contains(capable, token) {
+					t.Errorf("%s: model-capable section is missing %q", path, token)
+				}
+				if !strings.Contains(small, token) {
+					t.Errorf("%s: model-small section is missing %q", path, token)
+				}
+			}
+		})
+	}
+}
+
+// #4114: docs/openspec-config.md documents that sdd-verify reads
+// `rules.verify` from openspec/config.yaml, the same way sdd-apply already
+// reads `rules.apply` — but the sdd-verify skill never actually said so.
+func TestSDDApplyAndVerifyReadPhaseScopedConfigRules(t *testing.T) {
+	cases := map[string]string{
+		"sdd-apply":  "rules.apply",
+		"sdd-verify": "rules.verify",
+	}
+	for phase, token := range cases {
+		t.Run(phase, func(t *testing.T) {
+			path := "skills/" + phase + "/SKILL.md"
+			if content := MustRead(path); !strings.Contains(content, token) {
+				t.Fatalf("%s must mention %q (see docs/openspec-config.md phase table)", path, token)
+			}
+		})
+	}
+}
+
+// #4114: strict-tdd-verify.md carries its own "Rules (Strict TDD Verify
+// specific)" list and is loaded instead of relying solely on the base
+// SKILL.md Hard Rules once Strict TDD is active, so it must repeat the
+// rules.verify instruction rather than let it apply only outside TDD mode.
+func TestStrictTDDVerifyModuleRepeatsRulesConfigInstruction(t *testing.T) {
+	path := "skills/sdd-verify/strict-tdd-verify.md"
+	if content := MustRead(path); !strings.Contains(content, "rules.verify") {
+		t.Fatalf("%s must mention \"rules.verify\" since it carries its own Rules list", path)
+	}
+}

--- a/internal/assets/skills/sdd-apply/SKILL.md
+++ b/internal/assets/skills/sdd-apply/SKILL.md
@@ -312,6 +312,7 @@ You are an IMPLEMENTER sub-agent. You receive specific tasks and implement them 
 - Never minify the diff (strip comments, blank lines, docs, or tests) to fit the review budget; implement the cohesive slice honestly and report the final count with a `size:exception` recommendation when it stays over
 - If previous apply-progress exists, read it via mem_search + mem_get_observation and MERGE before saving
 - Focused remediation is the sole `all_done` exception and must bind evidence to the exact failed_evidence_revision from native status
+- Apply any `rules.apply` from `openspec/config.yaml`
 
 ## Steps
 

--- a/internal/assets/skills/sdd-verify/SKILL.md
+++ b/internal/assets/skills/sdd-verify/SKILL.md
@@ -45,6 +45,7 @@ The orchestrator should provide structured status from `skills/_shared/sdd-statu
 - Persist `verify-report` according to mode: Engram, openspec file, hybrid both, or inline-only for `none`.
 - For the final OpenSpec `verify` work unit, persist the canonical passing `openspec/changes/{change}/verify-report.md` before settlement. Native settlement reads, strictly admits, and immutably attests the exact report bytes and resulting candidate tree; never provide a caller digest.
 - If Strict TDD is active, load `strict-tdd-verify.md` from this skill directory; if inactive, never load it.
+- Apply any `rules.verify` from `openspec/config.yaml`
 - Return the Section D envelope from `../_shared/sdd-phase-common.md`.
 - Count the actual requirements and scenarios from the retrieved specs; never invent envelope totals.
 - Native status counts only `### Requirement:` / `### REQ-<n>:` and `#### Scenario:` headings. If the envelope totals differ from that count, status keeps `verify: ready` and names the mismatch in `blockedReasons`; fix the totals and re-verify instead of re-validating the same envelope.
@@ -149,6 +150,7 @@ You are a VERIFY sub-agent. Your job: check implemented changes match spec accep
 - Return ordinary verification evidence with the result. Terminal reviewer closure remains capture-owned and informational.
 - Build the complete report as exact candidate bytes, then run `gentle-ai sdd-verify-validate` with authoritative spec counts before any OpenSpec or Engram write. If the validator is unavailable or denies admission, make zero writes and leave the prior report untouched; otherwise persist the same bytes, including a valid `fail`.
 - For the final OpenSpec `verify` work unit, persist the canonical passing `openspec/changes/{change}/verify-report.md` before settlement. Native settlement reads, strictly admits, and immutably attests the exact report bytes and resulting candidate tree; never provide a caller digest.
+- Apply any `rules.verify` from `openspec/config.yaml`
 - Return minimal report
 
 ## Return Minimal Report

--- a/internal/assets/skills/sdd-verify/strict-tdd-verify.md
+++ b/internal/assets/skills/sdd-verify/strict-tdd-verify.md
@@ -267,3 +267,4 @@ If zero issues found, report: "**Assertion quality**: ✅ All assertions verify 
 - Test layer distribution is informational — SUGGESTION level only
 - DO NOT fix issues — only report. The orchestrator decides.
 - If coverage/quality tools are not available, say so cleanly and move on — never flag missing tools as failures
+- Apply any `rules.verify` from `openspec/config.yaml`

--- a/internal/cli/sdd_verify_validate.go
+++ b/internal/cli/sdd_verify_validate.go
@@ -148,6 +148,7 @@ func renderSDDVerifyValidateHelp(stdout io.Writer) error {
 	_, _ = fmt.Fprintln(stdout, "\nReport contract:")
 	_, _ = fmt.Fprintf(stdout, "  schema: %s\n", contract.Schema)
 	_, _ = fmt.Fprintf(stdout, "  required envelope fields: %s\n", strings.Join(contract.RequiredFields, ", "))
+	_, _ = fmt.Fprintln(stdout, "  evidence_revision, test_output_hash, and build_output_hash must each be sha256:<64 lowercase hex>.")
 	_, _ = fmt.Fprintf(stdout, "  accepted verdicts: %s\n", strings.Join(contract.Verdicts, ", "))
 	_, _ = fmt.Fprintf(stdout, "  maximum report size: %d bytes (%s)\n", contract.MaxBytes, formatSDDVerifyValidateByteLimit(contract.MaxBytes))
 	_, _ = fmt.Fprintln(stdout, "  the first non-empty line must be ```yaml (```yml and any letter case are admitted) and the envelope closes with ```.")

--- a/internal/cli/sdd_verify_validate_test.go
+++ b/internal/cli/sdd_verify_validate_test.go
@@ -83,6 +83,32 @@ func TestRunSDDVerifyValidateHelpNamesTheFenceContract(t *testing.T) {
 	}
 }
 
+// #4089: --help listed evidence_revision as required but never documented
+// its accepted format, so a caller had no way to construct a valid value
+// without reading the Go source.
+func TestRunSDDVerifyValidateHelpNamesTheEvidenceRevisionFormat(t *testing.T) {
+	var output bytes.Buffer
+	if err := runSDDVerifyValidate([]string{"-h"}, strings.NewReader("must not be read"), &output); err != nil {
+		t.Fatalf("runSDDVerifyValidate(-h): %v", err)
+	}
+	for _, want := range []string{"evidence_revision", "test_output_hash", "build_output_hash", "sha256:<64 lowercase hex>"} {
+		if !strings.Contains(output.String(), want) {
+			t.Fatalf("help omits the evidence_revision format %q:\n%s", want, output.String())
+		}
+	}
+}
+
+// #4089: an invalid evidence_revision was refused with an opaque "invalid
+// evidence_revision" message that named no resolution.
+func TestRunSDDVerifyValidateRefusalNamesEvidenceRevisionFormat(t *testing.T) {
+	report := "```yaml\nschema: gentle-ai.verify-result/v1\nevidence_revision: sha256:nope\nverdict: fail\nblockers: 1\ncritical_findings: 0\nrequirements: 1/1\nscenarios: 1/1\ntest_command: go test ./...\ntest_exit_code: 0\ntest_output_hash: sha256:" + strings.Repeat("b", 64) + "\nbuild_command: go vet ./...\nbuild_exit_code: 0\nbuild_output_hash: sha256:" + strings.Repeat("c", 64) + "\n```"
+	err := runSDDVerifyValidate([]string{"--input", "-", "--requirements", "1", "--scenarios", "1"}, strings.NewReader(report), &bytes.Buffer{})
+	const want = "evidence_revision must be sha256:<64 lowercase hex>"
+	if err == nil || !strings.Contains(err.Error(), want) {
+		t.Fatalf("error = %v, want containing %q", err, want)
+	}
+}
+
 func TestRunSDDVerifyValidateHelpExcludesMissingReviewSkipProtocol(t *testing.T) {
 	var output bytes.Buffer
 	if err := runSDDVerifyValidate([]string{"-h"}, strings.NewReader("must not be read"), &output); err != nil {

--- a/internal/sddstatus/verification.go
+++ b/internal/sddstatus/verification.go
@@ -220,7 +220,7 @@ func parseVerifyReport(text string) (verifyReport, string) {
 	}
 	for _, field := range []string{"evidence_revision", "test_output_hash", "build_output_hash"} {
 		if !sha256IdentityPattern.MatchString(fields[field]) {
-			return report, fmt.Sprintf("invalid %s in verify result envelope", field)
+			return report, fmt.Sprintf("%s must be sha256:<64 lowercase hex> in verify result envelope", field)
 		}
 	}
 	if !isConcreteEvidence(fields["test_command"]) || !isConcreteEvidence(fields["build_command"]) {

--- a/internal/sddstatus/verification_test.go
+++ b/internal/sddstatus/verification_test.go
@@ -76,7 +76,9 @@ func TestValidateVerifyReportAdmission(t *testing.T) {
 		{"unknown", strings.Replace(valid, "verdict: pass", "verdict: pass\nextra: value", 1), "unknown", false},
 		{"malformed", strings.Replace(valid, "blockers: 0", "blockers", 1), "malformed", false},
 		{"missing", strings.Replace(valid, "build_command: go test ./cmd/gentle-ai\n", "", 1), "missing build_command", false},
-		{"invalid hash", strings.Replace(valid, "sha256:"+strings.Repeat("b", 64), "sha256:nope", 1), "invalid test_output_hash", false},
+		// #4089: the refusal must name the expected shape, not just the field.
+		{"invalid hash", strings.Replace(valid, "sha256:"+strings.Repeat("b", 64), "sha256:nope", 1), "test_output_hash must be sha256:<64 lowercase hex>", false},
+		{"invalid evidence_revision", strings.Replace(valid, "sha256:"+strings.Repeat("a", 64), "sha256:nope", 1), "evidence_revision must be sha256:<64 lowercase hex>", false},
 		{"placeholder command", strings.Replace(valid, "test_command: go test ./internal/example", "test_command: placeholder", 1), "concrete", false},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
Closes #4114
Closes #4118
Closes #4089

## Summary
- sdd-apply model-small now carries `rules.apply`; sdd-verify (both tiers) and strict-tdd-verify carry `rules.verify`; a ratchet test asserts every rendered tier of an sdd-<phase> skill keeps its `rules.<phase>` instruction so tiers cannot drift again.
- `sdd-verify-validate --help` documents that `evidence_revision`, `test_output_hash` and `build_output_hash` must be `sha256:<64 lowercase hex>`, and the refusal names the format instead of "invalid evidence_revision".

| File | Change |
|------|--------|
| `internal/assets/skills/sdd-apply/SKILL.md`, `sdd-verify/SKILL.md`, `sdd-verify/strict-tdd-verify.md` | rules instructions |
| `internal/assets/sdd_phase_rules_tier_parity_test.go` | tier parity ratchet + direct checks |
| `internal/sddstatus/verification.go`, `internal/cli/sdd_verify_validate.go` + tests | format in help and refusal |

## Test plan
- [x] `go test ./internal/assets/ -count=1` (no golden changes)
- [x] `go test ./internal/sddstatus/... -count=1`
- [x] `go test ./internal/cli/ -run 'SddVerify|Golden|Skill|Help|Refusal' -count=1`; refusal ratchet passes
- [x] Native review approved and acknowledged (lineage review-8a89b293b3a3fb04)

https://claude.ai/code/session_01SYqbaaqyJcAv1FYtSJXx6M

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - SDD apply and verify workflows now consistently honor phase-specific rules configured in `openspec/config.yaml`.
  - Verification guidance now documents the required format for evidence and output hashes.

- **Bug Fixes**
  - Verification errors now clearly identify hashes that do not use the required `sha256:` prefix and 64 lowercase hexadecimal characters.
  - Invalid evidence revisions receive actionable format-specific feedback.

- **Tests**
  - Added regression coverage to ensure phase rules and hash validation remain consistent across supported workflow variants.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->