### PR TITLE
fix(reviewtransaction): tolerate git before 2.38 and bound staging output

### DIFF
--- a/internal/reviewtransaction/frozen_candidate_context.go
+++ b/internal/reviewtransaction/frozen_candidate_context.go
@@ -11,6 +11,7 @@ import (
 	"path/filepath"
 	"reflect"
 	"strings"
+	"sync"
 )
 
 const (
@@ -386,6 +387,71 @@ func (builder SnapshotBuilder) InspectCandidate(ctx context.Context, snapshot Sn
 	return payload, inspectErr
 }
 
+// gitShowObjectFormatUnsupported caches, for the rest of this process,
+// whether the installed git predates 2.38's `rev-parse --show-object-format`
+// (#3541): that git echoes the unrecognized flag back instead of failing,
+// which would otherwise be misread as the object format on every call.
+var (
+	gitShowObjectFormatMu          sync.Mutex
+	gitShowObjectFormatUnsupported bool
+)
+
+// gitObjectFormat determines a repository's object hash algorithm across the
+// git version gap #3541 reports. git >= 2.38 answers directly. Older git
+// echoes the unrecognized flag back verbatim (the same "unsupported option
+// echo" shape canonicalGitDirectory already guards against for
+// --path-format=absolute), recognized here by its leading "--", and degrades
+// to the fallback below, caching the negative result.
+func gitObjectFormat(ctx context.Context, repo string) (string, error) {
+	gitShowObjectFormatMu.Lock()
+	unsupported := gitShowObjectFormatUnsupported
+	gitShowObjectFormatMu.Unlock()
+	if !unsupported {
+		output, err := runGit(ctx, repo, nil, nil, "rev-parse", "--show-object-format")
+		if err != nil {
+			return "", err
+		}
+		format := strings.TrimSpace(string(output))
+		switch {
+		case format == "sha1" || format == "sha256":
+			return format, nil
+		case strings.HasPrefix(format, "--"):
+			gitShowObjectFormatMu.Lock()
+			gitShowObjectFormatUnsupported = true
+			gitShowObjectFormatMu.Unlock()
+		default:
+			return "", fmt.Errorf("unsupported Git object format %q", format)
+		}
+	}
+	return legacyGitObjectFormat(ctx, repo)
+}
+
+// legacyGitObjectFormat determines the object format for git < 2.38, which
+// has no --show-object-format flag. A SHA-256 repository predates that flag
+// too (git init --object-format=sha256, supported since git 2.29) and
+// records its choice in extensions.objectformat; every other repository is
+// sha1, the only format that existed before that extension did.
+func legacyGitObjectFormat(ctx context.Context, repo string) (string, error) {
+	output, err := runGit(ctx, repo, nil, nil, "config", "--get", "extensions.objectformat")
+	if err != nil {
+		var commandErr *GitCommandError
+		if errors.As(err, &commandErr) && commandErr.ExitCode == 1 {
+			// `git config --get` exits 1 when the key is unset; on git that
+			// predates extensions.objectformat entirely, unset IS sha1.
+			return "sha1", nil
+		}
+		return "", err
+	}
+	format := strings.ToLower(strings.TrimSpace(string(output)))
+	if format == "" {
+		format = "sha1"
+	}
+	if format != "sha1" && format != "sha256" {
+		return "", fmt.Errorf("unsupported Git object format %q", format)
+	}
+	return format, nil
+}
+
 func isolatedImmutableTreeGit(ctx context.Context, repo string) ([]string, func() error, error) {
 	isolation, _, cleanup, err := isolatedImmutableTreeGitWithAttributesFile(ctx, repo)
 	return isolation, cleanup, err
@@ -396,13 +462,9 @@ func isolatedImmutableTreeGitWithAttributesFile(ctx context.Context, repo string
 	if err != nil {
 		return nil, "", func() error { return nil }, err
 	}
-	objectFormatOutput, err := runGit(ctx, identity.RepositoryRoot, nil, nil, "rev-parse", "--show-object-format")
+	objectFormat, err := gitObjectFormat(ctx, identity.RepositoryRoot)
 	if err != nil {
 		return nil, "", func() error { return nil }, err
-	}
-	objectFormat := strings.TrimSpace(string(objectFormatOutput))
-	if objectFormat != "sha1" && objectFormat != "sha256" {
-		return nil, "", func() error { return nil }, fmt.Errorf("unsupported Git object format %q", objectFormat)
 	}
 	// The repository Git directory is the reliable writable location when a
 	// sandboxed caller does not expose an accessible process temp directory.

--- a/internal/reviewtransaction/frozen_candidate_context_test.go
+++ b/internal/reviewtransaction/frozen_candidate_context_test.go
@@ -751,6 +751,89 @@ func frozenCandidateGitDiff(t *testing.T, repo string, frozen FrozenCandidateCon
 	return output
 }
 
+// installShowObjectFormatRejectingGitShim puts a `git` shim first on PATH
+// that reproduces #3541: it rejects only `rev-parse --show-object-format`,
+// the exact way git < 2.38 does — printing the unrecognized flag back
+// verbatim on stdout with exit 0 — and delegates every other invocation to
+// the real git.
+func installShowObjectFormatRejectingGitShim(t *testing.T) {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("PATH shim requires a POSIX shell")
+	}
+	realGit, err := exec.LookPath("git")
+	if err != nil {
+		t.Skip("git is unavailable")
+	}
+	shimDir := t.TempDir()
+	shim := "#!/bin/sh\n" +
+		"for arg in \"$@\"; do\n" +
+		"  if [ \"$arg\" = \"--show-object-format\" ]; then\n" +
+		"    printf '%s\\n' \"$arg\"\n" +
+		"    exit 0\n" +
+		"  fi\n" +
+		"done\n" +
+		"exec \"$GENTLE_AI_TEST_REAL_GIT\" \"$@\"\n"
+	if err := os.WriteFile(filepath.Join(shimDir, "git"), []byte(shim), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("GENTLE_AI_TEST_REAL_GIT", realGit)
+	t.Setenv("PATH", shimDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+}
+
+// resetGitObjectFormatCapabilityCache isolates #3541's process-wide cache
+// between tests: without this, whichever test runs first would decide the
+// cached capability for every test that runs after it in the same process.
+func resetGitObjectFormatCapabilityCache(t *testing.T) {
+	t.Helper()
+	gitShowObjectFormatMu.Lock()
+	previous := gitShowObjectFormatUnsupported
+	gitShowObjectFormatUnsupported = false
+	gitShowObjectFormatMu.Unlock()
+	t.Cleanup(func() {
+		gitShowObjectFormatMu.Lock()
+		gitShowObjectFormatUnsupported = previous
+		gitShowObjectFormatMu.Unlock()
+	})
+}
+
+// TestGitObjectFormatDegradesOnPreShowObjectFormatGit reproduces #3541: on
+// git < 2.38, `rev-parse --show-object-format` is unrecognized and git
+// echoes it back verbatim with exit 0 instead of failing, which previously
+// made gitObjectFormat misread the echoed flag as the object format and
+// reject every repository as "unsupported Git object format". It must
+// instead degrade to reading extensions.objectformat directly, and it must
+// do so only once per process (the second call below runs with the shim
+// still installed, proving the cached decision skips the failing probe
+// rather than re-discovering it).
+func TestGitObjectFormatDegradesOnPreShowObjectFormatGit(t *testing.T) {
+	requireSnapshotGit(t)
+	resetGitObjectFormatCapabilityCache(t)
+	repo := initSnapshotRepo(t)
+	installShowObjectFormatRejectingGitShim(t)
+
+	format, err := gitObjectFormat(context.Background(), repo)
+	if err != nil {
+		t.Fatalf("gitObjectFormat with a pre-2.38 git = %v, want the extensions.objectformat fallback", err)
+	}
+	if format != "sha1" {
+		t.Fatalf("gitObjectFormat = %q, want sha1 for a repository with no extensions.objectformat override", format)
+	}
+	gitShowObjectFormatMu.Lock()
+	cached := gitShowObjectFormatUnsupported
+	gitShowObjectFormatMu.Unlock()
+	if !cached {
+		t.Fatal("gitObjectFormat did not cache the unsupported --show-object-format capability")
+	}
+
+	// The cached decision must be reused: a second call must not re-probe
+	// --show-object-format and must still succeed via the fallback.
+	format, err = gitObjectFormat(context.Background(), repo)
+	if err != nil || format != "sha1" {
+		t.Fatalf("cached gitObjectFormat = %q, err=%v, want sha1 with no error", format, err)
+	}
+}
+
 func frozenCandidatePorcelainGitDiff(t *testing.T, repo string, frozen FrozenCandidateContext, logicalPath string) []byte {
 	t.Helper()
 	args := []string{

--- a/internal/reviewtransaction/snapshot.go
+++ b/internal/reviewtransaction/snapshot.go
@@ -1238,7 +1238,12 @@ func (builder *SnapshotBuilder) buildCurrentChanges(ctx context.Context, intende
 	}
 	if projection != ProjectionStaged {
 		if len(cachedEntries) > 0 {
-			if _, err := runGit(ctx, builder.Repo, env, nil, "add", "-u", "--", "."); err != nil {
+			// #3993: this step's result is the exit code alone, so it discards
+			// output instead of bounding it, and its timeout scales with the
+			// tracked-path count `ls-files` just reported instead of the fixed
+			// local budget.
+			trackedPaths := bytes.Count(cachedEntries, []byte{0})
+			if err := runGitDiscardOutput(ctx, builder.Repo, env, nil, stagingCommandTimeout(trackedPaths), "add", "-u", "--", "."); err != nil {
 				return "", "", "", err
 			}
 		}
@@ -1784,6 +1789,35 @@ var gitCommandWaitDelay = time.Second
 var gitCommandContext = exec.CommandContext
 var gitProcessTreeStarter = startGitProcessTree
 
+// StagingCommandTimeoutFloor and StagingCommandTimeoutPerTrackedPath bound
+// the runtime candidate's staging step (`git add -u -- .`, #3993). A fixed
+// LocalGitCommandTimeout starves that step on a repository whose tracked-path
+// count is large enough to make the walk I/O-bound rather than CPU-bound on a
+// slow filesystem (a WSL translation layer, network storage): every path is
+// individually fast, but the full walk is not. The floor keeps every existing
+// repository's effective budget unchanged; the per-path rate only ever adds
+// time, and StagingCommandTimeoutCeiling caps the product so a wedged walk on
+// a very large repository still releases the index lock within a bounded
+// window instead of holding the capture for hours. Exported, like the
+// timeouts above, as test seams.
+var StagingCommandTimeoutFloor = LocalGitCommandTimeout
+var StagingCommandTimeoutPerTrackedPath = 25 * time.Millisecond
+var StagingCommandTimeoutCeiling = 10 * time.Minute
+
+// stagingCommandTimeout returns the staging step's budget for a repository
+// with the given tracked-path count: the floor, or the proportional budget
+// when that is larger, clamped to the ceiling.
+func stagingCommandTimeout(trackedPaths int) time.Duration {
+	budget := StagingCommandTimeoutFloor
+	if proportional := time.Duration(trackedPaths) * StagingCommandTimeoutPerTrackedPath; proportional > budget {
+		budget = proportional
+	}
+	if StagingCommandTimeoutCeiling > 0 && budget > StagingCommandTimeoutCeiling {
+		budget = StagingCommandTimeoutCeiling
+	}
+	return budget
+}
+
 const (
 	defaultGitOutputLimit = 8 << 20
 	// defaultGitInventoryLimit bounds `git ls-files` inventories, whose size
@@ -1822,10 +1856,32 @@ func runGitCaptured(ctx context.Context, repo string, extraEnv []string, stdin [
 	return output, err
 }
 
+// runGitDiscardOutput runs a Git command whose stdout/stderr the caller does
+// not read at all: it never rejects on overflow, so a command that
+// incidentally emits more than the shared capture buffers hold (thousands of
+// tracked paths each triggering a CRLF or embedded-repository warning on
+// `git add -u -- .`, #3993) fails only on its actual exit code, never on
+// buffered-output size nobody downstream inspects. timeout overrides the
+// standard local/remote selection when positive.
+func runGitDiscardOutput(ctx context.Context, repo string, extraEnv []string, stdin []byte, timeout time.Duration, args ...string) error {
+	_, _, err := runGitCapturedRangeWithTimeout(ctx, repo, extraEnv, stdin, 0, defaultGitOutputLimit, false, false, false, timeout, args...)
+	return err
+}
+
 func runGitCapturedRange(ctx context.Context, repo string, extraEnv []string, stdin []byte, outputOffset, outputLimit int, isolateConfig, rejectStderr, rejectOverflow bool, args ...string) ([]byte, int, error) {
+	return runGitCapturedRangeWithTimeout(ctx, repo, extraEnv, stdin, outputOffset, outputLimit, isolateConfig, rejectStderr, rejectOverflow, 0, args...)
+}
+
+// runGitCapturedRangeWithTimeout is runGitCapturedRange with an optional
+// override for the standard local/remote timeout selection (#3993): a
+// positive timeout replaces it, zero keeps the existing selection unchanged
+// for every other caller.
+func runGitCapturedRangeWithTimeout(ctx context.Context, repo string, extraEnv []string, stdin []byte, outputOffset, outputLimit int, isolateConfig, rejectStderr, rejectOverflow bool, timeoutOverride time.Duration, args ...string) ([]byte, int, error) {
 	remote := len(args) > 0 && args[0] == "ls-remote"
 	timeout := LocalGitCommandTimeout
-	if remote {
+	if timeoutOverride > 0 {
+		timeout = timeoutOverride
+	} else if remote {
 		timeout = RemoteGitCommandTimeout
 	}
 	commandContext, cancel := context.WithTimeout(ctx, timeout)

--- a/internal/reviewtransaction/snapshot_test.go
+++ b/internal/reviewtransaction/snapshot_test.go
@@ -336,6 +336,62 @@ func TestSnapshotProjectionValidationAndIdentity(t *testing.T) {
 	}
 }
 
+// installLargeStderrGitAddShim puts a `git` shim first on PATH that
+// reproduces #3993's byte-cap bound: `git add -u -- .` emits more than 64
+// KiB of incidental warning output (the shape thousands of tracked paths
+// triggering CRLF or embedded-repository warnings produce) and still exits
+// 0, exactly like a real large `git add -u` would. Every other invocation
+// delegates to the real git so the rest of buildCurrentChanges works
+// normally.
+func installLargeStderrGitAddShim(t *testing.T) {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("PATH shim requires a POSIX shell")
+	}
+	realGit, err := exec.LookPath("git")
+	if err != nil {
+		t.Skip("git is unavailable")
+	}
+	shimDir := t.TempDir()
+	shim := "#!/bin/sh\n" +
+		"prev=\"\"\n" +
+		"for arg in \"$@\"; do\n" +
+		"  if [ \"$prev\" = \"add\" ] && [ \"$arg\" = \"-u\" ]; then\n" +
+		"    i=0\n" +
+		"    while [ $i -lt 2000 ]; do\n" +
+		"      printf 'warning: adding embedded git repository or CRLF notice for path %d\\n' \"$i\" >&2\n" +
+		"      i=$((i + 1))\n" +
+		"    done\n" +
+		"    exit 0\n" +
+		"  fi\n" +
+		"  prev=\"$arg\"\n" +
+		"done\n" +
+		"exec \"$GENTLE_AI_TEST_REAL_GIT\" \"$@\"\n"
+	if err := os.WriteFile(filepath.Join(shimDir, "git"), []byte(shim), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("GENTLE_AI_TEST_REAL_GIT", realGit)
+	t.Setenv("PATH", shimDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+}
+
+// TestBuildCurrentChangesToleratesLargeStagingOutput reproduces #3993: a
+// repository whose tracked paths make `git add -u -- .` emit more than the
+// shared 64 KiB stderr capture buffer must not fail candidate capture on
+// that account. Before the fix, the staging step used the same overflow-
+// rejecting capture as every other Git call, so this exact shape returned
+// "output exceeds deterministic 65536-byte limit" before an attempt token
+// was ever issued.
+func TestBuildCurrentChangesToleratesLargeStagingOutput(t *testing.T) {
+	requireSnapshotGit(t)
+	repo := initSnapshotRepo(t)
+	writeSnapshotFile(t, repo, "tracked.txt", "changed\n")
+	installLargeStderrGitAddShim(t)
+
+	if _, err := (SnapshotBuilder{Repo: repo}).Build(context.Background(), Target{Kind: TargetCurrentChanges, IntendedUntracked: []string{}}); err != nil {
+		t.Fatalf("Build() with a staging step producing >64 KiB of output error = %v, want tolerated", err)
+	}
+}
+
 // TestSnapshotIdentityIsRepresentationInvariant is the headline proof for
 // issue #2659 (root 21 of #2471): a declared intended-untracked path and the
 // exact same path staged into the index instead are two REPRESENTATIONS of
@@ -1957,4 +2013,30 @@ func gitSnapshot(t *testing.T, repo string, args ...string) string {
 func gitSnapshotSucceeds(repo string, args ...string) bool {
 	cmd := exec.Command("git", append([]string{"-C", repo}, args...)...)
 	return cmd.Run() == nil
+}
+
+func TestStagingCommandTimeoutIsBoundedByFloorAndCeiling(t *testing.T) {
+	t.Parallel()
+
+	floor := StagingCommandTimeoutFloor
+	perPath := StagingCommandTimeoutPerTrackedPath
+	ceiling := StagingCommandTimeoutCeiling
+	if ceiling <= floor {
+		t.Fatalf("ceiling %s must exceed floor %s", ceiling, floor)
+	}
+	if got := stagingCommandTimeout(0); got != floor {
+		t.Fatalf("zero tracked paths: got %s, want floor %s", got, floor)
+	}
+	small := int(floor/perPath) / 2
+	if got := stagingCommandTimeout(small); got != floor {
+		t.Fatalf("%d tracked paths: got %s, want floor %s", small, got, floor)
+	}
+	mid := int(floor/perPath) * 2
+	if got, want := stagingCommandTimeout(mid), time.Duration(mid)*perPath; got != want {
+		t.Fatalf("%d tracked paths: got %s, want proportional %s", mid, got, want)
+	}
+	huge := int(ceiling/perPath) * 100
+	if got := stagingCommandTimeout(huge); got != ceiling {
+		t.Fatalf("%d tracked paths: got %s, want ceiling %s", huge, got, ceiling)
+	}
 }


### PR DESCRIPTION
Closes #3541
Closes #3993

## Summary
- `sdd-attempt settle` no longer fails with `unsupported Git object format "--show-object-format"` on git older than 2.38: the echo is detected once, cached, and `extensions.objectformat` is read with a `sha1` default.
- The runtime staging step (`git add -u -- .`) discards its output instead of rejecting the acquire when warnings exceed the 64 KiB stderr limit, and its deadline scales with the tracked-path count between the existing floor and a ten-minute ceiling.

## Changes
| File | Change |
|------|--------|
| `internal/reviewtransaction/frozen_candidate_context.go` | Legacy object-format fallback with a process-wide cache |
| `internal/reviewtransaction/snapshot.go` | `runGitDiscardOutput`, `stagingCommandTimeout` with floor and ceiling |
| `internal/reviewtransaction/*_test.go` | Fake-git shim tests for the pre-2.38 echo, large staging output, and the bounded timeout |

## Test plan
- [x] `go test ./internal/reviewtransaction/ -run 'Git|Snapshot|Stage|ObjectFormat|Staging' -count=1`
- [x] Deadcode ratchet passes
- [x] Native review: correction (timeout ceiling, 44/132 lines) validated and approved (lineage review-b563ee2e92ddd68b), acknowledged

https://claude.ai/code/session_01SYqbaaqyJcAv1FYtSJXx6M

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added compatibility for older Git versions when determining repository object formats.
  * Improved staging reliability when Git produces large amounts of diagnostic output.
  * Staging operations now use time limits that adjust to the number of tracked paths, while remaining within safe bounds.

* **Tests**
  * Added coverage for older Git compatibility, large staging output, and staging timeout limits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->