### PR TITLE
fix(sddstatus): extract edit-authority paths by affirmative inclusion first

### DIFF
--- a/internal/sddstatus/edit_authority.go
+++ b/internal/sddstatus/edit_authority.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"sort"
+	"strconv"
 	"strings"
 
 	"github.com/gentleman-programming/gentle-ai/v2/internal/pathquote"
@@ -44,20 +45,31 @@ var backtickedSpan = regexp.MustCompile("`([^`]+)`")
 // gate for a target it does not annotate.
 var readOnlyMarkerAfterToken = regexp.MustCompile(`(?i)^\s*\(read-only\)`)
 
+// explicitPathContextMarker recognizes a line-level declared-path context
+// (`Files:`, `Edit:`, `Touch:`) that authorizes an otherwise-inconclusive
+// backticked token (no extension, does not yet exist) as an edit target.
+// It is deliberately line-scoped, not token-scoped: an explicit marker names
+// the whole line as a path declaration.
+var explicitPathContextMarker = regexp.MustCompile(`(?i)\b(?:files?|edits?|touch(?:es)?)\s*:`)
+
 // editTargetTokens is the one derivation of "which tokens on this line are
 // edit targets": none when the line is not a checkbox, otherwise every
 // path-like backticked token that is not itself annotated `(read-only)`.
 // Both the edit-authority detector and the runtime-topology guard route
 // through it so a read-only input never blocks either, and an unmarked
