### PR TITLE
fix(review): account for renames when charging changed lines and sizing reviewer context

### DIFF
--- a/internal/reviewtransaction/frozen_candidate_context.go
+++ b/internal/reviewtransaction/frozen_candidate_context.go
@@ -6,6 +6,7 @@ import (
 	"encoding/base64"
 	"errors"
 	"fmt"
+	"maps"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -91,7 +92,22 @@ type FrozenCandidateContext struct {
 	CandidateTree       string
 	LegacyCandidateDiff *FrozenCandidateDiff
 	ChangedPathManifest []ChangedPathManifestEntry
-	repositoryRoot      string
+	// RenamePairs is the rename pairing frozenRenamePairs computed once
+	// during THIS inspector's own preparation (#4107/#3208): it is exactly
+	// what this same inspector's rename-aware patch reads used, so a
+	// reviewer or context builder inspecting this frozen candidate sees the
+	// pairing its own patches were built from. It is not synchronized with
+	// any other caller's separate invocation of the same derivation (for
+	// example ChangedLines' rename-aware sizing, computed independently,
+	// ordinarily at a different time for a different purpose) -- on the
+	// ordinary path both agree because the derivation is deterministic over
+	// the same immutable trees, but each has its own failure mode.
+	RenamePairs map[string]renamePairInfo
+	// RenamePairingDegraded is true when the rename pairing lookup itself
+	// failed for this boundary; RenamePairs is then empty and every rename
+	// pair fell back to the conservative --no-renames read.
+	RenamePairingDegraded bool
+	repositoryRoot        string
 }
 
 type PreparedCandidateInspector struct {
@@ -100,6 +116,13 @@ type PreparedCandidateInspector struct {
 	attributesFile string
 	cleanup        func() error
 	closed         bool
+	// renamePartners maps one manifest path to the other side of a
+	// git-detected rename pair (#3208). The manifest itself stays
+	// rename-disabled -- Status is never "R" -- so this is used only to size
+	// the per-path "patch" read: a moved file's two manifest entries would
+	// otherwise each materialize the entire file (a full delete, a full
+	// insert) instead of the small change git's own diff reports for it.
+	renamePartners map[string]string
 }
 
 // WithLegacyCandidateDiff adds the exact published v1 candidate transport.
@@ -212,19 +235,57 @@ func (builder SnapshotBuilder) PrepareCandidateInspector(ctx context.Context, sn
 		}
 		manifest = append(manifest, entry)
 	}
+	// Rename pairing is computed exactly once for THIS inspector's own
+	// preparation, via the single canonical derivation (frozenRenamePairs)
+	// ChangedLines' rename-aware sizing also calls -- so the two can never
+	// disagree on the pairing LOGIC, though each still runs its own git
+	// invocation and does not observe the other's result (#4107/#3208). A
+	// failed lookup here degrades this inspector's own pairing to empty --
+	// recorded observably as RenamePairingDegraded so a reviewer/context
+	// builder can see it -- with every path in THIS inspector falling back
+	// to the plain --no-renames read, rather than aborting preparation.
+	renamePairs, renameDegraded := frozenRenamePairs(ctx, repo, isolation, snapshot.BaseTree, snapshot.CandidateTree)
+	renamePartners := renamePartnersFromManifest(renamePairs, manifest)
 	return &PreparedCandidateInspector{
 		frozen: FrozenCandidateContext{
 			BaseTree: snapshot.BaseTree, CandidateTree: snapshot.CandidateTree,
 			ChangedPathManifest: manifest, repositoryRoot: repo,
+			RenamePairs: renamePairs, RenamePairingDegraded: renameDegraded,
 		},
 		isolation: isolation, attributesFile: attributesFile, cleanup: cleanup,
+		renamePartners: renamePartners,
 	}, nil
+}
+
+// renamePartnersFromManifest narrows an already-computed rename pairing (see
+// frozenRenamePairs) to the pairs this exact manifest recognizes as a clean
+// delete/add pair (issue #3208's counterpart to #4107): it performs no Git
+// invocation of its own, and the manifest's paths and rename-disabled Status
+// enum are never touched.
+func renamePartnersFromManifest(pairs map[string]renamePairInfo, manifest []ChangedPathManifestEntry) map[string]string {
+	statusByPath := make(map[string]CandidatePathStatus, len(manifest))
+	for _, entry := range manifest {
+		statusByPath[entry.Path] = entry.Status
+	}
+	partners := make(map[string]string, len(pairs))
+	for path, info := range pairs {
+		if statusByPath[path] != CandidatePathDeleted || statusByPath[info.partner] != CandidatePathAdded {
+			continue
+		}
+		partners[path] = info.partner
+		partners[info.partner] = path
+	}
+	return partners
 }
 
 // FrozenCandidateContext returns a copy that cannot mutate later inspection scope.
 func (inspector *PreparedCandidateInspector) FrozenCandidateContext() FrozenCandidateContext {
 	frozen := inspector.frozen
 	frozen.ChangedPathManifest = append(frozen.ChangedPathManifest[:0:0], frozen.ChangedPathManifest...)
+	// RenamePairs is a map: the struct copy above shares it with
+	// inspector.frozen unless cloned here, which would let a caller mutating
+	// the returned value corrupt this inspector's own recorded pairing.
+	frozen.RenamePairs = maps.Clone(frozen.RenamePairs)
 	return frozen
 }
 
