### PR TITLE
fix(review): launch Windows batch shims with a rebuilt command line and correct a target-identity echo

### DIFF
--- a/.deadcode-baseline.txt
+++ b/.deadcode-baseline.txt
@@ -77,6 +77,9 @@ internal/installcmd/testhelper.go	OverrideGetenv
 internal/installcmd/testhelper.go	OverrideGoVersion
 internal/installcmd/testhelper.go	OverrideLookPath
 internal/reviewerprovider/runtimes.go	RegisteredRuntimeIdentities
+internal/reviewerprovider/windows_batch_cmdline.go	isWindowsBatchFile
+internal/reviewerprovider/windows_batch_cmdline.go	quoteWindowsArgument
+internal/reviewerprovider/windows_batch_cmdline.go	windowsBatchCommandLine
 internal/reviewtransaction/authority_repair.go	AssessAuthorityRepair
 internal/reviewtransaction/candidate_decline.go	CandidateDeclineAuthorization.validate
 internal/reviewtransaction/candidate_decline.go	candidateDeclineDigest

--- a/internal/cli/review_lens_context.go
+++ b/internal/cli/review_lens_context.go
@@ -524,13 +524,13 @@ Scope. The %s sections below are the complete and only view of this candidate: a
 
 Causality. Report only what this candidate caused. Give every BLOCKER or CRITICAL finding an evidence_class and a causal_disposition, and mark what the base already contained as pre-existing or base-only rather than as a blocker.
 
