### PR TITLE
fix(reviewtransaction): refuse immutable snapshots while a local graft is active

### DIFF
--- a/internal/reviewtransaction/snapshot.go
+++ b/internal/reviewtransaction/snapshot.go
@@ -1315,6 +1315,9 @@ func (builder SnapshotBuilder) resolveExactRevision(ctx context.Context, revisio
 	if revision == "" || strings.Contains(revision, "...") {
 		return "", "", errors.New("commit-range requires one exact commit or A..B range")
 	}
+	if err := builder.rejectActiveLocalGraft(ctx); err != nil {
+		return "", "", err
+	}
 	if strings.Contains(revision, "..") {
 		parts := strings.Split(revision, "..")
 		if len(parts) != 2 || !exactObjectPattern.MatchString(parts[0]) || !exactObjectPattern.MatchString(parts[1]) {
@@ -1353,6 +1356,65 @@ func (builder SnapshotBuilder) resolveExactRevision(ctx context.Context, revisio
 		return "", "", err
 	}
 	return strings.TrimSpace(string(emptyTreeOutput)), candidate, nil
+}
+
+// LocalGraftActiveError marks a repository-local Git graft as the
+// ANTICIPATED condition that made exact-revision derivation refuse -- the
+// same role UntrackedScopeRefusalError plays for an anticipated
+// working-tree shape: an operator's own repository state, not a product
+// defect worth a defect report.
+type LocalGraftActiveError struct{ Cause error }
+
+func (err *LocalGraftActiveError) Error() string { return err.Cause.Error() }
+func (err *LocalGraftActiveError) Unwrap() error { return err.Cause }
+
+// rejectActiveLocalGraft refuses exact-revision derivation while a
+// repository-local Git graft is active (#1719). Git's graft file lets
+// $GIT_COMMON_DIR/info/grafts substitute an arbitrary parent for a commit's
+// true one. `--no-replace-objects` (issue #1093) disables the newer
+// replace-ref mechanism, and stripping GIT_GRAFT_FILE from the child
+// environment (sanitizedGitEnvironmentForRun, also #1093) only blocks an env
+// override -- neither touches the repository's own info/grafts file. Left
+// unchecked, resolveExactRevision's `rev-list --parents` silently returns the
+// grafted parent, so the same full commit ID can freeze a different base
+// tree and changed-path set while the candidate tree stays identical.
+//
+// The common Git directory -- not builder.Repo -- is resolved so a linked
+// worktree is covered too: info/grafts is one of the files Git shares across
+// every worktree of a repository, never one it keeps per-worktree.
+func (builder SnapshotBuilder) rejectActiveLocalGraft(ctx context.Context) error {
+	commonDir, err := resolveGitDirectory(ctx, builder.Repo, "--git-common-dir")
+	if err != nil {
+		return err
+	}
+	graftPath := filepath.Join(commonDir, "info", "grafts")
+	content, err := os.ReadFile(graftPath)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil
+		}
+		return fmt.Errorf("read repository-local Git graft file %s: %w", graftPath, err)
+	}
+	if !activeGraftFileContent(content) {
+		return nil
+	}
+	return &LocalGraftActiveError{Cause: fmt.Errorf("repository-local Git graft file %s is active; it can substitute an arbitrary parent for a commit's true one, so an exact-revision snapshot cannot be trusted while it exists -- remove it (`rm %s`) or delete its offending lines before deriving one", graftPath, graftPath)} // refusal:by-design world-action: disabling a repository-local graft is a repository-layout edit outside any command this product runs
+}
+
+// activeGraftFileContent reports whether a graft file's bytes contain at
+// least one effective entry. Git's graft format ignores blank lines and
+// lines starting with '#' (a comment), so an empty or comment-only file --
+// left over from a since-cleared graft, for instance -- has no ancestry
+// effect and must not trip this refusal.
+func activeGraftFileContent(content []byte) bool {
+	for _, line := range strings.Split(string(content), "\n") {
+		line = strings.TrimSpace(strings.TrimSuffix(line, "\r"))
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		return true
+	}
+	return false
 }
 
 func (builder SnapshotBuilder) resolveTree(ctx context.Context, revision string) (string, error) {

--- a/internal/reviewtransaction/snapshot_test.go
+++ b/internal/reviewtransaction/snapshot_test.go
@@ -1180,6 +1180,159 @@ func TestSnapshotBuilderExactRevisionIgnoresReplacementObjects(t *testing.T) {
 	}
 }
 