@@ -274,8 +335,18 @@ func (inspector *PreparedCandidateInspector) Inspect(ctx context.Context, operat
 		// preserved by the isolation this inspector already installs: an empty
 		// attributes file plus GIT_ATTR_NOSYSTEM, so neither the repository's
 		// .gitattributes nor the machine's can move the classification.
-		path := ":(literal)" + frozen.ChangedPathManifest[pathIndex].Path
-		args = append(common, "diff", "--patch", "--full-index", "--no-color", "--no-ext-diff", "--no-textconv", "--no-renames", "--diff-algorithm=myers", "--no-indent-heuristic", "--unified=3", "--ignore-submodules=none", frozen.BaseTree, frozen.CandidateTree, "--", path)
+		entryPath := frozen.ChangedPathManifest[pathIndex].Path
+		renameFlag, paths := "--no-renames", []string{":(literal)" + entryPath}
+		// A git-detected rename charges this read as one small change-inside
+		// -the-moved-file patch instead of a full delete or full insert, so a
+		// candidate dominated by pure moves stays inside the reviewer context
+		// byte budget (#3208). Both manifest entries in the pair render the
+		// same rename patch; each is still tagged with its own path above.
+		if partner, ok := inspector.renamePartners[entryPath]; ok {
+			renameFlag, paths = "-M", []string{":(literal)" + entryPath, ":(literal)" + partner}
+		}
+		args = append(common, "diff", "--patch", "--full-index", "--no-color", "--no-ext-diff", "--no-textconv", renameFlag, "--diff-algorithm=myers", "--no-indent-heuristic", "--unified=3", "--ignore-submodules=none", frozen.BaseTree, frozen.CandidateTree, "--")
+		args = append(args, paths...)
 	case "object":
 		tree := frozen.CandidateTree
 		if side == "base" {

--- a/internal/reviewtransaction/frozen_candidate_context_test.go
+++ b/internal/reviewtransaction/frozen_candidate_context_test.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"reflect"
 	"runtime"
+	"slices"
 	"strings"
 	"testing"
 )
@@ -468,8 +469,11 @@ func TestPreparedCandidateInspectorReusesOneSetupForFourReads(t *testing.T) {
 			t.Fatalf("Inspect(%q, %d) error = %v", read.operation, read.pathIndex, err)
 		}
 	}
