### PR TITLE
fix(sdd): report whether max_changed_lines came from the default

### DIFF
--- a/internal/cli/sdd_attempt.go
+++ b/internal/cli/sdd_attempt.go
@@ -70,6 +70,17 @@ func runSDDAttempt(ctx context.Context, args []string, stdout io.Writer) error {
 	if flags.NArg() != 0 {
 		return fmt.Errorf("unexpected sdd-attempt argument %q", flags.Arg(0))
 	}
+	// --max-changed-lines is pre-defaulted at flags.Int (registerSDDAttemptIntFlag)
+	// so an omitted flag and an explicitly-typed default are indistinguishable
+	// from the parsed value alone; flags.Visit sees only flags the caller
+	// actually typed, so it is the one place that still knows which happened
+	// (#2589). acquire/begin surface it as max_changed_lines_source below.
+	maxChangedLinesExplicit := false
+	flags.Visit(func(f *flag.Flag) {
+		if f.Name == "max-changed-lines" {
+			maxChangedLinesExplicit = true
+		}
+	})
 	// Identity/revision-shaped values are trimmed at this CLI boundary so
 	// incidental leading/trailing whitespace from a shell or PowerShell
 	// copy-paste (e.g. `Get-FileHash`/`shasum` output) does not itself cause
@@ -181,7 +192,8 @@ func runSDDAttempt(ctx context.Context, args []string, stdout io.Writer) error {
 	case "begin":
 		result, err = store.Begin(ctx, sddstatus.BeginAttemptRequest{
 			ExpectedRevision: *expected, RequestID: *requestID, WorkUnit: *workUnit, EvidenceGoal: *evidenceGoal,
-			MaxAttempts: *maxAttempts, MaxChangedLines: *maxChangedLines, IntendedUntracked: intended,
+			MaxAttempts: *maxAttempts, MaxChangedLines: *maxChangedLines, MaxChangedLinesExplicit: maxChangedLinesExplicit,
+			IntendedUntracked: intended,
 		})
 	case "finish":
 		result, err = store.Finish(ctx, sddstatus.FinishAttemptRequest{
@@ -217,7 +229,8 @@ func runSDDAttempt(ctx context.Context, args []string, stdout io.Writer) error {
 			BeginAttemptRequest: sddstatus.BeginAttemptRequest{
 				ExpectedRevision: *expected,
 				RequestID:        *requestID, WorkUnit: *workUnit, EvidenceGoal: *evidenceGoal,
-				MaxAttempts: *maxAttempts, MaxChangedLines: *maxChangedLines, IntendedUntracked: intended,
+				MaxAttempts: *maxAttempts, MaxChangedLines: *maxChangedLines, MaxChangedLinesExplicit: maxChangedLinesExplicit,
+				IntendedUntracked: intended,
 			},
 			Token:                      *token,
 			RemediatesEvidenceRevision: *remediatesEvidenceRevision,

--- a/internal/cli/sdd_attempt_budget_provenance_test.go
+++ b/internal/cli/sdd_attempt_budget_provenance_test.go
@@ -1,0 +1,106 @@
+package cli
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+)
+
+// TestSDDAttemptBeginReportsMaxChangedLinesSource is issue #2589: an omitted
+// --max-changed-lines silently applied the compiled 200-line default with no
+// marker distinguishing it from a maintainer who typed 200 on purpose.
+// `begin`'s RuntimeStatus answer now names which one happened.
+func TestSDDAttemptBeginReportsMaxChangedLinesSource(t *testing.T) {
+	t.Run("omitted flag reports default", func(t *testing.T) {
+		repo := initReviewCLIRepo(t)
+		status := runSDDAttemptStatus(t, []string{
+			"begin", "--cwd", repo, "--change", "budget-default", "--expected-revision=",
+			"--request-id", "budget-default-begin", "--work-unit", "budget-proof",
+			"--evidence-goal", "prove the default budget is reported",
+		})
+		if status.Objective == nil || status.Objective.MaxChangedLines != 200 || status.Objective.MaxChangedLinesSource != "default" {
+			t.Fatalf("omitted-flag objective = %#v, want 200 changed lines sourced \"default\"", status.Objective)
+		}
+	})
+
+	t.Run("explicit flag reports explicit", func(t *testing.T) {
+		repo := initReviewCLIRepo(t)
+		status := runSDDAttemptStatus(t, []string{
+			"begin", "--cwd", repo, "--change", "budget-explicit", "--expected-revision=",
+			"--request-id", "budget-explicit-begin", "--work-unit", "budget-proof",
+			"--evidence-goal", "prove an explicit budget is reported",
+			"--max-attempts", "2", "--max-changed-lines", "200",
+		})
+		if status.Objective == nil || status.Objective.MaxChangedLines != 200 || status.Objective.MaxChangedLinesSource != "explicit" {
+			t.Fatalf("explicit-flag objective = %#v, want 200 changed lines sourced \"explicit\"", status.Objective)
+		}
+	})
+}
+
+// TestSDDAttemptAcquireReportsAppliedDefaultOnly is issue #2589's acquire
+// half: the compact projection stays bounded for an explicit budget
+// (TestRunSDDAttemptCompactOutputStaysBoundedAcrossHistory already pins
+// that), but an omitted --max-changed-lines now surfaces the applied default
+// on the same proceed answer instead of only through a separate `status`
+// call.
+func TestSDDAttemptAcquireReportsAppliedDefaultOnly(t *testing.T) {
+	t.Run("omitted flag surfaces the default", func(t *testing.T) {
+		repo := initReviewCLIRepo(t)
+		acquired, payload := runCompactSDDAttempt(t, []string{
+			"acquire", "--cwd", repo, "--change", "acquire-budget-default",
+			"--request-id", "acquire-budget-default-1", "--work-unit", "compact-unit",
+			"--evidence-goal", "prove acquire reports the applied default",
+		})
+		if acquired.State != "proceed" || acquired.MaxChangedLines != 200 || acquired.MaxChangedLinesSource != "default" {
+			t.Fatalf("acquire with omitted flag = %#v, want proceed with 200 changed lines sourced \"default\"", acquired)
+		}
+		assertCompactPayloadKeys(t, payload, "state", "token", "max_changed_lines", "max_changed_lines_source")
+	})
+
+	t.Run("explicit flag stays bounded", func(t *testing.T) {
+		repo := initReviewCLIRepo(t)
+		acquired, payload := runCompactSDDAttempt(t, compactAcquireArgs(repo, "acquire-budget-explicit", "acquire-budget-explicit-1", 2))
+		if acquired.State != "proceed" || acquired.MaxChangedLines != 0 || acquired.MaxChangedLinesSource != "" {
+			t.Fatalf("acquire with explicit flag = %#v, want no budget fields", acquired)
+		}
+		assertCompactPayloadKeys(t, payload, "state", "token")
+	})
+}
+
+// TestSDDAttemptBeginRequestDigestSurvivesMaxChangedLinesExplicitField pins
+// the replay-time hazard #2589's new BeginAttemptRequest.MaxChangedLinesExplicit
+// field could have introduced: validateRuntimeBeginEvent reconstructs the
+// original request from the persisted event to check its digest, and had to
+// learn the new field too, or every explicit-budget begin would fail replay
+// with "begin_request_digest_match" the moment its own record was read back.
+func TestSDDAttemptBeginRequestDigestSurvivesMaxChangedLinesExplicitField(t *testing.T) {
+	repo := initReviewCLIRepo(t)
+	args := []string{
+		"begin", "--cwd", repo, "--change", "digest-survives-explicit", "--expected-revision=",
+		"--request-id", "digest-begin-1", "--work-unit", "digest-proof",
+		"--evidence-goal", "prove the request digest survives explicit provenance",
+		"--max-attempts", "2", "--max-changed-lines", "40",
+	}
+	began := runSDDAttemptStatus(t, args)
+	if began.Objective == nil || began.ActiveAttempt == nil {
+		t.Fatalf("begin = %#v", began)
+	}
+	// Replay: reading status back re-derives the whole chain from disk,
+	// which is exactly where validateRuntimeBeginEvent runs.
+	var output bytes.Buffer
+	if err := RunSDDAttempt([]string{"status", "--cwd", repo, "--change", "digest-survives-explicit"}, &output); err != nil {
+		t.Fatalf("status after begin: %v", err)
+	}
+	var decoded struct {
+		Objective *struct {
+			MaxChangedLines       int    `json:"max_changed_lines"`
+			MaxChangedLinesSource string `json:"max_changed_lines_source"`
+		} `json:"objective"`
+	}
+	if err := json.Unmarshal(output.Bytes(), &decoded); err != nil {
+		t.Fatal(err)
+	}
+	if decoded.Objective == nil || decoded.Objective.MaxChangedLines != 40 || decoded.Objective.MaxChangedLinesSource != "explicit" {
+		t.Fatalf("replayed objective = %#v", decoded.Objective)
+	}
+}

--- a/internal/cli/sdd_attempt_compact_test.go
+++ b/internal/cli/sdd_attempt_compact_test.go
@@ -26,6 +26,12 @@ type compactAttemptOutput struct {
 	// passing settle will already owe, named while the attempt is still
 	// unspent.
 	SettleObligation string `json:"settle_obligation,omitempty"`
+	// MaxChangedLines/MaxChangedLinesSource ride the proceed envelope too
+	// (#2589): the runtime line budget this attempt opened against, and
+	// whether it came from an explicit --max-changed-lines or the compiled
+	// default.
+	MaxChangedLines       int    `json:"max_changed_lines,omitempty"`
+	MaxChangedLinesSource string `json:"max_changed_lines_source,omitempty"`
 }
 
 func TestRunSDDAttemptCompactOutputStaysBoundedAcrossHistory(t *testing.T) {

--- a/internal/sddstatus/runtime_compact.go
+++ b/internal/sddstatus/runtime_compact.go
@@ -70,6 +70,16 @@ type CompactAttemptResult struct {
 	// the token is real. Empty whenever the chain holds nothing, because a
 	// field that is always populated is noise.
 	SettleObligation string `json:"settle_obligation,omitempty"`
+	// MaxChangedLines and MaxChangedLinesSource report an applied DEFAULT
+	// runtime line budget on the proceed answer itself (#2589): before this,
+	// an omitted --max-changed-lines was charged silently, and a caller
+	// learned only from a separate `status` call that a 200-line ceiling had
+	// already been applied. Both stay empty for an explicit budget and for
+	// every non-proceed answer -- an explicit caller already knows the value
+	// it typed, and this compact projection stays bounded for the ordinary
+	// case (TestRunSDDAttemptCompactOutputStaysBoundedAcrossHistory).
+	MaxChangedLines       int    `json:"max_changed_lines,omitempty"`
+	MaxChangedLinesSource string `json:"max_changed_lines_source,omitempty"`
 }
 
 // CompactAcquireRequest is the bounded orchestration projection of
@@ -264,6 +274,7 @@ func (store RuntimeStore) Acquire(ctx context.Context, request CompactAcquireReq
 	}); terminal {
 		if result.State == CompactStateProceed {
 			result.SettleObligation = runtimeSettleObligation(replay.Status)
+			result = compactAcquireBudgetResult(result, replay.Status.Objective)
 		}
 		return result, nil
 	}
@@ -289,12 +300,27 @@ func (store RuntimeStore) Acquire(ctx context.Context, request CompactAcquireReq
 	if err != nil {
 		return store.compactMutationFailure(err, false, begin), nil
 	}
-	return CompactAttemptResult{
+	return compactAcquireBudgetResult(CompactAttemptResult{
 		State: CompactStateProceed, Token: started.Revision,
 		// Derived from the PRE-mutation chain: the obligation this attempt
 		// inherits is the one that existed when it was opened.
 		SettleObligation: runtimeSettleObligation(replay.Status),
-	}, nil
+	}, started.Objective), nil
+}
+
+// compactAcquireBudgetResult surfaces the applied DEFAULT runtime line budget
+// on a proceed answer (#2589) -- the one case this compact projection was
+// silent about: an omitted --max-changed-lines charged a 200-line ceiling
+// with nothing in the answer to say so. An explicit budget adds nothing here,
+// preserving the bounded/unchanging compact output an explicit acquire call
+// already guarantees (TestRunSDDAttemptCompactOutputStaysBoundedAcrossHistory)
+// -- the caller who typed the value already knows it.
+func compactAcquireBudgetResult(result CompactAttemptResult, objective *RuntimeObjective) CompactAttemptResult {
+	if objective != nil && objective.MaxChangedLinesSource == runtimeChangedLinesSourceDefault {
+		result.MaxChangedLines = objective.MaxChangedLines
+		result.MaxChangedLinesSource = objective.MaxChangedLinesSource
+	}
+	return result
 }
 
 // Settle closes the attempt selected by Token through the ordinary Finish
@@ -488,6 +514,9 @@ func compactAcquireResult(replay runtimeReplay, request BeginAttemptRequest, own
 		Status: replay.Status, AttemptTokens: replay.AttemptTokens,
 		Request: request, PresentedToken: ownedToken,
 	}); terminal {
+		if result.State == CompactStateProceed {
+			result = compactAcquireBudgetResult(result, replay.Status.Objective)
+		}
 		return result
 	}
 	return compactBlocked(CompactBlockInvalidContinuation, "")

--- a/internal/sddstatus/runtime_ledger.go
+++ b/internal/sddstatus/runtime_ledger.go
@@ -218,6 +218,29 @@ type RuntimeObjective struct {
 	InitialCandidateTree     string `json:"initial_candidate_tree"`
 	MaxAttempts              int    `json:"max_attempts"`
 	MaxChangedLines          int    `json:"max_changed_lines"`
+	// MaxChangedLinesSource reports whether MaxChangedLines came from an
+	// explicit --max-changed-lines or from the compiled
+	// DefaultRuntimeChangedLines fallback (#2589): before this, an omitted
+	// flag silently became a 200-line ceiling with nothing in the
+	// begin/acquire answer distinguishing it from a maintainer who typed 200
+	// on purpose. An objective replayed from a record written before this
+	// provenance was tracked reports "default", the same as an unmarked
+	// explicit value would -- there is no way to recover which one a legacy
+	// record was, so this never asserts "explicit" without the caller's own
+	// say-so.
+	MaxChangedLinesSource string `json:"max_changed_lines_source,omitempty"`
+}
+
+const (
+	runtimeChangedLinesSourceExplicit = "explicit"
+	runtimeChangedLinesSourceDefault  = "default"
+)
+
+func runtimeChangedLinesSource(explicit bool) string {
+	if explicit {
+		return runtimeChangedLinesSourceExplicit
+	}
+	return runtimeChangedLinesSourceDefault
 }
 
 type RuntimeAttempt struct {
@@ -373,13 +396,25 @@ type RuntimeStatus struct {
 }
 
 type BeginAttemptRequest struct {
-	ExpectedRevision  string   `json:"expected_revision"`
-	RequestID         string   `json:"request_id"`
-	WorkUnit          string   `json:"work_unit"`
-	EvidenceGoal      string   `json:"evidence_goal"`
-	MaxAttempts       int      `json:"max_attempts"`
-	MaxChangedLines   int      `json:"max_changed_lines"`
-	IntendedUntracked []string `json:"intended_untracked"`
+	ExpectedRevision string `json:"expected_revision"`
+	RequestID        string `json:"request_id"`
+	WorkUnit         string `json:"work_unit"`
+	EvidenceGoal     string `json:"evidence_goal"`
+	MaxAttempts      int    `json:"max_attempts"`
+	MaxChangedLines  int    `json:"max_changed_lines"`
+	// MaxChangedLinesExplicit is caller (CLI) provenance: true when the
+	// caller actually typed --max-changed-lines, false when MaxChangedLines
+	// is the compiled default the flag registered on the caller's behalf
+	// (#2589). It has no bearing on admission or request identity -- only on
+	// what a fresh objective's MaxChangedLinesSource reports -- so it is
+	// excluded from the request digest entirely (json:"-"): an explicit
+	// request digest must stay byte-identical to what a binary predating
+	// this field computed, or an in-flight ledger replayed after an upgrade
+	// would fail begin_request_digest_match on its own pre-upgrade records.
+	// The genuine persisted marker lives on runtimeBeginEvent instead, which
+	// is never a digest input.
+	MaxChangedLinesExplicit bool     `json:"-"`
+	IntendedUntracked       []string `json:"intended_untracked"`
 }
 
 // legacyBeginAttemptRequest preserves replay of records written before
@@ -584,15 +619,20 @@ type runtimeAdvanceEvent struct {
 }
 
 type runtimeBeginEvent struct {
-	ObjectiveID            string `json:"objective_id"`
-	ObjectiveGeneration    int    `json:"objective_generation,omitempty"`
-	WorkUnit               string `json:"work_unit"`
-	EvidenceGoal           string `json:"evidence_goal"`
-	MaxAttempts            int    `json:"max_attempts"`
-	MaxChangedLines        int    `json:"max_changed_lines"`
-	Ordinal                int    `json:"ordinal"`
-	BeginCandidateIdentity string `json:"begin_candidate_identity"`
-	BeginCandidateTree     string `json:"begin_candidate_tree"`
+	ObjectiveID         string `json:"objective_id"`
+	ObjectiveGeneration int    `json:"objective_generation,omitempty"`
+	WorkUnit            string `json:"work_unit"`
+	EvidenceGoal        string `json:"evidence_goal"`
+	MaxAttempts         int    `json:"max_attempts"`
+	MaxChangedLines     int    `json:"max_changed_lines"`
+	// MaxChangedLinesExplicit mirrors BeginAttemptRequest's field of the same
+	// name (#2589), persisted so replay can reconstruct
+	// RuntimeObjective.MaxChangedLinesSource deterministically. Absent on a
+	// record written before this field existed.
+	MaxChangedLinesExplicit bool   `json:"max_changed_lines_explicit,omitempty"`
+	Ordinal                 int    `json:"ordinal"`
+	BeginCandidateIdentity  string `json:"begin_candidate_identity"`
+	BeginCandidateTree      string `json:"begin_candidate_tree"`
 	// A nil pointer preserves records written before candidate provenance was
 	// introduced; a non-nil empty slice is a modern, explicit empty selection.
 	IntendedUntracked *[]string `json:"intended_untracked,omitempty"`
@@ -884,7 +924,7 @@ func (store RuntimeStore) Begin(ctx context.Context, request BeginAttemptRequest
 		}
 		event := &runtimeBeginEvent{
 			ObjectiveID: objectiveID, ObjectiveGeneration: generation, WorkUnit: request.WorkUnit, EvidenceGoal: request.EvidenceGoal,
-			MaxAttempts: request.MaxAttempts, MaxChangedLines: request.MaxChangedLines,
+			MaxAttempts: request.MaxAttempts, MaxChangedLines: request.MaxChangedLines, MaxChangedLinesExplicit: request.MaxChangedLinesExplicit,
 			Ordinal: status.NextOrdinal, BeginCandidateIdentity: snapshot.Identity, BeginCandidateTree: snapshot.CandidateTree,
 			IntendedUntracked: &intendedUntracked, EligibleUntrackedInventory: &eligibleInventory,
 			BeginWorktree: store.Workspace, EffectiveWorktree: store.Workspace,
@@ -2247,6 +2287,7 @@ func applyRuntimeBeginEvent(replay *runtimeReplay, revision string, record runti
 			ID: event.ObjectiveID, Generation: generation, WorkUnit: event.WorkUnit, EvidenceGoal: event.EvidenceGoal,
 			InitialCandidateIdentity: event.BeginCandidateIdentity, InitialCandidateTree: event.BeginCandidateTree,
 			MaxAttempts: event.MaxAttempts, MaxChangedLines: event.MaxChangedLines,
+			MaxChangedLinesSource: runtimeChangedLinesSource(event.MaxChangedLinesExplicit),
 		}
 		replay.Status.ObjectiveGeneration = generation
 	} else {
@@ -2373,6 +2414,10 @@ func applyRuntimeRescopeEvent(replay *runtimeReplay, revision string, record run
 		ID: event.ObjectiveID, Generation: generation, WorkUnit: event.WorkUnit, EvidenceGoal: event.EvidenceGoal,
 		InitialCandidateIdentity: event.RescopeCandidateIdentity, InitialCandidateTree: event.RescopeCandidateTree,
 		MaxAttempts: event.MaxAttempts, MaxChangedLines: event.MaxChangedLines,
+		// AUDITED NARROWING RESCOPE always requires an explicit positive
+		// --max-changed-lines (normalizeRescopeObjectiveRequest); there is no
+		// default path here to report.
+		MaxChangedLinesSource: runtimeChangedLinesSourceExplicit,
 	}
 	replay.Status.ObjectiveGeneration = generation
 	replay.Status.EvidenceRevision = ""
@@ -2707,6 +2752,10 @@ func validateRuntimeBeginEvent(record runtimeRecord) error {
 	if event.IntendedUntracked != nil {
 		intendedUntracked = *event.IntendedUntracked
 	}
+	// MaxChangedLinesExplicit is deliberately not reconstructed here: it is
+	// excluded from BeginAttemptRequest's digest (json:"-"), so it plays no
+	// part in this replay-time digest match regardless of what the event
+	// carries.
 	request := BeginAttemptRequest{
 		ExpectedRevision: record.PreviousRevision, RequestID: record.RequestID, WorkUnit: event.WorkUnit,
 		EvidenceGoal: event.EvidenceGoal, MaxAttempts: event.MaxAttempts, MaxChangedLines: event.MaxChangedLines,

--- a/internal/sddstatus/runtime_ledger_budget_provenance_digest_test.go
+++ b/internal/sddstatus/runtime_ledger_budget_provenance_digest_test.go
@@ -1,0 +1,129 @@
+package sddstatus
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"strings"
+	"testing"
+)
+
+// TestBeginAttemptRequestDigestIsIndependentOfMaxChangedLinesExplicit pins
+// the exact property a refuter escalated on: MaxChangedLinesExplicit
+// (#2589 provenance) must never change BeginAttemptRequest's request digest.
+// It is excluded entirely (json:"-"), not merely omitted when false, so an
+// in-flight ledger holding explicit-budget begins written by a binary that
+// predates this field replays against the identical digest after an
+// upgrade, whichever value this field happens to hold.
+func TestBeginAttemptRequestDigestIsIndependentOfMaxChangedLinesExplicit(t *testing.T) {
+	base := BeginAttemptRequest{
+		ExpectedRevision: "", RequestID: "digest-parity", WorkUnit: "unit", EvidenceGoal: "goal",
+		MaxAttempts: 2, MaxChangedLines: 40, IntendedUntracked: []string{},
+	}
+	explicit := base
+	explicit.MaxChangedLinesExplicit = true
+	defaulted := base
+	defaulted.MaxChangedLinesExplicit = false
+
+	explicitDigest := runtimeValueHash("gentle-ai.sdd-runtime-begin-request/v1", explicit)
+	defaultedDigest := runtimeValueHash("gentle-ai.sdd-runtime-begin-request/v1", defaulted)
+	if explicitDigest != defaultedDigest {
+		t.Fatalf("digest depends on MaxChangedLinesExplicit: explicit=%s defaulted=%s", explicitDigest, defaultedDigest)
+	}
+}
+
+// TestRuntimeLedgerLegacyShapedBeginEventReplaysAndDigestMatches is the
+// end-to-end counterpart: a begin whose budget was NOT explicit persists an
+// event with no max_changed_lines_explicit key at all (omitempty), which is
+// byte-for-byte the same shape a binary written before this field existed
+// would have produced. A fresh store re-reading that record from disk must
+// replay it without begin_request_digest_match, and must report the
+// provenance as "default" rather than asserting an explicit value it was
+// never told.
+func TestRuntimeLedgerLegacyShapedBeginEventReplaysAndDigestMatches(t *testing.T) {
+	repo := initRuntimeLedgerRepo(t)
+	store, err := OpenRuntimeStore(context.Background(), repo, "legacy-shaped-begin")
+	if err != nil {
+		t.Fatal(err)
+	}
+	began, err := store.Begin(context.Background(), BeginAttemptRequest{
+		ExpectedRevision: "", RequestID: "legacy-begin-1", WorkUnit: "legacy-unit",
+		EvidenceGoal: "prove legacy replay", MaxAttempts: 2, MaxChangedLines: DefaultRuntimeChangedLines,
+		MaxChangedLinesExplicit: false,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	raw, err := os.ReadFile(store.recordPath(began.Revision))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(raw), "max_changed_lines_explicit") {
+		t.Fatalf("a non-explicit begin persisted the provenance key, which a legacy record could never have had:\n%s", raw)
+	}
+
+	reopened, err := OpenRuntimeStore(context.Background(), repo, "legacy-shaped-begin")
+	if err != nil {
+		t.Fatal(err)
+	}
+	replayed, err := reopened.Status()
+	if err != nil {
+		t.Fatalf("replay a legacy-shaped begin event: %v", err)
+	}
+	if replayed.Objective == nil || replayed.Objective.MaxChangedLines != DefaultRuntimeChangedLines ||
+		replayed.Objective.MaxChangedLinesSource != runtimeChangedLinesSourceDefault || replayed.Revision != began.Revision {
+		t.Fatalf("replayed legacy-shaped objective = %#v", replayed.Objective)
+	}
+}
+
+// TestRuntimeLedgerExplicitBeginRoundTrips is the explicit counterpart: an
+// explicit budget persists the marker and survives a fresh replay with its
+// provenance intact.
+func TestRuntimeLedgerExplicitBeginRoundTrips(t *testing.T) {
+	repo := initRuntimeLedgerRepo(t)
+	store, err := OpenRuntimeStore(context.Background(), repo, "explicit-begin-roundtrip")
+	if err != nil {
+		t.Fatal(err)
+	}
+	began, err := store.Begin(context.Background(), BeginAttemptRequest{
+		ExpectedRevision: "", RequestID: "explicit-begin-1", WorkUnit: "explicit-unit",
+		EvidenceGoal: "prove explicit round trip", MaxAttempts: 2, MaxChangedLines: 40,
+		MaxChangedLinesExplicit: true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if began.Objective == nil || began.Objective.MaxChangedLinesSource != runtimeChangedLinesSourceExplicit {
+		t.Fatalf("began objective = %#v, want source %q", began.Objective, runtimeChangedLinesSourceExplicit)
+	}
+
+	raw, err := os.ReadFile(store.recordPath(began.Revision))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var onDisk struct {
+		Begin struct {
+			MaxChangedLinesExplicit bool `json:"max_changed_lines_explicit"`
+		} `json:"begin"`
+	}
+	if err := json.Unmarshal(raw, &onDisk); err != nil {
+		t.Fatal(err)
+	}
+	if !onDisk.Begin.MaxChangedLinesExplicit {
+		t.Fatalf("persisted record did not carry the explicit marker:\n%s", raw)
+	}
+
+	reopened, err := OpenRuntimeStore(context.Background(), repo, "explicit-begin-roundtrip")
+	if err != nil {
+		t.Fatal(err)
+	}
+	replayed, err := reopened.Status()
+	if err != nil {
+		t.Fatalf("replay an explicit begin event: %v", err)
+	}
+	if replayed.Objective == nil || replayed.Objective.MaxChangedLines != 40 ||
+		replayed.Objective.MaxChangedLinesSource != runtimeChangedLinesSourceExplicit || replayed.Revision != began.Revision {
+		t.Fatalf("replayed explicit objective = %#v", replayed.Objective)
+	}
+}

--- a/internal/sddstatus/runtime_ledger_reset_test.go
+++ b/internal/sddstatus/runtime_ledger_reset_test.go
@@ -490,3 +490,87 @@ func TestRuntimeLedgerResetWithoutDriftStillRequiresTerminalScope(t *testing.T) 
 		t.Fatalf("undrifted early reset error = %v, want ErrRuntimeResetNotAllowed", err)
 	}
 }
+
+// TestRuntimeLedgerResetAlreadyAdmitsAMaintainerAuthorizedBudgetRaise is
+// issue #1947: after an exhausted budget forces decision_required, the
+// existing `reset` already opens the way to a genuinely fresh objective, and
+// Begin already reads MaxChangedLines straight off its own request rather
+// than the retired objective's ceiling once Reset has cleared it
+// (runtime_admission.go's continuing-objective comparison never runs when
+// status.Objective is nil). This test proves a maintainer-authorized raise is
+// already possible through that existing path -- default stays 200 when
+// omitted, an explicit raise on the post-reset begin takes effect, and a
+// fresh replay of the ledger preserves it -- with no new reset fields needed.
+func TestRuntimeLedgerResetAlreadyAdmitsAMaintainerAuthorizedBudgetRaise(t *testing.T) {
+	repo := initRuntimeLedgerRepo(t)
+	store, err := OpenRuntimeStore(context.Background(), repo, "reset-budget-raise")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Default: an omitted MaxChangedLines is the CLI's job to default (#2589);
+	// the ledger itself still requires an explicit positive value in 1..max.
+	defaulted, err := store.Begin(context.Background(), BeginAttemptRequest{
+		ExpectedRevision: "", RequestID: "raise-begin-default", WorkUnit: "size-exception-harness",
+		EvidenceGoal: "prove default budget", MaxAttempts: 1, MaxChangedLines: DefaultRuntimeChangedLines,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if defaulted.Objective == nil || defaulted.Objective.MaxChangedLines != 200 {
+		t.Fatalf("default objective = %#v, want 200 changed lines", defaulted.Objective)
+	}
+
+	// Exhaust the tiny budget: one failed attempt at MaxAttempts=1 drives the
+	// objective straight to decision_required, admitting reset.
+	exhausted, err := store.Finish(context.Background(), FinishAttemptRequest{
+		ExpectedRevision: defaulted.Revision, RequestID: "raise-finish-exhaust", Outcome: AttemptFailed,
+		EvidenceRevision: runtimeTestHash('2'), Diagnosis: "the tiny budget was consumed by design",
+		HarnessDisposition: HarnessReused, CleanupEvidence: "process group exited cleanly",
+		ProcessEvidence: "process scan found no surviving descendants",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !exhausted.DecisionRequired || exhausted.NextAction != RuntimeActionReset {
+		t.Fatalf("exhausted objective status = %#v", exhausted)
+	}
+
+	reset, err := store.Reset(context.Background(), ResetObjectiveRequest{
+		ExpectedRevision: exhausted.Revision, RequestID: "raise-reset-1",
+		Reason: "maintainer approved a larger size exception after the default budget was exhausted",
+		Actor:  "maintainer",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// The raise: an explicit --max-changed-lines on the post-reset begin,
+	// well above the retired objective's 200-line ceiling, with the same
+	// audited actor/reason authority reset already required.
+	const raisedBudget = 900
+	raised, err := store.Begin(context.Background(), BeginAttemptRequest{
+		ExpectedRevision: reset.Revision, RequestID: "raise-begin-2", WorkUnit: "size-exception-harness",
+		EvidenceGoal: "prove the raised budget", MaxAttempts: 2, MaxChangedLines: raisedBudget,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if raised.Objective == nil || raised.Objective.MaxChangedLines != raisedBudget {
+		t.Fatalf("post-reset objective = %#v, want %d changed lines", raised.Objective, raisedBudget)
+	}
+
+	// Replay: a fresh store instance re-reading the same on-disk ledger sees
+	// the identical raised ceiling, not the retired 200-line one.
+	reopened, err := OpenRuntimeStore(context.Background(), repo, "reset-budget-raise")
+	if err != nil {
+		t.Fatal(err)
+	}
+	replayed, err := reopened.Status()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if replayed.Objective == nil || replayed.Objective.MaxChangedLines != raisedBudget || replayed.Revision != raised.Revision {
+		t.Fatalf("replayed objective = %#v, want %d changed lines at revision %s", replayed.Objective, raisedBudget, raised.Revision)
+	}
+}


### PR DESCRIPTION
Closes #2589
Closes #1947

## Summary
- `sdd-attempt begin` reports `max_changed_lines_source` (`default` | `explicit`); `acquire` reports the applied default only when one was applied, preserving the bounded compact output for explicit calls.
- The explicit marker is persisted on the begin event only and excluded from the request digest, so pre-existing ledgers replay and digest-match unchanged (the native review's refuter concern; proven by tests).
- #1947 was already possible on main: after reset, begin/acquire read their own `--max-changed-lines`; `TestRuntimeLedgerResetAlreadyAdmitsAMaintainerAuthorizedBudgetRaise` pins it, including replay.

| File | Change |
|------|--------|
| `internal/sddstatus/runtime_ledger.go`, `runtime_compact.go` | source provenance, event marker, digest-neutral request field |
| `internal/cli/sdd_attempt.go` | explicitness detected via `flags.Visit` |
| tests | provenance on begin/acquire, digest independence, legacy replay, budget raise after reset |

## Test plan
- [x] `go test ./internal/sddstatus/ ./internal/cli/ -run 'Attempt|Budget|Lines|Reset|HelpContract|Digest' -count=1`
- [x] Refusal ratchet passes
- [x] Native review approved and acknowledged (lineage review-e0bc2ea808d6c458, four lenses, no correction)

https://claude.ai/code/session_01SYqbaaqyJcAv1FYtSJXx6M

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Runtime status responses now show the applied changed-line budget when the default limit is used.
  - Budget details identify whether the limit came from the default setting or an explicitly provided value.
  - After an authorized reset, a new attempt can use an explicitly increased changed-line limit.

- **Bug Fixes**
  - Budget information now remains accurate when attempts are replayed or resumed, including explicitly configured limits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->