### PR TITLE
fix(review): keep the untracked binding through correction and name an exit for interior anomalies

### DIFF
--- a/internal/cli/review_correction_untracked_binding_test.go
+++ b/internal/cli/review_correction_untracked_binding_test.go
@@ -1,0 +1,90 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"testing"
+
+	"github.com/gentleman-programming/gentle-ai/v2/internal/reviewtransaction"
+)
+
+// TestNegotiatedStatusPreservesUntrackedBindingThroughCorrectionLineage pins
+// issue #3849: a correction_required lineage whose frozen candidate carries
+// an explicit intended-untracked selection must keep offering its own
+// correction transition, bound to the authority's own target identity, on a
+// plain STATUS re-entry that names no untracked-scope flags -- exactly the
+// shape of the exact bound continuation `review.capture-correction-plan`
+// itself returns. It must not re-demand a fresh intended-untracked
+// declaration and bind the resulting collect input to a different (live,
+// declaration-less) target identity than the one the authority is bound to.
+func TestNegotiatedStatusPreservesUntrackedBindingThroughCorrectionLineage(t *testing.T) {
+	reviewEnabledHome(t)
+	repo := initReviewCLIRepo(t)
+	const lineage = "correction-untracked-binding-3849"
+	writeReviewStartCandidate(t, repo, "candidate.go", "package candidate\n\nfunc value() int { return 1 }\n", 0o644)
+	writeUndeclaredWorkspaceFile(t, repo, "notes.txt", "untracked but explicitly selected\n", 0o644)
+
+	_, digest, err := (reviewtransaction.SnapshotBuilder{Repo: repo}).IntendedUntrackedInventory(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	startedBytes, err := runLegacyFacadeStartForTestBytes(t, []string{
+		"--cwd", repo, "--lineage", lineage,
+		"--untracked-scope=select", "--expected-untracked-inventory=" + digest, "--intended-untracked", "notes.txt",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var started ReviewFacadeStartResult
+	decodeStrictReviewJSON(t, startedBytes, &started)
+	if len(started.SelectedLenses) != 1 {
+		t.Fatalf("started lenses = %v, want exactly one selected lens", started.SelectedLenses)
+	}
+
+	captureCLIReviewerResultWithFindings(t, repo, started, 0, []facadeFinding{{
+		Location: "candidate.go:1", Severity: "CRITICAL", Claim: "candidate exposes the wrong behavior",
+		ProofRefs:     []string{"exact changed hunk", "reproduced candidate failure"},
+		EvidenceClass: reviewtransaction.EvidenceDeterministic, CausalDisposition: reviewtransaction.CausalIntroduced,
+	}}, &bytes.Buffer{})
+
+	captureCorrectionPlanFromCurrentStatus(t, repo, lineage, 1)
+
+	store, err := reviewtransaction.CompactAuthoritativeStore(context.Background(), repo, lineage)
+	if err != nil {
+		t.Fatal(err)
+	}
+	record, err := store.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(record.State.InitialSnapshot.IntendedUntracked) != 1 || record.State.InitialSnapshot.IntendedUntracked[0] != "notes.txt" {
+		t.Fatalf("fixture did not freeze the declared untracked selection: %#v", record.State.InitialSnapshot)
+	}
+
+	// The exact bound STATUS continuation `review.capture-correction-plan`
+	// returns carries no untracked-scope flags: it is a plain
+	// `--next-transition --lineage` re-entry, exactly like the operation
+	// shape issue #3849 reports.
+	status := negotiatedReviewStatusForLineage(t, repo, lineage)
+	if status.NextTransition == nil {
+		t.Fatal("correction lineage STATUS produced no next transition")
+	}
+	if status.NextTransition.Kind == reviewNextTransitionCollect && status.NextTransition.ReasonCode == "intended_untracked_selection_required" {
+		t.Fatalf("correction lineage dead-ended into a fresh intended-untracked declaration: %#v", status.NextTransition)
+	}
+	if status.NextTransition.ReasonCode != "corrected_candidate_unavailable" {
+		t.Fatalf("next transition reason = %q, want corrected_candidate_unavailable", status.NextTransition.ReasonCode)
+	}
+	if status.TargetIdentity != record.State.CurrentSnapshot.Identity {
+		t.Fatalf("status target identity = %q, want the authority's own bound target identity %q", status.TargetIdentity, record.State.CurrentSnapshot.Identity)
+	}
+	if status.NextTransition.Collect != nil {
+		for _, input := range status.NextTransition.Collect.Inputs {
+			for _, argument := range input.Arguments {
+				if argument.Name == "target_identity" && argument.Value != record.State.CurrentSnapshot.Identity {
+					t.Fatalf("collect input target_identity = %q, want authority target identity %q", argument.Value, record.State.CurrentSnapshot.Identity)
+				}
+			}
+		}
+	}
+}

--- a/internal/cli/review_facade.go
+++ b/internal/cli/review_facade.go
@@ -904,12 +904,34 @@ func runReviewStatus(ctx context.Context, args []string, stdout io.Writer) error
 				record, loadErr := store.LoadContext(ctx)
 				if loadErr == nil {
 					// Only an approved compact authority that still owns its
-					// acknowledgement can resume its immutable terminal target. Every
-					// other occupied lineage must derive live scope so correction and
-					// recovery detect new untracked artifacts and target changes.
-					if _, pending := reviewtransaction.PendingApprovedCompactAcknowledgement(record); pending {
+					// acknowledgement can resume its immutable terminal target. A
+					// correction-required authority that already froze a non-empty
+					// intended-untracked SELECTION resumes it too, but only while the
+					// live workspace's eligible untracked population is still exactly
+					// that declared set: the exact bound STATUS continuation
+					// `review.capture-correction-plan` itself returns carries no
+					// untracked-scope flags, so demanding a fresh declaration on that
+					// plain re-entry dead-ended the correction lineage and bound the
+					// resulting collect input to a different (live, declaration-less)
+					// target identity than the one the authority is bound to (issue
+					// #3849). A frozen EXCLUDE declaration (empty selection) is left
+					// alone here -- it is indistinguishable on its own from "nothing
+					// was ever declared", and a brand new untracked artifact appearing
+					// mid-correction must still force a fresh declaration exactly as
+					// before (design intent: "detect new untracked artifacts").
+					_, pendingApproval := reviewtransaction.PendingApprovedCompactAcknowledgement(record)
+					resumeCorrectionUntracked := false
+					declaredUntracked := record.State.InitialSnapshot.IntendedUntracked
+					if record.State.State == reviewtransaction.StateCorrectionRequired && len(declaredUntracked) != 0 {
+						inventory, _, inventoryErr := builder.IntendedUntrackedInventory(ctx)
+						if inventoryErr != nil {
+							return reviewPreflightError(inventoryErr)
+						}
+						resumeCorrectionUntracked = reviewSameUntrackedPaths(inventory, declaredUntracked)
+					}
+					if pendingApproval || resumeCorrectionUntracked {
 						intendedScope = reviewIntendedUntrackedScope{
-							Intended: append([]string{}, record.State.InitialSnapshot.IntendedUntracked...), Declared: true,
+							Intended: append([]string{}, declaredUntracked...), Declared: true,
 						}
 						hydratedIntendedScope = true
 					}

--- a/internal/cli/review_intended_untracked.go
+++ b/internal/cli/review_intended_untracked.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"sort"
 	"strings"
 
 	"github.com/gentleman-programming/gentle-ai/v2/internal/model"
@@ -147,6 +148,27 @@ func reviewIntendedUntrackedCollection(status ReviewTargetStatusResult, scope re
 		input.Submission = &ReviewTransitionSubmission{OperationToken: "status", ArgumentTokens: tokens, Value: &ReviewTransitionSubmissionValue{Slot: "intended_untracked_selection", Domain: "schema_bound_json", Schema: reviewIntendedUntrackedSelectionSchema, SubstitutionLocation: 4}}
 	}
 	return reviewCollectTransition("intended_untracked_selection_required", input)
+}
+
+// reviewSameUntrackedPaths reports whether two path lists name exactly the
+// same set, independent of order. Both `IntendedUntrackedInventory` and a
+// stored `IntendedUntracked` selection are canonicalized and sorted at their
+// own source, but this comparison does not depend on that: it sorts its own
+// copies so a caller never has to reason about either side's ordering.
+func reviewSameUntrackedPaths(left, right []string) bool {
+	if len(left) != len(right) {
+		return false
+	}
+	sortedLeft := append([]string{}, left...)
+	sortedRight := append([]string{}, right...)
+	sort.Strings(sortedLeft)
+	sort.Strings(sortedRight)
+	for index, path := range sortedLeft {
+		if path != sortedRight[index] {
+			return false
+		}
+	}
+	return true
 }
 
 func reviewStartIntendedUntrackedArguments(scope reviewIntendedUntrackedScope) []ReviewTransitionArgument {

--- a/internal/reviewtransaction/compact_inspect.go
+++ b/internal/reviewtransaction/compact_inspect.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"slices"
+	"strings"
 )
 
 const (
@@ -244,6 +245,24 @@ func SanctionedCompactRecoveryExits(ctx context.Context, repo string, report Com
 			// This is #2014's "nothing applies" gap: neither reconcile nor
 			// abandon accepted the edge before Wave 2's disposition plan.
 			exit.Operation = CompactRecoveryEdgeExitRepair
+		case compactRecoveryReconciliationAnomalyClass(edge):
+			// Issue #2422: reconciliation's own two anomaly classes
+			// (unchanged_target, malformed_recovery_authorization) lost their
+			// only runnable exit when Wave 7 S3a retired `review
+			// reconcile-authority` with no replacement. A leaf successor in
+			// either class still gets `review abandon` above; this is reached
+			// only for an INTERIOR successor -- one another lineage already
+			// recovers from, so abandon's own read-only prediction refuses it
+			// -- where neither abandon nor repair (scoped to the disjoint
+			// content-mismatch class) ever applies. Naming the universal kill
+			// switch here does not repair the malformed recovery metadata; it
+			// is the one maintainer-authority path that actually unblocks a
+			// consumer today, so the stop is honest instead of terminal.
+			exit.Blocked = fmt.Sprintf(
+				"no repair or abandon operation admits this edge (anomaly classes: %s): its recovery metadata is malformed, but it has a successor of its own, so `review abandon` refuses it, and `review repair` covers only the disjoint content_mismatched_recovery_authorization class. "+
+					"This does not repair the edge, but a maintainer can stop it from blocking further review activity in this exact repository with `gentle-ai review mode disable --scope clone --cwd %s`. "+
+					"This report, with anomaly_classes and non_reconcilable_reason, is the artifact to escalate for an actual repair.",
+				strings.Join(edge.AnomalyClasses, ","), root)
 		default:
 			exit.Blocked = "no advertised operation admits this edge: `review abandon` does not accept the successor, and no other operation applies to this anomaly class. " +
 				"Nothing quarantines this shape today, so no command clears it and the entry stays exactly as persisted. " +
@@ -252,6 +271,22 @@ func SanctionedCompactRecoveryExits(ctx context.Context, repo string, report Com
 		exits = append(exits, exit)
 	}
 	return exits, nil
+}
+
+// compactRecoveryReconciliationAnomalyClass reports whether edge carries
+// either of reconciliation's own two retired anomaly classes (unchanged_target,
+// malformed_recovery_authorization, compact_reconcile.go). It is deliberately
+// narrower than edge.AnomalyClasses being non-empty in general: the
+// content_mismatched_recovery_authorization class the disposition plan
+// already covers is a DIFFERENT (disjoint) classification that never sets
+// these two, so this check cannot accidentally shadow that exit.
+func compactRecoveryReconciliationAnomalyClass(edge CompactRecoveryEdgeInspection) bool {
+	for _, class := range edge.AnomalyClasses {
+		if class == compactRecoveryEdgeUnchangedTarget || class == compactRecoveryEdgeMalformedAuthorization {
+			return true
+		}
+	}
+	return false
 }
 
 // inspectCompactRecoveryRecordSet applies the canonical all-edge inspection to

--- a/internal/reviewtransaction/compact_recovery_disposition_gap_test.go
+++ b/internal/reviewtransaction/compact_recovery_disposition_gap_test.go
@@ -1,0 +1,125 @@
+package reviewtransaction
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestSanctionedRecoveryExitNamesMaintainerPathForInteriorReconciliationAnomaly
+// is issue #2422. Wave 7 S3a retired `review reconcile-authority`, the only
+// exit reconciliation's two anomaly classes (unchanged_target,
+// malformed_recovery_authorization) ever had. A LEAF successor in either
+// class still gets `review abandon` today
+// (TestForgedRecoveryAuthorizationOnNonTerminalSuccessorHasSanctionedAbandonExit
+// proves the same for the disjoint content-mismatch corruption class), but an
+// INTERIOR successor -- one that itself has a successor recovering from it,
+// so InspectCompactPristineAbandonment's own read-only prediction refuses it
+// -- had no exit left at all: SanctionedCompactRecoveryExits fell through to
+// prose naming no runnable `gentle-ai` invocation, so the block was terminal
+// for a consumer.
+func TestSanctionedRecoveryExitNamesMaintainerPathForInteriorReconciliationAnomaly(t *testing.T) {
+	ctx := context.Background()
+	repo := initSnapshotRepo(t)
+
+	// L1: an escalated predecessor, exactly like forgedRecoveryPair's own.
+	predecessor := correctedCompactTestState(t, repo, "chain-l1")
+	predecessor.State = StateEscalated
+	predecessorStore, err := CompactAuthoritativeStore(ctx, repo, predecessor.LineageID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	predecessorRecord := writeCompactFixtureRecord(t, predecessorStore, predecessor)
+
+	// L2 recovers from L1 without the candidate content changing at all --
+	// the unchanged_target anomaly class -- with an exact, contract-bound
+	// authorization (never the pre-contract free-form text that would
+	// instead classify as malformed_recovery_authorization).
+	l2State := newCompactTestState(t, repo, "chain-l2")
+	l2State.Generation = predecessor.Generation + 1
+	l2Store, err := CompactAuthoritativeStore(ctx, repo, l2State.LineageID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	l2State, _ = startReviewingCompactFixture(t, repo, l2State)
+	l2State.Recovery = &CompactRecoveryProvenance{
+		PredecessorLineageID: predecessor.LineageID, PredecessorRevision: predecessorRecord.Revision,
+		Disposition: RecoveryEscalated, Reason: "retry", Actor: "maintainer@example.com",
+		RecoveredAt: time.Date(2026, 7, 24, 12, 0, 0, 0, time.UTC),
+		MaintainerAuthorization: compactRecoveryAuthorizationBinding(
+			predecessor.LineageID, predecessorRecord.Revision, l2State.InitialSnapshot.Identity, "maintainer@example.com", "retry"),
+	}
+	l2Record := writeCompactFixtureRecord(t, l2Store, l2State)
+
+	// L3 recovers from L2, making L2 an INTERIOR node of the chain: abandon's
+	// own read-only prediction refuses any lineage another lineage recovers
+	// from (compact_abandon.go), independent of that further edge's own
+	// validity -- exactly the topology the #2422 field report describes.
+	l3State := newCompactTestState(t, repo, "chain-l3")
+	l3State.Generation = l2State.Generation + 1
+	l3Store, err := CompactAuthoritativeStore(ctx, repo, l3State.LineageID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	l3State, _ = startReviewingCompactFixture(t, repo, l3State)
+	l3State.Recovery = &CompactRecoveryProvenance{
+		PredecessorLineageID: l2State.LineageID, PredecessorRevision: l2Record.Revision,
+		Disposition: RecoveryEscalated, Reason: "retry", Actor: "maintainer@example.com",
+		RecoveredAt: time.Date(2026, 7, 24, 12, 0, 0, 0, time.UTC),
+		MaintainerAuthorization: compactRecoveryAuthorizationBinding(
+			l2State.LineageID, l2Record.Revision, l3State.InitialSnapshot.Identity, "maintainer@example.com", "retry"),
+	}
+	writeCompactFixtureRecord(t, l3Store, l3State)
+
+	report, err := InspectCompactRecoveryEdges(ctx, repo)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var l2Edge *CompactRecoveryEdgeInspection
+	for index := range report.Edges {
+		if report.Edges[index].SuccessorLineageID == l2State.LineageID {
+			l2Edge = &report.Edges[index]
+		}
+	}
+	if l2Edge == nil || l2Edge.Valid || !compactRecoveryDispositionGapContainsString(l2Edge.AnomalyClasses, compactRecoveryEdgeUnchangedTarget) {
+		t.Fatalf("l2 edge = %#v, want an invalid unchanged_target edge", report.Edges)
+	}
+
+	eligibility, err := InspectCompactPristineAbandonment(ctx, repo, l2State.LineageID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if eligibility.Eligible {
+		t.Fatalf("l2 abandon eligibility = %#v, want ineligible: it has its own successor l3", eligibility)
+	}
+
+	exits, err := SanctionedCompactRecoveryExits(ctx, repo, report)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var l2Exit *CompactRecoverySanctionedExit
+	for index := range exits {
+		if exits[index].SuccessorLineageID == l2State.LineageID {
+			l2Exit = &exits[index]
+		}
+	}
+	if l2Exit == nil {
+		t.Fatalf("exits = %#v, want an exit entry for l2", exits)
+	}
+	if l2Exit.Operation != "" {
+		t.Fatalf("l2 exit = %#v, want no automatic operation for an interior reconciliation anomaly", *l2Exit)
+	}
+	if !strings.Contains(l2Exit.Blocked, "gentle-ai review mode disable") {
+		t.Fatalf("l2 exit Blocked = %q, want a literal runnable gentle-ai invocation naming the maintainer path", l2Exit.Blocked)
+	}
+}
+
+func compactRecoveryDispositionGapContainsString(values []string, want string) bool {
+	for _, value := range values {
+		if value == want {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
Closes #3849
Closes #2422

## Summary
- A `correction_required` lineage re-entered through its own bound STATUS continuation no longer dead-ends: the frozen intended-untracked selection is reused when the live untracked inventory still matches it exactly, so the correction-plan transition keeps the correct target identity. A genuinely new untracked artifact still forces re-declaration.
- An interior successor carrying `unchanged_target` or `malformed_recovery_authorization` now gets a runnable maintainer exit (`gentle-ai review mode disable --scope clone --cwd <repo>`, stated as an unblock) pointing at the anomaly artifact, instead of prose naming no command.

## Changes
| File | Change |
|------|--------|
| `internal/cli/review_facade.go`, `internal/cli/review_intended_untracked.go` | Reuse the frozen selection on plain re-entry (`reviewSameUntrackedPaths`) |
| `internal/cli/review_correction_untracked_binding_test.go` | Reproduces the dead end, green after the fix |
| `internal/reviewtransaction/compact_inspect.go` | Sanctioned exit for the interior anomaly |
| `internal/reviewtransaction/compact_recovery_disposition_gap_test.go` | L1→L2→L3 chain reproducing the field topology |

## Test plan
- [x] Targeted `internal/cli` and `internal/reviewtransaction` suites, refusal and deadcode ratchets
- [x] Native review approved (lineage review-1a754c22f6546794), acknowledged

https://claude.ai/code/session_01SYqbaaqyJcAv1FYtSJXx6M