### PR TITLE
fix(uninstall): scope opencode-gentle-logo removal to the OpenCode agent

### DIFF
--- a/internal/components/uninstall/service.go
+++ b/internal/components/uninstall/service.go
@@ -850,6 +850,9 @@ func (s *Service) componentOperations(adapter agents.Adapter, componentID model.
 			ops = append(ops, removeDirIfEmpty(filepath.Dir(paths[0])))
 		}
 	case model.ComponentOpenCodeGentleLogo:
+		if adapter.Agent() != model.AgentOpenCode {
+			break
+		}
 		pluginPath := filepath.Join(homeDir, ".config", "opencode", "tui-plugins", "gentle-logo.tsx")
 		targets = append(targets, pluginPath)
 		ops = append(ops, removeFile(pluginPath), removeDirIfEmpty(filepath.Dir(pluginPath)))

--- a/internal/components/uninstall/service_test.go
+++ b/internal/components/uninstall/service_test.go
@@ -635,6 +635,54 @@ func TestPartialUninstallClaudeThemeRemovesOnlyThemeAssets(t *testing.T) {
 	}
 }
 
+func TestPartialUninstallOpenCodeLogoScopedToOpenCodeAgent(t *testing.T) {
+	homeDir := t.TempDir()
+	workspaceDir := t.TempDir()
+
+	svc, err := NewService(homeDir, workspaceDir, "dev")
+	if err != nil {
+		t.Fatalf("NewService() error = %v", err)
+	}
+	svc.snapshotter = stubSnapshotter{}
+
+	logoPath := filepath.Join(homeDir, ".config", "opencode", "tui-plugins", "gentle-logo.tsx")
+	if err := os.MkdirAll(filepath.Dir(logoPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(logoPath, []byte("// managed logo"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Uninstalling an unrelated agent must not touch the OpenCode-owned logo —
+	// both when the logo component is named explicitly and, the issue's actual
+	// repro, when the default component list (nil) includes it (#4229).
+	for _, components := range [][]model.ComponentID{
+		{model.ComponentOpenCodeGentleLogo},
+		nil, // default: allManagedComponents
+	} {
+		if _, err := svc.PartialUninstall(
+			[]model.AgentID{model.AgentGeminiCLI},
+			components,
+		); err != nil {
+			t.Fatalf("PartialUninstall(gemini-cli, %v) error = %v", components, err)
+		}
+		if got, err := os.ReadFile(logoPath); err != nil || string(got) != "// managed logo" {
+			t.Fatalf("OpenCode logo removed by gemini-cli uninstall (components %v): got %q, %v; want preserved", components, got, err)
+		}
+	}
+
+	// Positive control: the OpenCode adapter itself still removes the logo.
+	if _, err := svc.PartialUninstall(
+		[]model.AgentID{model.AgentOpenCode},
+		[]model.ComponentID{model.ComponentOpenCodeGentleLogo},
+	); err != nil {
+		t.Fatalf("PartialUninstall(opencode) error = %v", err)
+	}
+	if _, err := os.Stat(logoPath); !os.IsNotExist(err) {
+		t.Fatalf("OpenCode logo should be removed by opencode uninstall: %v", err)
+	}
+}
+
 func readJSONFileForTest(t *testing.T, path string) map[string]any {
 	t.Helper()
 	data, err := os.ReadFile(path)


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #4229

---

## 🏷️ PR Type

- [x] `type:bug` — Bug fix (non-breaking change that fixes an issue)

---

## 📝 Summary

`componentOperations` handled `ComponentOpenCodeGentleLogo` without checking the adapter agent, so `gentle-ai uninstall --agent gemini-cli` (or any other agent) also deleted the OpenCode-owned `.config/opencode/tui-plugins/gentle-logo.tsx` theme file. This scopes the removal to the OpenCode adapter itself, matching the guard pattern already used elsewhere in the same switch.

---

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/components/uninstall/service.go` | Guard the `ComponentOpenCodeGentleLogo` case on `adapter.Agent() == model.AgentOpenCode` |
| `internal/components/uninstall/service_test.go` | Regression test: unrelated-agent uninstall preserves the logo (both for the explicit component and the default `allManagedComponents` set); OpenCode uninstall still removes it |

---

## 🤖 AI Assistance

- [x] **Material assistance used**

**Tool/model:** Pi coding-agent sessions (driven by the contributor)

**Material scope:** regression test design (RED before the guard, GREEN after) and the one-clause guard implementation

**Verification performed:** TDD run locally (RED reproduced the issue exactly; GREEN after the guard), full package suite `go test ./internal/components/uninstall/`, blast-radius suites (`internal/catalog`, `internal/cli` uninstall tests), `go vet`, `go run ./internal/gofmtcheck`

---

## 🧪 Test Plan

- [x] Unit tests pass (`go test ./...`) — all packages pass except one **pre-existing, unrelated** failure: `TestInjectClaudeWorkspaceIsDiscoveredByNativeClaudeMCPList` in `internal/components/mcp` (issue #3969, gated by open PR #4157). Verified pre-existing by re-running it on pristine `origin/main` (stash) in this worktree; it does not touch the uninstall package.
- [x] Go format passes (`go run ./internal/gofmtcheck`)
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`) — Docker-based; scoped uninstall logic change is covered by the unit regression test, leaving E2E to CI
- [x] Manually tested locally — the regression test reproduces the issue scenario (isolated HOME, logo on disk, unrelated-agent uninstall) in both the explicit-component and default-components paths

---

## 💬 Notes for Reviewers

The `type:bug` label cannot be applied by this account (pull-only); requesting it from a maintainer so the label check can go green. Split out of #3534 on purpose to stay bounded, per that issue's note.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - OpenCode logo cleanup during uninstallation is now limited to OpenCode, preventing other agent uninstallations from removing the logo.
  - Uninstalling Gemini CLI no longer affects OpenCode-specific files, preserving the OpenCode setup for continued use.

- **Tests**
  - Added coverage confirming the logo remains when uninstalling Gemini CLI and is removed when uninstalling OpenCode.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->