### PR TITLE
fix(review): sync published directories, report trace persistence, and expose repair truncation

### DIFF
--- a/internal/cli/review_facade.go
+++ b/internal/cli/review_facade.go
@@ -106,6 +106,58 @@ type ReviewFacadeStartResult struct {
 	// Acknowledgement is present only for a v2 zero-lens approved START. It
 	// carries the exact continuation that burns the pending compact authority.
 	Acknowledgement *ReviewTransitionExecution `json:"acknowledgement,omitempty"`
+	// Trace is present only when --trace was explicitly requested for this
+	// START (#1854). The authority mutation above always represents what
+	// actually committed; Trace separately reports whether the requested
+	// diagnostic entry was also persisted, never the other way around.
+	Trace *ReviewTraceOutcome `json:"trace,omitempty"`
+}
+
+// reviewTraceRetryGuidance is informational only: it never changes command
+// behavior. The authority named by CommittedRevision is already durable, so
+// repeating the same command with a writable --trace path is always safe --
+// it cannot create a second authority transition or duplicate the trace row
+// this outcome already accounts for.
+const reviewTraceRetryGuidance = "rerun the same command with a writable --trace path; the authority is already committed and an identical retry is idempotent"
+
+// ReviewTraceOutcome reports what happened to an explicitly requested
+// --trace diagnostic entry after its authority mutation already committed
+// (issue #1854). It is absent entirely unless --trace was requested, and its
+// presence or content never changes whether the mutation itself committed.
+type ReviewTraceOutcome struct {
+	// RequestedPath is a redacted identity of the --trace value, the same
+	// way this surface avoids ever publishing a raw filesystem path.
+	RequestedPath string `json:"requested_path,omitempty"`
+	Persisted     bool   `json:"persisted"`
+	// ErrorClass distinguishes mkdir/open/write/fsync/close failures; empty
+	// when Persisted is true.
+	ErrorClass        string `json:"error_class,omitempty"`
+	CommittedRevision string `json:"committed_revision,omitempty"`
+	// EventIdentity lets a caller confirm a later retry describes the same
+	// event, without trusting free-form text.
+	EventIdentity string `json:"event_identity,omitempty"`
+	// Retry is present only when Persisted is false.
+	Retry string `json:"retry,omitempty"`
+}
+
+// reviewTraceOutcomeResult projects a committed trace outcome into the
+// path-free CLI result shape. It returns nil when no trace was requested for
+// this commit, so callers can assign it directly to the omitempty field.
+func reviewTraceOutcomeResult(tracePath string, outcome *reviewtransaction.CompactTraceOutcome) *ReviewTraceOutcome {
+	if outcome == nil {
+		return nil
+	}
+	result := &ReviewTraceOutcome{
+		RequestedPath:     facadePayloadHash([]byte(tracePath)),
+		Persisted:         outcome.Persisted,
+		ErrorClass:        outcome.ErrorClass,
+		CommittedRevision: outcome.Revision,
+		EventIdentity:     outcome.Identity(),
+	}
+	if !outcome.Persisted {
+		result.Retry = reviewTraceRetryGuidance
+	}
+	return result
 }
 
 // ReviewStartConsentDeclinedThisCandidate reports that the user answered the
@@ -1990,6 +2042,10 @@ func runReviewFacadeStart(ctx context.Context, args []string, stdout io.Writer) 
 		if err != nil {
 			return reviewPreflightError(fmt.Errorf("prepare compact atomic facade review: %w", err))
 		}
+		// #1854: threaded through so the exact atomic START commit below can
+		// also report a requested trace's committed-but-degraded outcome,
+		// not only the zero-lens completion commit further down.
+		request.TracePath = strings.TrimSpace(*tracePath)
 		if err := reviewLensContextCompactAtomicStartBudgetRefusal(ctx, root, request); err != nil {
 			return err
 		}
@@ -2030,6 +2086,11 @@ func runReviewFacadeStart(ctx context.Context, args []string, stdout io.Writer) 
 			if err != nil {
 				return fmt.Errorf("resolve zero-lens review authority: %w", err)
 			}
+			// #1854: an explicitly requested --trace is wired here. The
+			// commit above proceeds exactly as it would without one; a
+			// failed trace write is reported through Trace, never a
+			// rolled-back commit or a stderr-only warning.
+			store.TracePath = strings.TrimSpace(*tracePath)
 			acknowledgement, err := reviewtransaction.CommitApprovedCompactAcknowledgement(ctx, store, record.Revision, "review/complete-review", state)
 			if err != nil {
 				return fmt.Errorf("commit zero-lens review acknowledgement: %w", err)
@@ -2037,6 +2098,7 @@ func runReviewFacadeStart(ctx context.Context, args []string, stdout io.Writer) 
 			legacyResult := reviewFacadeStartResultFor("closed", false, state)
 			legacyResult.Acknowledgement = reviewApprovedAcknowledgementTransition(root, acknowledgement)
 			legacyResult.RiskEvidence = reviewConsentRiskEvidence(assessment)
+			legacyResult.Trace = reviewTraceOutcomeResult(store.TracePath, acknowledgement.TraceOutcome)
 			if !negotiated {
 				return encodeReviewJSON(stdout, legacyResult)
 			}
@@ -2055,6 +2117,7 @@ func runReviewFacadeStart(ctx context.Context, args []string, stdout io.Writer) 
 			legacyResult.Action = "replayed"
 		}
 		legacyResult.RiskEvidence = reviewConsentRiskEvidence(assessment)
+		legacyResult.Trace = reviewTraceOutcomeResult(request.TracePath, started.TraceOutcome)
 		if !negotiated {
 			return encodeReviewJSON(stdout, legacyResult)
 		}