-Return. Emit exactly one JSON object and nothing else: no prose before or after it, no markdown fence, no task envelope. It must validate against the schema in %s. Set subject_hash to exactly %s. Set inspection.status to "completed" and inspection.paths to the complete unique unordered set of every manifest path. Each finding location is one path:line or path:start-end inclusive span. findings and evidence must both be present, and evidence must be non-empty.
+Return. Emit exactly one JSON object and nothing else: no prose before or after it, no markdown fence, no task envelope. It must validate against the schema in %s. Set subject_hash to exactly %s -- this is the %s section's own subject_hash field above, and only that field; never echo a target or target_identity value carried elsewhere in this context, even though it is also a sha256: string. Set inspection.status to "completed" and inspection.paths to the complete unique unordered set of every manifest path. Each finding location is one path:line or path:start-end inclusive span. findings and evidence must both be present, and evidence must be non-empty.
 
 Citations. Every finding location, and every path cited inside an evidence string or a proof_refs entry, must be a repository-relative path exactly as it appears in the changed-path manifest, optionally with :line or :start-end. Never cite absolute paths, bare file basenames without their directory, or non-path colon-number shapes such as host:port. Any token shaped like path:line is validated against the frozen repository, and one unknown path rejects the entire result. A finding whose causal_disposition is introduced, behavior-activated, or worsened must anchor its location entirely within lines this candidate changed: every line of a path:start-end span is validated as candidate-changed, one unchanged context line in the span rejects the entire result, and observations about unchanged code belong under pre-existing or base-only instead. When the candidate's own content contains a path-shaped literal that is not a real repository path (for example a traversal or fixture token inside a test), never reproduce that token in evidence or proof_refs: describe it in words and cite the manifest file and line that contain it.
 
 Honesty. If you could not inspect the candidate, say so in evidence and do not return a clean result: an access failure is not a completed inspection, and reporting one as clean is the single outcome this review cannot recover from.`,
 		title, focus, reviewLensContextPatch, paths, reviewLensContextContextHeader,
-		reviewLensContextResultSchema, binding.SubjectHash), nil
+		reviewLensContextResultSchema, binding.SubjectHash, reviewLensContextBindingHeader), nil
 }
 
 // reviewLensContextWriteLine writes one header plus its canonical one-line

--- a/internal/cli/review_provider_correction.go
+++ b/internal/cli/review_provider_correction.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
 
 	"github.com/gentleman-programming/gentle-ai/v2/internal/model"
@@ -37,7 +38,53 @@ type reviewProviderCapture struct {
 }
 
 func (capture reviewProviderCapture) admit(ctx context.Context, raw []byte) (reviewProviderAdmittedResult, error) {
-	return reviewProviderAdmitRaw(ctx, capture.root, capture.state, capture.state.CapturePhaseRevision, capture.frozen, capture.subject, raw)
+	corrected := reviewProviderCorrectSubjectHashEcho(raw, capture.state.InitialSnapshot.Identity, capture.subject.SubjectHash)
+	return reviewProviderAdmitRaw(ctx, capture.root, capture.state, capture.state.CapturePhaseRevision, capture.frozen, capture.subject, corrected)
+}
+
+// reviewProviderCorrectSubjectHashEcho rewrites a raw in-process reviewer
+// payload's subject_hash field in place when -- and only when -- it exactly
+// echoes this transaction's target_identity instead of the lens binding's own
+// subject_hash (issue #4027).
+//
+// This narrow substitution is safe specifically because the caller is the
+// in-process capture path: the reviewer that produced raw is a fresh,
+// tool-free subprocess this same invocation just spawned with exactly one
+// candidate binding, so it has no other subject_hash to have confused this
+// one with. A wrong-but-explainable echo -- the model copying the adjacent
+// target_identity field the same materialized prompt also carries, rather
+// than the subject_hash field the prompt named -- is not evidence of a stale
+// or malicious result the way it would be for an externally submitted
+// --input payload (which reviewProviderAdmitRaw alone continues to validate
+// exactly as strictly as before; this correction never runs on that path).
+// Any other echoed value -- one that doesn't match target_identity either --
+// is left untouched and still fails admission exactly as before.
+func reviewProviderCorrectSubjectHashEcho(raw []byte, targetIdentity, expectedSubjectHash string) []byte {
+	if targetIdentity == "" || expectedSubjectHash == "" || targetIdentity == expectedSubjectHash {
+		return raw
+	}
+	var fields map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &fields); err != nil {
+		return raw
+	}
+	rawHash, present := fields["subject_hash"]
+	if !present {
+		return raw
+	}
+	var echoed string
+	if err := json.Unmarshal(rawHash, &echoed); err != nil || echoed != targetIdentity {
+		return raw
+	}
+	corrected, err := json.Marshal(expectedSubjectHash)
+	if err != nil {
+		return raw
+	}
+	fields["subject_hash"] = corrected
+	rewritten, err := json.Marshal(fields)
+	if err != nil {
+		return raw
+	}
+	return rewritten
 }
 
 func (capture reviewProviderCapture) preserve(ctx context.Context, attempt int, admission error, raw []byte) string {

--- a/internal/cli/review_provider_correction_test.go
+++ b/internal/cli/review_provider_correction_test.go
@@ -301,6 +301,114 @@ func TestRawInputCapturePreservesRejectedResultWithoutInvokingProvider(t *testin
 	}
 }
 
+// Issue #4027: the in-process reviewer sometimes echoed the transaction's
+// target_identity in the subject_hash field instead of the lens binding's own
+// subject_hash. Admission correctly refused it (the fail-closed default), but
+// that made the lens slot permanently unfillable whenever the model repeated
+// the same mistake. The fix corrects this one specific, explainable
+// confusion -- the model reading an adjacent field of the same prompt --
+// before admission, deterministically and without a second invocation.
+func TestProviderCaptureCorrectsSubjectHashEchoedAsTargetIdentity(t *testing.T) {
+	repo, binding, record, _ := newCandidateInspectionReview(t, "candidate\n", false)
+	lens := record.State.SelectedLenses[0]
+	result := admittedReviewerResultForTest(t, repo, record, lens, 0)
+	correctSubjectHash := result.SubjectHash
+	if correctSubjectHash == record.State.InitialSnapshot.Identity {
+		t.Fatal("test fixture's subject hash coincides with target identity; cannot exercise the confusion")
+	}
+	result.SubjectHash = record.State.InitialSnapshot.Identity // the exact #4027 confusion
+	misbound, err := json.Marshal(result)
+	if err != nil {
+		t.Fatal(err)
+	}
+	prompts := recordingProviderAdapter(t, func() ([]byte, error) { return misbound, nil })
+
+	store, err := reviewtransaction.CompactAuthoritativeStore(context.Background(), repo, record.State.LineageID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var output bytes.Buffer
+	if err := RunReviewCaptureResult(append(binding, "--agent", string(model.AgentClaudeCode)), &output); err != nil {
+		t.Fatalf("capture with a target-identity-echoed subject hash: %v\n%s", err, output.String())
+	}
+	if len(*prompts) != 1 {
+		t.Fatalf("provider reviewer invocations = %d, want exactly 1 (no correction round needed)", len(*prompts))
+	}
+	// This lineage selects exactly one lens, so capturing it closes the review:
+	// terminal approval -- reached only via a completed admitted lens result --
+	// is the strongest available proof that the corrected subject hash, not the
+	// echoed target identity, is what admission actually bound.
+	var terminal reviewLastEventClosureResult
+	decodeStrictReviewJSON(t, output.Bytes(), &terminal)
+	if terminal.Schema != reviewLastEventClosureSchema || terminal.State != reviewtransaction.StateApproved {
+		t.Fatalf("terminal capture after subject hash correction = %#v", terminal)
+	}
+	assertApprovedCompactAuthorityBurned(t, store, record.State.LineageID)
+}
+
+// A wrong subject_hash that is NOT explainable as the adjacent target_identity
+// field must still be refused exactly as before: the correction is narrowly
+// scoped to the one confusion #4027 reported, not a general "trust the
+// binding always" relaxation.
+func TestProviderCaptureStillRefusesAnUnexplainedWrongSubjectHash(t *testing.T) {
+	repo, binding, record, _ := newCandidateInspectionReview(t, "candidate\n", false)
+	lens := record.State.SelectedLenses[0]
+	result := admittedReviewerResultForTest(t, repo, record, lens, 0)
+	result.SubjectHash = "sha256:" + strings.Repeat("b", 64)
+	wrong, err := json.Marshal(result)
+	if err != nil {
+		t.Fatal(err)
+	}
+	prompts := recordingProviderAdapter(t,
+		func() ([]byte, error) { return wrong, nil },
+		func() ([]byte, error) { return wrong, nil },
+	)
+
+	err = RunReviewCaptureResult(append(binding, "--agent", string(model.AgentClaudeCode)), io.Discard)
+	if err == nil || !strings.Contains(err.Error(), "binding_mismatch") {
+		t.Fatalf("unexplained wrong subject hash = %v, want a binding_mismatch refusal", err)
+	}
+	if len(*prompts) != 2 {
+		t.Fatalf("provider reviewer invocations = %d, want exactly 2 (first attempt plus the one corrective retry)", len(*prompts))
+	}
+}
+
+// reviewProviderCorrectSubjectHashEcho itself, in isolation: the pure
+// substitution logic the two capture-level tests above exercise end to end.
+func TestReviewProviderCorrectSubjectHashEcho(t *testing.T) {
+	const target = "sha256:1111111111111111111111111111111111111111111111111111111111111111"
+	const expected = "sha256:2222222222222222222222222222222222222222222222222222222222222222"
+	tests := []struct {
+		name string
+		raw  []byte
+		want string // "" means the input must come back byte-identical
+	}{
+		{"rewrites an echoed target identity", []byte(`{"subject_hash":"` + target + `","findings":[]}`), expected},
+		{"leaves an unrelated wrong value untouched", []byte(`{"subject_hash":"sha256:` + strings.Repeat("9", 64) + `"}`), ""},
+		{"leaves a correct echo untouched", []byte(`{"subject_hash":"` + expected + `"}`), ""},
+		{"no-ops on malformed payloads instead of guessing", []byte("not json"), ""},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := reviewProviderCorrectSubjectHashEcho(test.raw, target, expected)
+			if test.want == "" {
+				if !bytes.Equal(got, test.raw) {
+					t.Fatalf("correction touched an input it should not have: %q", got)
+				}
+				return
+			}
+			var fields map[string]json.RawMessage
+			var echoed string
+			if err := json.Unmarshal(got, &fields); err != nil || json.Unmarshal(fields["subject_hash"], &echoed) != nil || echoed != test.want {
+				t.Fatalf("corrected subject_hash = %q (err=%v), want %q", got, err, test.want)
+			}
+			if _, present := fields["findings"]; !present {
+				t.Fatal("correction dropped an unrelated field")
+			}
+		})
+	}
+}
+
 func TestProviderCaptureRefusesPreflightBeforeInvocationOrPreservation(t *testing.T) {
 	repo, binding, record, _ := newCandidateInspectionReview(t, "candidate\n", false)
 	prompts := recordingProviderAdapter(t,

--- a/internal/reviewerprovider/claude_adapter.go
+++ b/internal/reviewerprovider/claude_adapter.go
@@ -60,6 +60,12 @@ func (adapter *ClaudeAdapter) Review(ctx context.Context, invocation Invocation)
 	}
 	command := commandContext(ctx, binary, claudeReviewerArguments...)
 	command.Dir = scratch
+	// On Windows, `claude` from an npm-style install resolves to a `.cmd`
+	// shim; launching it goes through cmd.exe's own command-line reparsing,
+	// which needs its own quoting when the resolved path contains a space
+	// (issue #4039). This is a no-op for every other binary and platform: the
+	// binary is otherwise launched directly, with no shell.
+	configureWindowsBatchLaunch(command, binary, claudeReviewerArguments)
 	command.Stdin = bytes.NewReader(invocation.Prompt())
 	var stdout, stderr bytes.Buffer
 	command.Stdout, command.Stderr = &stdout, &stderr

--- a/internal/reviewerprovider/claude_adapter_posix.go
+++ b/internal/reviewerprovider/claude_adapter_posix.go
@@ -1,0 +1,11 @@
+//go:build !windows
+
+package reviewerprovider
+
+import "os/exec"
+
+// configureWindowsBatchLaunch is a no-op outside Windows: only Windows routes
+// .bat/.cmd execution through cmd.exe's own command-line reparsing (issue
+// #4039). POSIX exec never involves a shell for this adapter, so a space in
+// the binary path is never a hazard here.
+func configureWindowsBatchLaunch(*exec.Cmd, string, []string) {}

--- a/internal/reviewerprovider/claude_adapter_test.go
+++ b/internal/reviewerprovider/claude_adapter_test.go
@@ -72,6 +72,36 @@ func TestClaudeAdapterUsesStdinAndReturnsUntouchedRawOutput(t *testing.T) {
 	}
 }
 
+// Issue #4039: the reviewer transport must launch the resolved client binary
+// directly by argv, never through a shell that could split an unquoted path
+// on its first space. This exercises the real (unmocked) commandContext, with
+// the binary itself placed under a directory whose name contains a space --
+// exactly the shape of a "Program Files" or per-user-profile install path --
+// and asserts it launches and returns output normally.
+func TestClaudeAdapterLaunchesBinaryWhosePathContainsASpace(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("uses a POSIX shebang script; the Windows .cmd/.bat quoting path is covered by windows_batch_cmdline_test.go")
+	}
+	scriptDir := filepath.Join(t.TempDir(), "Program Files", "claude cli")
+	if err := os.MkdirAll(scriptDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	binaryPath := filepath.Join(scriptDir, "claude")
+	script := "#!/bin/sh\ncat >/dev/null\nprintf 'stub reviewer output'\n"
+	if err := os.WriteFile(binaryPath, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	adapter := &ClaudeAdapter{LookPath: func(string) (string, error) { return binaryPath, nil }}
+	raw, err := adapter.Review(context.Background(), NewInvocation([]byte("provider prompt")))
+	if err != nil {
+		t.Fatalf("Review() error = %v, want the space-containing path to launch directly with no shell involved", err)
+	}
+	if string(raw) != "stub reviewer output" {
+		t.Fatalf("Review() = %q, want %q", raw, "stub reviewer output")
+	}
+}
+
 func TestClaudeAdapterHelperProcess(t *testing.T) {
 	mode := os.Getenv(claudeAdapterHelperEnvironment)
 	if mode == "" {

--- a/internal/reviewerprovider/claude_adapter_windows.go
+++ b/internal/reviewerprovider/claude_adapter_windows.go
@@ -1,0 +1,19 @@
+//go:build windows
+
+package reviewerprovider
+
+import (
+	"os/exec"
+	"syscall"
+)
+
+// configureWindowsBatchLaunch rebuilds command's Windows command line when
+// binary is a .bat/.cmd target, so a space in its path survives cmd.exe's own
+// command-line reparsing (see windowsBatchCommandLine for why). It is a no-op
+// for an ordinary .exe, which Go's default quoting already launches correctly.
+func configureWindowsBatchLaunch(command *exec.Cmd, binary string, args []string) {
+	if !isWindowsBatchFile(binary) {
+		return
+	}
+	command.SysProcAttr = &syscall.SysProcAttr{CmdLine: windowsBatchCommandLine(binary, args)}
+}

--- a/internal/reviewerprovider/windows_batch_cmdline.go
+++ b/internal/reviewerprovider/windows_batch_cmdline.go
@@ -1,0 +1,74 @@
+package reviewerprovider
+
+import "strings"
+
+// isWindowsBatchFile reports whether path names a Windows batch script rather
+// than a native executable. Only .bat and .cmd carry the quoting hazard this
+// file exists to work around; matching is case-insensitive because Windows
+// path extensions are.
+func isWindowsBatchFile(path string) bool {
+	lower := strings.ToLower(path)
+	return strings.HasSuffix(lower, ".bat") || strings.HasSuffix(lower, ".cmd")
+}
+
+// windowsBatchCommandLine builds the single command-line string Windows must
+// hand to cmd.exe to launch a .bat/.cmd target whose path contains a space.
+//
+// Windows cannot run a batch file directly: it re-invokes cmd.exe with the
+// already-built command-line text appended after "/c". That text follows the
+// CommandLineToArgvW-compatible quoting Go's exec.Command builds for ordinary
+// executables, but cmd.exe's own command-name lookup does not honor it --
+// cmd.exe recognizes a leading quote only when the ENTIRE line is wrapped in
+// one more, outer pair of quotes. Without that outer pair, cmd.exe splits the
+// quoted path on its first space, exactly the issue #4039 failure: a client
+// shim under a path containing a space fails every capture with
+// `"C:\Program" is not recognized as an internal or external command`.
+//
+// Go's own exec.Command doc names this exact gap: "msiexec.exe and cmd.exe
+// (and thus, all batch files) ... have a different unquoting algorithm. ...
+// you can do the quoting yourself and provide the full command line in
+// SysProcAttr.CmdLine". This function is that quoting.
+func windowsBatchCommandLine(binary string, args []string) string {
+	tokens := make([]string, 0, len(args)+1)
+	tokens = append(tokens, quoteWindowsArgument(binary))
+	for _, arg := range args {
+		tokens = append(tokens, quoteWindowsArgument(arg))
+	}
+	return `"` + strings.Join(tokens, " ") + `"`
+}
+
+// quoteWindowsArgument applies the same CommandLineToArgvW-compatible escaping
+// Go's stdlib uses for an ordinary executable: a backslash run is doubled only
+// when it immediately precedes a double quote (or the closing quote), and any
+// double quote is itself escaped. An argument with no space, tab, or quote
+// needs no quoting at all, which also keeps the empty-flag-value arguments
+// this reviewer transport passes (`--tools ""`) rendering as a literal `""`
+// rather than vanishing.
+func quoteWindowsArgument(arg string) string {
+	if arg != "" && !strings.ContainsAny(arg, " \t\"") {
+		return arg
+	}
+	var quoted strings.Builder
+	quoted.WriteByte('"')
+	backslashes := 0
+	for _, r := range arg {
+		switch r {
+		case '\\':
+			backslashes++
+			quoted.WriteRune(r)
+		case '"':
+			for ; backslashes > 0; backslashes-- {
+				quoted.WriteByte('\\')
+			}
+			quoted.WriteString(`\"`)
+		default:
+			backslashes = 0
+			quoted.WriteRune(r)
+		}
+	}
+	for ; backslashes > 0; backslashes-- {
+		quoted.WriteByte('\\')
+	}
+	quoted.WriteByte('"')
+	return quoted.String()
+}