-	if children != 11 {
-		t.Fatalf("Git children for prepare plus four reads = %d, want 11", children)
+	// 12, not 11: prepare now also runs one rename-aware numstat (-M) to
+	// build the patch operation's rename pairing (#3208), on top of its prior
+	// setup and raw-diff reads.
+	if children != 12 {
+		t.Fatalf("Git children for prepare plus four reads = %d, want 12", children)
 	}
 	builder := SnapshotBuilder{Repo: repo}
 	for _, inspection := range []struct {
@@ -511,6 +515,171 @@ func TestPreparedCandidateInspectorReusesOneSetupForFourReads(t *testing.T) {
 	}
 	if calls != 1 {
 		t.Fatalf("cleanup calls = %d, want 1", calls)
+	}
+}
+
+// renamedManifestFixture builds a staged candidate with one pure file move
+// (a git-detected rename pair) alongside one unrelated add and one unrelated
+// delete of unrelated content (never a rename pair with anything), and
+// returns the repo, its prepared inspector, and the manifest indices needed
+// to inspect each interesting path.
+func renamedManifestFixture(t *testing.T) (repo string, inspector *PreparedCandidateInspector, oldIndex, newIndex, unrelatedAddedIndex, unrelatedDeletedIndex int) {
+	t.Helper()
+	requireSnapshotGit(t)
+	repo = initSnapshotRepo(t)
+	writeSnapshotFile(t, repo, "moved-source.txt", "line one\nline two\nline three\n")
+	writeSnapshotFile(t, repo, "stays-deleted.txt", "unrelated content to delete\n")
+	gitSnapshot(t, repo, "add", "--", "moved-source.txt", "stays-deleted.txt")
+	gitSnapshot(t, repo, "commit", "-m", "base")
+	gitSnapshot(t, repo, "mv", "moved-source.txt", "moved-destination.txt")
+	gitSnapshot(t, repo, "rm", "--", "stays-deleted.txt")
+	writeSnapshotFile(t, repo, "unrelated-add.txt", "unrelated content to add\n")
+	gitSnapshot(t, repo, "add", "-A", "--")
+
+	snapshot, err := (SnapshotBuilder{Repo: repo}).Build(context.Background(), Target{Kind: TargetCurrentChanges, Projection: ProjectionStaged, IntendedUntracked: []string{}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	inspector, err = (SnapshotBuilder{Repo: repo}).PrepareCandidateInspector(context.Background(), snapshot)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = inspector.Close() })
+	frozen := inspector.FrozenCandidateContext()
+	indexOf := func(path string) int {
+		for index, entry := range frozen.ChangedPathManifest {
+			if entry.Path == path {
+				return index
+			}
+		}
+		t.Fatalf("manifest is missing %q: %#v", path, frozen.ChangedPathManifest)
+		return -1
+	}
+	return repo, inspector, indexOf("moved-source.txt"), indexOf("moved-destination.txt"), indexOf("unrelated-add.txt"), indexOf("stays-deleted.txt")
+}
+
+// TestFrozenCandidateContextRenamePairsIsNotAliasedToTheInspector proves
+// FrozenCandidateContext()'s copy promise holds for RenamePairs too: it is a
+// map, a reference type the struct-value copy alone does not protect, so
+// without an explicit clone a caller mutating the returned map would corrupt
+// the inspector's own recorded pairing.
+func TestFrozenCandidateContextRenamePairsIsNotAliasedToTheInspector(t *testing.T) {
+	_, inspector, oldIndex, _, _, _ := renamedManifestFixture(t)
+	frozen := inspector.FrozenCandidateContext()
+	if len(frozen.RenamePairs) == 0 {
+		t.Fatal("fixture has no rename pairs to prove non-aliasing with")
+	}
+	for path := range frozen.RenamePairs {
+		delete(frozen.RenamePairs, path)
+	}
+	frozen.RenamePairs["forged"] = renamePairInfo{partner: "forged-partner"}
+
+	replayed := inspector.FrozenCandidateContext()
+	if len(replayed.RenamePairs) == 0 {
+		t.Fatal("mutating the first returned RenamePairs map emptied the inspector's own recorded pairing")
+	}
+	if _, forged := replayed.RenamePairs["forged"]; forged {
+		t.Fatal("mutating the first returned RenamePairs map leaked a forged entry into the inspector's own recorded pairing")
+	}
+	// The patch read itself must still be rename-aware: mutating the
+	// returned copy must not have touched what Inspect actually uses.
+	payload, err := inspector.Inspect(context.Background(), "patch", oldIndex, "")
+	if err != nil {
+		t.Fatalf("Inspect(patch, old) error = %v", err)
+	}
+	if !strings.Contains(string(payload), "rename from") {
+		t.Fatalf("Inspect(patch, old) = %q, want it to remain rename-aware after the returned map was mutated", payload)
+	}
+}
+
+// TestPreparedCandidateInspectorPatchIsRenameAwareForAPairedPath is issue
+// #3208's behavioral proof: a git-detected rename pair's "patch" read comes
+// back as one compact `-M` rename patch, tagged under both manifest indices,
+// instead of a full delete plus a full insert.
+func TestPreparedCandidateInspectorPatchIsRenameAwareForAPairedPath(t *testing.T) {
+	_, inspector, oldIndex, newIndex, _, _ := renamedManifestFixture(t)
+	for _, index := range []int{oldIndex, newIndex} {
+		payload, err := inspector.Inspect(context.Background(), "patch", index, "")
+		if err != nil {
+			t.Fatalf("Inspect(patch, %d) error = %v", index, err)
+		}
+		text := string(payload)
+		if !strings.Contains(text, "rename from moved-source.txt") || !strings.Contains(text, "rename to moved-destination.txt") {
+			t.Fatalf("Inspect(patch, %d) = %q, want a rename patch", index, text)
+		}
+		if strings.Contains(text, "deleted file mode") || strings.Contains(text, "new file mode") {
+			t.Fatalf("Inspect(patch, %d) = %q, want no full delete/insert markers for a paired rename", index, text)
+		}
+	}
+}
+
+// TestPreparedCandidateInspectorPatchStaysNoRenameForAnUnpairedPath proves
+// the rename-aware path is scoped to genuine pairs: an unrelated add and an
+// unrelated delete (never paired with anything) still each read as the
+// ordinary single-path --no-renames patch.
+func TestPreparedCandidateInspectorPatchStaysNoRenameForAnUnpairedPath(t *testing.T) {
+	_, inspector, _, _, addedIndex, deletedIndex := renamedManifestFixture(t)
+	added, err := inspector.Inspect(context.Background(), "patch", addedIndex, "")
+	if err != nil {
+		t.Fatalf("Inspect(patch, added) error = %v", err)
+	}
+	if !strings.Contains(string(added), "new file mode") || strings.Contains(string(added), "rename") {
+		t.Fatalf("Inspect(patch, added) = %q, want an ordinary new-file patch", added)
+	}
+	deleted, err := inspector.Inspect(context.Background(), "patch", deletedIndex, "")
+	if err != nil {
+		t.Fatalf("Inspect(patch, deleted) error = %v", err)
+	}
+	if !strings.Contains(string(deleted), "deleted file mode") || strings.Contains(string(deleted), "rename") {
+		t.Fatalf("Inspect(patch, deleted) = %q, want an ordinary deleted-file patch", deleted)
+	}
+}
+
+// TestPreparedCandidateInspectorDegradesToNoRenamesWhenPairingFails is the
+// counterpart to fix 2: when the rename-pairing lookup itself fails during
+// PrepareCandidateInspector, preparation must still succeed, degrading to no
+// paired reads (the ordinary --no-renames patch for every path) rather than
+// aborting the whole inspector over an advisory sizing failure.
+func TestPreparedCandidateInspectorDegradesToNoRenamesWhenPairingFails(t *testing.T) {
+	requireSnapshotGit(t)
+	repo := initSnapshotRepo(t)
+	writeSnapshotFile(t, repo, "moved-source.txt", "line one\nline two\nline three\n")
+	gitSnapshot(t, repo, "add", "--", "moved-source.txt")
+	gitSnapshot(t, repo, "commit", "-m", "base")
+	gitSnapshot(t, repo, "mv", "moved-source.txt", "moved-destination.txt")
+	gitSnapshot(t, repo, "add", "-A", "--")
+	snapshot, err := (SnapshotBuilder{Repo: repo}).Build(context.Background(), Target{Kind: TargetCurrentChanges, Projection: ProjectionStaged, IntendedUntracked: []string{}})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	original := gitCommandContext
+	t.Cleanup(func() { gitCommandContext = original })
+	gitCommandContext = func(ctx context.Context, name string, args ...string) *exec.Cmd {
+		if slices.Contains(args, "-M") {
+			return exec.CommandContext(ctx, "git", "not-a-real-git-subcommand-for-testing")
+		}
+		return original(ctx, name, args...)
+	}
+
+	inspector, err := (SnapshotBuilder{Repo: repo}).PrepareCandidateInspector(context.Background(), snapshot)
+	if err != nil {
+		t.Fatalf("PrepareCandidateInspector() error = %v, want it to degrade instead of aborting", err)
+	}
+	defer inspector.Close()
+	frozen := inspector.FrozenCandidateContext()
+	var oldIndex int
+	for index, entry := range frozen.ChangedPathManifest {
+		if entry.Path == "moved-source.txt" {
+			oldIndex = index
+		}
+	}
+	payload, err := inspector.Inspect(context.Background(), "patch", oldIndex, "")
+	if err != nil {
+		t.Fatalf("Inspect(patch, old) error = %v", err)
+	}
+	if !strings.Contains(string(payload), "deleted file mode") {
+		t.Fatalf("Inspect(patch, old) = %q, want the ordinary --no-renames deleted-file patch after pairing failed", payload)
 	}
 }
 

--- a/internal/reviewtransaction/risk.go
+++ b/internal/reviewtransaction/risk.go
@@ -895,12 +895,194 @@ func asciiLower(value string) string {
 	}, value)
 }
 
