### PR TITLE
fix(review): resume committed-range acknowledgement and bind corrections to a real predecessor

### DIFF
--- a/internal/cli/review_committed_base_diff_acknowledgement_test.go
+++ b/internal/cli/review_committed_base_diff_acknowledgement_test.go
@@ -1,0 +1,108 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/gentleman-programming/gentle-ai/v2/internal/reviewtransaction"
+)
+
+// TestSelectorlessStatusResumesCommittedRangeApprovedAcknowledgement pins
+// gentle-pi#569: a committed-range (base-diff, committed-only) review that
+// reaches approved must still offer its exact `review.acknowledge-approved`
+// continuation when STATUS is queried selector-free (no --base-ref, no
+// --committed-only) — the shape the public acknowledgement operation actually
+// issues before executing the returned transition. Before the fix, the
+// selectorless refresh silently defaulted to a current-changes target, which
+// projects an empty diff on the clean approved worktree and reports the
+// approved lineage as unrelated instead of offering its acknowledgement.
+func TestSelectorlessStatusResumesCommittedRangeApprovedAcknowledgement(t *testing.T) {
+	reviewEnabledHome(t)
+	t.Setenv(reviewPiHostRelayContractEnvironment, reviewPiHostRelayContract)
+	repo := initReviewCLIRepo(t)
+	const baseRef = "frozen-base"
+	const lineage = "committed-range-approved-acknowledgement"
+	runReviewCLIGit(t, repo, "branch", baseRef, "HEAD")
+	writeReviewStartCandidate(t, repo, "candidate.go", "package candidate\nfunc value() int {\n\treturn 1\n}\n", 0o644)
+	runReviewCLIGit(t, repo, "add", "candidate.go")
+	runReviewCLIGit(t, repo, "commit", "-qm", "candidate")
+
+	startedBytes, err := runLegacyFacadeStartForTestBytes(t, []string{
+		"--cwd", repo, "--lineage", lineage, "--base-ref", baseRef, "--committed-only",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var started ReviewFacadeStartResult
+	decodeStrictReviewJSON(t, startedBytes, &started)
+	if len(started.SelectedLenses) == 0 {
+		t.Fatalf("committed base-diff START selected no lenses: %#v", started)
+	}
+
+	// Drive every lens capture clean, so the lineage reaches approved and
+	// mints a pending acknowledgement.
+	for order := 0; order < len(started.SelectedLenses)-1; order++ {
+		captureCleanCLIReviewerResult(t, repo, started, order, &bytes.Buffer{})
+	}
+	var closureOutput bytes.Buffer
+	captureCleanCLIReviewerResult(t, repo, started, len(started.SelectedLenses)-1, &closureOutput)
+
+	var closure reviewLastEventClosureResult
+	decodeStrictReviewJSON(t, closureOutput.Bytes(), &closure)
+	if closure.State != reviewtransaction.StateApproved || closure.Acknowledgement == nil {
+		t.Fatalf("committed base-diff final capture closure = %#v, want approved with a pending acknowledgement", closure)
+	}
+	wantAcknowledgement, err := reviewTransitionArgumentMap(closure.Acknowledgement.Arguments)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// The named branch is mutable and irrelevant after approval; the
+	// selectorless refresh must resume the frozen tree, never the ref.
+	runReviewCLIGit(t, repo, "branch", "-f", baseRef, "HEAD")
+
+	// This is the exact selectorless shape the public acknowledge-approved
+	// operation issues: no --base-ref, no --committed-only, no --workspace-overlay.
+	var statusOutput bytes.Buffer
+	if err := RunReview([]string{
+		"status", "--cwd", repo, "--contract", ReviewIntegrationContractV2, "--next-transition", "--lineage", lineage,
+	}, &statusOutput); err != nil {
+		t.Fatalf("selectorless committed-range approved status: %v\n%s", err, statusOutput.String())
+	}
+	var status ReviewTargetStatusResult
+	decodeStrictReviewJSON(t, statusOutput.Bytes(), &status)
+	if status.Authority == nil || status.Authority.LineageID != lineage || status.Authority.State != reviewtransaction.StateApproved {
+		t.Fatalf("selectorless committed-range status authority = %#v, want approved lineage %q", status.Authority, lineage)
+	}
+	if status.NextTransition == nil || status.NextTransition.Execute == nil ||
+		status.NextTransition.Execute.Operation != "review.acknowledge-approved" {
+		t.Fatalf("selectorless committed-range status next transition = %#v, want review.acknowledge-approved", status.NextTransition)
+	}
+	gotAcknowledgement, err := reviewTransitionArgumentMap(status.NextTransition.Execute.Arguments)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, name := range []string{"lineage", "target", "expected-revision", "token"} {
+		if gotAcknowledgement[name] != wantAcknowledgement[name] {
+			t.Fatalf("selectorless status acknowledge-approved argument %q = %q, want %q (from the terminal capture closure)", name, gotAcknowledgement[name], wantAcknowledgement[name])
+		}
+	}
+
+	// The acknowledgement STATUS offered must actually succeed.
+	statusArgs := []string{strings.TrimPrefix(status.NextTransition.Execute.Operation, "review.")}
+	for _, argument := range status.NextTransition.Execute.Arguments {
+		statusArgs = append(statusArgs, argument.Token)
+	}
+	var ackOutput bytes.Buffer
+	if err := RunReview(statusArgs, &ackOutput); err != nil {
+		t.Fatalf("run status-offered acknowledge-approved: %v\n%s", err, ackOutput.String())
+	}
+
+	store, err := reviewtransaction.CompactAuthoritativeStore(context.Background(), repo, lineage)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertApprovedCompactAuthorityBurned(t, store, lineage)
+}

--- a/internal/cli/review_facade.go
+++ b/internal/cli/review_facade.go
@@ -899,6 +899,12 @@ func runReviewStatus(ctx context.Context, args []string, stdout io.Writer) error
 		}
 		intendedScope := reviewIntendedUntrackedScope{Intended: []string{}}
 		hydratedIntendedScope := false
+		// pendingApprovedTerminalTarget carries the exact frozen target kind
+		// and base ref an approved-pending lineage resumed below, so a
+		// selectorless refresh can rebuild the same committed-range
+		// projection instead of silently defaulting to current-changes
+		// (gentle-pi#569).
+		var pendingApprovedTerminalTarget *reviewtransaction.Snapshot
 		if selectedProjection == reviewtransaction.ProjectionStaged {
 			if reviewIntendedUntrackedDeclared(untrackedScope, intendedUntracked, expectedUntrackedInventory) {
 				return reviewPreflightError(errors.New("staged projection does not accept intended-untracked selection; remove those flags and rerun `gentle-ai review status --projection staged`"))
@@ -920,6 +926,8 @@ func runReviewStatus(ctx context.Context, args []string, stdout io.Writer) error
 							Intended: append([]string{}, record.State.InitialSnapshot.IntendedUntracked...), Declared: true,
 						}
 						hydratedIntendedScope = true
+						terminal := record.State.CurrentSnapshot
+						pendingApprovedTerminalTarget = &terminal
 					}
 				} else if reviewtransaction.IsCompactAuthorityOperationalFailure(loadErr) {
 					return fmt.Errorf("load explicit review lineage: %w", loadErr)
@@ -941,6 +949,22 @@ func runReviewStatus(ctx context.Context, args []string, stdout io.Writer) error
 			if selectedBaseTree != "" {
 				target.BaseRef = selectedBaseTree
 			}
+		}
+		// Issue gentle-pi#569: a caller-authorized committed-range approval
+		// (base-diff, committed-only) must survive a selectorless STATUS
+		// refresh performed only to reach `review.acknowledge-approved`. The
+		// caller supplied no --base-ref/--committed-only/--workspace-overlay
+		// of its own, so nothing above already claimed this target; without
+		// this, the default current-changes target above projects an empty
+		// diff on the clean approved worktree and the acknowledgement
+		// continuation is never offered. The subsequent status assessment
+		// re-derives the live snapshot from this exact target and compares
+		// its identity against the frozen one, so a worktree that actually
+		// drifted since approval still fails closed instead of being forced
+		// current.
+		if pendingApprovedTerminalTarget != nil && selectedBaseRef == "" && !*workspaceOverlay &&
+			pendingApprovedTerminalTarget.Kind == reviewtransaction.TargetBaseDiff {
+			target.Kind, target.BaseRef = reviewtransaction.TargetBaseDiff, pendingApprovedTerminalTarget.BaseTree
 		}
 		target.IntendedUntracked = intendedScope.Intended
 		var prePR *reviewtransaction.PrePRRequest