+// TestSnapshotBuilderExactRevisionRejectsActiveLocalGraft reproduces #1719:
+// a repository-local .git/info/grafts entry lets the same full commit ID
+// resolve to a different parent, base tree, and changed-path set while the
+// candidate tree stays identical. Unlike a replacement object
+// (TestSnapshotBuilderExactRevisionIgnoresReplacementObjects), Git's graft
+// mechanism is not disabled by --no-replace-objects, so exact-revision
+// derivation must detect and refuse it explicitly instead of silently
+// freezing a snapshot over rewritten ancestry.
+func TestSnapshotBuilderExactRevisionRejectsActiveLocalGraft(t *testing.T) {
+	if testing.Short() {
+		t.Skip("uses real git commands")
+	}
+	repo := initSnapshotRepo(t)
+	parentCommit := strings.TrimSpace(gitSnapshot(t, repo, "rev-parse", "HEAD"))
+	writeSnapshotFile(t, repo, "tracked.txt", "second\n")
+	gitSnapshot(t, repo, "add", "--", "tracked.txt")
+	gitSnapshot(t, repo, "commit", "-m", "second")
+	targetCommit := strings.TrimSpace(gitSnapshot(t, repo, "rev-parse", "HEAD"))
+	target := Target{Kind: TargetExactRevision, Revision: targetCommit}
+
+	baseline, err := (SnapshotBuilder{Repo: repo}).Build(context.Background(), target)
+	if err != nil {
+		t.Fatalf("Build(baseline, no graft) error = %v", err)
+	}
+
+	// Build an alternate history from the same original parent so the graft
+	// has a real, different tree to substitute.
+	gitSnapshot(t, repo, "checkout", "--detach", parentCommit)
+	writeSnapshotFile(t, repo, "other.txt", "alternate\n")
+	gitSnapshot(t, repo, "add", "--", "other.txt")
+	gitSnapshot(t, repo, "commit", "-m", "alternate")
+	alternateCommit := strings.TrimSpace(gitSnapshot(t, repo, "rev-parse", "HEAD"))
+	gitSnapshot(t, repo, "checkout", "--detach", targetCommit)
+
+	commonDir := strings.TrimSpace(gitSnapshot(t, repo, "rev-parse", "--git-common-dir"))
+	if !filepath.IsAbs(commonDir) {
+		commonDir = filepath.Join(repo, commonDir)
+	}
+	graftDir := filepath.Join(commonDir, "info")
+	if err := os.MkdirAll(graftDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll(%s): %v", graftDir, err)
+	}
+	graftPath := filepath.Join(graftDir, "grafts")
+	graftLine := targetCommit + " " + alternateCommit + "\n"
+	if err := os.WriteFile(graftPath, []byte(graftLine), 0o644); err != nil {
+		t.Fatalf("WriteFile(%s): %v", graftPath, err)
+	}
+
+	// Sanity-check the graft actually rewrites what plain Git reports, the
+	// same way the issue's reproduction confirms it before exercising the
+	// product.
+	graftedParents := strings.Fields(gitSnapshot(t, repo, "-c", "advice.graftFileDeprecated=false", "rev-list", "--parents", "-n", "1", targetCommit))
+	if len(graftedParents) != 2 || graftedParents[1] != alternateCommit {
+		t.Fatalf("graft fixture did not rewrite ancestry: rev-list --parents = %v", graftedParents)
+	}
+
+	_, err = (SnapshotBuilder{Repo: repo}).Build(context.Background(), target)
+	var graftErr *LocalGraftActiveError
+	if !errors.As(err, &graftErr) {
+		t.Fatalf("Build() with active graft error = %v, want *LocalGraftActiveError", err)
+	}
+	if !strings.Contains(err.Error(), graftPath) {
+		t.Fatalf("error %q does not name the graft file %q", err.Error(), graftPath)
+	}
+	if !strings.Contains(err.Error(), "rm "+graftPath) {
+		t.Fatalf("error %q does not name a runnable resolution", err.Error())
+	}
+
+	if err := os.Remove(graftPath); err != nil {
+		t.Fatalf("Remove(%s): %v", graftPath, err)
+	}
+	recovered, err := (SnapshotBuilder{Repo: repo}).Build(context.Background(), target)
+	if err != nil {
+		t.Fatalf("Build() after removing graft error = %v", err)
+	}
+	if recovered.Identity != baseline.Identity {
+		t.Fatalf("Identity after removing graft = %q, want the ungrafted identity %q", recovered.Identity, baseline.Identity)
+	}
+}
+
+// TestSnapshotBuilderExactRevisionRejectsActiveLocalGraftFromLinkedWorktree
+// proves the graft check resolves the repository's actual COMMON Git
+// directory rather than the per-worktree one: info/grafts lives in the
+// common directory and is shared by every worktree, so a graft written
+// through the main checkout must still be caught when the snapshot is built
+// from a linked worktree.
+func TestSnapshotBuilderExactRevisionRejectsActiveLocalGraftFromLinkedWorktree(t *testing.T) {
+	if testing.Short() {
+		t.Skip("uses real git commands")
+	}
+	repo := initSnapshotRepo(t)
+	parentCommit := strings.TrimSpace(gitSnapshot(t, repo, "rev-parse", "HEAD"))
+	writeSnapshotFile(t, repo, "tracked.txt", "second\n")
+	gitSnapshot(t, repo, "add", "--", "tracked.txt")
+	gitSnapshot(t, repo, "commit", "-m", "second")
+	targetCommit := strings.TrimSpace(gitSnapshot(t, repo, "rev-parse", "HEAD"))
+
+	gitSnapshot(t, repo, "checkout", "--detach", parentCommit)
+	writeSnapshotFile(t, repo, "other.txt", "alternate\n")
+	gitSnapshot(t, repo, "add", "--", "other.txt")
+	gitSnapshot(t, repo, "commit", "-m", "alternate")
+	alternateCommit := strings.TrimSpace(gitSnapshot(t, repo, "rev-parse", "HEAD"))
+	gitSnapshot(t, repo, "checkout", "--detach", targetCommit)
+
+	commonDir := strings.TrimSpace(gitSnapshot(t, repo, "rev-parse", "--git-common-dir"))
+	if !filepath.IsAbs(commonDir) {
+		commonDir = filepath.Join(repo, commonDir)
+	}
+	graftDir := filepath.Join(commonDir, "info")
+	if err := os.MkdirAll(graftDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll(%s): %v", graftDir, err)
+	}
+	graftPath := filepath.Join(graftDir, "grafts")
+	if err := os.WriteFile(graftPath, []byte(targetCommit+" "+alternateCommit+"\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile(%s): %v", graftPath, err)
+	}
+
+	worktree := canonicalTempDir(t)
+	if err := os.RemoveAll(worktree); err != nil {
+		t.Fatalf("RemoveAll(%s): %v", worktree, err)
+	}
+	gitSnapshot(t, repo, "worktree", "add", "--detach", worktree, targetCommit)
+
+	target := Target{Kind: TargetExactRevision, Revision: targetCommit}
+	_, err := (SnapshotBuilder{Repo: worktree}).Build(context.Background(), target)
+	var graftErr *LocalGraftActiveError
+	if !errors.As(err, &graftErr) {
+		t.Fatalf("Build() from linked worktree with active graft error = %v, want *LocalGraftActiveError", err)
+	}
+}
+
+func TestActiveGraftFileContentIgnoresCommentsAndBlankLines(t *testing.T) {
+	tests := []struct {
+		name    string
+		content string
+		want    bool
+	}{
+		{name: "empty", content: "", want: false},
+		{name: "blank lines only", content: "\n\n \n", want: false},
+		{name: "comment only", content: "# no grafts configured\n"},
+		{name: "comment and blank mixed", content: "# note\n\n"},
+		{name: "one entry", content: strings.Repeat("a", 40) + " " + strings.Repeat("b", 40) + "\n", want: true},
+		{name: "entry after comment", content: "# note\n" + strings.Repeat("a", 40) + "\n", want: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := activeGraftFileContent([]byte(tt.content)); got != tt.want {
+				t.Fatalf("activeGraftFileContent(%q) = %v, want %v", tt.content, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestBaseWorkspaceOverlayFreezesFullBoundaryWithoutMutation(t *testing.T) {
 	repo := initSnapshotRepo(t)
 	base := strings.TrimSpace(gitSnapshot(t, repo, "rev-parse", "HEAD"))


### PR DESCRIPTION
Closes #1719

## Summary
- An exact-revision snapshot can no longer be frozen over a grafted history: `--no-replace-objects` neutralises replace refs but not the deprecated `.git/info/grafts` file, which `git rev-list --parents` still honours, so the same commit id could yield a different base tree. The builder now reads the shared common-dir graft file (correct from linked worktrees too) and refuses with `LocalGraftActiveError` naming the file to remove when it has any active entry.

## Changes
| File | Change |
|------|--------|
| `internal/reviewtransaction/snapshot.go` | `rejectActiveLocalGraft`, `activeGraftFileContent`, `LocalGraftActiveError` |
| `internal/reviewtransaction/snapshot_test.go` | Reproduces the issue's repro, linked-worktree coverage, comment/blank-line handling, identity restored after removing the graft |

## Test plan
- [x] `go test ./internal/reviewtransaction/ -run 'Graft|ExactRevision' -count=1`
- [x] Refusal and deadcode ratchets pass
- [x] Native review approved (lineage review-c0490b5d60ce39a9), acknowledged

https://claude.ai/code/session_01SYqbaaqyJcAv1FYtSJXx6M

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Exact-revision snapshots now stop with a clear error when an active local Git graft could alter repository history.
  * The error identifies the graft file and provides a command to resolve the issue.
  * Graft detection works consistently for linked worktrees and ignores blank lines or comments in the graft file.
  * Snapshot identity returns to the expected result after the graft is removed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->