+// ChangedLines charges only the authored change, not the accounting shape a
+// path-keyed diff stat has to use. A pure rename/move keeps snapshot identity
+// and the manifest exactly as DiffStats already reports them -- one deleted
+// entry at the old path, one added entry at the new path -- but counting each
+// entry's full text as authored would charge a relocation as a full delete
+// plus a full insert. This asks git's own rename heuristic for the change
+// actually authored inside the moved file and charges that instead (#4107).
 func (builder SnapshotBuilder) ChangedLines(ctx context.Context, snapshot Snapshot) (int, error) {
 	stats, err := builder.DiffStats(ctx, snapshot)
 	if err != nil {
 		return 0, err
 	}
-	return CountChangedLines(stats)
+	total, err := CountChangedLines(stats)
+	if err != nil {
+		return 0, err
+	}
+	// Rename-aware sizing is advisory, never load-bearing: a charge this
+	// attempt's budget depends on must not hard-fail because a second,
+	// independent diff invocation for sizing alone failed. Any error here
+	// falls back to the conservative no-rename total (zero savings) rather
+	// than refusing the charge outright.
+	if savings, savingsErr := builder.renameAwareSavings(ctx, snapshot, stats); savingsErr == nil {
+		total -= savings
+	}
+	return total, nil
+}
+
+// renameAwareSavings detects renames within the snapshot's base/candidate
+// boundary using git's own similarity heuristic (`-M`) and, for every
+// deleted/added path pair CountChangedLines charged as a full deletion plus a
+// full insertion, returns how many of those lines git's rename-aware diff
+// says were never actually touched. It reads an independent diff purely to
+// size an already-frozen pair; snapshot paths, the manifest, and candidate
+// identity are untouched.
+func (builder SnapshotBuilder) renameAwareSavings(ctx context.Context, snapshot Snapshot, stats []DiffStat) (int, error) {
+	repo, err := builder.repositoryRoot(ctx)
+	if err != nil {
+		return 0, err
+	}
+	isolation, cleanup, err := isolatedImmutableTreeGit(ctx, repo)
+	if err != nil {
+		return 0, err
+	}
+	defer cleanup()
+	pairs, degraded := frozenRenamePairs(ctx, repo, isolation, snapshot.BaseTree, snapshot.CandidateTree)
+	if degraded {
+		// This call's own pairing lookup failed: fall back to no rename
+		// credit here, the same rule PrepareCandidateInspector applies to
+		// ITS OWN independent lookup (--no-renames reads) on
+		// FrozenCandidateContext.RenamePairingDegraded. Both consumers
+		// share the fallback RULE, not this one invocation's result: a
+		// concurrent or later PrepareCandidateInspector call runs its own
+		// git invocation and is not informed by this failure (#4107/#3208).
+		return 0, nil
+	}
+	statsByPath := make(map[string]DiffStat, len(stats))
+	for _, stat := range stats {
+		statsByPath[stat.Path] = stat
+	}
+	savings := 0
+	seen := make(map[string]struct{}, len(pairs))
+	for path, info := range pairs {
+		if _, done := seen[path]; done {
+			continue
+		}
+		seen[path] = struct{}{}
+		seen[info.partner] = struct{}{}
+		first, ok := statsByPath[path]
+		if !ok {
+			continue
+		}
+		second, ok := statsByPath[info.partner]
+		if !ok {
+			continue
+		}
+		var oldStat, newStat DiffStat
+		switch {
+		case first.Additions == 0 && first.Deletions > 0 && second.Deletions == 0 && second.Additions > 0:
+			oldStat, newStat = first, second
+		case second.Additions == 0 && second.Deletions > 0 && first.Deletions == 0 && first.Additions > 0:
+			oldStat, newStat = second, first
+		default:
+			// Not the clean delete/add shape a no-rename diff charges for a
+			// pure move; leave the pairing's contribution as-is.
+			continue
+		}
+		if oldStat.Binary || oldStat.ModeOnly || newStat.Binary || newStat.ModeOnly ||
+			isGeneratedGoldenPath(oldStat.Path) || isGeneratedGoldenPath(newStat.Path) {
+			continue
+		}
+		overcounted := oldStat.Deletions + newStat.Additions
+		actual := info.additions + info.deletions
+		if overcounted > actual {
+			savings += overcounted - actual
+		}
+	}
+	return savings, nil
+}
+
+// renamePairInfo is one git-detected rename pairing between a base and
+// candidate tree, together with the actual line-level change git's own diff
+// reports for it -- independent of whatever a no-rename diff charges the two
+// endpoints separately.
+type renamePairInfo struct {
+	partner              string
+	additions, deletions int
+}
+
+// frozenRenamePairs is the single canonical rename-pairing DERIVATION for one
+// frozen base/candidate tree boundary: ChangedLines' rename-aware sizing and
+// PrepareCandidateInspector's rename-aware patch reads both call exactly this
+// function rather than each hand-rolling its own git invocation, so the two
+// can never disagree on LOGIC -- same flags, same parsing, same degradation
+// rule. It does NOT share a computed RESULT across those two call sites:
+// each caller runs its own independent git subprocess against the same
+// immutable trees, ordinarily at different times for different purposes
+// (charging a budget at settle vs. building reviewer context at review time).
+// On the ordinary path both invocations return identical pairings, because
+// the derivation is a pure function of two immutable tree SHAs, but a
+// transient failure hitting only one of the two invocations means that one
+// instance's result (or degraded flag) is not guaranteed to match the
+// other's for that occurrence (#4107/#3208). It never returns an error --
+// a lookup failure degrades that ONE invocation to an empty pairing with
+// degraded=true, the fallback its own caller then applies consistently for
+// itself (no rename credit for ChangedLines, --no-renames reads for the
+// inspector), never a partial or crashing failure within one call.
+func frozenRenamePairs(ctx context.Context, repo string, isolation []string, baseTree, candidateTree string) (pairs map[string]renamePairInfo, degraded bool) {
+	detected, err := detectRenamePairs(ctx, repo, isolation, baseTree, candidateTree)
+	if err != nil {
+		return nil, true
+	}
+	return detected, false
+}
+
+// detectRenamePairs asks git's own similarity heuristic (`-M`) which deleted
+// and added paths between base and candidate are the same file relocated, and
+// returns the pairing keyed by both sides so a caller can look it up from
+// either endpoint. It never mutates the snapshot's path set or manifest: it
+// only reads one independent diff to characterize pairs that set already
+// contains.
+func detectRenamePairs(ctx context.Context, repo string, isolation []string, baseTree, candidateTree string) (map[string]renamePairInfo, error) {
+	output, err := runGitIsolated(ctx, repo, isolation, nil, "diff", "--numstat", "-M", "-z",
+		"--no-ext-diff", "--no-textconv", "--ignore-submodules=none", baseTree, candidateTree, "--")
+	if err != nil {
+		return nil, err
+	}
+	pairs := make(map[string]renamePairInfo)
+	records := bytes.Split(output, []byte{0})
+	for index := 0; index < len(records); index++ {
+		record := records[index]
+		if len(record) == 0 {
+			continue
+		}
+		fields := bytes.SplitN(record, []byte{'\t'}, 3)
+		if len(fields) != 3 {
+			return nil, fmt.Errorf("unexpected rename-aware diff stat %q", record) // refusal:by-design world-action: malformed Git protocol output cannot be made trustworthy by a review command
+		}
+		if len(fields[2]) != 0 {
+			// An ordinary (non-rename) numstat record; nothing to pair.
+			continue
+		}
+		if index+2 >= len(records) {
+			return nil, fmt.Errorf("truncated rename-aware diff stat %q", record) // refusal:by-design world-action: malformed Git protocol output cannot be made trustworthy by a review command
+		}
+		oldPath, err := normalizeLogicalPath(string(records[index+1]))
+		if err != nil {
+			return nil, err
+		}
+		newPath, err := normalizeLogicalPath(string(records[index+2]))
+		if err != nil {
+			return nil, err
+		}
+		index += 2
+		var additions, deletions int
+		if !bytes.Equal(fields[0], []byte{'-'}) {
+			additions, err = strconv.Atoi(string(fields[0]))
+			if err != nil {
+				return nil, fmt.Errorf("parse rename additions for %q: %w", newPath, err)
+			}
+			deletions, err = strconv.Atoi(string(fields[1]))
+			if err != nil {
+				return nil, fmt.Errorf("parse rename deletions for %q: %w", newPath, err)
+			}
+		}
+		pairs[oldPath] = renamePairInfo{partner: newPath, additions: additions, deletions: deletions}
+		pairs[newPath] = renamePairInfo{partner: oldPath, additions: additions, deletions: deletions}
+	}
+	return pairs, nil
 }
 
 func isRegularNonExecutableGitMode(mode string) bool {

--- a/internal/reviewtransaction/risk_test.go
+++ b/internal/reviewtransaction/risk_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"math"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"reflect"
 	"runtime"
@@ -348,6 +349,222 @@ func TestCountChangedLinesHasOneCrossAdapterRule(t *testing.T) {
 	}
 	if _, err := CountChangedLines([]DiffStat{{Path: "same.go", Additions: 1}, {Path: "same.go", Deletions: 1}}); err == nil {
 		t.Fatal("CountChangedLines() accepted duplicate logical paths")
+	}
+}
+
+// TestChangedLinesIsRenameAwareForAPureFileMove is issue #4107: a pure
+// relocation of a 100-line file used to be charged as a full 100-line
+// deletion at the old path plus a full 100-line insertion at the new path
+// (200 changed lines), even though nothing inside the file changed.
+func TestChangedLinesIsRenameAwareForAPureFileMove(t *testing.T) {
+	requireSnapshotGit(t)
+	repo := initSnapshotRepo(t)
+	var lines strings.Builder
+	for i := 0; i < 100; i++ {
+		fmt.Fprintf(&lines, "line %d\n", i)
+	}
+	writeSnapshotFile(t, repo, "big.txt", lines.String())
+	gitSnapshot(t, repo, "add", "--", "big.txt")
+	gitSnapshot(t, repo, "commit", "-m", "add big file")
+
+	gitSnapshot(t, repo, "mv", "big.txt", "moved-big.txt")
+	gitSnapshot(t, repo, "add", "-A", "--")
+
+	snapshot, err := (SnapshotBuilder{Repo: repo}).Build(context.Background(), Target{Kind: TargetCurrentChanges, Projection: ProjectionStaged, IntendedUntracked: []string{}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, err := (SnapshotBuilder{Repo: repo}).ChangedLines(context.Background(), snapshot)
+	if err != nil {
+		t.Fatalf("ChangedLines() error = %v", err)
+	}
+	if got != 0 {
+		t.Fatalf("ChangedLines() = %d, want 0 for a pure file move", got)
+	}
+}
+
+// TestChangedLinesRenameAwareStillCountsAuthoredEditsInsideTheMovedFile
+// proves the rename-aware accounting only removes the accounting artifact of
+// the move; a genuine edit made alongside the move is still charged.
+func TestChangedLinesRenameAwareStillCountsAuthoredEditsInsideTheMovedFile(t *testing.T) {
+	requireSnapshotGit(t)
+	repo := initSnapshotRepo(t)
+	var lines strings.Builder
+	for i := 0; i < 100; i++ {
+		fmt.Fprintf(&lines, "line %d\n", i)
+	}
+	writeSnapshotFile(t, repo, "big.txt", lines.String())
+	gitSnapshot(t, repo, "add", "--", "big.txt")
+	gitSnapshot(t, repo, "commit", "-m", "add big file")
+
+	gitSnapshot(t, repo, "mv", "big.txt", "moved-big.txt")
+	writeSnapshotFile(t, repo, "moved-big.txt", lines.String()+"one more authored line\n")
+	gitSnapshot(t, repo, "add", "-A", "--")
+
+	snapshot, err := (SnapshotBuilder{Repo: repo}).Build(context.Background(), Target{Kind: TargetCurrentChanges, Projection: ProjectionStaged, IntendedUntracked: []string{}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, err := (SnapshotBuilder{Repo: repo}).ChangedLines(context.Background(), snapshot)
+	if err != nil {
+		t.Fatalf("ChangedLines() error = %v", err)
+	}
+	if got != 1 {
+		t.Fatalf("ChangedLines() = %d, want 1 for one authored line inside a moved file", got)
+	}
+}
+
+// TestChangedLinesFallsBackToConservativeTotalWhenRenameSizingFails proves
+// rename-aware sizing is advisory, never load-bearing: when the independent
+// diff invocation renameAwareSavings depends on fails, ChangedLines must
+// still charge the ordinary no-rename total instead of refusing the charge.
+func TestChangedLinesFallsBackToConservativeTotalWhenRenameSizingFails(t *testing.T) {
+	requireSnapshotGit(t)
+	repo := initSnapshotRepo(t)
+	var lines strings.Builder
+	for i := 0; i < 100; i++ {
+		fmt.Fprintf(&lines, "line %d\n", i)
+	}
+	writeSnapshotFile(t, repo, "big.txt", lines.String())
+	gitSnapshot(t, repo, "add", "--", "big.txt")
+	gitSnapshot(t, repo, "commit", "-m", "add big file")
+	gitSnapshot(t, repo, "mv", "big.txt", "moved-big.txt")
+	gitSnapshot(t, repo, "add", "-A", "--")
+
+	snapshot, err := (SnapshotBuilder{Repo: repo}).Build(context.Background(), Target{Kind: TargetCurrentChanges, Projection: ProjectionStaged, IntendedUntracked: []string{}})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	original := gitCommandContext
+	t.Cleanup(func() { gitCommandContext = original })
+	gitCommandContext = func(ctx context.Context, name string, args ...string) *exec.Cmd {
+		if slices.Contains(args, "-M") {
+			// Fail only the rename-aware sizing invocation; every other Git
+			// call (DiffStats, etc.) runs normally.
+			return exec.CommandContext(ctx, "git", "not-a-real-git-subcommand-for-testing")
+		}
+		return original(ctx, name, args...)
+	}
+
+	got, err := (SnapshotBuilder{Repo: repo}).ChangedLines(context.Background(), snapshot)
+	if err != nil {
+		t.Fatalf("ChangedLines() error = %v, want a fallback to the conservative no-rename total instead of a hard failure", err)
+	}
+	if got != 200 {
+		t.Fatalf("ChangedLines() = %d, want 200 (the conservative no-rename total: 100 deletions + 100 insertions)", got)
+	}
+}
+
+// pureMoveSnapshotForAgreement builds a staged pure file move and returns its
+// snapshot, shared by the two agreement tests below.
+func pureMoveSnapshotForAgreement(t *testing.T) (string, Snapshot) {
+	t.Helper()
+	requireSnapshotGit(t)
+	repo := initSnapshotRepo(t)
+	var lines strings.Builder
+	for i := 0; i < 100; i++ {
+		fmt.Fprintf(&lines, "line %d\n", i)
+	}
+	writeSnapshotFile(t, repo, "big.txt", lines.String())
+	gitSnapshot(t, repo, "add", "--", "big.txt")
+	gitSnapshot(t, repo, "commit", "-m", "add big file")
+	gitSnapshot(t, repo, "mv", "big.txt", "moved-big.txt")
+	gitSnapshot(t, repo, "add", "-A", "--")
+	snapshot, err := (SnapshotBuilder{Repo: repo}).Build(context.Background(), Target{Kind: TargetCurrentChanges, Projection: ProjectionStaged, IntendedUntracked: []string{}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return repo, snapshot
+}
+
+// TestChangedLinesAndInspectorAgreeOnTheSameRenamePairForAPureMove is the R4
+// correction's core proof: ChangedLines' rename-aware sizing and
+// PrepareCandidateInspector both derive their pairing via the same
+// frozenRenamePairs derivation (each still its own git invocation), so for
+// the identical frozen boundary they see the identical pair on the ordinary
+// (non-failing) path.
+func TestChangedLinesAndInspectorAgreeOnTheSameRenamePairForAPureMove(t *testing.T) {
+	repo, snapshot := pureMoveSnapshotForAgreement(t)
+
+	lines, err := (SnapshotBuilder{Repo: repo}).ChangedLines(context.Background(), snapshot)
+	if err != nil {
+		t.Fatalf("ChangedLines() error = %v", err)
+	}
+	if lines != 0 {
+		t.Fatalf("ChangedLines() = %d, want 0 for a pure move", lines)
+	}
+
+	inspector, err := (SnapshotBuilder{Repo: repo}).PrepareCandidateInspector(context.Background(), snapshot)
+	if err != nil {
+		t.Fatalf("PrepareCandidateInspector() error = %v", err)
+	}
+	defer inspector.Close()
+	frozen := inspector.FrozenCandidateContext()
+	if frozen.RenamePairingDegraded {
+		t.Fatal("FrozenCandidateContext.RenamePairingDegraded = true, want false")
+	}
+	pair, ok := frozen.RenamePairs["big.txt"]
+	if !ok || pair.partner != "moved-big.txt" {
+		t.Fatalf("FrozenCandidateContext.RenamePairs[big.txt] = %#v, ok=%v; want partner moved-big.txt", pair, ok)
+	}
+	// The same pairing sizing used: additions+deletions inside the moved
+	// file account for the whole 0-line ChangedLines() result above.
+	if pair.additions+pair.deletions != 0 {
+		t.Fatalf("recorded pair additions+deletions = %d, want 0 to agree with ChangedLines()", pair.additions+pair.deletions)
+	}
+}
+
+// TestChangedLinesAndInspectorDegradeConsistentlyWhenRenamePairingFails is
+// the R4 correction's degradation proof: when both invocations of the shared
+// frozenRenamePairs derivation fail (injected here for both), ChangedLines'
+// sizing (no rename credit) and PrepareCandidateInspector's patch reads
+// (--no-renames) fall back the same way, each recording its own failure the
+// identical way -- RenamePairingDegraded observable on the inspector side.
+func TestChangedLinesAndInspectorDegradeConsistentlyWhenRenamePairingFails(t *testing.T) {
+	repo, snapshot := pureMoveSnapshotForAgreement(t)
+
+	original := gitCommandContext
+	t.Cleanup(func() { gitCommandContext = original })
+	gitCommandContext = func(ctx context.Context, name string, args ...string) *exec.Cmd {
+		if slices.Contains(args, "-M") {
+			return exec.CommandContext(ctx, "git", "not-a-real-git-subcommand-for-testing")
+		}
+		return original(ctx, name, args...)
+	}
+
+	lines, err := (SnapshotBuilder{Repo: repo}).ChangedLines(context.Background(), snapshot)
+	if err != nil {
+		t.Fatalf("ChangedLines() error = %v, want a fallback instead of a hard failure", err)
+	}
+	if lines != 200 {
+		t.Fatalf("ChangedLines() = %d, want 200 (no rename credit once pairing degrades)", lines)
+	}
+
+	inspector, err := (SnapshotBuilder{Repo: repo}).PrepareCandidateInspector(context.Background(), snapshot)
+	if err != nil {
+		t.Fatalf("PrepareCandidateInspector() error = %v, want it to degrade instead of aborting", err)
+	}
+	defer inspector.Close()
+	frozen := inspector.FrozenCandidateContext()
+	if !frozen.RenamePairingDegraded {
+		t.Fatal("FrozenCandidateContext.RenamePairingDegraded = false, want true once pairing failed")
+	}
+	if len(frozen.RenamePairs) != 0 {
+		t.Fatalf("FrozenCandidateContext.RenamePairs = %#v, want empty once pairing failed", frozen.RenamePairs)
+	}
+	var oldIndex int
+	for index, entry := range frozen.ChangedPathManifest {
+		if entry.Path == "big.txt" {
+			oldIndex = index
+		}
+	}
+	payload, err := inspector.Inspect(context.Background(), "patch", oldIndex, "")
+	if err != nil {
+		t.Fatalf("Inspect(patch, old) error = %v", err)
+	}
+	if !strings.Contains(string(payload), "deleted file mode") {
+		t.Fatalf("Inspect(patch, old) = %q, want the ordinary --no-renames deleted-file patch once pairing degraded", payload)
 	}
 }
 


### PR DESCRIPTION
Closes #4107
Closes #3208

## Summary
- `ChangedLines` charges a pure move as the lines that actually changed inside the moved file, not delete plus insert; the reviewer context patch read emits a rename patch for a paired path.
- Rename pairs are derived by one shared function per frozen candidate; sizing and inspection degrade together (no rename credit, `--no-renames` reads) when detection fails, recorded as `RenamePairingDegraded` on the frozen context. `FrozenCandidateContext()` clones the pairing map so callers cannot mutate the inspector.
- Native review drove three corrections (fail-open degradation, shared derivation, map aliasing and honest comments about what is and is not shared).

size:exception: about 220 production lines plus the agreement, degradation, patch-read and aliasing tests; one work unit.

| File | Change |
|------|--------|
| `internal/reviewtransaction/risk.go` | rename-aware `ChangedLines`, shared `frozenRenamePairs` |
| `internal/reviewtransaction/frozen_candidate_context.go` | rename-aware patch read, recorded pairing and degradation flag, cloned accessor |
| tests | pure move, edits inside a move, fallback, agreement, degradation, patch reads, aliasing |

## Test plan
- [x] `go test ./internal/reviewtransaction/ -run 'ChangedLines|Snapshot|Rename|Frozen|Inspect' -count=1`
- [x] Refusal ratchet passes
- [x] Native review approved and acknowledged (lineage review-99cf1588dd646d96, one bounded correction)

https://claude.ai/code/session_01SYqbaaqyJcAv1FYtSJXx6M

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved handling of renamed or moved files in review diffs, displaying focused changes instead of full deletion and addition pairs.
  - Changed-line counts now distinguish file movement from actual edits, so pure moves do not inflate review totals.

- **Bug Fixes**
  - Added graceful fallback behavior when rename detection is unavailable, preserving complete and conservative change reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->