--- a/internal/reviewerprovider/windows_batch_cmdline_test.go
+++ b/internal/reviewerprovider/windows_batch_cmdline_test.go
@@ -1,0 +1,51 @@
+package reviewerprovider
+
+import "testing"
+
+// Issue #4039: a `.cmd`/`.bat` client shim under a path containing a space
+// broke every capture, because cmd.exe's own command-line reparsing does not
+// honor the quoting Go's exec.Command builds for an ordinary executable. These
+// tests exercise the pure quoting logic directly -- no process launch, no
+// build-tagged file, portable to any OS this suite runs on -- so the exact
+// cmd.exe-compatible string this fix produces is pinned regardless of host.
+
+func TestIsWindowsBatchFile(t *testing.T) {
+	tests := []struct {
+		path string
+		want bool
+	}{
+		{`C:\Program Files\nodejs\claude.cmd`, true},
+		{`C:\tools\claude.CMD`, true},
+		{`C:\tools\claude.bat`, true},
+		{`C:\tools\claude.exe`, false},
+		{`/usr/local/bin/claude`, false},
+	}
+	for _, test := range tests {
+		if got := isWindowsBatchFile(test.path); got != test.want {
+			t.Errorf("isWindowsBatchFile(%q) = %v, want %v", test.path, got, test.want)
+		}
+	}
+}
+
+func TestQuoteWindowsArgument(t *testing.T) {
+	tests := []struct{ arg, want string }{
+		{"--print", "--print"}, // plain tokens need no quoting at all
+		{"", `""`},
+		{"a b", `"a b"`},
+		{`say "hi"`, `"say \"hi\""`},
+		{`c:\path with space\`, `"c:\path with space\\"`},
+	}
+	for _, test := range tests {
+		if got := quoteWindowsArgument(test.arg); got != test.want {
+			t.Errorf("quoteWindowsArgument(%q) = %q, want %q", test.arg, got, test.want)
+		}
+	}
+}
+
+func TestWindowsBatchCommandLineWrapsQuotedPathInOneMoreOuterPair(t *testing.T) {
+	got := windowsBatchCommandLine(`C:\Program Files\nodejs\claude.cmd`, []string{"--print", "--tools", ""})
+	want := `""C:\Program Files\nodejs\claude.cmd" --print --tools """`
+	if got != want {
+		t.Fatalf("windowsBatchCommandLine() = %q, want %q", got, want)
+	}
+}


### PR DESCRIPTION
Closes #4039
Closes #4027

## Summary
- Windows: the claude client resolves to a `.cmd` npm shim and cmd.exe does not honour Go's `exec.Command` quoting, so an install path with a space broke every reviewer launch. For `.bat`/`.cmd` targets the transport now sets `SysProcAttr.CmdLine` with cmd.exe quoting; POSIX is untouched. Real launch test from a directory named `Program Files/claude cli`.
- In-process Claude reviewer: the instruction names the per-lens `subject_hash` binding explicitly and warns not to echo `target_identity`; when the echo exactly equals `target_identity`, the in-process transport corrects it from the lens binding it built itself. Any other wrong subject hash is still refused; the external `--input` path is unchanged.
- #3991 checked: the claude CLI exposes no output cap flag and the runaway path is the installed agent definition, not this transport; nothing to wire here.

| File | Change |
|------|--------|
| `internal/reviewerprovider/claude_adapter.go`, `windows_batch_cmdline.go`, `claude_adapter_windows.go`, `claude_adapter_posix.go` | batch-shim command line |
| `internal/cli/review_provider_correction.go`, `review_lens_context.go` | subject-hash echo correction and instruction clause |
| tests | quoting/wrapping, path-with-space launch, echo correction and refusal |

## Test plan
- [x] `go test ./internal/reviewerprovider/ -count=1`; `GOOS=windows go build ./internal/reviewerprovider/...`
- [x] `go test ./internal/cli/ -run 'Claude|Reviewer|Transport|Capture' -count=1 -timeout 40m`: only `TestReviewCaptureRefuterExecuteDeadlineFailsClosedWithoutCapture` fails, identically on main (#3948, host-dependent)
- [x] Refusal ratchet passes
- [x] Native review approved and acknowledged (lineage review-d8e3d2e8d5695600, four lenses, no correction)

https://claude.ai/code/session_01SYqbaaqyJcAv1FYtSJXx6M

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed reviewer launches on Windows when the configured command-line client is installed in a path containing spaces.
  - Corrected reviewer responses that incorrectly echoed a transaction identity as the subject hash, preventing unnecessary retries while continuing to reject unrelated invalid hashes.
  - Clarified reviewer instructions so subject hashes are taken from the correct binding section.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->