### PR TITLE
fix(sdd-attempt): accept every sdd-status change name and derive settle evidence from remediation

### DIFF
--- a/internal/cli/sdd_attempt.go
+++ b/internal/cli/sdd_attempt.go
@@ -54,6 +54,7 @@ func runSDDAttempt(ctx context.Context, args []string, stdout io.Writer) error {
 	cleanupEvidence := registerSDDAttemptStringFlag(flags, operation, "cleanup-evidence")
 	processEvidence := registerSDDAttemptStringFlag(flags, operation, "process-evidence")
 	remediatesEvidenceRevision := registerSDDAttemptStringFlag(flags, operation, "remediates-evidence-revision")
+	remediationEvidence := registerSDDAttemptStringFlag(flags, operation, "remediation-evidence")
 	reason := registerSDDAttemptStringFlag(flags, operation, "reason")
 	actor := registerSDDAttemptStringFlag(flags, operation, "actor")
 	var roots sddAttemptRootList
@@ -242,6 +243,7 @@ func runSDDAttempt(ctx context.Context, args []string, stdout io.Writer) error {
 			HarnessDisposition: sddstatus.HarnessDisposition(*harnessDisposition),
 			CleanupEvidence:    *cleanupEvidence, ProcessEvidence: *processEvidence,
 			RemediatesEvidenceRevision: *remediatesEvidenceRevision,
+			RemediationEvidence:        *remediationEvidence,
 			IntendedUntracked:          settlementUntracked, ExpectedUntrackedInventory: settlementInventory,
 		})
 	case "grant":
@@ -412,6 +414,7 @@ var sddAttemptOperationDefinitions = []sddAttemptOperationContract{
 		{name: "cleanup-evidence", required: true, usage: "required; trimmed single-line text, at most 500 bytes"},
 		{name: "process-evidence", required: true, usage: "required; trimmed single-line text, at most 500 bytes"},
 		{name: "remediates-evidence-revision", usage: "optional; repaired sha256:<64 lowercase hex> failed evidence"},
+		{name: "remediation-evidence", usage: "optional; strict gentle-ai.remediation-evidence/v1 JSON; derives --evidence-revision when it is omitted"},
 		{name: "untracked-scope", usage: "required when this attempt left eligible untracked files; select or exclude"},
 		{name: "expected-untracked-inventory", usage: "required with untracked-scope; inventory digest"},
 		{name: "intended-untracked", kind: sddAttemptRepeatableStringFlag, usage: "repeatable selected repo-relative untracked path"},
@@ -647,7 +650,11 @@ func missingSDDAttemptOperationFlags(args []string, operation, parsedOutcome str
 			names = append(names, flagDefinition.name)
 		}
 	}
