### PR TITLE
fix(review): name --consent relay in the negotiated start guidance

### DIFF
--- a/internal/cli/review_facade.go
+++ b/internal/cli/review_facade.go
@@ -191,6 +191,13 @@ const reviewUndeclaredRuntimeIdentitySlot = "<your-runtime-identity>"
 // (issue #2440). Naming the caller's own runtime keeps that check meaningful:
 // a runtime whose transport is unsupported is then refused, which is the
 // correct outcome for this build.
+//
+// It also names --consent relay (issue #2870): this is the exact invocation a
+// reader is most likely to copy and run verbatim, and reviewStartArguments
+// (the STATUS-supplied transition command, review_next_transition.go) already
+// includes it for every v2 contract. Without it here, a caller that copies
+// this named continuation and runs it without a TTY silently mints a
+// medium/high-risk review lineage with no consent envelope.
 func reviewNegotiatedStartCommand(snapshot reviewtransaction.Snapshot, runtimeAgent string) string {
 	identity := strings.TrimSpace(runtimeAgent)
 	command := fmt.Sprintf("gentle-ai review start --contract %s", ReviewIntegrationContractV2)
@@ -204,6 +211,7 @@ func reviewNegotiatedStartCommand(snapshot reviewtransaction.Snapshot, runtimeAg
 	case reviewtransaction.TargetBaseWorkspaceOverlay:
 		command += " --base-ref " + snapshot.BaseTree + " --workspace-overlay"
 	}
+	command += " --consent relay"
 	return command
 }
 

--- a/internal/cli/review_start_direct_route_refusal_test.go
+++ b/internal/cli/review_start_direct_route_refusal_test.go
@@ -43,6 +43,14 @@ func TestReviewFacadeStartDirectRouteRefusesUncompletableReview(t *testing.T) {
 	if !strings.Contains(err.Error(), "--base-ref") || !strings.Contains(err.Error(), "--committed-only") {
 		t.Fatalf("refusal error = %v, want it to carry the base-diff continuation flags", err)
 	}
+	// Issue #2870: the named negotiated continuation must itself ask for
+	// consent, exactly like the STATUS-supplied transition command already
+	// does (reviewStartArguments). Without --consent relay, a caller that
+	// copies this exact provider-supplied invocation and runs it without a
+	// TTY mints a medium/high-risk review lineage with no consent envelope.
+	if !strings.Contains(err.Error(), "--consent relay") {
+		t.Fatalf("refusal error = %v, want the named negotiated continuation to include --consent relay", err)
+	}
 
 	stores, storesErr := reviewtransaction.CompactAuthorityLeaves(context.Background(), repo)
 	if storesErr != nil {

--- a/internal/cli/review_start_evidence_test.go
+++ b/internal/cli/review_start_evidence_test.go
@@ -355,8 +355,19 @@ func TestReviewFacadeStartBaseDiffRefusalReplaysFrozenSelector(t *testing.T) {
 	if err := RunReview(args, &replay); err != nil {
 		t.Fatalf("named negotiated START failed: %v\n%s", err, replay.String())
 	}
+	// Issue #2870: the named continuation now asks for consent (it carries
+	// --consent relay) instead of silently minting a lineage; answer the
+	// question's own granted invocation for the exact frozen candidate.
+	question := decodeConsentQuestion(t, replay.Bytes())
+	if question.Action != "consent_required" || len(question.Choices) != 2 {
+		t.Fatalf("named negotiated START did not ask for consent: %#v", question)
+	}
+	var granted bytes.Buffer
+	if err := RunReview(invocationArgs(t, question.Choices[0].Invocation), &granted); err != nil {
+		t.Fatalf("granted negotiated START failed: %v\n%s", err, granted.String())
+	}
 	var negotiated ReviewIntegrationStartResult
-	decodeStrictReviewJSON(t, replay.Bytes(), &negotiated)
+	decodeStrictReviewJSON(t, granted.Bytes(), &negotiated)
 	if negotiated.RepositoryContext == nil {
 		t.Fatalf("named negotiated START carried no repository_context: %#v", negotiated)
 	}


### PR DESCRIPTION
Closes #2870

## Summary
- The refusal that redirects a direct `--base-ref --committed-only` start to the negotiated form now names `--consent relay`, matching the STATUS-supplied transition.
- Replaying that guidance without a TTY now returns the `consent_required` envelope instead of silently minting a high-risk lineage.

## Changes
| File | Change |
|------|--------|
| `internal/cli/review_facade.go` | `reviewNegotiatedStartCommand` appends `--consent relay` |
| `internal/cli/review_start_direct_route_refusal_test.go` | Asserts the refusal names `--consent relay` |
| `internal/cli/review_start_evidence_test.go` | Replay test grants the consent envelope before decoding START |

## Test plan
- [x] `go test ./internal/cli/ -run 'ReviewMode|Consent|Start|BaseDiff|Committed'`
- [x] Refusal ratchet passes
- [x] Native review approved (lineage review-57563d1aa5063e8b), acknowledged

https://claude.ai/code/session_01SYqbaaqyJcAv1FYtSJXx6M

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Safety**
  - Negotiated review continuations now include an explicit consent step before starting.
  - Continuations can be safely run without an interactive terminal, preventing reviews from starting without a consent envelope.

- **Bug Fixes**
  - Updated refusal guidance now provides a complete continuation command with the required consent option.
  - Consent responses are correctly handled when replaying negotiated review starts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->