--- a/internal/cli/review_repair_test.go
+++ b/internal/cli/review_repair_test.go
@@ -1099,6 +1099,13 @@ func TestReviewRepairPreflightNamesAWayForwardWhenTheStoreExceedsTheBound(t *tes
 	if preflight.Continuation != reviewRepairTruncatedContinuation {
 		t.Fatalf("truncated preflight continuation = %q, want the named way forward %q", preflight.Continuation, reviewRepairTruncatedContinuation)
 	}
+	// issue #3371: a truncated preflight must say so and how far it got
+	// (cap 256, scanned 257 -- one past the cap, the exact directory-listing
+	// bound), never leave every count at zero as if this 512-lineage store
+	// were healthy.
+	if !preflight.Assessment.Truncated || preflight.Assessment.TruncationCap != 256 || preflight.Assessment.TruncationScanned != 257 {
+		t.Fatalf("oversized-store preflight truncation bound = %#v", preflight.Assessment)
+	}
 	if !strings.Contains(output.String(), "gentle-ai review inspect-authority") {
 		t.Fatalf("truncated preflight named no runnable continuation:\n%s", output.String())
 	}

--- a/internal/cli/review_start_contract.go
+++ b/internal/cli/review_start_contract.go
@@ -47,6 +47,11 @@ type ReviewIntegrationStartResult struct {
 	RepositoryContext   *ReviewRepositoryContextReference             `json:"repository_context,omitempty"`
 	Acknowledgement     *ReviewTransitionExecution                    `json:"acknowledgement,omitempty"`
 	NextTransition      *ReviewNextTransition                         `json:"next_transition,omitempty"`
+	// Trace mirrors ReviewFacadeStartResult.Trace (#1854). It is carried
+	// only on the current (non-legacy-transport) envelope, the same gating
+	// Acknowledgement and NextTransition already use, so the frozen v1
+	// legacy-transport wire shape (start-v2.schema.json) never gains a field.
+	Trace *ReviewTraceOutcome `json:"trace,omitempty"`
 }
 
 // ReviewRepositoryContextReference is the path-free provider context that a
@@ -85,6 +90,7 @@ func newReviewIntegrationStartResult(legacy ReviewFacadeStartResult, assessment 
 	if !legacyTransport {
 		result.Acknowledgement = legacy.Acknowledgement
 		result.NextTransition = nextTransition
+		result.Trace = legacy.Trace
 	}
 	if targetMode == reviewtransaction.TargetBaseWorkspaceOverlay {
 		result.TargetMode = targetMode

--- a/internal/cli/review_trace_test.go
+++ b/internal/cli/review_trace_test.go
@@ -1,0 +1,129 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/gentleman-programming/gentle-ai/v2/internal/reviewtransaction"
+)
+
+// TestZeroLensStartCommitsAndReportsUnwritableTraceOutcome is issue #1854,
+// reworked to the issue's own accepted scope: `review start
+// --trace=<existing-empty-directory>` on a zero-lens candidate must commit
+// exactly as it would without a requested trace -- the transition genuinely
+// succeeded -- and represent the failed trace as a typed, committed-but-
+// degraded outcome instead of a stderr-only warning. Zero lenses (ordinary
+// low-risk documentation) is what routes review start through the exact
+// CommitApprovedCompactAcknowledgement call this fix guards.
+func TestZeroLensStartCommitsAndReportsUnwritableTraceOutcome(t *testing.T) {
+	reviewEnabledHome(t)
+	repo := initReviewCLIRepo(t)
+	lines := make([]string, 129)
+	for index := range lines {
+		lines[index] = fmt.Sprintf("ordinary documentation line %03d", index+1)
+	}
+	writeReviewStartCandidate(t, repo, "docs/ordinary-guide.md", strings.Join(lines, "\n")+"\n", 0o644)
+
+	traceDir := t.TempDir() // an existing directory: never openable as a file
+
+	var startOutput bytes.Buffer
+	if err := RunReview(boundNegotiatedStartArgs(t, []string{
+		"start", "--contract", ReviewIntegrationContractV2, "--cwd", repo, "--trace", traceDir,
+	}), &startOutput); err != nil {
+		t.Fatalf("RunReview() with an unwritable requested trace: %v\n%s", err, startOutput.String())
+	}
+	var started ReviewIntegrationStartResult
+	decodeStrictReviewJSON(t, startOutput.Bytes(), &started)
+	if started.Action != "closed" || started.Acknowledgement == nil {
+		t.Fatalf("zero-lens START did not commit despite the trace failure: %#v", started)
+	}
+	store, err := reviewtransaction.CompactAuthoritativeStore(context.Background(), repo, started.LineageID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertApprovedCompactAuthorityBurned(t, store, started.LineageID)
+
+	if started.Trace == nil {
+		t.Fatal("no trace outcome reported for a requested --trace")
+	}
+	if started.Trace.Persisted {
+		t.Fatalf("trace outcome = %#v, want persisted=false for an unwritable target", started.Trace)
+	}
+	if started.Trace.ErrorClass == "" {
+		t.Fatal("trace outcome has no error class")
+	}
+	if started.Trace.CommittedRevision == "" || started.Trace.CommittedRevision != started.Acknowledgement.Binding.Revision {
+		t.Fatalf("trace outcome committed revision = %q, want the exact committed revision %q", started.Trace.CommittedRevision, started.Acknowledgement.Binding.Revision)
+	}
+	if started.Trace.EventIdentity == "" {
+		t.Fatal("trace outcome has no event identity")
+	}
+	if started.Trace.Retry == "" {
+		t.Fatal("a failed trace outcome must name the retry guidance")
+	}
+	if started.Trace.RequestedPath == "" || strings.Contains(started.Trace.RequestedPath, traceDir) {
+		t.Fatalf("trace outcome requested_path = %q, want a redacted identity, not the raw path", started.Trace.RequestedPath)
+	}
+
+	traceEntries, err := os.ReadDir(traceDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(traceEntries) != 0 {
+		t.Fatalf("unwritable trace target unexpectedly gained entries: %v", traceEntries)
+	}
+}
+
+// TestZeroLensStartRecordsTraceWhenTracePathIsWritable is the positive-path
+// sibling: a writable --trace path commits normally and reports
+// persisted=true with the committed revision and no error class.
+func TestZeroLensStartRecordsTraceWhenTracePathIsWritable(t *testing.T) {
+	reviewEnabledHome(t)
+	repo := initReviewCLIRepo(t)
+	lines := make([]string, 129)
+	for index := range lines {
+		lines[index] = fmt.Sprintf("ordinary documentation line %03d", index+1)
+	}
+	writeReviewStartCandidate(t, repo, "docs/ordinary-guide.md", strings.Join(lines, "\n")+"\n", 0o644)
+
+	tracePath := filepath.Join(t.TempDir(), "trace.jsonl")
+
+	var startOutput bytes.Buffer
+	if err := RunReview(boundNegotiatedStartArgs(t, []string{
+		"start", "--contract", ReviewIntegrationContractV2, "--cwd", repo, "--trace", tracePath,
+	}), &startOutput); err != nil {
+		t.Fatalf("RunReview() with a writable trace path: %v\n%s", err, startOutput.String())
+	}
+	var started ReviewIntegrationStartResult
+	decodeStrictReviewJSON(t, startOutput.Bytes(), &started)
+	if started.Action != "closed" {
+		t.Fatalf("zero-lens START with a writable trace = %#v", started)
+	}
+	store, err := reviewtransaction.CompactAuthoritativeStore(context.Background(), repo, started.LineageID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertApprovedCompactAuthorityBurned(t, store, started.LineageID)
+
+	if started.Trace == nil {
+		t.Fatal("no trace outcome reported for a requested --trace")
+	}
+	if !started.Trace.Persisted || started.Trace.ErrorClass != "" || started.Trace.Retry != "" {
+		t.Fatalf("trace outcome = %#v, want persisted=true, no error class, no retry guidance", started.Trace)
+	}
+	if started.Trace.CommittedRevision == "" || started.Trace.EventIdentity == "" {
+		t.Fatalf("trace outcome missing identity fields: %#v", started.Trace)
+	}
+	payload, err := os.ReadFile(tracePath)
+	if err != nil {
+		t.Fatalf("requested trace was not written: %v", err)
+	}
+	if !bytes.Contains(payload, []byte(`"review/complete-review"`)) {
+		t.Fatalf("trace payload missing the committed operation: %s", payload)
+	}
+}

--- a/internal/reviewtransaction/authority_repair.go
+++ b/internal/reviewtransaction/authority_repair.go
@@ -56,6 +56,16 @@ type AuthorityRepairAssessment struct {
 	Counts              AuthorityRepairCounts      `json:"counts"`
 	SupportedOperations []string                   `json:"supported_operations"`
 	AuthorizationSchema string                     `json:"authorization_schema"`
+	// Truncated, TruncationCap and TruncationScanned are set only when Status
+	// is AuthorityRepairTruncated (#3371). The bounded scan can hit its
+	// lineage cap before classifying a single entry -- e.g. a v2/ directory
+	// with more entries than the cap reads none of them -- which otherwise
+	// left every Counts field at zero, indistinguishable from a genuinely
+	// healthy store. These fields make the truncation itself, and how far it
+	// got, explicit rather than inferred from an all-zero Counts.
+	Truncated         bool `json:"truncated,omitempty"`
+	TruncationCap     int  `json:"truncation_cap,omitempty"`
+	TruncationScanned int  `json:"truncation_scanned,omitempty"`
 }
 
 type AuthorityRepairCandidate struct {
@@ -117,16 +127,27 @@ type authorityRepairBudget struct {
 }
 
 type authorityRepairScan struct {
-	assessment       AuthorityRepairAssessment
-	base             string
-	binding          string
-	maintenanceOwned bool
-	candidates       []AuthorityRepairCandidate
-	unsupported      int
-	conflicts        int
-	truncated        bool
-	compact          map[string]CompactRecord
-	legacy           map[string]struct{}
+	assessment        AuthorityRepairAssessment
+	base              string
+	binding           string
+	maintenanceOwned  bool
+	candidates        []AuthorityRepairCandidate
+	unsupported       int
+	conflicts         int
+	truncated         bool
+	truncationScanned int
+	compact           map[string]CompactRecord
+	legacy            map[string]struct{}
+}
+
+// noteTruncationScanned records how many entries the scan had actually
+// looked at when a bound tripped, keeping the largest value seen across
+// whichever bound fired (#3371): a directory-entry-count trip reports it
+// immediately from the raw listing, before a single lineage is classified.
+func (scan *authorityRepairScan) noteTruncationScanned(scanned int) {
+	if scanned > scan.truncationScanned {
+		scan.truncationScanned = scanned
+	}
 }
 
 var errAuthorityRepairTruncated = errors.New("authority repair assessment limit exceeded")
@@ -224,6 +245,10 @@ func (scan *authorityRepairScan) run(ctx context.Context) error {
 			scan.conflicts++
 		}
 	}
+	// #3371: a bound tripped inside the shared per-entry loop (rather than at
+	// the raw directory listing) is reflected only in budget.entries; fold it
+	// in here so every truncation path reports how far the scan actually got.
+	scan.noteTruncationScanned(budget.entries)
 	return nil
 }
 
@@ -232,6 +257,7 @@ func (scan *authorityRepairScan) scanCompact(ctx context.Context, budget *author
 	entries, err := readAuthorityRepairDirectory(root, authorityRepairMaxLineages)
 	if err != nil {
 		if errors.Is(err, errAuthorityRepairTruncated) {
+			scan.noteTruncationScanned(len(entries))
 			return err
 		}
 		if os.IsNotExist(err) {
@@ -298,6 +324,7 @@ func (scan *authorityRepairScan) scanLegacy(ctx context.Context, budget *authori
 	entries, err := readAuthorityRepairDirectory(root, authorityRepairMaxLineages)
 	if err != nil {
 		if errors.Is(err, errAuthorityRepairTruncated) {
+			scan.noteTruncationScanned(len(entries))
 			return err
 		}
 		if os.IsNotExist(err) {
@@ -378,7 +405,11 @@ func readAuthorityRepairDirectory(dir string, limit int) ([]os.DirEntry, error) 
 		return nil, err
 	}
 	if len(entries) > limit {
-		return nil, errAuthorityRepairTruncated
+		// #3371: entries travels with the error (rather than nil) so a
+		// truncation-counting caller can report exactly how many raw
+		// directory entries it saw before giving up, instead of a bare
+		// refusal that looks identical to a store with nothing to report.
+		return entries, errAuthorityRepairTruncated
 	}
 	sort.Slice(entries, func(i, j int) bool { return entries[i].Name() < entries[j].Name() })
 	return entries, nil
@@ -406,6 +437,9 @@ func (scan *authorityRepairScan) finish() {
 	switch {
 	case scan.truncated:
 		scan.assessment.Status = AuthorityRepairTruncated
+		scan.assessment.Truncated = true
+		scan.assessment.TruncationCap = authorityRepairMaxLineages
+		scan.assessment.TruncationScanned = scan.truncationScanned
 	case scan.conflicts > 0:
 		scan.assessment.Status = AuthorityRepairConflicting
 	case len(scan.candidates) > 1 || len(scan.candidates) == 1 && scan.unsupported > 0:
@@ -757,7 +791,8 @@ func (assessment AuthorityRepairAssessment) Validate() error {
 			assessment.Disposition != AuthorityRepairDispositionQuarantineHistoricalAlias || !validSHA256(assessment.RepositoryBinding) ||
 			candidate == nil || validateLineageID(candidate.LineageID) != nil || !validSHA256(candidate.Revision) || !validSHA256(candidate.ChainIdentity) ||
 			candidate.EventCount < 2 || candidate.EventCount > authorityRepairMaxEvents || candidate.AliasEventCount < 1 || candidate.AliasEventCount > candidate.EventCount ||
-			len(candidate.Operations) == 0 || !repairOperationsSupported(candidate.Operations) || counts.EligibleCandidates != 1 || counts.UnsupportedLineages != 0 || counts.Conflicts != 0 {
+			len(candidate.Operations) == 0 || !repairOperationsSupported(candidate.Operations) || counts.EligibleCandidates != 1 || counts.UnsupportedLineages != 0 || counts.Conflicts != 0 ||
+			assessment.Truncated || assessment.TruncationCap != 0 || assessment.TruncationScanned != 0 {
 			return errors.New("eligible authority repair assessment is incomplete")
 		}
 		return nil
@@ -767,6 +802,18 @@ func (assessment AuthorityRepairAssessment) Validate() error {
 	}
 	if assessment.Class != "" || assessment.Cause != "" || assessment.Disposition != "" || assessment.RepositoryBinding != "" || assessment.Candidate != nil {
 		return errors.New("stopped authority repair assessment contains an executable candidate")
+	}
+	// #3371: a truncated assessment must say so and how far it got, rather
+	// than leaving every Counts field at zero and indistinguishable from a
+	// genuinely healthy store; every other status must carry none of this.
+	if assessment.Status == AuthorityRepairTruncated {
+		if !assessment.Truncated || assessment.TruncationCap != authorityRepairMaxLineages || assessment.TruncationScanned < 1 {
+			// refusal:by-design world-action: this assessment is built by scan.finish() from its own truncation bookkeeping a few lines above; reaching this means a product defect in that producer, not an operator input to fix
+			return errors.New("truncated authority repair assessment is missing its scan bound")
+		}
+	} else if assessment.Truncated || assessment.TruncationCap != 0 || assessment.TruncationScanned != 0 {
+		// refusal:by-design world-action: same producer-only invariant as above, for the inverse direction -- these fields are set only inside the scan.truncated branch of finish()
+		return errors.New("authority repair assessment truncation fields require a truncated status")
 	}
 	return nil
 }

--- a/internal/reviewtransaction/authority_repair_test.go
+++ b/internal/reviewtransaction/authority_repair_test.go
@@ -251,6 +251,13 @@ func TestAssessAuthorityRepairStopsLockedAndTruncatedInventory(t *testing.T) {
 		if err != nil || assessment.Status != AuthorityRepairTruncated || assessment.Candidate != nil {
 			t.Fatalf("truncated assessment = %#v, %v", assessment, err)
 		}
+		// issue #3371: even a truncation that trips deep inside per-lineage
+		// reading (not the raw directory listing) must say so and how far it
+		// got, not leave Counts looking like a healthy, nothing-to-repair
+		// store.
+		if !assessment.Truncated || assessment.TruncationCap != authorityRepairMaxLineages || assessment.TruncationScanned < 1 {
+			t.Fatalf("truncated assessment scan bound = %#v", assessment)
+		}
 	})
 
 	t.Run("too many unexpected entries", func(t *testing.T) {
@@ -263,6 +270,9 @@ func TestAssessAuthorityRepairStopsLockedAndTruncatedInventory(t *testing.T) {
 		if err := os.MkdirAll(versionRoot, 0o700); err != nil {
 			t.Fatal(err)
 		}
+		// authorityRepairMaxLineages+1 = 257 entries: past the 256-lineage
+		// cap from issue #3371 ("gentle-ai review repair --preflight is
+		// blind past 256 lineages").
 		for index := 0; index <= authorityRepairMaxLineages; index++ {
 			path := filepath.Join(versionRoot, fmt.Sprintf("unexpected-%03d.json", index))
 			if err := os.WriteFile(path, []byte("residue\n"), 0o600); err != nil {
@@ -272,6 +282,18 @@ func TestAssessAuthorityRepairStopsLockedAndTruncatedInventory(t *testing.T) {
 		assessment, err := AssessAuthorityRepair(context.Background(), repo)
 		if err != nil || assessment.Status != AuthorityRepairTruncated || assessment.Candidate != nil {
 			t.Fatalf("entry-bound assessment = %#v, %v", assessment, err)
+		}
+		// issue #3371's exact reported shape: hitting the cap at the raw
+		// directory listing, before a single entry is classified, must never
+		// report all-zero counts as if the store were healthy. It must say
+		// truncated=true with the cap (256) and how many entries it actually
+		// saw (257, the exact bound-plus-one ReadDir returned).
+		if assessment.Counts != (AuthorityRepairCounts{}) {
+			t.Fatalf("truncated assessment reported non-zero classified counts = %#v", assessment.Counts)
+		}
+		if !assessment.Truncated || assessment.TruncationCap != authorityRepairMaxLineages || assessment.TruncationScanned != authorityRepairMaxLineages+1 {
+			t.Fatalf("entry-bound assessment scan bound = %#v, want truncated=true cap=%d scanned=%d",
+				assessment, authorityRepairMaxLineages, authorityRepairMaxLineages+1)
 		}
 	})
 }

--- a/internal/reviewtransaction/bundle.go
+++ b/internal/reviewtransaction/bundle.go
@@ -277,6 +277,12 @@ func (store Store) installBundle(chain ValidatedChain, events []ChainBundleEvent
 			return ValidatedChain{}, err
 		}
 	}
+	// #1721: same events/-before-HEAD ordering gap as the legacy append path.
+	if len(events) > 0 {
+		if err := SyncReviewDirectory(filepath.Join(store.Dir, "events")); err != nil {
+			return ValidatedChain{}, &directorySyncError{path: filepath.Join(store.Dir, "events"), cause: err}
+		}
+	}
 	if err := writeAtomic(filepath.Join(store.Dir, "HEAD"), []byte(chain.HeadRevision+"\n"), 0o644); err != nil {
 		return ValidatedChain{}, err
 	}

--- a/internal/reviewtransaction/compact_atomic_start_test.go
+++ b/internal/reviewtransaction/compact_atomic_start_test.go
@@ -126,6 +126,49 @@ func TestCompactStoreCreateOrReplayAtomicStartReplaysExactActiveBindingWithoutMu
 	}
 }
 
+// TestCompactStoreFirstAtomicStartSyncsV2ParentDirectory is issue #1721's
+// second gap: the first compact publication under a previously absent v2/
+// must synchronize v2/ itself (the parent that names the new lineage
+// directory), not only the lineage directory that writeAtomic's own
+// post-rename sync already covers.
+func TestCompactStoreFirstAtomicStartSyncsV2ParentDirectory(t *testing.T) {
+	const lineage = "compact-atomic-start-first-publication-syncs-v2"
+	repo := initSnapshotRepo(t)
+	base, _, err := reviewAuthorityRoot(context.Background(), repo)
+	if err != nil {
+		t.Fatal(err)
+	}
+	versionRoot := filepath.Join(base, "v2")
+	if _, err := os.Stat(versionRoot); !os.IsNotExist(err) {
+		t.Fatalf("v2/ already exists before the first publication: stat = %v", err)
+	}
+
+	originalSync := syncReviewDirectory
+	var synced []string
+	syncReviewDirectory = func(path string) error {
+		synced = append(synced, path)
+		return originalSync(path)
+	}
+	t.Cleanup(func() { syncReviewDirectory = originalSync })
+
+	store := compactAtomicStartStore(t, repo, lineage)
+	request := compactAtomicStartFixture(t, repo, lineage)
+	if _, err := store.CreateOrReplayAtomicStart(context.Background(), request); err != nil {
+		t.Fatalf("CreateOrReplayAtomicStart(create): %v", err)
+	}
+
+	found := false
+	for _, path := range synced {
+		if path == versionRoot {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("first compact publication never synced its newly created v2/ parent %s; recorded = %v", versionRoot, synced)
+	}
+}
+
 func TestCompactStoreCreateOrReplayAtomicStartRefusesEveryBindingMismatchWithoutMutation(t *testing.T) {
 	tests := []struct {
 		name   string

--- a/internal/reviewtransaction/compact_burn.go
+++ b/internal/reviewtransaction/compact_burn.go
@@ -55,6 +55,11 @@ type ApprovedCompactAcknowledgement struct {
 	TargetIdentity   string
 	ExpectedRevision string
 	Token            string
+	// TraceOutcome is set only when CommitApprovedCompactAcknowledgement was
+	// asked to record a trace for this exact commit (#1854). It is nil for
+	// every other construction of this type (PendingApprovedCompactAcknowledgement
+	// re-reads an already-committed record and issues no new trace write).
+	TraceOutcome *CompactTraceOutcome
 }
 
 func validCompactAcknowledgementToken(token string) bool {
@@ -105,6 +110,15 @@ func CommitApprovedCompactAcknowledgement(ctx context.Context, store CompactStor
 		return ApprovedCompactAcknowledgement{}, err
 	}
 	next.ApprovedAckToken = token
+	// #1854: TraceOutcome is filled in place by replaceContextGuarded through
+	// this shared pointer, after the CAS transition above has already
+	// committed. store is a local copy (value receiver), so setting this
+	// field here affects only this call's commit.
+	var traceOutcome *CompactTraceOutcome
+	if store.TracePath != "" {
+		traceOutcome = &CompactTraceOutcome{}
+		store.TraceOutcome = traceOutcome
+	}
 	revision, err := store.ReplaceContext(ctx, expectedRevision, operation, next)
 	if err != nil {
 		return ApprovedCompactAcknowledgement{}, err
@@ -113,6 +127,7 @@ func CommitApprovedCompactAcknowledgement(ctx context.Context, store CompactStor
 		LineageID:        next.LineageID,
 		TargetIdentity:   next.CurrentSnapshot.Identity,
 		ExpectedRevision: revision,
+		TraceOutcome:     traceOutcome,
 		Token:            token,
 	}, nil
 }

--- a/internal/reviewtransaction/compact_store.go
+++ b/internal/reviewtransaction/compact_store.go
@@ -189,6 +189,11 @@ type CompactStore struct {
 	lockPath            string
 	maintenanceLockPath string
 	TracePath           string
+	// TraceOutcome, when non-nil, receives the outcome of a requested trace
+	// write a commit on this store performs (#1854). It is a pointer so a
+	// value-receiver commit method can report back through the caller's own
+	// CompactStore value without changing any exported commit signature.
+	TraceOutcome *CompactTraceOutcome
 }
 
 // CompactAtomicStartRequest holds the state prepared by the compact lifecycle
@@ -196,6 +201,9 @@ type CompactStore struct {
 type CompactAtomicStartRequest struct {
 	State   CompactState
 	Binding CompactAtomicStartBinding
+	// TracePath optionally requests a diagnostic trace entry for this exact
+	// atomic START, mirroring CompactStore.TracePath (#1854).
+	TracePath string
 }
 
 // CompactAtomicStartResult reports whether an exact atomic START created one
@@ -203,6 +211,9 @@ type CompactAtomicStartRequest struct {
 type CompactAtomicStartResult struct {
 	Record   CompactRecord
 	Replayed bool
+	// TraceOutcome is set only when TracePath was requested and this call
+	// actually committed (never on replay, which committed nothing new).
+	TraceOutcome *CompactTraceOutcome
 }
 
 // CompactAtomicStartConflictError reports an immutable field conflict without
@@ -1396,7 +1407,19 @@ func (store CompactStore) CreateOrReplayAtomicStart(ctx context.Context, request
 	if err := writeAtomic(store.StatePath(), recordPayload, 0o644); err != nil {
 		return CompactAtomicStartResult{}, err
 	}
-	return CompactAtomicStartResult{Record: record}, nil
+	result := CompactAtomicStartResult{Record: record}
+	// #1854: authority has already committed above; a requested trace that
+	// fails to persist is reported on the returned result, never a
+	// rolled-back commit. The outcome always has a home here (the function's
+	// own return value), so no stderr fallback is needed on this path.
+	if request.TracePath != "" {
+		outcome, _ := recordCompactTrace(request.TracePath, CompactTraceEntry{
+			Operation: "review/start", Revision: record.Revision,
+			State: state.State, RecordedAt: time.Now().UTC().Format(time.RFC3339Nano),
+		})
+		result.TraceOutcome = &outcome
+	}
+	return result, nil
 }
 
 func compactAtomicStartActive(state State) bool {
@@ -1585,11 +1608,22 @@ func (store CompactStore) replaceContextGuarded(ctx context.Context, expectedRev
 	if err := writeAtomic(store.StatePath(), payload, 0o644); err != nil {
 		return "", err
 	}
+	// #1854: the transition above already committed. A requested trace that
+	// fails to persist is reported through TraceOutcome as a committed
+	// result, never a reason to roll back or refuse an authority mutation
+	// that genuinely succeeded. TraceOutcome is opt-in (a caller sets it
+	// alongside TracePath), so a caller that sets TracePath without it still
+	// gets the stderr fallback below rather than total silence.
 	if store.TracePath != "" {
-		recordCompactTrace(store.TracePath, CompactTraceEntry{
+		outcome, traceErr := recordCompactTrace(store.TracePath, CompactTraceEntry{
 			Operation: operation, PreviousRevision: currentRevision, Revision: record.Revision,
 			State: next.State, RecordedAt: time.Now().UTC().Format(time.RFC3339Nano),
 		})
+		if store.TraceOutcome != nil {
+			*store.TraceOutcome = outcome
+		} else if traceErr != nil {
+			compactTraceWarn(operation, store.TracePath, traceErr)
+		}
 	}
 	return record.Revision, nil
 }
@@ -2125,47 +2159,130 @@ func deleteRetiredCompactField(fields map[string]json.RawMessage, path []string)
 	return true, nil
 }
 
-// compactTraceWarn reports a lost diagnostic-trace write (issue #1854). A
-// caller that supplies TracePath explicitly asked for that observability; the
-// authority mutation has already committed by the time this runs and must
-// never be rolled back or fail because of it, so this is report-only. It
-// follows the same "WARNING: ..." convention run.go already uses at the CLI
-// boundary for other non-fatal, already-succeeded-but-partially-degraded
-// operations (e.g. "could not add %s to PATH"). It is a package-level var, in
-// keeping with this file's existing test-seam convention (see
-// finalCompactInvalidationHook and similar hooks), so tests can observe the
-// report without capturing real stderr.
+// CompactTraceOutcome reports what happened to one requested, best-effort
+// diagnostic trace entry after its authority mutation already committed
+// (#1854). It is never a reason to fail or roll back the mutation that
+// produced it: Revision and Operation name the exact committed transition, so
+// a caller can represent "committed, trace degraded" as one typed fact
+// instead of a stderr-only warning a machine consumer cannot see.
+type CompactTraceOutcome struct {
+	// Persisted is true once the trace entry is durably appended.
+	Persisted bool
+	// ErrorClass names which phase of the write failed (see the
+	// compactTraceFailure* constants) when Persisted is false; empty when
+	// Persisted is true.
+	ErrorClass string
+	// Revision is the exact authority revision this trace entry describes,
+	// whether or not persistence succeeded.
+	Revision string
+	// Operation is the exact operation this trace entry describes.
+	Operation string
+}
+
+// Identity is a stable, path-free content identity for the exact trace entry
+// this outcome describes (#1854's "event_identity"): a caller who fixes the
+// trace path and wants to confirm they are looking at the same event, rather
+// than a different one, can compare this instead of trusting free-form text.
+func (outcome CompactTraceOutcome) Identity() string {
+	sum := sha256.Sum256([]byte("gentle-ai.compact-trace-entry/v1\n" + outcome.Operation + "\n" + outcome.Revision))
+	return "sha256:" + hex.EncodeToString(sum[:])
+}
+
+// compactTraceFailure* classifies exactly which phase of a best-effort trace
+// append failed (#1854's "distinguish mkdir/open/write/fsync/close
+// failures"), rather than reducing every failure to one undifferentiated
+// message.
+const (
+	compactTraceFailureMkdir = "mkdir_failed"
+	compactTraceFailureOpen  = "open_failed"
+	compactTraceFailureWrite = "write_failed"
+	compactTraceFailureSync  = "sync_failed"
+	compactTraceFailureClose = "close_failed"
+)
+
+// compactTraceWriteError carries the failed phase alongside the underlying
+// cause, so recordCompactTrace can classify a failure without re-deriving it
+// from an opaque *os.PathError.
+type compactTraceWriteError struct {
+	class string
+	cause error
+}
+
+func (err *compactTraceWriteError) Error() string {
+	return fmt.Sprintf("review trace %s: %v", err.class, err.cause)
+}
+
+func (err *compactTraceWriteError) Unwrap() error { return err.cause }
+
+// compactTraceWarn is the fallback report for a trace write failure on a
+// call path with no projected machine result to carry CompactTraceOutcome
+// (#1854): a native review finding (R4) is exactly this -- TraceOutcome is
+// opt-in per call, and a caller that sets TracePath without also wiring
+// TraceOutcome must still learn about a failure somehow, rather than the
+// mutation succeeding in total silence. Every caller that DOES project a
+// typed result must not also call this, so an operator never sees the same
+// failure reported twice. It follows the same "WARNING: ..." convention
+// run.go already uses at the CLI boundary for other non-fatal,
+// already-succeeded-but-partially-degraded operations (e.g. "could not add
+// %s to PATH"). It is a package-level var, in keeping with this file's
+// existing test-seam convention (see finalCompactInvalidationHook and
+// similar hooks), so tests can observe the report without capturing real
+// stderr.
 var compactTraceWarn = func(operation, path string, err error) {
 	fmt.Fprintf(os.Stderr, "WARNING: review trace for %s was not recorded at %s: %v\n", operation, path, err)
 }
 
-// recordCompactTrace appends a diagnostic trace entry and reports rather than
-// swallows a write failure. The trace is best-effort diagnostics only: it
-// never carries authority, so its failure must never affect an already
-// committed mutation's success/failure outcome.
-func recordCompactTrace(path string, entry CompactTraceEntry) {
-	if err := appendCompactTrace(path, entry); err != nil {
-		compactTraceWarn(entry.Operation, path, err)
+// recordCompactTrace appends a diagnostic trace entry and reports the result
+// as a typed outcome, returning the classifying error alongside it so a
+// caller with no projected result can still warn instead of falling silent
+// (#1854). The trace is best-effort diagnostics only: it never carries
+// authority, and its failure must never affect an already committed
+// mutation's success/failure outcome -- every caller invokes this only after
+// its own commit has already succeeded.
+func recordCompactTrace(path string, entry CompactTraceEntry) (CompactTraceOutcome, error) {
+	outcome := CompactTraceOutcome{Revision: entry.Revision, Operation: entry.Operation}
+	err := appendCompactTrace(path, entry)
+	if err != nil {
+		var writeErr *compactTraceWriteError
+		if errors.As(err, &writeErr) {
+			outcome.ErrorClass = writeErr.class
+		} else {
+			outcome.ErrorClass = "unknown_failed"
+		}
+		return outcome, err
 	}
+	outcome.Persisted = true
+	return outcome, nil
 }
 
+// appendCompactTrace distinguishes mkdir/open/write/fsync/close failures
+// (#1854) and, unlike a bare `defer file.Close()`, surfaces a close-only
+// failure instead of silently discarding it.
 func appendCompactTrace(path string, entry CompactTraceEntry) error {
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
-		return err
+		return &compactTraceWriteError{class: compactTraceFailureMkdir, cause: err}
 	}
 	file, err := os.OpenFile(path, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0o644)
 	if err != nil {
-		return err
+		return &compactTraceWriteError{class: compactTraceFailureOpen, cause: err}
 	}
-	defer file.Close()
 	payload, err := json.Marshal(entry)
 	if err != nil {
-		return err
+		_ = file.Close()
+		return &compactTraceWriteError{class: compactTraceFailureWrite, cause: err}
 	}
 	if _, err := file.Write(append(payload, '\n')); err != nil {
-		return err
+		_ = file.Close()
+		return &compactTraceWriteError{class: compactTraceFailureWrite, cause: err}
 	}
-	return file.Sync()
+	if err := file.Sync(); err != nil {
+		_ = file.Close()
+		return &compactTraceWriteError{class: compactTraceFailureSync, cause: err}
+	}
+	if err := file.Close(); err != nil {
+		return &compactTraceWriteError{class: compactTraceFailureClose, cause: err}
+	}
+	return nil
 }
 
 func (store CompactStore) ExportTransport() (CompactTransport, error) {

--- a/internal/reviewtransaction/compact_store_test.go
+++ b/internal/reviewtransaction/compact_store_test.go
@@ -1,9 +1,12 @@
 package reviewtransaction
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
+	"os"
+	"path/filepath"
 	"reflect"
 	"strings"
 	"testing"
@@ -231,6 +234,140 @@ func newCompactTestStateWithIntended(t *testing.T, repo, lineage string, intende
 		t.Fatal(err)
 	}
 	return state
+}
+
+// TestReplaceContextGuardedCommitsAndReportsUnwritableTraceOutcome is issue
+// #1854, reworked to the issue's own accepted scope: the transition
+// genuinely succeeds, so it must commit exactly as it would without a
+// requested trace. A trace that cannot be persisted is represented as a
+// typed, committed-but-degraded outcome -- never a rolled-back commit and
+// never a stderr-only warning. The reproduction matches the issue exactly:
+// an existing directory supplied as the trace target, which can never be
+// opened as a file.
+func TestReplaceContextGuardedCommitsAndReportsUnwritableTraceOutcome(t *testing.T) {
+	const lineage = "compact-trace-unwritable-commits-and-reports"
+	repo := initSnapshotRepo(t)
+	state := newCompactTestState(t, repo, lineage)
+	store, err := CompactAuthoritativeStore(context.Background(), repo, lineage)
+	if err != nil {
+		t.Fatal(err)
+	}
+	store.TracePath = t.TempDir() // an existing directory: never openable as a file
+	var outcome CompactTraceOutcome
+	store.TraceOutcome = &outcome
+
+	var warned []string
+	originalWarn := compactTraceWarn
+	compactTraceWarn = func(operation, path string, err error) { warned = append(warned, operation) }
+	t.Cleanup(func() { compactTraceWarn = originalWarn })
+
+	revision, err := store.Replace("", "review/start", state)
+	if err != nil {
+		t.Fatalf("Replace() with an unwritable requested trace: %v", err)
+	}
+	if _, statErr := os.Stat(store.StatePath()); statErr != nil {
+		t.Fatalf("authority did not commit despite the trace failure: stat(review-state.json) = %v", statErr)
+	}
+	if outcome.Persisted || outcome.ErrorClass == "" || outcome.Revision != revision || outcome.Operation != "review/start" {
+		t.Fatalf("trace outcome = %#v, want persisted=false, a non-empty error class, and the committed revision %q", outcome, revision)
+	}
+	if outcome.Identity() == "" {
+		t.Fatal("trace outcome carries no event identity")
+	}
+	// A caller that wires TraceOutcome already has a home for this failure:
+	// the stderr fallback must not also fire, or an operator would see the
+	// same failure reported twice.
+	if len(warned) != 0 {
+		t.Fatalf("a projected trace outcome must suppress the stderr fallback, got warnings = %v", warned)
+	}
+}
+
+// TestReplaceContextGuardedWarnsWhenNoTraceOutcomeIsProjected is the R4
+// finding this test closes: a caller that sets TracePath without also
+// wiring TraceOutcome (no machine result exists to carry the outcome on that
+// call path) must still learn about a trace failure through the stderr
+// fallback, never total silence.
+func TestReplaceContextGuardedWarnsWhenNoTraceOutcomeIsProjected(t *testing.T) {
+	const lineage = "compact-trace-unwritable-warns-without-outcome"
+	repo := initSnapshotRepo(t)
+	state := newCompactTestState(t, repo, lineage)
+	store, err := CompactAuthoritativeStore(context.Background(), repo, lineage)
+	if err != nil {
+		t.Fatal(err)
+	}
+	store.TracePath = t.TempDir() // an existing directory: never openable as a file
+	// store.TraceOutcome is deliberately left nil: no result on this call
+	// path can carry the outcome.
+
+	var warned []string
+	originalWarn := compactTraceWarn
+	compactTraceWarn = func(operation, path string, err error) {
+		if path != store.TracePath || err == nil {
+			t.Errorf("compactTraceWarn(%q, %q, %v)", operation, path, err)
+		}
+		warned = append(warned, operation)
+	}
+	t.Cleanup(func() { compactTraceWarn = originalWarn })
+
+	if _, err := store.Replace("", "review/start", state); err != nil {
+		t.Fatalf("Replace() with an unwritable requested trace: %v", err)
+	}
+	if _, statErr := os.Stat(store.StatePath()); statErr != nil {
+		t.Fatalf("authority did not commit despite the trace failure: stat(review-state.json) = %v", statErr)
+	}
+	if !reflect.DeepEqual(warned, []string{"review/start"}) {
+		t.Fatalf("stderr fallback warnings = %v, want exactly one for review/start", warned)
+	}
+}
+
+// TestReplaceContextGuardedCommitsAndReportsPersistedTraceOutcome is the
+// positive-path sibling: a writable trace path commits normally and reports
+// persisted=true with the committed revision.
+func TestReplaceContextGuardedCommitsAndReportsPersistedTraceOutcome(t *testing.T) {
+	const lineage = "compact-trace-writable-commits-and-reports"
+	repo := initSnapshotRepo(t)
+	state := newCompactTestState(t, repo, lineage)
+	store, err := CompactAuthoritativeStore(context.Background(), repo, lineage)
+	if err != nil {
+		t.Fatal(err)
+	}
+	store.TracePath = filepath.Join(t.TempDir(), "trace.jsonl")
+	var outcome CompactTraceOutcome
+	store.TraceOutcome = &outcome
+
+	revision, err := store.Replace("", "review/start", state)
+	if err != nil {
+		t.Fatalf("Replace() with a writable requested trace: %v", err)
+	}
+	if !outcome.Persisted || outcome.ErrorClass != "" || outcome.Revision != revision || outcome.Operation != "review/start" {
+		t.Fatalf("trace outcome = %#v, want persisted=true, no error class, and the committed revision %q", outcome, revision)
+	}
+	payload, err := os.ReadFile(store.TracePath)
+	if err != nil {
+		t.Fatalf("requested trace was not written: %v", err)
+	}
+	if !bytes.Contains(payload, []byte(`"review/start"`)) {
+		t.Fatalf("trace payload missing the committed operation: %s", payload)
+	}
+}
+
+// TestReplaceContextGuardedCommitsWhenNoTraceIsRequested pins the "no trace
+// requested preserves current behavior" bound from #1854: an empty
+// TracePath must never attempt a write or affect the commit.
+func TestReplaceContextGuardedCommitsWhenNoTraceIsRequested(t *testing.T) {
+	const lineage = "compact-trace-absent-commits-normally"
+	repo := initSnapshotRepo(t)
+	state := newCompactTestState(t, repo, lineage)
+	store, err := CompactAuthoritativeStore(context.Background(), repo, lineage)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.Replace("", "review/start", state); err != nil {
+		t.Fatalf("Replace() with no requested trace: %v", err)
+	}
+	if _, statErr := os.Stat(store.StatePath()); statErr != nil {
+		t.Fatalf("authority did not commit: stat(review-state.json) = %v", statErr)
+	}
 }
 
 func pendingCompactCorrection(t *testing.T, repo, lineage string) (CompactState, Snapshot) {

--- a/internal/reviewtransaction/store.go
+++ b/internal/reviewtransaction/store.go
@@ -36,6 +36,46 @@ var syncReviewDirectory = func(path string) error {
 	return directory.Close()
 }
 
+// mkdirAllSync creates the directory chain for path, like os.MkdirAll, but
+// synchronizes the parent of every directory it actually creates (#1721): a
+// newly created directory entry is not durable until its parent's own
+// directory data is synced, and a caller that publishes a file beneath a
+// freshly created directory (e.g. the first compact lineage under v2/) needs
+// that entry durable before it reports the publish as complete.
+//
+// Components are created one at a time with os.Mkdir rather than detected via
+// a Stat-before-MkdirAll check: os.Mkdir's own success/EEXIST outcome is race
+// free, where a preceding Stat would leave a TOCTOU window against a
+// concurrent creator.
+func mkdirAllSync(path string, mode os.FileMode) error {
+	path = filepath.Clean(path)
+	parent := filepath.Dir(path)
+	if parent == path {
+		return nil
+	}
+	if err := mkdirAllSync(parent, mode); err != nil {
+		return err
+	}
+	switch err := os.Mkdir(path, mode); {
+	case err == nil:
+		return SyncReviewDirectory(parent)
+	case errors.Is(err, os.ErrExist):
+		// Stat, not Lstat: an existing entry may be a symlink to a directory
+		// (e.g. macOS /var -> /private/var), which must not be rejected as
+		// "not a directory".
+		info, statErr := os.Stat(path)
+		if statErr != nil {
+			return statErr
+		}
+		if !info.IsDir() {
+			return &os.PathError{Op: "mkdir", Path: path, Err: syscall.ENOTDIR}
+		}
+		return nil
+	default:
+		return err
+	}
+}
+
 type directorySyncError struct {
 	path  string
 	cause error
@@ -164,7 +204,11 @@ func (store Store) append(expectedRevision string, record Record) (string, error
 		}
 		defer maintenance.Release()
 	}
-	if err := os.MkdirAll(filepath.Join(store.Dir, "events"), 0o755); err != nil {
+	// #1721: mkdirAllSync (not os.MkdirAll) so a first review/start on this
+	// lineage syncs the v1/ parent for the newly created lineage directory,
+	// and store.Dir for the newly created events/ directory, before any
+	// event or HEAD naming them is published below.
+	if err := mkdirAllSync(filepath.Join(store.Dir, "events"), 0o755); err != nil {
 		return "", err
 	}
 	lockPath := filepath.Join(store.Dir, "LOCK")
@@ -274,6 +318,13 @@ func (store Store) append(expectedRevision string, record Record) (string, error
 		} else {
 			return "", err
 		}
+	}
+	// #1721: HEAD is about to name this event as durable. Without syncing
+	// events/ first, a crash between the rename above and this point can
+	// leave a durable HEAD pointing at an event entry the directory never
+	// actually recorded.
+	if err := SyncReviewDirectory(filepath.Join(store.Dir, "events")); err != nil {
+		return "", &directorySyncError{path: eventPath, cause: err}
 	}
 	if err := writeAtomic(filepath.Join(store.Dir, "HEAD"), []byte(revision+"\n"), 0o644); err != nil {
 		return "", err
@@ -883,7 +934,7 @@ func readRevision(path string) (string, error) {
 }
 
 func writeAtomic(path string, payload []byte, mode os.FileMode) error {
-	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+	if err := mkdirAllSync(filepath.Dir(path), 0o755); err != nil {
 		return err
 	}
 	temp, err := os.CreateTemp(filepath.Dir(path), ".atomic-*")

--- a/internal/reviewtransaction/store_test.go
+++ b/internal/reviewtransaction/store_test.go
@@ -61,6 +61,111 @@ func TestWriteAtomicToleratesUnsupportedParentDirectorySync(t *testing.T) {
 	}
 }
 
+// TestMkdirAllSyncSyncsParentOfEveryCreatedDirectory is issue #1721: a newly
+// created Unix authority directory entry must be durable (its parent synced)
+// before any dependent state is published beneath it. This uses the same
+// syncReviewDirectory recording seam as the writeAtomic tests above.
+func TestMkdirAllSyncSyncsParentOfEveryCreatedDirectory(t *testing.T) {
+	originalSync := syncReviewDirectory
+	var synced []string
+	syncReviewDirectory = func(path string) error {
+		synced = append(synced, path)
+		return nil
+	}
+	t.Cleanup(func() { syncReviewDirectory = originalSync })
+
+	root := t.TempDir()
+	target := filepath.Join(root, "v2", "lineage-one", "leaf")
+	if err := mkdirAllSync(target, 0o755); err != nil {
+		t.Fatalf("mkdirAllSync() error = %v", err)
+	}
+	for _, dir := range []string{target, filepath.Dir(target), filepath.Join(root, "v2")} {
+		if info, err := os.Stat(dir); err != nil || !info.IsDir() {
+			t.Fatalf("expected directory at %s, stat = %v, %v", dir, info, err)
+		}
+	}
+	want := map[string]bool{root: false, filepath.Join(root, "v2"): false, filepath.Join(root, "v2", "lineage-one"): false}
+	for _, path := range synced {
+		if _, tracked := want[path]; tracked {
+			want[path] = true
+		}
+	}
+	for parent, seen := range want {
+		if !seen {
+			t.Fatalf("mkdirAllSync() never synced parent %s of a newly created directory; recorded = %v", parent, synced)
+		}
+	}
+
+	// A second call against the same, now fully-existing chain must not
+	// re-sync anything: nothing new was created.
+	synced = nil
+	if err := mkdirAllSync(target, 0o755); err != nil {
+		t.Fatalf("mkdirAllSync() on existing chain error = %v", err)
+	}
+	if len(synced) != 0 {
+		t.Fatalf("mkdirAllSync() synced already-existing directories: %v", synced)
+	}
+}
+
+// TestMkdirAllSyncRejectsAFileWhereADirectoryIsRequired keeps the TOCTOU-free
+// Mkdir-per-component design from silently accepting a name collision.
+func TestMkdirAllSyncRejectsAFileWhereADirectoryIsRequired(t *testing.T) {
+	root := t.TempDir()
+	blocked := filepath.Join(root, "not-a-dir")
+	if err := os.WriteFile(blocked, []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := mkdirAllSync(filepath.Join(blocked, "child"), 0o755); err == nil {
+		t.Fatal("mkdirAllSync() accepted a file where a directory was required")
+	}
+}
+
+// TestStoreAppendRefusesHeadPublicationWhenEventsDirectorySyncFails is issue
+// #1721: the events/ directory must be durable before HEAD can name an event
+// inside it. Injecting a sync failure scoped to exactly the events/ path
+// proves the ordering: HEAD must never be written past that failure.
+func TestStoreAppendRefusesHeadPublicationWhenEventsDirectorySyncFails(t *testing.T) {
+	// EvalSymlinks: on macOS, t.TempDir() resolves through the /var ->
+	// /private/var symlink, which the store lock's O_NOFOLLOW parent walk
+	// (secure_open_unix.go) refuses to traverse for a root outside a real
+	// gentle-ai/review-transactions layout. Using the resolved path keeps
+	// this test about the events/-before-HEAD ordering, not that unrelated
+	// platform detail.
+	base, err := filepath.EvalSymlinks(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	store := Store{Dir: filepath.Join(base, "review-store")}
+	eventsDir := filepath.Join(store.Dir, "events")
+	originalSync := syncReviewDirectory
+	syncReviewDirectory = func(path string) error {
+		if path == eventsDir {
+			return errors.New("simulated events/ sync failure")
+		}
+		return originalSync(path)
+	}
+	t.Cleanup(func() { syncReviewDirectory = originalSync })
+
+	tx := newTestTransaction(t, ModeOrdinary4R)
+	if err := tx.StartReview(); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.Append("", Record{Operation: "review/start", Transaction: *tx}); err == nil ||
+		!strings.Contains(err.Error(), "sync parent directory") {
+		t.Fatalf("Append() error = %v, want an events/ sync failure", err)
+	}
+	if _, err := os.Stat(filepath.Join(store.Dir, "HEAD")); !os.IsNotExist(err) {
+		t.Fatalf("HEAD published despite a failed events/ directory sync: stat = %v", err)
+	}
+	entries, err := os.ReadDir(eventsDir)
+	if err != nil {
+		t.Fatalf("ReadDir(events) error = %v", err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("event count = %d, want the event durably published even though HEAD was refused", len(entries))
+	}
+}
+
 func TestStoreIsAppendOnlyAtomicAndRejectsStaleWriters(t *testing.T) {
 	store := Store{Dir: filepath.Join(t.TempDir(), "review-store")}
 	tx := newTestTransaction(t, ModeOrdinary4R)


### PR DESCRIPTION
Closes #1721
Closes #1854
Closes #3371

## Summary
- #1721: every directory the store creates is fsynced (`mkdirAllSync`), and `events/` is synced before `HEAD` on the legacy store and the bundle-install path, so a crash cannot publish a pointer to a missing file. Compact-v2 first publication syncs the `v2/` parent.
- #1854 (per the issue's accepted scope): the commit proceeds and the result carries a typed trace outcome (`persisted`, error class, committed revision, idempotent retry guidance); the stderr warning survives only on paths with no projected result (native review correction R4). `--trace` is wired into the zero-lens auto-close path, where it was dead.
- #3371: `review repair --preflight` past the 256-lineage cap reports `truncated`, the cap and the scanned count instead of all-zero healthy-looking counts; `Validate()` enforces the shape. No pinned schema changed.

size:exception: about 300 production lines across store, bundle, compact store, repair assessment and facade, plus the fsync seam, trace and truncation tests; three related integrity work units on one store.

## Test plan
- [x] `go test ./internal/reviewtransaction/ -run 'Trace|Compact|Publish|Sync|Repair|MkdirAllSync' -count=1` (only the known environmental lock-path failures)
- [x] `go test ./internal/cli/ -run 'Trace|Repair|Pinned|Start' -count=1 -timeout 30m`
- [x] Refusal ratchet passes; `contracts/` untouched
- [x] Native review approved and acknowledged (lineage review-32b89f4f82e256cb, one bounded correction)

https://claude.ai/code/session_01SYqbaaqyJcAv1FYtSJXx6M

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - `review start --trace` now reports whether diagnostic traces were saved, including failure details and retry guidance, while preserving successful reviews.
  - Trace outcomes are available in the modern review-start response.
  - Authority repair results now show when inventory scanning was truncated and how much was examined.

- **Reliability**
  - Improved storage durability and crash recovery when writing review events and metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->