-	if (operation == "finish" || operation == "settle") && parsedOutcome == "interrupted" {
+	// #2896: --remediation-evidence derives --evidence-revision, so a settle
+	// carrying it no longer needs the caller to also invent one.
+	dropEvidenceRevision := (operation == "finish" || operation == "settle") && parsedOutcome == "interrupted" ||
+		operation == "settle" && presentSDDAttemptFlags(args, "remediation-evidence") == 1
+	if dropEvidenceRevision {
 		filtered := names[:0]
 		for _, name := range names {
 			if name != "evidence-revision" {

--- a/internal/cli/sdd_attempt_test.go
+++ b/internal/cli/sdd_attempt_test.go
@@ -277,7 +277,7 @@ func TestRunSDDAttemptHelpContractsCoverEveryOperation(t *testing.T) {
 		{"rescope", []string{"cwd", "change", "expected-revision", "request-id", "work-unit", "evidence-goal", "max-attempts", "max-changed-lines", "reason", "actor", "untracked-scope", "expected-untracked-inventory", "intended-untracked"}, []string{"explicit limit", "cannot exceed current objective"}},
 		{"acquire", []string{"cwd", "change", "token", "expected-revision", "request-id", "work-unit", "evidence-goal", "max-attempts", "max-changed-lines", "remediates-evidence-revision", "untracked-scope", "expected-untracked-inventory", "intended-untracked"}, []string{"default 2", "default 200", "failed evidence correction"}},
 		{"repair", []string{"cwd", "change", "expected-revision", "request-id", "reason", "actor"}, []string{"unreadable sha256", "500 bytes", "128 bytes"}},
-		{"settle", []string{"cwd", "change", "token", "request-id", "outcome", "evidence-revision", "diagnosis", "harness-disposition", "cleanup-evidence", "process-evidence", "remediates-evidence-revision", "untracked-scope", "expected-untracked-inventory", "intended-untracked"}, []string{"opaque token returned by acquire", "required for failed/passed; omit for interrupted"}},
+		{"settle", []string{"cwd", "change", "token", "request-id", "outcome", "evidence-revision", "diagnosis", "harness-disposition", "cleanup-evidence", "process-evidence", "remediates-evidence-revision", "remediation-evidence", "untracked-scope", "expected-untracked-inventory", "intended-untracked"}, []string{"opaque token returned by acquire", "required for failed/passed; omit for interrupted"}},
 		{"grant", []string{"cwd", "change", "expected-revision", "root", "change-instance", "request-id", "actor", "reason"}, []string{"repeatable", "1..32", "4096 bytes"}},
 	}
 
@@ -568,5 +568,76 @@ func TestRunSDDAttemptTrimsWhitespaceFromRevisionShapedFlags(t *testing.T) {
 	last := finished.Attempts[len(finished.Attempts)-1]
 	if last.EvidenceRevision != hash {
 		t.Fatalf("finish with a whitespace-padded --evidence-revision = %#v, want trimmed evidence_revision %q", last, hash)
+	}
+}
+
+// TestRunSDDAttemptSettleRemediationEvidenceDropsEvidenceRevisionRequirement
+// is the CLI-level behavioral proof for #2896's flag-requirement carve-out
+// (missingSDDAttemptOperationFlags): --remediation-evidence must let settle
+// actually reach Settle and complete without --evidence-revision, and
+// omitting BOTH flags must still raise the ordinary requirement refusal.
+// Asserted on behavior (the settle call's real outcome), not on the help
+// table.
+func TestRunSDDAttemptSettleRemediationEvidenceDropsEvidenceRevisionRequirement(t *testing.T) {
+	repo := initReviewCLIRepo(t)
+	const change = "cli-remediation-evidence"
+	failedEvidence := cliAttemptHash('a')
+
+	acquired1, _ := runCompactSDDAttempt(t, []string{
+		"acquire", "--cwd", repo, "--change", change, "--request-id", "cli-rem-acquire-1",
+		"--work-unit", "verify", "--evidence-goal", "prove CLI remediation evidence",
+		"--max-attempts", "5", "--max-changed-lines", "800",
+	})
+	failed, _ := runCompactSDDAttempt(t, []string{
+		"settle", "--cwd", repo, "--change", change, "--token", acquired1.Token,
+		"--request-id", "cli-rem-settle-1", "--outcome", "failed", "--evidence-revision", failedEvidence,
+		"--diagnosis", "verification found a correction", "--harness-disposition", "reused",
+		"--cleanup-evidence", "cleanup completed", "--process-evidence", "no descendants",
+	})
+	if failed.State != "proceed" {
+		t.Fatalf("failed settle = %#v", failed)
+	}
+	acquired2, _ := runCompactSDDAttempt(t, []string{
+		"acquire", "--cwd", repo, "--change", change, "--request-id", "cli-rem-acquire-2",
+		"--work-unit", "verify", "--evidence-goal", "prove CLI remediation evidence",
+		"--max-attempts", "5", "--max-changed-lines", "800", "--remediates-evidence-revision", failedEvidence,
+	})
+	trackedFile := filepath.Join(repo, "tracked.txt")
+	existing, err := os.ReadFile(trackedFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(trackedFile, append(existing, []byte("corrected\n")...), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	evidence := `{"schema":"gentle-ai.remediation-evidence/v1","failed_evidence_revision":"` + failedEvidence + `",` +
+		`"commands":[{"command":"go test ./...","exit_code":0,"result":"293 passed"}],` +
+		`"runtime_harness":{"status":"not_applicable","na_reason":"no runtime harness because this change is test-only"},` +
+		`"rollback":{"boundary":"commit 9ec76eec32","evidence":"git revert 9ec76eec32 restores the prior passing state"}}`
+
+	// (a) --remediation-evidence with no --evidence-revision must reach
+	// Settle and complete, not merely pass flag validation.
+	settled, _ := runCompactSDDAttempt(t, []string{
+		"settle", "--cwd", repo, "--change", change, "--token", acquired2.Token,
+		"--request-id", "cli-rem-settle-2", "--outcome", "passed",
+		"--diagnosis", "correction passed verification", "--harness-disposition", "reused",
+		"--cleanup-evidence", "cleanup completed", "--process-evidence", "no descendants",
+		"--remediates-evidence-revision", failedEvidence, "--remediation-evidence", evidence,
+	})
+	if settled.State != "complete" {
+		t.Fatalf("settle with --remediation-evidence and no --evidence-revision = %#v, want it to complete", settled)
+	}
+
+	// (b) neither flag: the ordinary requirement refusal still fires.
+	var output bytes.Buffer
+	err = RunSDDAttempt([]string{
+		"settle", "--cwd", repo, "--change", change, "--token", cliAttemptHash('f'),
+		"--request-id", "cli-rem-settle-3", "--outcome", "passed",
+		"--diagnosis", "diagnosis", "--harness-disposition", "reused",
+		"--cleanup-evidence", "cleanup", "--process-evidence", "process",
+	}, &output)
+	want := "sdd-attempt settle requires --evidence-revision"
+	if err == nil || !strings.Contains(err.Error(), want) {
+		t.Fatalf("settle with neither flag error = %v, want it to contain %q", err, want)
 	}
 }

--- a/internal/sddstatus/runtime_change_identity_test.go
+++ b/internal/sddstatus/runtime_change_identity_test.go
@@ -8,17 +8,27 @@ import (
 )
 
 // The native runtime authority must accept every change identity that
-// sdd-status already resolves. Rejecting an Engram identity such as
-// DEC-EXAMPLE-CHANGE stalls the whole attempt gate for a change whose
-// artifacts resolve normally.
+// sdd-status already resolves (#2116): sdd-status's directory-based and
+// Engram-backed resolution impose no character-shape restriction of their
+// own, so the runtime authority cannot impose one narrower than "whatever a
+// filesystem path segment or a JSON string can safely represent". This table
+// covers the reported classes directly: dashes (the original kebab-case
+// contract), uppercase and underscores (DEC-EXAMPLE-CHANGE, tag_improvement),
+// dots (3.14), spaces and "@" (a human-readable Engram identity), and a
+// nested/topic-namespaced identity containing "/".
 func TestOpenRuntimeStoreAcceptsChangeIdentitiesResolvedBySDDStatus(t *testing.T) {
 	repo := initRuntimeLedgerRepo(t)
 	for _, change := range []string{
+		"kebab-case",
 		"DEC-EXAMPLE-CHANGE",
 		"Add-User-Auth",
 		"add_user_auth",
 		"2116-fix-sdd-attempt",
 		"MixedCase_And-Digits2",
+		"3.14",
+		"Change.With.Dots",
+		"tag improvement @ v2",
+		"features/sub-change",
 	} {
 		store, err := OpenRuntimeStore(context.Background(), repo, change)
 		if err != nil {
@@ -30,7 +40,51 @@ func TestOpenRuntimeStoreAcceptsChangeIdentitiesResolvedBySDDStatus(t *testing.T
 	}
 }
 
-// Widening the accepted identity must not widen what reaches the filesystem.
+// The ledger directory derived for a name containing "/" or "." must stay a
+// single flat component under the encoded namespace: it must not reintroduce
+// extra directory levels (which "/" would create verbatim) or resolve
+// outside the runtime store's own base directory.
+func TestOpenRuntimeStoreEncodesPathLikeChangeAsOneFlatComponent(t *testing.T) {
+	repo := initRuntimeLedgerRepo(t)
+	for _, change := range []string{"features/sub-change", "3.14", "a.b/c.d"} {
+		store, err := OpenRuntimeStore(context.Background(), repo, change)
+		if err != nil {
+			t.Fatalf("OpenRuntimeStore(%q) error = %v", change, err)
+		}
+		base := filepath.Dir(store.Dir)
+		if filepath.Base(base) != encodedRuntimeChangeNamespace {
+			t.Fatalf("OpenRuntimeStore(%q).Dir = %q, want a single leaf directly under %q", change, store.Dir, encodedRuntimeChangeNamespace)
+		}
+		if strings.ContainsAny(filepath.Base(store.Dir), `/\`) {
+			t.Fatalf("OpenRuntimeStore(%q) leaf %q still contains a path separator", change, filepath.Base(store.Dir))
+		}
+	}
+}
+
+// Every identity the pre-#2116 validator already accepted (letters, digits,
+// hyphens, and underscores) must keep resolving to the exact ledger
+// directory the old encoding produced -- `strings.ToLower(change)` verbatim,
+// with no byte substitution -- or an attempt acquired before this change
+// becomes unreachable after it: it cannot be settled, its max-attempts
+// budget silently resets, and its request-id replay is lost.
+func TestOpenRuntimeStoreEncodedLabelIsStableForPreviouslyValidIdentities(t *testing.T) {
+	repo := initRuntimeLedgerRepo(t)
+	for _, change := range []string{"DEC-EXAMPLE-CHANGE", "MixedCase_And-Digits2", "tag_improvement-v2"} {
+		store, err := OpenRuntimeStore(context.Background(), repo, change)
+		if err != nil {
+			t.Fatal(err)
+		}
+		wantLabel := strings.ToLower(change)
+		if leaf := filepath.Base(store.Dir); !strings.HasPrefix(leaf, wantLabel+"-") {
+			t.Fatalf("OpenRuntimeStore(%q) leaf = %q, want the unchanged pre-#2116 label %q preserved verbatim", change, leaf, wantLabel)
+		}
+	}
+}
+
+// Widening the accepted identity must not widen what reaches the filesystem:
+// these stay rejected because sdd-status itself can never resolve them (a
+// change name cannot be "..", cannot escape via a "../" segment, and the
+// filesystem/JSON hazards below have no legitimate identity behind them).
 func TestOpenRuntimeStoreRejectsUnsafeChangeName(t *testing.T) {
 	repo := initRuntimeLedgerRepo(t)
 	for _, change := range []string{
@@ -38,14 +92,10 @@ func TestOpenRuntimeStoreRejectsUnsafeChangeName(t *testing.T) {
 		".",
 		"..",
 		"../escape",
-		"nested/change",
+		"escape/../../outside",
 		`nested\change`,
-		"-leading",
-		"trailing-",
-		"double--hyphen",
-		".hidden",
-		"has space",
 		"has:colon",
+		"control\x00char",
 		strings.Repeat("a", 97),
 	} {
 		if _, err := OpenRuntimeStore(context.Background(), repo, change); err == nil {
@@ -58,15 +108,15 @@ func TestOpenRuntimeStoreRejectsUnsafeChangeName(t *testing.T) {
 // otherwise callers are left guessing the flag contract.
 func TestOpenRuntimeStoreRejectionNamesValueAndShape(t *testing.T) {
 	repo := initRuntimeLedgerRepo(t)
-	_, err := OpenRuntimeStore(context.Background(), repo, "nested/change")
+	_, err := OpenRuntimeStore(context.Background(), repo, "has:colon")
 	if err == nil {
 		t.Fatal("OpenRuntimeStore error = nil, want rejection")
 	}
 	message := err.Error()
-	if !strings.Contains(message, `"nested/change"`) {
+	if !strings.Contains(message, `"has:colon"`) {
 		t.Fatalf("error %q does not name the rejected value", message)
 	}
-	if !strings.Contains(message, "letters, digits") {
+	if !strings.Contains(message, "non-empty identity") {
 		t.Fatalf("error %q does not state the expected shape", message)
 	}
 	if !strings.Contains(message, "gentle-ai sdd-status") {

--- a/internal/sddstatus/runtime_compact.go
+++ b/internal/sddstatus/runtime_compact.go
@@ -3,6 +3,7 @@ package sddstatus
 import (
 	"context"
 	"errors"
+	"fmt"
 	"slices"
 )
 
@@ -133,6 +134,15 @@ type CompactSettleRequest struct {
 	ProcessEvidence    string
 
 	RemediatesEvidenceRevision string
+
+	// RemediationEvidence is an optional strict gentle-ai.remediation-
+	// evidence/v1 JSON object (#2896). When present, Settle derives the
+	// canonical successful EvidenceRevision from it instead of requiring the
+	// caller to invent one: before this, a passing remediation settle had no
+	// provider-owned value to put in --evidence-revision, only the caller's
+	// own unverifiable evidence. An explicit EvidenceRevision alongside this
+	// field must equal the derived value.
+	RemediationEvidence string
 
 	// The settle-time untracked declaration, forwarded verbatim to Finish.
 	// Nil means the caller declared nothing.
@@ -327,6 +337,19 @@ func compactAcquireBudgetResult(result CompactAttemptResult, objective *RuntimeO
 // transition. Its only remediation authority is the immutable SDD failed-
 // evidence chain; review bindings and successors do not participate.
 func (store RuntimeStore) Settle(ctx context.Context, request CompactSettleRequest) (CompactAttemptResult, error) {
+	// Deriving before anything else (#2896) means a replayed settle (the
+	// request-id branch just below) sees the exact same EvidenceRevision the
+	// original call derived, since both start from the same admitted bytes.
+	if request.RemediationEvidence != "" {
+		derived, deriveErr := DeriveRemediationEvidenceRevision(request.RemediationEvidence, request.RemediatesEvidenceRevision)
+		if deriveErr != nil {
+			return CompactAttemptResult{}, deriveErr
+		}
+		if request.EvidenceRevision != "" && request.EvidenceRevision != derived {
+			return CompactAttemptResult{}, fmt.Errorf("--evidence-revision %s does not match the revision derived from --remediation-evidence (%s); rerun `gentle-ai sdd-attempt settle` omitting --evidence-revision, or with exactly the derived value", request.EvidenceRevision, derived)
+		}
+		request.EvidenceRevision = derived
+	}
 	replay, err := store.load()
 	if err != nil {
 		return compactBlockedByUnreadableAuthority(err), nil

--- a/internal/sddstatus/runtime_compact_test.go
+++ b/internal/sddstatus/runtime_compact_test.go
@@ -279,6 +279,87 @@ func TestCompactSettlePreservesFailedEvidenceAndReplay(t *testing.T) {
 	}
 }
 
+// TestCompactSettleDerivesEvidenceRevisionFromRemediationEvidence reproduces
+// #2896: a passing remediation settle had no provider-owned value for
+// --evidence-revision, only the caller's own unverifiable hash. Passing
+// --remediation-evidence must let settle derive and publish that revision
+// itself, leaving the caller nothing to invent.
+func TestCompactSettleDerivesEvidenceRevisionFromRemediationEvidence(t *testing.T) {
+	repo := initRuntimeLedgerRepo(t)
+	store := mustRuntimeStore(t, repo, "compact-remediation-evidence")
+	failedEvidence := runtimeTestHash('a')
+	first, err := store.Begin(context.Background(), BeginAttemptRequest{
+		RequestID: "failed-begin", WorkUnit: "verify", EvidenceGoal: "independent verification",
+		MaxAttempts: 2, MaxChangedLines: 20,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.Finish(context.Background(), FinishAttemptRequest{
+		ExpectedRevision: first.Revision, RequestID: "failed-settle", Outcome: AttemptFailed,
+		EvidenceRevision: failedEvidence, Diagnosis: "verification found a correction",
+		HarnessDisposition: HarnessReused, CleanupEvidence: "cleanup completed", ProcessEvidence: "no descendants",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	acquired, err := store.Acquire(context.Background(), CompactAcquireRequest{BeginAttemptRequest: BeginAttemptRequest{
+		RequestID: "correction-acquire", WorkUnit: "verify", EvidenceGoal: "independent verification",
+		MaxAttempts: 2, MaxChangedLines: 20,
+	}, RemediatesEvidenceRevision: failedEvidence})
+	if err != nil || acquired.State != CompactStateProceed {
+		t.Fatalf("correction acquire = %#v err=%v", acquired, err)
+	}
+	appendRuntimeLedgerFile(t, repo, "bounded correction\n")
+
+	evidence := remediationEvidenceFixture(failedEvidence)
+	wantRevision, err := DeriveRemediationEvidenceRevision(evidence, failedEvidence)
+	if err != nil {
+		t.Fatalf("DeriveRemediationEvidenceRevision setup: %v", err)
+	}
+
+	request := CompactSettleRequest{
+		Token: acquired.Token, RequestID: "correction-settle", Outcome: AttemptPassed,
+		Diagnosis:          "correction passed verification",
+		HarnessDisposition: HarnessReused, CleanupEvidence: "cleanup completed", ProcessEvidence: "no descendants",
+		RemediatesEvidenceRevision: failedEvidence, RemediationEvidence: evidence,
+	}
+	result, err := store.Settle(context.Background(), request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.State != CompactStateComplete {
+		t.Fatalf("compact remediation-evidence result = %#v", result)
+	}
+	status, err := store.Status()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !status.Complete || status.EvidenceRevision != wantRevision || status.EvidenceRevision == failedEvidence {
+		t.Fatalf("status.EvidenceRevision = %q, want the derived %q (and never the failed evidence it repairs)", status.EvidenceRevision, wantRevision)
+	}
+
+	// An explicit --evidence-revision that disagrees with the derivation is
+	// refused; the derivation is authoritative, not advisory.
+	mismatched := CompactSettleRequest{
+		Token: "unused", RequestID: "mismatch-settle", Outcome: AttemptPassed,
+		EvidenceRevision: runtimeTestHash('c'), Diagnosis: "correction passed verification",
+		HarnessDisposition: HarnessReused, CleanupEvidence: "cleanup completed", ProcessEvidence: "no descendants",
+		RemediatesEvidenceRevision: failedEvidence, RemediationEvidence: evidence,
+	}
+	if _, err := store.Settle(context.Background(), mismatched); err == nil {
+		t.Fatal("Settle with a mismatched --evidence-revision error = nil, want rejection")
+	}
+}
+
+// remediationEvidenceFixture returns a strict gentle-ai.remediation-
+// evidence/v1 JSON object admissible against failedEvidence.
+func remediationEvidenceFixture(failedEvidence string) string {
+	return `{"schema":"gentle-ai.remediation-evidence/v1","failed_evidence_revision":"` + failedEvidence + `",` +
+		`"commands":[{"command":"go test ./...","exit_code":0,"result":"293 passed"}],` +
+		`"runtime_harness":{"status":"not_applicable","na_reason":"no runtime harness because this change is test-only"},` +
+		`"rollback":{"boundary":"commit 9ec76eec32","evidence":"git revert 9ec76eec32 restores the prior passing state"}}`
+}
+
 func TestCompactSettleReplaysCanonicalLegacyInterruptedRequest(t *testing.T) {
 	repo := initRuntimeLedgerRepo(t)
 	store := mustRuntimeStore(t, repo, "compact-legacy-interrupted-replay")

--- a/internal/sddstatus/runtime_ledger.go
+++ b/internal/sddstatus/runtime_ledger.go
@@ -165,8 +165,18 @@ var (
 	runtimeRequestIDPattern    = regexp.MustCompile(`^[a-z0-9][a-z0-9._-]{0,127}$`)
 	runtimeRevisionPattern     = regexp.MustCompile(`^sha256:[a-f0-9]{64}$`)
 	runtimeGitTreePattern      = regexp.MustCompile(`^[a-f0-9]{40}(?:[a-f0-9]{24})?$`)
-	runtimeChangePattern       = regexp.MustCompile(`^[A-Za-z0-9]+(?:[-_][A-Za-z0-9]+)*$`)
 	legacyRuntimeChangePattern = regexp.MustCompile(`^[a-z0-9]+(?:-[a-z0-9]+)*$`)
+	// runtimeChangeUnsafeBytePattern matches the only characters
+	// validRuntimeChange still refuses (#2116): ASCII control bytes
+	// (including NUL) that would corrupt JSON or a rendered instruction
+	// string, backslash (an alternate path separator on Windows, ambiguous
+	// with "/"), and colon (reserved by NTFS drive letters and alternate
+	// data streams). sdd-status's own directory-based resolution
+	// (status.go's resolveByPreferenceOrder/resolveEngramStatus) imposes no
+	// shape restriction beyond what the filesystem or Engram itself
+	// refuses, so this is the narrowest floor that still lets every
+	// identity sdd-status resolves reach the runtime authority.
+	runtimeChangeUnsafeBytePattern = regexp.MustCompile(`[\x00-\x1f\x7f\\:]`)
 
 	runtimePublishRecord                     = reviewtransaction.PublishFileNoReplace
 	runtimeReplaceHead                       = reviewtransaction.ReplaceFileAtomic
@@ -767,7 +777,7 @@ type runtimeReplay struct {
 
 func OpenRuntimeStore(ctx context.Context, repo, change string) (RuntimeStore, error) {
 	if !validRuntimeChange(change) {
-		return RuntimeStore{}, fmt.Errorf("invalid SDD change name %q; want letters, digits, and single hyphens or underscores between them, at most 96 characters; run `gentle-ai sdd-status --cwd <repo> --json` to read the resolved changeName", change)
+		return RuntimeStore{}, fmt.Errorf("invalid SDD change name %q; want a non-empty identity of at most 96 characters with no control characters, backslash, colon, or \".\"/\"..\" path segment; run `gentle-ai sdd-status --cwd <repo> --json` to read the resolved changeName", change)
 	}
 	root, err := (reviewtransaction.SnapshotBuilder{Repo: repo}).ResolveRepositoryRoot(ctx)
 	if err != nil {
@@ -807,8 +817,27 @@ func (err *RuntimeRepositoryRequiredError) Error() string {
 
 func (err *RuntimeRepositoryRequiredError) Unwrap() error { return err.Cause }
 
+// validRuntimeChange accepts exactly the identities sdd-status can resolve
+// (#2116): a directory-listed OpenSpec name, or an opaque Engram-backed
+// identity, neither of which is shape-restricted beyond what a filesystem
+// path segment or a JSON string can represent at all. "/" is accepted (a
+// literal path separator, not embedded in a single segment) because
+// resolveBindingChangeRoot (review_binding.go) already joins it under
+// openspec/changes/ and rejects anything that resolves outside the
+// repository via EvalSymlinks + containment, and runtimeChangeLedgerDir below
+// never lets it (or "..") reach a real path: it only ever appears inside a
+// digest-suffixed, non-legacy label whose non-alphanumeric bytes are always
+// collapsed first.
 func validRuntimeChange(change string) bool {
-	return len(change) <= 96 && runtimeChangePattern.MatchString(change)
+	if change == "" || len(change) > 96 || runtimeChangeUnsafeBytePattern.MatchString(change) {
+		return false
+	}
+	for _, segment := range strings.Split(change, "/") {
+		if segment == "" || segment == "." || segment == ".." {
+			return false
+		}
+	}
+	return true
 }
 
 // legacyRuntimeChangeDir reports whether a change identity is one the runtime
@@ -846,7 +875,35 @@ func runtimeChangeLedgerDir(base, change string) string {
 		return filepath.Join(base, "v1", change)
 	}
 	digest := strings.TrimPrefix(runtimeValueHash("gentle-ai.sdd-runtime-change-identity/v1", change), "sha256:")
-	return filepath.Join(base, "v1", encodedRuntimeChangeNamespace, strings.ToLower(change)+"-"+digest[:encodedRuntimeChangeDigestWidth])
+	return filepath.Join(base, "v1", encodedRuntimeChangeNamespace, runtimeChangeEncodedLabel(change)+"-"+digest[:encodedRuntimeChangeDigestWidth])
+}
+
+// runtimeChangeEncodedLabel keeps the encoded ledger directory human-legible
+// without letting the identity's own bytes reopen a path hazard now that
+// validRuntimeChange accepts "/" and "." (#2116): every byte outside
+// [a-z0-9_-] collapses to "_", so "features/sub-change", "3.14", and "Tag
+// Name" each fold into one flat directory component instead of walking back
+// out of sdd-runtime/v1/_encoded or splitting into extra directory levels.
+// Hyphen and underscore are preserved verbatim rather than folded, because
+// the pre-#2116 encoding was `strings.ToLower(change)` with no substitution
+// at all: every identity the old validator already accepted used only
+// letters, digits, hyphens, and underscores, so folding either one now would
+// move that identity's ledger directory and orphan any attempt state already
+// recorded under it (acquired-but-unsettled attempts, the max-attempts
+// budget, request-id replay). The trailing digest (added by the caller)
+// still keeps identities that collapse to the same label apart.
+func runtimeChangeEncodedLabel(change string) string {
+	lower := strings.ToLower(change)
+	label := make([]byte, len(lower))
+	for i := 0; i < len(lower); i++ {
+		switch c := lower[i]; {
+		case (c >= 'a' && c <= 'z') || (c >= '0' && c <= '9') || c == '-' || c == '_':
+			label[i] = c
+		default:
+			label[i] = '_'
+		}
+	}
+	return string(label)
 }
 
 func (store RuntimeStore) Status() (RuntimeStatus, error) {

--- a/internal/sddstatus/verification.go
+++ b/internal/sddstatus/verification.go
@@ -1,7 +1,10 @@
 package sddstatus
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"regexp"
@@ -11,6 +14,7 @@ import (
 
 const VerifyResultSchema = "gentle-ai.verify-result/v1"
 const RemediationResultSchema = "gentle-ai.remediation-result/v1"
+const RemediationEvidenceSchema = "gentle-ai.remediation-evidence/v1"
 const MaxVerifyReportBytes = 1 << 20
 
 // VerifyReportContract is the stable, user-facing shape validated before an
@@ -595,7 +599,7 @@ func remediationFenceContainsResult(lines []string) bool {
 		line = remediationFenceContent(line)
 		if strings.HasPrefix(line, "schema:") {
 			schema := strings.TrimSpace(strings.TrimPrefix(line, "schema:"))
-			if schema == RemediationResultSchema || schema == "gentle-ai.remediation-evidence/v1" {
+			if schema == RemediationResultSchema || schema == RemediationEvidenceSchema {
 				return true
 			}
 		}
@@ -603,7 +607,7 @@ func remediationFenceContainsResult(lines []string) bool {
 	var fields map[string]any
 	if err := json.Unmarshal([]byte(strings.Join(remediationFenceContents(lines), "\n")), &fields); err == nil {
 		schema, _ := fields["schema"].(string)
-		return schema == RemediationResultSchema || schema == "gentle-ai.remediation-evidence/v1"
+		return schema == RemediationResultSchema || schema == RemediationEvidenceSchema
 	}
 	return false
 }
@@ -689,7 +693,13 @@ func parseRemediationEvidence(lines []string) (remediationEvidence, bool) {
 	if end < 0 || strings.TrimSpace(text[end+4:]) != "" {
 		return remediationEvidence{}, false
 	}
-	decoder := json.NewDecoder(strings.NewReader(text[:end]))
+	return decodeRemediationEvidenceJSON(text[:end])
+}
+
+// decodeRemediationEvidenceJSON strictly decodes one gentle-ai.remediation-
+// evidence/v1 object: no unknown fields, no trailing content, exact schema.
+func decodeRemediationEvidenceJSON(text string) (remediationEvidence, bool) {
+	decoder := json.NewDecoder(strings.NewReader(text))
 	decoder.DisallowUnknownFields()
 	var evidence remediationEvidence
 	if err := decoder.Decode(&evidence); err != nil {
@@ -699,10 +709,62 @@ func parseRemediationEvidence(lines []string) (remediationEvidence, bool) {
 	if err := decoder.Decode(&extra); err != io.EOF {
 		return remediationEvidence{}, false
 	}
-	if evidence.Schema != "gentle-ai.remediation-evidence/v1" {
+	if evidence.Schema != RemediationEvidenceSchema {
 		return remediationEvidence{}, false
 	}
 	return evidence, true
+}
+
+// DeriveRemediationEvidenceRevision admits a strict gentle-ai.remediation-
+// evidence/v1 JSON object bound to expectedFailedRevision and returns the
+// canonical successful evidence revision it authorizes (#2896): the SHA-256
+// of the admitted object's own deterministic JSON re-encoding (json.Marshal
+// always emits struct fields in declaration order, which is what makes this
+// reproducible from the same admitted bytes). This is the value settle needs
+// for a remediation's --evidence-revision; before this, only the actor that
+// ran the correction could see whether its own evidence was concrete and
+// passing, and had no safe way to turn that into the required native
+// SHA-256 without inventing authority. The caller still has to supply
+// concrete, passing evidence — this does not manufacture success, only its
+// identity once admission has already required it.
+func DeriveRemediationEvidenceRevision(evidenceJSON, expectedFailedRevision string) (string, error) {
+	const rerun = "; correct it and rerun `gentle-ai sdd-attempt settle` with the fixed --remediation-evidence"
+	evidence, ok := decodeRemediationEvidenceJSON(strings.TrimSpace(evidenceJSON))
+	if !ok {
+		return "", errors.New("remediation evidence is not a strict gentle-ai.remediation-evidence/v1 JSON object: no unknown fields, no trailing content, exact schema" + rerun)
+	}
+	if evidence.FailedEvidenceRevision == "" || evidence.FailedEvidenceRevision != expectedFailedRevision {
+		return "", fmt.Errorf("remediation evidence's failed_evidence_revision must equal --remediates-evidence-revision %s"+rerun, expectedFailedRevision)
+	}
+	if len(evidence.Commands) == 0 {
+		return "", errors.New("remediation evidence has no commands; want at least one with exit_code 0 and concrete command/result text" + rerun)
+	}
+	for _, command := range evidence.Commands {
+		if command.ExitCode != 0 || !isConcreteEvidence(command.Command) || !isConcreteEvidence(command.Result) {
+			return "", fmt.Errorf("remediation evidence command %q is not concrete passing evidence"+rerun, command.Command)
+		}
+	}
+	switch evidence.RuntimeHarness.Status {
+	case "passed":
+		if !isConcreteEvidence(evidence.RuntimeHarness.Command) || !isConcreteEvidence(evidence.RuntimeHarness.Result) {
+			return "", errors.New("remediation evidence runtime_harness is \"passed\" but its command/result is not concrete" + rerun)
+		}
+	case "not_applicable":
+		if !isConcreteNAReason(evidence.RuntimeHarness.NAReason) {
+			return "", errors.New("remediation evidence runtime_harness is \"not_applicable\" but na_reason is not a concrete justification" + rerun)
+		}
+	default:
+		return "", errors.New(`remediation evidence runtime_harness.status must be "passed" or "not_applicable"` + rerun)
+	}
+	if !isConcreteEvidence(evidence.Rollback.Boundary) || !isConcreteEvidence(evidence.Rollback.Evidence) {
+		return "", errors.New("remediation evidence rollback boundary/evidence is not concrete" + rerun)
+	}
+	canonical, err := json.Marshal(evidence)
+	if err != nil {
+		return "", err
+	}
+	sum := sha256.Sum256(canonical)
+	return "sha256:" + hex.EncodeToString(sum[:]), nil
 }
 
 func isConcreteEvidence(value string) bool {

--- a/internal/sddstatus/verification_test.go
+++ b/internal/sddstatus/verification_test.go
@@ -180,3 +180,53 @@ func itoa(value int) string {
 	}
 	return "1"
 }
+
+// TestDeriveRemediationEvidenceRevision pins #2896: a passing remediation
+// settle must be able to derive its authoritative --evidence-revision from
+// admitted evidence instead of requiring the caller to invent one.
+func TestDeriveRemediationEvidenceRevision(t *testing.T) {
+	failed := "sha256:" + strings.Repeat("a", 64)
+	valid := `{"schema":"gentle-ai.remediation-evidence/v1","failed_evidence_revision":"` + failed + `",` +
+		`"commands":[{"command":"go test ./...","exit_code":0,"result":"293 passed"}],` +
+		`"runtime_harness":{"status":"not_applicable","na_reason":"no runtime harness because this change is test-only"},` +
+		`"rollback":{"boundary":"commit 9ec76eec32","evidence":"git revert 9ec76eec32 restores the prior passing state"}}`
+
+	t.Run("valid evidence derives a stable revision", func(t *testing.T) {
+		first, err := DeriveRemediationEvidenceRevision(valid, failed)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !sha256IdentityPattern.MatchString(first) {
+			t.Fatalf("derived revision %q is not sha256:<64 lowercase hex>", first)
+		}
+		if first == failed {
+			t.Fatalf("derived revision must not equal the failed evidence it repairs")
+		}
+		second, err := DeriveRemediationEvidenceRevision(valid, failed)
+		if err != nil || second != first {
+			t.Fatalf("DeriveRemediationEvidenceRevision is not deterministic: %q vs %q (err=%v)", first, second, err)
+		}
+	})
+
+	tests := []struct {
+		name           string
+		evidence       string
+		expectedFailed string
+	}{
+		{name: "malformed JSON", evidence: "{not json", expectedFailed: failed},
+		{name: "unknown field rejected", evidence: strings.Replace(valid, `"schema"`, `"extra":"x","schema"`, 1), expectedFailed: failed},
+		{name: "wrong schema", evidence: strings.Replace(valid, "gentle-ai.remediation-evidence/v1", "gentle-ai.remediation-evidence/v2", 1), expectedFailed: failed},
+		{name: "failed_evidence_revision mismatch", evidence: valid, expectedFailed: "sha256:" + strings.Repeat("b", 64)},
+		{name: "no commands", evidence: strings.Replace(valid, `"commands":[{"command":"go test ./...","exit_code":0,"result":"293 passed"}]`, `"commands":[]`, 1), expectedFailed: failed},
+		{name: "failing command exit code", evidence: strings.Replace(valid, `"exit_code":0`, `"exit_code":1`, 1), expectedFailed: failed},
+		{name: "runtime_harness status not passed or not_applicable", evidence: strings.Replace(valid, `"status":"not_applicable"`, `"status":"skipped"`, 1), expectedFailed: failed},
+		{name: "rollback boundary not concrete", evidence: strings.Replace(valid, `"boundary":"commit 9ec76eec32"`, `"boundary":"n/a"`, 1), expectedFailed: failed},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if _, err := DeriveRemediationEvidenceRevision(test.evidence, test.expectedFailed); err == nil {
+				t.Fatalf("DeriveRemediationEvidenceRevision(%q) error = nil, want rejection", test.name)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Closes #2116
Closes #2896

## Summary
- `sdd-attempt` accepts every change name `sdd-status` resolves (dots, nested paths, uppercase, underscores) and rejects only genuine hazards (empty, `.`/`..` segments, control characters, backslash, colon, over 96 bytes). The encoded ledger leaf stays byte-identical for every previously valid identity, so existing attempt state is not orphaned on upgrade.
- `sdd-attempt settle` accepts `--remediation-evidence`, a typed `gentle-ai.remediation-evidence/v1` object bound to the failed revision, and derives `evidence_revision` from its canonical encoding, so a remediation no longer needs a hand-invented revision.

## Changes
| File | Change |
|------|--------|
| `internal/sddstatus/runtime_ledger.go` | Segment-based change validator; stable `runtimeChangeEncodedLabel` |
| `internal/sddstatus/verification.go` | `DeriveRemediationEvidenceRevision` |
| `internal/sddstatus/runtime_compact.go` | `Settle` derives the revision before replay |
| `internal/cli/sdd_attempt.go` | `--remediation-evidence` flag; requirement carve-out |
| tests | Identity table, ledger-leaf stability, settle derivation, CLI settle behavior |

## Size exception
461 lines; the validator, the leaf encoding, and the settle derivation share the ledger types and their tests, so a split would land an untested contract.

## Test plan
- [x] `go test ./internal/sddstatus/ -count=1`
- [x] `go test ./internal/cli/ -run 'SDDAttempt|SddAttempt|Settle|Remediation' -count=1`
- [x] Refusal and deadcode ratchets pass
- [x] Native review: correction (112/175 lines) validated and approved (lineage review-bd15e504c45f55cf), acknowledged

https://claude.ai/code/session_01SYqbaaqyJcAv1FYtSJXx6M