### PR TITLE
fix(sdd): raise the intended-untracked selection cap and name a completable route

### DIFF
--- a/internal/sddstatus/runtime_ledger.go
+++ b/internal/sddstatus/runtime_ledger.go
@@ -46,10 +46,19 @@ const (
 	runtimeOperationHandoff                  = "attempt/handoff"
 	runtimeOperationGrant                    = "authority/grant"
 	maximumRuntimeGrantRoots                 = 32
-	maximumRuntimeIntendedUntracked          = 32
-	runtimeLockAcquireAttempts               = 3
-	finalVerifyWorkUnit                      = "verify"
-	finalVerifyAttestationWorkUnit           = "verify-attestation"
+	// maximumRuntimeIntendedUntracked bounds one attempt's untracked
+	// declaration (#4029). 256 is chosen over a chunked multi-call
+	// declaration path: it keeps the existing single-call digest/inventory
+	// binding exact (one declared list, one canonical digest, one capture) at
+	// a size that already covers the large real work units reported stuck at
+	// 32 (40 born-during files was enough to deadlock one), while a chunked
+	// path would need a new partial-declaration protocol, its own ledger
+	// event shape, and cross-call inventory-digest reconciliation for a
+	// problem a bigger constant already solves.
+	maximumRuntimeIntendedUntracked = 256
+	runtimeLockAcquireAttempts      = 3
+	finalVerifyWorkUnit             = "verify"
+	finalVerifyAttestationWorkUnit  = "verify-attestation"
 
 	// runtimeLedgerStatusPointer suffixes every ledger refusal an ordinary
 	// caller can hit (budget exhausted, active attempt, no active attempt,
@@ -2916,7 +2925,7 @@ func canonicalRuntimeIntendedUntracked(paths []string) ([]string, error) {
 		return []string{}, nil
 	}
 	if len(canonical) > maximumRuntimeIntendedUntracked {
-		return nil, fmt.Errorf("intended_untracked must name at most %d paths; rerun `gentle-ai sdd-attempt acquire` or `gentle-ai sdd-attempt begin` with an inventory-validated selection", maximumRuntimeIntendedUntracked)
+		return nil, fmt.Errorf("intended_untracked must name at most %d paths; `git add` the excess born-during paths so they are tracked (tracked changes and the index are always captured, uncapped) and declare only the remaining untracked paths, or declare none with --untracked-scope=exclude if every born-during path is now tracked; rerun `gentle-ai sdd-attempt acquire`, `gentle-ai sdd-attempt begin`, `gentle-ai sdd-attempt settle`, or `gentle-ai sdd-attempt finish` with that selection", maximumRuntimeIntendedUntracked)
 	}
 	slices.Sort(canonical)
 	for index, path := range canonical {

--- a/internal/sddstatus/runtime_ledger_untracked_test.go
+++ b/internal/sddstatus/runtime_ledger_untracked_test.go
@@ -522,3 +522,99 @@ func TestRuntimeFinishRefusesADeclarationAgainstAStaleInventory(t *testing.T) {
 		t.Fatalf("stale declaration mutated authority: status=%#v err=%v", status, err)
 	}
 }
+
+// TestRuntimeFinishSettlesAFortyPathBornDuringSelection is #4029: settle
+// refused any born-during declaration over 32 paths, deadlocking a work unit
+// whose honest accounting needed more (a change touching 40 new files was
+// enough). A 40-path selection must settle cleanly under the raised cap while
+// the digest/inventory binding stays exact.
+func TestRuntimeFinishSettlesAFortyPathBornDuringSelection(t *testing.T) {
+	repo := initRuntimeLedgerRepo(t)
+	store, err := OpenRuntimeStore(context.Background(), repo, "born-during-forty")
+	if err != nil {
+		t.Fatal(err)
+	}
+	started, err := store.Begin(context.Background(), BeginAttemptRequest{
+		RequestID: "forty-begin", WorkUnit: "born during", EvidenceGoal: "a large work unit borns many untracked files",
+		MaxAttempts: 2, MaxChangedLines: 400,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	const count = 40
+	selection := make([]string, count)
+	for index := range selection {
+		name := fmt.Sprintf("born-%02d.txt", index)
+		if err := os.WriteFile(filepath.Join(repo, name), []byte("line\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		selection[index] = name
+	}
+	digest := currentUntrackedInventoryDigest(t, repo)
+	finished, err := store.Finish(context.Background(), FinishAttemptRequest{
+		ExpectedRevision: started.Revision, RequestID: "forty-finish", Outcome: AttemptPassed,
+		EvidenceRevision: runtimeTestHash('a'), Diagnosis: "forty born-during files settle cleanly",
+		HarnessDisposition: HarnessReused, CleanupEvidence: "cleanup completed", ProcessEvidence: "process scan clean",
+		IntendedUntracked: &selection, ExpectedUntrackedInventory: digest,
+	})
+	if err != nil {
+		t.Fatalf("a %d-path selection was refused: %v", count, err)
+	}
+	if !finished.Complete || finished.ActiveAttempt != nil {
+		t.Fatalf("forty-path settle = %#v", finished)
+	}
+	last := finished.Attempts[len(finished.Attempts)-1]
+	if len(last.IntendedUntracked) != count || last.ChangedLines != count {
+		t.Fatalf("forty-path settle did not record the full selection: %#v", last)
+	}
+}
+
+// TestRuntimeFinishRefusesOverCapWithACompletableRoute pins #4029's other
+// half: whichever cap is chosen, exceeding it must name a route the caller
+// can actually complete, not just the number it rejected. Tracked and staged
+// changes are always captured uncapped, so `git add` on the excess paths is
+// that route regardless of how large the cap is.
+func TestRuntimeFinishRefusesOverCapWithACompletableRoute(t *testing.T) {
+	repo := initRuntimeLedgerRepo(t)
+	store, err := OpenRuntimeStore(context.Background(), repo, "born-during-over-cap")
+	if err != nil {
+		t.Fatal(err)
+	}
+	started, err := store.Begin(context.Background(), BeginAttemptRequest{
+		RequestID: "over-cap-begin", WorkUnit: "born during", EvidenceGoal: "more born-during files than the cap allows",
+		MaxAttempts: 2, MaxChangedLines: 400,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	selection := make([]string, maximumRuntimeIntendedUntracked+1)
+	for index := range selection {
+		name := fmt.Sprintf("over-%03d.txt", index)
+		if err := os.WriteFile(filepath.Join(repo, name), []byte("line\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		selection[index] = name
+	}
+	digest := currentUntrackedInventoryDigest(t, repo)
+	_, err = store.Finish(context.Background(), FinishAttemptRequest{
+		ExpectedRevision: started.Revision, RequestID: "over-cap-finish", Outcome: AttemptPassed,
+		EvidenceRevision: runtimeTestHash('b'), Diagnosis: "over-cap selection must name a completable route",
+		HarnessDisposition: HarnessReused, CleanupEvidence: "cleanup completed", ProcessEvidence: "process scan clean",
+		IntendedUntracked: &selection, ExpectedUntrackedInventory: digest,
+	})
+	if err == nil {
+		t.Fatal("a selection over the cap settled instead of being refused")
+	}
+	for _, want := range []string{
+		fmt.Sprintf("at most %d paths", maximumRuntimeIntendedUntracked),
+		"git add", "sdd-attempt settle", "sdd-attempt finish",
+	} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("cap refusal does not name a completable route (%q):\n%v", want, err)
+		}
+	}
+	status, err := store.Status()
+	if err != nil || status.Revision != started.Revision || status.ActiveAttempt == nil {
+		t.Fatalf("over-cap refusal mutated authority: status=%#v err=%v", status, err)
+	}
+}


### PR DESCRIPTION
Closes #4029

## Summary
- Settlement required declaring every untracked file born during an attempt but refused selections over 32 paths, deadlocking large work units. The cap is now 256, which keeps the single-call inventory/digest binding exact and covers real work units (the report's 40 files settle; 257 still refuses).
- The refusal names a route that actually completes: `git add` the excess paths or `--untracked-scope=exclude`, naming all four affected commands.

| File | Change |
|------|--------|
| `internal/sddstatus/runtime_ledger.go` | cap and refusal message |
| `internal/sddstatus/runtime_ledger_untracked_test.go` | 40-path selection settles; over-cap refusal names the route |

## Test plan
- [x] `go test ./internal/sddstatus/ -run 'Untracked|Finish|Settle' -count=1`
- [x] Native review approved and acknowledged (lineage review-ee0fac93c24f7111, four lenses, no correction)

https://claude.ai/code/session_01SYqbaaqyJcAv1FYtSJXx6M

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Increased the supported limit for untracked paths from 32 to 256 during runtime operations.
  - Improved overflow messages with clearer guidance for tracking excess paths or excluding untracked files.
  - Added rerunnable recovery guidance for settling or finishing interrupted operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->