--- a/internal/reviewtransaction/selectorless_committed_correction_binding_test.go
+++ b/internal/reviewtransaction/selectorless_committed_correction_binding_test.go
@@ -1,0 +1,277 @@
+package reviewtransaction
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestSelectorlessCommittedBaseDiffCorrectionsRequireMatchingPredecessor pins
+// issue #2345: a small, unrelated new candidate must never bind to a stale
+// historical correction_required lineage merely because that lineage's
+// genesis paths happen to be broad enough to admit the live diff. Binding is
+// legitimate only when the correction lineage's own frozen current candidate
+// is the exact predecessor the live candidate continues from.
+//
+// The fixture builds three lineages that all happen to touch the same file
+// ("candidate.go"):
+//   - "stale-correction": reviewed the file at commit1 (base commit0), found
+//     a severe finding, reached correction_required, and was then abandoned.
+//     Its own recorded OriginalChangedLines reflects that original,
+//     substantially larger diff.
+//   - "approved-lineage": a later, unrelated, properly approved review of the
+//     same file (base commit1, candidate commit2). This is already excluded
+//     by RebuildCommittedBaseDiffCorrectionCandidate's own state check (it is
+//     not correction_required); it is included only to prove its presence
+//     does not change the outcome.
+//   - the live candidate: one small additional one-line edit committed
+//     directly on top of the approved delivery (commit3, parent commit2).
+//
+// Before the fix, selectorlessCommittedBaseDiffCorrections rebuilt
+// "stale-correction" from ITS OWN frozen initial base (commit0) to the
+// current HEAD (commit3); since only candidate.go ever changed across the
+// whole history, that rebuilt diff stayed a subset of the stale lineage's
+// genesis paths and bound successfully, incorrectly attaching the live
+// candidate to it and reporting its unrelated, much larger changed-line
+// count instead of the live candidate's own tiny diff.
+func TestSelectorlessCommittedBaseDiffCorrectionsRequireMatchingPredecessor(t *testing.T) {
+	requireSnapshotGit(t)
+	repo := initSnapshotRepo(t)
+	ctx := context.Background()
+	builder := SnapshotBuilder{Repo: repo}
+
+	commit0 := strings.TrimSpace(gitSnapshot(t, repo, "rev-parse", "HEAD"))
+	commit0Tree := strings.TrimSpace(gitSnapshot(t, repo, "rev-parse", "HEAD^{tree}"))
+
+	// commit1: the stale lineage's own original ("wrong") candidate: a
+	// substantially sized change so its recorded line count is unmistakably
+	// its own, not the live candidate's.
+	writeSnapshotFile(t, repo, "candidate.go", "package candidate\n\n"+
+		"func value() int {\n\treturn 1\n}\n\n"+
+		"func other() int {\n\treturn 2\n}\n\n"+
+		"func third() int {\n\treturn 3\n}\n\n"+
+		"func fourth() int {\n\treturn 4\n}\n")
+	gitSnapshot(t, repo, "add", "candidate.go")
+	gitSnapshot(t, repo, "commit", "-qm", "stale candidate")
+
+	staleState := newCompactFixtureStateForTarget(t, repo, "stale-correction", Target{
+		Kind: TargetBaseDiff, BaseRef: commit0Tree, IntendedUntracked: []string{},
+	})
+	if len(staleState.SelectedLenses) == 0 {
+		t.Fatal("stale correction fixture unexpectedly selected no lenses")
+	}
+	staleOriginalLines := staleState.OriginalChangedLines
+	staleState, staleStore := startReviewingCompactFixture(t, repo, staleState)
+	staleFinding := Finding{
+		ID: "R3-001", Lens: staleState.SelectedLenses[0], Location: "candidate.go:4", Severity: "CRITICAL",
+		Claim: "wrong value", ProofRefs: []string{"candidate.go:4 changed hunk"},
+	}
+	staleResults := make([]LensResult, len(staleState.SelectedLenses))
+	for index, lens := range staleState.SelectedLenses {
+		staleResults[index] = LensResult{Lens: lens, Findings: []Finding{}, Evidence: []string{"reviewed"}}
+	}
+	staleResults[0].Findings = []Finding{staleFinding}
+	staleState, staleStarted := captureAndCompleteCompactReview(t, staleStore, staleState, CompactReviewInput{
+		LensResults: staleResults,
+		Classifications: []FindingEvidence{{
+			FindingID: staleFinding.ID, Class: EvidenceDeterministic, Causality: CausalIntroduced, Proof: "changed hunk",
+		}},
+		RefuterOutcomes: []EvidenceResult{},
+	})
+	if staleState.State != StateCorrectionRequired {
+		t.Fatalf("stale fixture state = %q, want %q", staleState.State, StateCorrectionRequired)
+	}
+	staleRevision, err := staleStore.Replace(staleStarted.Revision, "review/complete-review", staleState)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// RebuildCommittedBaseDiffCorrectionCandidate is only eligible once a
+	// correction has been forecasted (ProposedCorrectionLines set): a bare
+	// correction_required lineage that never began its correction is
+	// naturally excluded before the predecessor-binding policy is even
+	// reached, so exercising that policy requires forecasting first, exactly
+	// as an abandoned in-progress correction would.
+	if err := staleState.BeginCorrection(1); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := staleStore.Replace(staleRevision, "review/begin-fix", staleState); err != nil {
+		t.Fatal(err)
+	}
+
+	// Abandon commit1 entirely: reset back to commit0 so the stale lineage's
+	// frozen candidate tree leaves HEAD's history for good.
+	gitSnapshot(t, repo, "reset", "--hard", commit0)
+
+	// commit2: a later, unrelated, properly approved delivery of the same
+	// file, built directly from commit0 (never through the abandoned commit1).
+	writeSnapshotFile(t, repo, "candidate.go", "package candidate\n\n"+
+		"func value() int {\n\treturn 5\n}\n\n"+
+		"func other() int {\n\treturn 2\n}\n\n"+
+		"func third() int {\n\treturn 3\n}\n\n"+
+		"func fourth() int {\n\treturn 4\n}\n")
+	gitSnapshot(t, repo, "add", "candidate.go")
+	gitSnapshot(t, repo, "commit", "-qm", "approved delivery")
+
+	approvedState := newCompactFixtureStateForTarget(t, repo, "approved-lineage", Target{
+		Kind: TargetBaseDiff, BaseRef: commit0Tree, IntendedUntracked: []string{},
+	})
+	if len(approvedState.SelectedLenses) == 0 {
+		t.Fatal("approved fixture unexpectedly selected no lenses")
+	}
+	approvedState, approvedStore := startReviewingCompactFixture(t, repo, approvedState)
+	approvedResults := make([]LensResult, len(approvedState.SelectedLenses))
+	for index, lens := range approvedState.SelectedLenses {
+		approvedResults[index] = LensResult{Lens: lens, Findings: []Finding{}, Evidence: []string{"reviewed"}}
+	}
+	approvedState, approvedStarted := captureAndCompleteCompactReview(t, approvedStore, approvedState, CompactReviewInput{
+		LensResults:     approvedResults,
+		Classifications: []FindingEvidence{},
+		RefuterOutcomes: []EvidenceResult{},
+	})
+	if approvedState.State == StateValidating {
+		if err := approvedState.CloseCleanReviewOnLastEvent(); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if approvedState.State != StateApproved {
+		t.Fatalf("approved fixture state = %q, want %q", approvedState.State, StateApproved)
+	}
+	if _, err := approvedStore.Replace(approvedStarted.Revision, "review/complete-review", approvedState); err != nil {
+		t.Fatal(err)
+	}
+
+	// commit3: the small, live, unrelated follow-up candidate, committed
+	// directly on top of the approved delivery: a single one-line edit.
+	writeSnapshotFile(t, repo, "candidate.go", "package candidate\n\n"+
+		"func value() int {\n\treturn 6\n}\n\n"+
+		"func other() int {\n\treturn 2\n}\n\n"+
+		"func third() int {\n\treturn 3\n}\n\n"+
+		"func fourth() int {\n\treturn 4\n}\n")
+	gitSnapshot(t, repo, "add", "candidate.go")
+	gitSnapshot(t, repo, "commit", "-qm", "small unrelated follow-up")
+
+	candidates, err := selectorlessCommittedBaseDiffCorrections(ctx, repo)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(candidates) != 0 {
+		lineages := make([]string, len(candidates))
+		for index, candidate := range candidates {
+			lineages[index] = candidate.lineage
+		}
+		t.Fatalf("selectorless committed-base-diff corrections bound to %v, want no match for an unrelated predecessor", lineages)
+	}
+
+	status, err := AssessTargetStatus(ctx, repo, TargetStatusRequest{
+		Target: Target{Kind: TargetCurrentChanges, IntendedUntracked: []string{}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if status.Applicability != TargetApplicabilityUnrelated || status.Action != TargetStatusActionStart || status.LineageID != "" {
+		t.Fatalf("status = %#v, want a fresh unrelated start with no bound lineage", status)
+	}
+
+	// The candidate's own diff (against its real immediate predecessor,
+	// commit2) is a single one-line change, nowhere near the stale lineage's
+	// much larger recorded OriginalChangedLines.
+	freshSnapshot, err := builder.Build(ctx, Target{Kind: TargetBaseDiff, BaseRef: "HEAD~1", IntendedUntracked: []string{}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, freshLines, err := builder.ClassifySnapshotRisk(ctx, freshSnapshot)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if freshLines != 2 {
+		t.Fatalf("candidate's own changed lines = %d, want 2 (one removed, one added line)", freshLines)
+	}
+	if freshLines >= staleOriginalLines {
+		t.Fatalf("candidate's own changed lines (%d) is not distinctly smaller than the stale lineage's unrelated OriginalChangedLines (%d)", freshLines, staleOriginalLines)
+	}
+}
+
+// TestSelectorlessCommittedBaseDiffCorrectionsPredecessorResolve pins
+// R3-predecessor-resolve-fails-open: only the unambiguous "root commit, no
+// parent" case cleanly reports no candidates; a real resolve failure must
+// surface as an error instead.
+func TestSelectorlessCommittedBaseDiffCorrectionsPredecessorResolve(t *testing.T) {
+	requireSnapshotGit(t)
+	ctx := context.Background()
+
+	t.Run("root commit has no predecessor", func(t *testing.T) {
+		repo := initSnapshotRepo(t)
+		if hasParent, err := selectorlessCommittedBaseDiffHasParentCommit(ctx, repo); err != nil || hasParent {
+			t.Fatalf("fixture precondition: hasParent=%v err=%v, want a true root commit", hasParent, err)
+		}
+		candidates, err := selectorlessCommittedBaseDiffCorrections(ctx, repo)
+		if err != nil {
+			t.Fatalf("root commit produced an error, want a clean empty result: %v", err)
+		}
+		if len(candidates) != 0 {
+			t.Fatalf("root commit unexpectedly matched candidates: %#v", candidates)
+		}
+	})
+
+	t.Run("real resolve failure fails closed", func(t *testing.T) {
+		repo := initSnapshotRepo(t)
+		writeSnapshotFile(t, repo, "extra.txt", "extra\n")
+		gitSnapshot(t, repo, "add", "extra.txt")
+		gitSnapshot(t, repo, "commit", "-qm", "second")
+
+		headPath := filepath.Join(repo, ".git", "HEAD")
+		original, err := os.ReadFile(headPath)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(headPath, []byte("this is not a valid ref\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		t.Cleanup(func() { _ = os.WriteFile(headPath, original, 0o644) })
+
+		if _, err := selectorlessCommittedBaseDiffAncestors(ctx, repo); err == nil {
+			t.Fatal("corrupted HEAD produced no error, want the resolve failure to surface")
+		}
+	})
+}
+
+// TestSelectorlessCommittedBaseDiffMatchedPredecessorWalksAncestry pins
+// R3-single-commit-only-resumption: a lineage's frozen candidate several
+// commits back from HEAD still matches, stopping at its own frozen base; a
+// candidate tree that never appears in the ancestry does not match.
+func TestSelectorlessCommittedBaseDiffMatchedPredecessorWalksAncestry(t *testing.T) {
+	ancestors := []selectorlessCommittedBaseDiffAncestor{{commit: "c2", tree: "t2"}, {commit: "c1", tree: "t1"}, {commit: "c0", tree: "t0"}}
+	resumed := CompactState{CurrentSnapshot: Snapshot{CandidateTree: "t1"}, InitialSnapshot: Snapshot{BaseTree: "t0"}}
+	if got := selectorlessCommittedBaseDiffMatchedPredecessor(ancestors, resumed); got != "t1" {
+		t.Fatalf("matched predecessor = %q, want t1 (two commits back)", got)
+	}
+	unrelated := CompactState{CurrentSnapshot: Snapshot{CandidateTree: "unrelated"}, InitialSnapshot: Snapshot{BaseTree: "t0"}}
+	if got := selectorlessCommittedBaseDiffMatchedPredecessor(ancestors, unrelated); got != "" {
+		t.Fatalf("matched predecessor = %q, want no match for a candidate tree absent from the ancestry", got)
+	}
+}
+
+// TestSelectorlessCommittedBaseDiffAncestorsWalksMultipleCommits pins the
+// ancestry-resolution half of the same fix: HEAD's first-parent ancestry
+// resolves several commits deep, nearest to HEAD first.
+func TestSelectorlessCommittedBaseDiffAncestorsWalksMultipleCommits(t *testing.T) {
+	requireSnapshotGit(t)
+	repo := initSnapshotRepo(t)
+	ctx := context.Background()
+	var trees []string
+	for _, name := range []string{"a", "b", "c"} {
+		writeSnapshotFile(t, repo, name+".txt", name+"\n")
+		gitSnapshot(t, repo, "add", name+".txt")
+		gitSnapshot(t, repo, "commit", "-qm", name)
+		trees = append(trees, strings.TrimSpace(gitSnapshot(t, repo, "rev-parse", "HEAD^{tree}")))
+	}
+	ancestors, err := selectorlessCommittedBaseDiffAncestors(ctx, repo)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(ancestors) < 2 || ancestors[0].tree != trees[1] || ancestors[1].tree != trees[0] {
+		t.Fatalf("ancestors = %#v, want [b, a] nearest-to-HEAD first", ancestors)
+	}
+}

--- a/internal/reviewtransaction/target_status.go
+++ b/internal/reviewtransaction/target_status.go
@@ -2,8 +2,12 @@ package reviewtransaction
 
 import (
 	"context"
+	"fmt"
+	"os"
 	"sort"
+	"strconv"
 	"strings"
+	"time"
 )
 
 type TargetApplicability string
@@ -175,12 +179,92 @@ type selectorlessCommittedBaseDiffCorrection struct {
 	snapshot Snapshot
 }
 
+// selectorlessCommittedBaseDiffCorrectionBinding is one candidate that
+// survived every binding-policy check in selectorlessCommittedBaseDiffCorrections,
+// paired with the recency (state file modification time) used to prefer the
+// most recent match when more than one lineage legitimately qualifies.
+type selectorlessCommittedBaseDiffCorrectionBinding struct {
+	candidate selectorlessCommittedBaseDiffCorrection
+	modTime   time.Time
+}
+
+// selectorlessCommittedBaseDiffAncestor pairs one HEAD-ancestry commit with its tree.
+type selectorlessCommittedBaseDiffAncestor struct {
+	commit string
+	tree   string
+}
+
+// selectorlessCommittedBaseDiffAncestorLimit bounds the ancestry walk below.
+const selectorlessCommittedBaseDiffAncestorLimit = 64
+
+// selectorlessCommittedBaseDiffHasParentCommit reports whether HEAD has a
+// parent via a query unambiguous either way (empty means root), unlike a
+// plain revision resolve whose failure looks identical for both cases.
+func selectorlessCommittedBaseDiffHasParentCommit(ctx context.Context, repo string) (bool, error) {
+	output, err := runGit(ctx, repo, nil, nil, "rev-list", "--max-count=1", "--skip=1", "HEAD")
+	if err != nil {
+		return false, err
+	}
+	return strings.TrimSpace(string(output)) != "", nil
+}
+
+// selectorlessCommittedBaseDiffAncestors returns HEAD's first-parent
+// ancestry, bounded, as (nil, nil) only for the unambiguous root-commit
+// case; every other Git failure is returned so the caller fails closed.
+func selectorlessCommittedBaseDiffAncestors(ctx context.Context, repo string) ([]selectorlessCommittedBaseDiffAncestor, error) {
+	hasParent, err := selectorlessCommittedBaseDiffHasParentCommit(ctx, repo)
+	if err != nil || !hasParent {
+		return nil, err
+	}
+	output, err := runGit(ctx, repo, nil, nil, "log", "--first-parent", "--format=%H %T",
+		"-n", strconv.Itoa(selectorlessCommittedBaseDiffAncestorLimit), "HEAD~1")
+	if err != nil {
+		return nil, err
+	}
+	trimmed := strings.TrimSpace(string(output))
+	if trimmed == "" {
+		return nil, nil
+	}
+	lines := strings.Split(trimmed, "\n")
+	ancestors := make([]selectorlessCommittedBaseDiffAncestor, 0, len(lines))
+	for _, line := range lines {
+		fields := strings.Fields(line)
+		if len(fields) != 2 {
+			return nil, fmt.Errorf("unexpected HEAD ancestry log line %q", line) // refusal:by-design world-action: git log --format=%H %T produced a line this parser cannot shape into a commit/tree pair; needs operator inspection, no command can repair it
+		}
+		ancestors = append(ancestors, selectorlessCommittedBaseDiffAncestor{commit: fields[0], tree: fields[1]})
+	}
+	return ancestors, nil
+}
+
+// selectorlessCommittedBaseDiffMatchedPredecessor finds the lineage's frozen
+// candidate tree among ancestors, stopping at its frozen base tree.
+func selectorlessCommittedBaseDiffMatchedPredecessor(ancestors []selectorlessCommittedBaseDiffAncestor, state CompactState) string {
+	for _, ancestor := range ancestors {
+		if ancestor.tree == state.CurrentSnapshot.CandidateTree {
+			return ancestor.tree
+		}
+		if ancestor.tree == state.InitialSnapshot.BaseTree {
+			break
+		}
+	}
+	return ""
+}
+
 func selectorlessCommittedBaseDiffCorrections(ctx context.Context, repo string) ([]selectorlessCommittedBaseDiffCorrection, error) {
 	stores, err := DiscoverCompactStores(ctx, repo)
 	if err != nil {
 		return nil, err
 	}
-	candidates := []selectorlessCommittedBaseDiffCorrection{}
+	builder := SnapshotBuilder{Repo: repo}
+	// Issue #2345: a lineage may only resume selector-free when its own
+	// frozen candidate tree sits in HEAD's history; a resolve failure here
+	// fails closed instead of silently emptying the candidate list.
+	ancestors, err := selectorlessCommittedBaseDiffAncestors(ctx, repo)
+	if err != nil {
+		return nil, err
+	}
+	bindings := []selectorlessCommittedBaseDiffCorrectionBinding{}
 	for _, store := range stores {
 		record, loadErr := store.LoadContext(ctx)
 		if loadErr != nil {
@@ -189,6 +273,11 @@ func selectorlessCommittedBaseDiffCorrections(ctx context.Context, repo string) 
 			}
 			continue
 		}
+		// Reconstruction is attempted for every lineage before the binding
+		// policy below narrows the result: an operational failure or an
+		// exceeded correction budget on ANY lineage's own frozen boundary
+		// must fail closed exactly as before, whether or not that lineage
+		// would otherwise qualify as this candidate's predecessor.
 		live, rebuildErr := RebuildCommittedBaseDiffCorrectionCandidate(ctx, repo, record.State)
 		if rebuildErr != nil {
 			if IsCompactAuthorityOperationalFailure(rebuildErr) || IsCorrectionBudgetExceeded(rebuildErr) {
@@ -196,7 +285,41 @@ func selectorlessCommittedBaseDiffCorrections(ctx context.Context, repo string) 
 			}
 			continue
 		}
-		candidates = append(candidates, selectorlessCommittedBaseDiffCorrection{lineage: record.State.LineageID, snapshot: live})
+		predecessorTree := selectorlessCommittedBaseDiffMatchedPredecessor(ancestors, record.State)
+		if predecessorTree == "" {
+			continue
+		}
+		// The live candidate's own changed paths (measured from the matched
+		// predecessor) must still overlap what this lineage's frozen
+		// manifest concerns. A coincidental predecessor-tree match over
+		// wholly disjoint paths is never a legitimate resumption.
+		ownPaths, pathsErr := builder.changedPaths(ctx, predecessorTree, live.CandidateTree)
+		if pathsErr != nil {
+			return nil, pathsErr
+		}
+		if !hasStringIntersection(ownPaths, record.State.CurrentSnapshot.Paths) {
+			continue
+		}
+		modTime := time.Time{}
+		if info, statErr := os.Stat(store.StatePath()); statErr == nil {
+			modTime = info.ModTime()
+		}
+		bindings = append(bindings, selectorlessCommittedBaseDiffCorrectionBinding{
+			candidate: selectorlessCommittedBaseDiffCorrection{lineage: record.State.LineageID, snapshot: live}, modTime: modTime,
+		})
+	}
+	if len(bindings) == 0 {
+		return nil, nil
+	}
+	// Prefer the most recent lineage when several independently qualify;
+	// only an exact modification-time tie remains ambiguous.
+	sort.Slice(bindings, func(i, j int) bool { return bindings[i].modTime.After(bindings[j].modTime) })
+	mostRecent := bindings[0].modTime
+	candidates := []selectorlessCommittedBaseDiffCorrection{}
+	for _, binding := range bindings {
+		if binding.modTime.Equal(mostRecent) {
+			candidates = append(candidates, binding.candidate)
+		}
 	}
 	sort.Slice(candidates, func(i, j int) bool { return candidates[i].lineage < candidates[j].lineage })
 	return candidates, nil


### PR DESCRIPTION
Closes #2345
Closes Gentleman-Programming/gentle-pi#569

## Summary
- A selectorless STATUS refresh for an approved-pending committed-only lineage now reconstructs the frozen base-diff target from the persisted snapshot, re-verifies it against the frozen identity, and offers the exact `review.acknowledge-approved` continuation instead of projecting an empty workspace diff.
- Selectorless committed-base-diff STATUS binds a candidate to a correction lineage only when the lineage's frozen candidate tree appears in the candidate's bounded first-parent ancestry (up to 64 commits, so multi-commit corrections still resume) and its frozen manifest intersects the candidate's own changed paths, preferring the most recent match. A root commit yields no match; any other ancestry failure fails closed. `original_changed_lines` comes from the candidate's own diff when nothing matches.

## Changes
| File | Change |
|------|--------|
| `internal/cli/review_facade.go` | Rebuild the terminal target from `CurrentSnapshot` on pending acknowledgement |
| `internal/reviewtransaction/target_status.go` | Predecessor-bound correction binding with bounded ancestry walk |
| `internal/cli/review_committed_base_diff_acknowledgement_test.go` | Selectorless STATUS returns and burns the acknowledgement |
| `internal/reviewtransaction/selectorless_committed_correction_binding_test.go` | Stale/unrelated lineages do not bind; ancestry walk; root commit and transient failure |

## Size exception
The committed-range target reconstruction and the predecessor-bound binding share the selectorless STATUS path and its fixtures; most of the overage is the reproduction tests for both reports.

## Test plan
- [x] `go test ./internal/reviewtransaction/... -run 'TargetStatus|CommittedBaseDiff|CommittedCorrection|Selectorless' -count=1`
- [x] `go test ./internal/cli/ -run 'CommittedCorrection|CommittedBaseDiff|TestSelectorlessStatusResumesCommittedRangeApprovedAcknowledgement' -count=1`
- [x] Refusal and deadcode ratchets pass
- [x] Native review: correction (181/193 lines) validated and approved (lineage review-e6616b2fabfc022a), acknowledged

https://claude.ai/code/session_01SYqbaaqyJcAv1FYtSJXx6M

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed selector-free review status checks so approved committed-range reviews correctly offer their pending acknowledgement action.
  - Preserved the original review snapshot during status refreshes, even when the referenced branch changes.
  - Prevented committed-range corrections from resuming against unrelated or stale changes.
  - Improved validation of review ancestry and changed-file overlap before restoring an in-progress review.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->