-// sibling on the same line still does.
-func editTargetTokens(line string) []string {
+// sibling on the same line still does. workspaceRoot lets pathLikeToken tell
+// a genuine repository path from prose that merely contains a slash (#4096,
+// #4192, gp#598): a candidate must resolve to an existing path, look like a
+// plausible new file, or sit in an explicit Files:/Edit:/Touch: declaration.
+func editTargetTokens(line string, workspaceRoot string) []string {
 	if taskCheckbox.FindStringIndex(line) == nil {
 		return nil
 	}
+	explicitContext := explicitPathContextMarker.MatchString(line)
 	var tokens []string
 	for _, span := range backtickedSpan.FindAllStringSubmatchIndex(line, -1) {
 		token := line[span[2]:span[3]]
-		if !pathLikeToken(token) || readOnlyMarkerAfterToken.MatchString(line[span[1]:]) {
+		if !pathLikeToken(token, workspaceRoot, explicitContext) || readOnlyMarkerAfterToken.MatchString(line[span[1]:]) {
 			continue
 		}
 		tokens = append(tokens, token)
@@ -87,7 +99,7 @@ func detectUnauthorizedEditRoots(tasksText string, workspaceRoot string, allowed
 
 	unauthorized := map[string]bool{}
 	for _, line := range strings.Split(tasksText, "\n") {
-		for _, token := range editTargetTokens(line) {
+		for _, token := range editTargetTokens(line, workspaceRoot) {
 			resolved := token
 			if !filepath.IsAbs(resolved) {
 				resolved = filepath.Join(workspaceRoot, resolved)
@@ -125,17 +137,91 @@ func sameRepositoryEditRoot(path string) string {
 	return path
 }
 
-// pathLikeTokens extracts the conservative candidate set from one checkbox
-// line: backticked tokens that contain a path separator (which subsumes
-// `../` prefixes and absolute paths). Tokens with whitespace are commands or
-// prose, and URL-like tokens are references, not filesystem targets.
-// pathLikeToken reports whether one backticked token reads as a path: no
-// whitespace, no URL scheme, and at least one separator.
-func pathLikeToken(token string) bool {
+// pathLikeToken reports whether one backticked token reads as a genuine
+// filesystem edit path rather than prose that merely contains a slash.
+//
+// Whitespace or a URL scheme always means a command or prose, never a path,
+// and a token without any separator is never a path either. Past that, the
+// affirmative signals run FIRST: an explicit Files:/Edit:/Touch: declaration
+// on the line, or the token (or its parent directory) already existing under
+// workspaceRoot, settle the question outright — a real target must never be
+// dropped by a shape-based exclusion just because it also happens to look
+// route-ish or glob-ish (a real absolute directory with no extension, or an
+// explicitly declared wildcard, still counts). Only when neither affirmative
+// signal holds do the two shape-based exclusions apply: a glob wildcard
+// (`*`, `?`, or an unbalanced/character-class `[...]`) reads as an
+// import-specifier or ignore glob, not a literal path (#4096's
+// `!../../i18n/*`) — except a `[...]` that is a clean, whole directory
+// segment of an otherwise extensioned path is a framework dynamic-route
+// name (`src/app/[id]/page.tsx`), not a glob; and a leading `/` with no file
+// extension reads as a URL route, not an absolute filesystem path (#4192's
+// bare `/`, gp#598's `/api/health`).
+func pathLikeToken(token string, workspaceRoot string, explicitContext bool) bool {
 	if strings.ContainsAny(token, " \t") || strings.Contains(token, "://") {
 		return false
 	}
-	return strings.ContainsRune(token, '/') || strings.ContainsRune(token, filepath.Separator)
+	if !strings.ContainsRune(token, '/') && !strings.ContainsRune(token, filepath.Separator) {
+		return false
+	}
+	if explicitContext || candidatePathExists(token, workspaceRoot) {
+		return true
+	}
+	if looksLikeGlobPattern(token) {
+		return false
+	}
+	if strings.HasPrefix(token, "/") && filepath.Ext(token) == "" {
+		return false
+	}
+	return filepath.Ext(token) != ""
+}
+
+// bracketedPathSegment matches a whole path segment that is nothing but a
+// `[...]` run (no nested slash or bracket) — a framework dynamic-route
+// directory name, e.g. `[id]` or `[...slug]`, not a glob character class.
+var bracketedPathSegment = regexp.MustCompile(`^\[[^/\[\]]+\]$`)
+
+// looksLikeGlobPattern reports whether token carries a wildcard that reads as
+// an import-specifier or ignore glob rather than a literal path. `*` and `?`
+// are unconditional glob signals. A `[`/`]` run only counts when it is not a
+// clean, whole bracketed directory segment of an otherwise extensioned path —
+// which rules out real dynamic-route files like `src/app/[id]/page.tsx`.
+func looksLikeGlobPattern(token string) bool {
+	if strings.ContainsAny(token, "*?") {
+		return true
+	}
+	if !strings.ContainsAny(token, "[]") {
+		return false
+	}
+	if filepath.Ext(token) == "" {
+		return true
+	}
+	for _, segment := range strings.Split(token, "/") {
+		if strings.ContainsAny(segment, "[]") && !bracketedPathSegment.MatchString(segment) {
+			return true
+		}
+	}
+	return false
+}
+
+// candidatePathExists reports whether token, resolved against workspaceRoot
+// when relative, already exists on disk — either the path itself or its
+// containing directory (a plausible new file location). The bare filesystem
+// root never counts: every absolute token trivially resolves under it, so
+// treating it as "existing" would readmit #4192's bare `/` route literal.
+func candidatePathExists(token string, workspaceRoot string) bool {
+	resolved := token
+	if !filepath.IsAbs(resolved) {
+		resolved = filepath.Join(workspaceRoot, resolved)
+	}
+	resolved = filepath.Clean(resolved)
+	if resolved == string(filepath.Separator) {
+		return false
+	}
+	if _, err := os.Lstat(resolved); err == nil {
+		return true
+	}
+	info, err := os.Stat(filepath.Dir(resolved))
+	return err == nil && info.IsDir()
 }
 
 // resolveExistingPath walks up to the nearest existing ancestor (task prose
@@ -205,18 +291,119 @@ func editAuthorityBlockedReason(roots []string) string {
 	)
 }
 
+// taskWorkUnitPrefix captures a checkbox line's own leading task number (the
+// whole-number part before an optional `.sub` suffix, e.g. "1" from "1.1" or
+// from a flat "2."), so lines sharing a phase number are one work unit.
+var taskWorkUnitPrefix = regexp.MustCompile(`^\s*(?:[-*]|\d+[.)])\s+\[[ xX]\]\s*(\d+)(?:\.\d+)*\b`)
+
+// taskWorkUnitKey extracts a checkbox line's leading work-unit number. ok is
+// false when the line carries no leading number, and the caller then
+// conservatively keeps that line in scope rather than guessing.
+func taskWorkUnitKey(line string) (unit int, ok bool) {
+	match := taskWorkUnitPrefix.FindStringSubmatch(line)
+	if match == nil {
+		return 0, false
+	}
+	n, err := strconv.Atoi(match[1])
+	if err != nil {
+		return 0, false
+	}
+	return n, true
+}
+
+// detectUnauthorizedEditRootsForCurrentWorkUnit scopes detection to the
+// current work unit (#4103): a later work unit's own external targets must
+// not block a distinct, currently-actionable work unit. "Current" is the
+// lowest-numbered work unit that still has a pending checkbox; completed
+// tasks are always in scope (their edits already happened), and a line whose
+// task number cannot be parsed is conservatively kept in scope — matching
+// detectUnauthorizedEditRoots's own whole-plan behavior when no work-unit
+// structure can be found at all. It returns the in-scope (blocking) roots
+// separately from the future work units' own roots, which are informational
+// only.
+func detectUnauthorizedEditRootsForCurrentWorkUnit(tasksText, workspaceRoot string, allowedEditRoots []string) (blocking []string, future []string) {
+	lines := strings.Split(tasksText, "\n")
+
+	currentUnit, hasCurrent := 0, false
+	for _, line := range lines {
+		state := taskCheckbox.FindStringSubmatch(line)
+		if state == nil || state[1] != " " {
+			continue
+		}
+		unit, ok := taskWorkUnitKey(line)
+		if !ok {
+			continue
+		}
+		if !hasCurrent || unit < currentUnit {
+			currentUnit, hasCurrent = unit, true
+		}
+	}
+
+	var inScope, outOfScope []string
+	for _, line := range lines {
+		state := taskCheckbox.FindStringSubmatch(line)
+		belongsToLaterUnit := false
+		if hasCurrent && state != nil && state[1] == " " {
+			if unit, ok := taskWorkUnitKey(line); ok && unit != currentUnit {
+				belongsToLaterUnit = true
+			}
+		}
+		if belongsToLaterUnit {
+			outOfScope = append(outOfScope, line)
+		} else {
+			inScope = append(inScope, line)
+		}
+	}
+
+	blocking = detectUnauthorizedEditRoots(strings.Join(inScope, "\n"), workspaceRoot, allowedEditRoots)
+	if len(outOfScope) == 0 {
+		return blocking, nil
+	}
+	blockingSet := make(map[string]bool, len(blocking))
+	for _, root := range blocking {
+		blockingSet[root] = true
+	}
+	for _, root := range detectUnauthorizedEditRoots(strings.Join(outOfScope, "\n"), workspaceRoot, allowedEditRoots) {
+		if !blockingSet[root] {
+			future = append(future, root)
+		}
+	}
+	return blocking, future
+}
+
+// futureEditRootsNote reports a later work unit's own unauthorized edit
+// targets without blocking the current work unit (#4103). It carries no
+// `blocked(...)` reason code, so it never flips applyState — it exists purely
+// so a human sees the future authority need before reaching that work unit.
+func futureEditRootsNote(roots []string) string {
+	quoted := make([]string, 0, len(roots))
+	for _, root := range roots {
+		quoted = append(quoted, pathquote.Quote(root))
+	}
+	return fmt.Sprintf(
+		"note(future_edit_roots): a later work unit in tasks.md targets edit paths outside the authorized edit roots: %s; this does not block the current work unit and needs no action until that work unit is reached",
+		strings.Join(quoted, ", "),
+	)
+}
+
 // applyEditAuthorityBlock forces applyState blocked before dependencies and
 // nextRecommended derive from it, so a plan whose work units the sdd-apply
 // outside-root guard would refuse never reports ready/apply. It runs only
 // when apply would otherwise be ready: completed work needs no forward edit
 // authority, and planning-blocked changes already carry their own reasons.
 // It also returns the unauthorized edit roots so the caller can raise the typed
-// consent question naming exactly them (#2563, S4b of #2540).
+// consent question naming exactly them (#2563, S4b of #2540). Detection is
+// scoped to the current work unit (#4103): a future work unit's own
+// unauthorized roots are reported through reasons as an informational note,
+// never as a blocker.
 func applyEditAuthorityBlock(applyState ApplyState, reasons *blockerReasons, tasksText string, workspaceRoot string, allowedEditRoots []string) (ApplyState, []string) {
 	if applyState != ApplyReady {
 		return applyState, nil
 	}
-	roots := detectUnauthorizedEditRoots(tasksText, workspaceRoot, allowedEditRoots)
+	roots, futureRoots := detectUnauthorizedEditRootsForCurrentWorkUnit(tasksText, workspaceRoot, allowedEditRoots)
+	if len(futureRoots) != 0 {
+		reasons.genuine = append(reasons.genuine, futureEditRootsNote(futureRoots))
+	}
 	if len(roots) == 0 {
 		return applyState, nil
 	}
@@ -261,7 +448,7 @@ func foreignRuntimeTopologyRoots(ctx context.Context, tasksText, workspaceRoot, 
 	}
 	foreign := map[string]bool{}
 	for _, line := range strings.Split(tasksText, "\n") {
-		for _, token := range editTargetTokens(line) {
+		for _, token := range editTargetTokens(line, workspaceRoot) {
 			resolved := token
 			if !filepath.IsAbs(resolved) {
 				resolved = filepath.Join(workspaceRoot, resolved)

--- a/internal/sddstatus/edit_authority_extraction_test.go
+++ b/internal/sddstatus/edit_authority_extraction_test.go
@@ -1,0 +1,240 @@
+package sddstatus
+
+import (
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+// This file pins the shared extractor fix for the "prose read as a
+// filesystem edit path" defect family:
+//
+//   - #4096: an oxlint `../../` import-glob inside backticked tasks.md prose
+//     is treated as an unauthorized external edit root.
+//   - #4192: a canonical web route literal `/` (and routes like
+//     `/api/health`) in prose is treated as a filesystem path requiring
+//     authority.
+//   - gp#598: backticked HTTP routes like `GET /api/health` are parsed as
+//     edit-authority filesystem paths.
+//   - #4103: edit authority is evaluated across the whole task plan, so a
+//     future task naming an external root blocks an unrelated current task.
+//
+// editTargetTokens is the one derivation both detectUnauthorizedEditRoots and
+// the runtime-topology guard route through, so fixing its candidate gating
+// fixes the whole family at the source.
+
+func TestExtractEditAuthorityTargetTokensExcludesNonPathProseAndKeepsRealPaths(t *testing.T) {
+	workspace := t.TempDir()
+	mkdir(t, filepath.Join(workspace, "internal", "sddstatus"))
+
+	tests := []struct {
+		name string
+		line string
+		want []string
+	}{
+		{
+			name: "oxlint import-glob with a double-dot traversal is not a filesystem edit path (#4096)",
+			line: "- [x] 3.2 `.oxlintrc.json`: MODIFY `src/some/dir/*` — add `!../../i18n/*`. Test-first: no — injection-probed.",
+			want: nil,
+		},
+		{
+			name: "canonical route literal `/` is not a filesystem edit path (#4192)",
+			line: "- [ ] 1.1 Document that the canonical route set includes `/` and other routes like `/api/health`.",
+			want: nil,
+		},
+		{
+			name: "backticked HTTP method and route is not a filesystem edit path (gp#598)",
+			line: "- [ ] 1.1 Add the readiness check for `GET /api/health`.",
+			want: nil,
+		},
+		{
+			name: "bare route path without a method prefix is still not a filesystem edit path (gp#598)",
+			line: "- [ ] 1.1 Document the route `/api/health` for the readiness check.",
+			want: nil,
+		},
+		{
+			name: "real repository-relative Go path is still extracted",
+			line: "- [ ] 1.1 Update `internal/cli/foo.go` with the new flag",
+			want: []string{"internal/cli/foo.go"},
+		},
+		{
+			name: "sibling repository TypeScript path is still extracted",
+			line: "- [ ] 1.1 Update `../shared/lib.ts` for the shared client",
+			want: []string{"../shared/lib.ts"},
+		},
+		{
+			name: "new markdown doc under an existing directory is still extracted",
+			line: "- [ ] 1.1 Write `docs/new-file.md` describing the rollout",
+			want: []string{"docs/new-file.md"},
+		},
+		{
+			name: "existing repository directory without an extension is still extracted",
+			line: "- [ ] 1.1 Update the tests under `internal/sddstatus`",
+			want: []string{"internal/sddstatus"},
+		},
+		{
+			name: "explicit Files marker authorizes an extensionless declared path",
+			line: "- [ ] 1.1 Files: `docs/adr` will hold the new decision record",
+			want: []string{"docs/adr"},
+		},
+		{
+			name: "extensionless path mentioned without a marker or an existing directory is not extracted",
+			line: "- [ ] 1.1 Mention `docs/adr` as a possible location",
+			want: nil,
+		},
+		{
+			name: "Next.js dynamic-route directory segment is still extracted, not treated as a glob",
+			line: "- [ ] 1.1 Add the loader to `src/app/[id]/page.tsx`",
+			want: []string{"src/app/[id]/page.tsx"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := editTargetTokens(tt.line, workspace)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Fatalf("editTargetTokens(%q) = %v, want %v", tt.line, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestExistingAbsoluteExtensionlessDirectoryOutsideRootsIsStillFlagged pins
+// the R3-absolute-extensionless-excluded fix: a real absolute directory with
+// no extension that already exists on disk outside every authorized root must
+// still be caught, not swallowed by the route-ish exclusion meant only for
+// URL literals like bare `/` or `/api/health`.
+func TestExistingAbsoluteExtensionlessDirectoryOutsideRootsIsStillFlagged(t *testing.T) {
+	workspace := t.TempDir()
+	planning := filepath.Join(workspace, "planning")
+	external := filepath.Join(workspace, "external-app", "deploy")
+	initEditAuthorityGitRepo(t, planning, false)
+	mkdir(t, external)
+
+	tasks := "- [ ] 1.1 Run the rollout script in `" + external + "`\n"
+	flagged := detectUnauthorizedEditRoots(tasks, planning, []string{planning})
+	want := realPath(t, external)
+	if len(flagged) != 1 || flagged[0] != want {
+		t.Fatalf("detectUnauthorizedEditRoots() = %v, want exactly [%s]", flagged, want)
+	}
+}
+
+// TestExplicitlyDeclaredWildcardTargetIsStillFlagged pins the
+// R3-glob-exclusion-false-negative fix: a wildcard target named under an
+// explicit Files:/Edit:/Touch: declaration is a genuine authorization
+// question, not prose to silently ignore.
+func TestExplicitlyDeclaredWildcardTargetIsStillFlagged(t *testing.T) {
+	workspace := t.TempDir()
+	planning := filepath.Join(workspace, "planning")
+	shared := filepath.Join(workspace, "shared")
+	initEditAuthorityGitRepo(t, planning, false)
+	initEditAuthorityGitRepo(t, shared, false)
+
+	tasks := "- [ ] 1.1 Files: `../shared/*.ts` for the generated client types\n"
+	flagged := detectUnauthorizedEditRoots(tasks, planning, []string{planning})
+	want := realPath(t, shared)
+	if len(flagged) != 1 || flagged[0] != want {
+		t.Fatalf("detectUnauthorizedEditRoots() = %v, want exactly [%s]", flagged, want)
+	}
+}
+
+// TestReportedFalsePositiveProseDoesNotBlockEditAuthorityApply is the
+// end-to-end regression for all three prose-shaped false positives in one
+// fixture: #4096's oxlint import glob, #4192's canonical route literal, and
+// gp#598's backticked HTTP method and route.
+func TestReportedFalsePositiveProseDoesNotBlockEditAuthorityApply(t *testing.T) {
+	repo := initRuntimeLedgerRepo(t)
+	seedReadyChange(t, repo, "false-positive-prose", strings.Join([]string{
+		"- [x] 1.1 Add the header check",
+		"- [ ] 1.2 `.oxlintrc.json`: MODIFY `src/some/dir/*` — add `!../../i18n/*`. Test-first: no — injection-probed.",
+		"- [ ] 1.3 Document that the canonical route set includes `/` and other routes like `/api/health`.",
+		"- [ ] 1.4 Add the readiness check for `GET /api/health`.",
+		"- [ ] 1.5 Update `internal/auth/login.go` with the route table",
+		"",
+	}, "\n"))
+
+	status, err := Resolve(ResolveOptions{CWD: repo, ChangeName: "false-positive-prose"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if status.ApplyState != ApplyReady || status.NextRecommended != "apply" {
+		t.Fatalf("prose-shaped false positive falsely blocked apply: applyState = %q, nextRecommended = %q, blockedReasons = %v",
+			status.ApplyState, status.NextRecommended, status.BlockedReasons)
+	}
+	if len(status.BlockedReasons) != 0 {
+		t.Fatalf("prose-shaped false positive produced unexpected blocked reasons: %v", status.BlockedReasons)
+	}
+}
+
+// TestFutureWorkUnitEditAuthorityRootIsInformationalNotBlocking pins #4103: a future
+// work unit (a higher leading task number, e.g. "2.1" following "1.x") that
+// genuinely targets an external root must not block the current work unit's
+// apply. Its unauthorized root is reported informationally instead.
+func TestFutureWorkUnitEditAuthorityRootIsInformationalNotBlocking(t *testing.T) {
+	workspace := t.TempDir()
+	planning := filepath.Join(workspace, "planning")
+	// deploy is deliberately NOT a Git repository: this test isolates the
+	// edit-authority scoping fix (#4103) from the unrelated runtime-topology
+	// guard, which independently blocks apply for a future task naming a
+	// foreign Git repository regardless of work-unit scope.
+	deploy := filepath.Join(workspace, "deploy-config")
+	initEditAuthorityGitRepo(t, planning, true)
+	mkdir(t, deploy)
+	mkdir(t, filepath.Join(planning, "internal", "auth"))
+	write(t, filepath.Join(planning, "internal", "auth", "login.go"), "package auth\n")
+
+	seedReadyChange(t, planning, "future-unit-rollout", strings.Join([]string{
+		"- [x] 1.1 Update `internal/auth/login.go` with the new claim check",
+		"- [ ] 1.2 Update `internal/auth/session.go` with the refreshed token flow",
+		"- [ ] 2.1 Deploy the change via `../deploy-config/scripts/rollout.sh`",
+		"",
+	}, "\n"))
+
+	status, err := Resolve(ResolveOptions{CWD: planning, ChangeName: "future-unit-rollout"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if status.ApplyState != ApplyReady || status.NextRecommended != "apply" {
+		t.Fatalf("future work unit's external root falsely blocked the current work unit: applyState = %q, nextRecommended = %q, blockedReasons = %v",
+			status.ApplyState, status.NextRecommended, status.BlockedReasons)
+	}
+	reasons := strings.Join(status.BlockedReasons, "\n")
+	if strings.Contains(reasons, "blocked(edit_authority_missing)") {
+		t.Fatalf("future work unit's external root produced a blocking reason: %v", status.BlockedReasons)
+	}
+	wantDeploy := realPath(t, deploy)
+	if !strings.Contains(reasons, "note(future_edit_roots)") || !strings.Contains(reasons, wantDeploy) {
+		t.Fatalf("blocked reasons must carry an informational future-edit-roots note naming %q: %v", wantDeploy, status.BlockedReasons)
+	}
+}
+
+// TestDetectUnauthorizedEditAuthorityRootsForCurrentWorkUnitScopesToCurrentUnit pins the
+// lower-level split: the current (lowest-numbered) pending work unit's targets
+// block, a later work unit's targets are reported as future only, and an
+// already-completed task's target stays in scope regardless of its number.
+func TestDetectUnauthorizedEditAuthorityRootsForCurrentWorkUnitScopesToCurrentUnit(t *testing.T) {
+	workspace := t.TempDir()
+	planning := filepath.Join(workspace, "planning")
+	serviceA := filepath.Join(workspace, "service-a")
+	serviceB := filepath.Join(workspace, "service-b")
+	initEditAuthorityGitRepo(t, planning, false)
+	initEditAuthorityGitRepo(t, serviceA, false)
+	initEditAuthorityGitRepo(t, serviceB, false)
+
+	tasks := strings.Join([]string{
+		"- [x] 1.1 Already touched `../service-a/legacy/done.go`",
+		"- [ ] 1.2 Still touching `../service-a/internal/api/handler.go`",
+		"- [ ] 2.1 Later touches `../service-b/internal/worker/consume.go`",
+		"",
+	}, "\n")
+
+	blocking, future := detectUnauthorizedEditRootsForCurrentWorkUnit(tasks, planning, []string{planning})
+	wantA := realPath(t, serviceA)
+	wantB := realPath(t, serviceB)
+	if !reflect.DeepEqual(blocking, []string{wantA}) {
+		t.Fatalf("blocking = %v, want [%s] (completed task stays in scope, current pending unit 1 stays in scope)", blocking, wantA)
+	}
+	if !reflect.DeepEqual(future, []string{wantB}) {
+		t.Fatalf("future = %v, want [%s] (unit 2 has not started)", future, wantB)
+	}
+}


### PR DESCRIPTION
Closes #4096
Closes #4103
Closes #4192
Closes Gentleman-Programming/gentle-pi#598

## Summary
- `sdd status` no longer reports `blocked(edit_authority_missing)` for prose fragments, route-like segments, or a bare `/` found in `tasks.md`.
- Real declared targets (explicit `Files:`/`Edit:`/`Touch:` markers, or tokens that resolve to an existing path such as `src/app/[id]/page.tsx`) are admitted before the shape-based exclusions run; the filesystem root never counts as an existing path.
- True positives stay flagged: an existing absolute extensionless directory outside the roots and an explicitly declared wildcard target both still block.

## Changes
| File | Change |
|------|--------|
| `internal/sddstatus/edit_authority.go` | Affirmative inclusion first, `looksLikeGlobPattern`, root guard in `candidatePathExists` |
| `internal/sddstatus/edit_authority_extraction_test.go` | Regression table for the four reported false positives plus true-positive guards |

## Size exception
457 lines, most of them table-driven regression tests for the four reports; the extractor change itself is one cohesive unit and cannot be split without landing an untested heuristic.

## Test plan
- [x] `go test ./internal/sddstatus/ -count=1`
- [x] Refusal ratchet passes
- [x] Native review: correction plan (116/191 lines) validated and approved (lineage review-cb40a11598df1a1f), acknowledged

https://claude.ai/code/session_01SYqbaaqyJcAv1FYtSJXx6M

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced false warnings caused by import patterns, URL routes, and HTTP routes being mistaken for file paths.
  * Edit-authority checks now focus on the current work unit, preventing unrelated future work from blocking application.
  * Explicitly declared wildcard targets and unauthorized absolute directories continue to be flagged appropriately.
  * Future work-unit edit roots are shown as informational notices instead of blocking errors.

* **Tests**
  * Added coverage for path detection, work-unit scoping, and prevention of false-positive blocking behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->