### PR TITLE
fix(review): ship the Claude refuter agent tool-free

### DIFF
--- a/internal/assets/claude/agents/review-refuter.md
+++ b/internal/assets/claude/agents/review-refuter.md
@@ -3,7 +3,7 @@ name: review-refuter
 description: Detached read-only refuter for one transaction-wide batch of inferential severe findings.
 model: {{CLAUDE_MODEL}}
 {{CLAUDE_EFFORT_FRONTMATTER}}
-tools: Read, Grep, Glob
+tools: []
 ---
 
 You are the **review refuter**, a detached read-only verifier. Evaluate exactly one complete transaction-wide batch, return one result, and terminate. Never edit, fix, delegate, or add findings.

--- a/internal/components/sdd/review_ledger_contract_test.go
+++ b/internal/components/sdd/review_ledger_contract_test.go
@@ -147,8 +147,14 @@ func TestDedicatedReviewersAndRefutersAreStructurallyReadOnly(t *testing.T) {
 			}
 		}
 	}
-	if frontmatter := markdownFrontmatter(t, "claude/agents/review-refuter.md"); strings.Contains(frontmatter, "Bash") || strings.Contains(frontmatter, "Write") || strings.Contains(frontmatter, "Edit") {
-		t.Errorf("Claude refuter grants an execution or mutation tool: %s", frontmatter)
+	if frontmatter := markdownFrontmatter(t, "claude/agents/review-refuter.md"); !strings.Contains(frontmatter, "tools: []") {
+		t.Errorf("Claude refuter is not tool-free (must match the tool-free fresh reviewer contract): %s", frontmatter)
+	} else {
+		for _, forbidden := range []string{"Bash", "Write", "Edit", "Read", "Grep", "Glob"} {
+			if strings.Contains(frontmatter, forbidden) {
+				t.Errorf("Claude refuter frontmatter grants live-worktree-reaching tool %q: %s", forbidden, frontmatter)
+			}
+		}
 	}
 	for _, path := range []string{
 		"kiro/agents/review-risk.md", "kiro/agents/review-readability.md",


### PR DESCRIPTION
Closes #2419

## Summary
- The four Claude Code lens agents already shipped `tools: []`; the refuter still declared `Read, Grep, Glob` reaching the live worktree. It now ships tool-free like the lenses (its input already carries the immutable review target inline), and `TestDedicatedReviewersAndRefutersAreStructurallyReadOnly` requires that shape for the refuter too.
- #4137 (deny rules re-triggering prompts on `cd &&` reads) was investigated in the same pass and deliberately not changed: the only rule shape that removes the friction is deleting every `Read(...)` secret-path rule, which trades a security control for ergonomics; the root cause is Claude Code's existence-only compound-command gate. Left as needs-design with the evidence on the issue.

| File | Change |
|------|--------|
| `internal/assets/claude/agents/review-refuter.md` | `tools: []` |
| `internal/components/sdd/review_ledger_contract_test.go` | refuter must be tool-free |

## Test plan
- [x] `go test ./internal/assets/ ./internal/components/sdd/ ./internal/components/permissions/ -count=1`
- [x] `go test ./internal/cli/ -run 'Golden|Asset|Agent|Claude' -count=1`
- [x] Native review approved and acknowledged (lineage review-bee1090b0933bf58)

https://claude.ai/code/session_01SYqbaaqyJcAv1FYtSJXx6M

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Review refuters are now strictly restricted from accessing, modifying, or executing project content.
  - Review validation now enforces these read-only restrictions consistently, preventing unintended tool access during automated review workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->