### PR TITLE
fix(engram): clarify mem_save content format

### DIFF
--- a/internal/assets/engram/protocol.md
+++ b/internal/assets/engram/protocol.md
@@ -39,11 +39,8 @@ Format for `mem_save`:
 - **scope**: `project` (default) | `personal`
 - **topic_key** (recommended for evolving topics): stable key like `architecture/auth-model`
 - **capture_prompt**: optional; default `true`. Do not set this for normal human/proactive saves. Set `false` only for automated artifacts such as SDD proposal/spec/design/tasks/apply/verify/archive/init reports, testing-capabilities caches, onboarding/state artifacts, or skill-registry output.
-- **content**:
-  - **What**: One sentence — what was done
-  - **Why**: What motivated it (user request, bug, performance, etc.)
-  - **Where**: Files or paths affected
-  - **Learned**: Gotchas, edge cases, things that surprised you (omit if none)
+- **content**: one plain string with labeled lines, for example:
+  `What: One sentence — what was done\nWhy: What motivated it\nWhere: Files or paths affected\nLearned: Gotchas or edge cases (omit if none)`
 
 Prompt capture behavior (Engram v1.15.3+):
 - `mem_save` captures the user prompt best-effort when the MCP process already has prompt context for the same `project + session_id`.

--- a/internal/components/engram/inject_test.go
+++ b/internal/components/engram/inject_test.go
@@ -235,6 +235,12 @@ func TestInjectOpenCodeMergesEngramToSettings(t *testing.T) {
 	if !strings.Contains(agentsText, "mem_save") {
 		t.Fatal("AGENTS.md missing engram protocol content (expected 'mem_save')")
 	}
+	if !strings.Contains(agentsText, "one plain string with labeled lines") {
+		t.Fatal("AGENTS.md must describe mem_save content as one plain string")
+	}
+	if strings.Contains(agentsText, "- **content**:\n  - **What**:") {
+		t.Fatal("AGENTS.md must not describe mem_save content as an object-shaped nested list")
+	}
 }
 
 func TestInjectOpenCodeIsIdempotent(t *testing.T) {

--- a/internal/components/engram/inject_test.go
+++ b/internal/components/engram/inject_test.go
@@ -238,6 +238,11 @@ func TestInjectOpenCodeMergesEngramToSettings(t *testing.T) {
 	if !strings.Contains(agentsText, "one plain string with labeled lines") {
 		t.Fatal("AGENTS.md must describe mem_save content as one plain string")
 	}
+	for _, label := range []string{"What:", "Why:", "Where:"} {
+		if !strings.Contains(agentsText, label) {
+			t.Fatalf("AGENTS.md missing required mem_save content label %q", label)
+		}
+	}
 	if strings.Contains(agentsText, "- **content**:\n  - **What**:") {
 		t.Fatal("AGENTS.md must not describe mem_save content as an object-shaped nested list")
 	}

--- a/internal/components/engram/inject_test.go
+++ b/internal/components/engram/inject_test.go
@@ -109,6 +109,7 @@ func TestInjectClaudeRefusesCorruptUserRegistryWithoutMutation(t *testing.T) {
 	}
 }
 
+// TestInjectClaudeWritesProtocolSection verifies Claude receives the shared Engram instructions.
 func TestInjectClaudeWritesProtocolSection(t *testing.T) {
 	home := t.TempDir()
 
@@ -139,6 +140,7 @@ func TestInjectClaudeWritesProtocolSection(t *testing.T) {
 	}
 }
 
+// TestInjectClaudeIsIdempotent verifies repeated setup does not duplicate Claude's protocol section.
 func TestInjectClaudeIsIdempotent(t *testing.T) {
 	home := t.TempDir()
 

--- a/internal/components/engram/inject_test.go
+++ b/internal/components/engram/inject_test.go
@@ -171,6 +171,7 @@ func TestInjectClaudeIsIdempotent(t *testing.T) {
 	}
 }
 
+// TestInjectOpenCodeMergesEngramToSettings verifies MCP setup and the labeled-string mem_save protocol.
 func TestInjectOpenCodeMergesEngramToSettings(t *testing.T) {
 	home := t.TempDir()
 
@@ -248,6 +249,7 @@ func TestInjectOpenCodeMergesEngramToSettings(t *testing.T) {
 	}
 }
 
+// TestInjectOpenCodeIsIdempotent verifies repeated injection leaves existing settings unchanged.
 func TestInjectOpenCodeIsIdempotent(t *testing.T) {
 	home := t.TempDir()
 

--- a/internal/components/engram/testdata/protocol-full.md
+++ b/internal/components/engram/testdata/protocol-full.md
@@ -38,11 +38,8 @@ Format for `mem_save`:
 - **scope**: `project` (default) | `personal`
 - **topic_key** (recommended for evolving topics): stable key like `architecture/auth-model`
 - **capture_prompt**: optional; default `true`. Do not set this for normal human/proactive saves. Set `false` only for automated artifacts such as SDD proposal/spec/design/tasks/apply/verify/archive/init reports, testing-capabilities caches, onboarding/state artifacts, or skill-registry output.
-- **content**:
-  - **What**: One sentence — what was done
-  - **Why**: What motivated it (user request, bug, performance, etc.)
-  - **Where**: Files or paths affected
-  - **Learned**: Gotchas, edge cases, things that surprised you (omit if none)
+- **content**: one plain string with labeled lines, for example:
+  `What: One sentence — what was done\nWhy: What motivated it\nWhere: Files or paths affected\nLearned: Gotchas or edge cases (omit if none)`
 
 Prompt capture behavior (Engram v1.15.3+):
 - `mem_save` captures the user prompt best-effort when the MCP process already has prompt context for the same `project + session_id`.

--- a/testdata/golden/combined-windsurf-global-rules.golden
+++ b/testdata/golden/combined-windsurf-global-rules.golden
@@ -616,11 +616,8 @@ Format for `mem_save`:
 - **scope**: `project` (default) | `personal`
 - **topic_key** (recommended for evolving topics): stable key like `architecture/auth-model`
 - **capture_prompt**: optional; default `true`. Do not set this for normal human/proactive saves. Set `false` only for automated artifacts such as SDD proposal/spec/design/tasks/apply/verify/archive/init reports, testing-capabilities caches, onboarding/state artifacts, or skill-registry output.
-- **content**:
-  - **What**: One sentence — what was done
-  - **Why**: What motivated it (user request, bug, performance, etc.)
-  - **Where**: Files or paths affected
-  - **Learned**: Gotchas, edge cases, things that surprised you (omit if none)
+- **content**: one plain string with labeled lines, for example:
+  `What: One sentence — what was done\nWhy: What motivated it\nWhere: Files or paths affected\nLearned: Gotchas or edge cases (omit if none)`
 
 Prompt capture behavior (Engram v1.15.3+):
 - `mem_save` captures the user prompt best-effort when the MCP process already has prompt context for the same `project + session_id`.

--- a/testdata/golden/engram-antigravity-rulesmd.golden
+++ b/testdata/golden/engram-antigravity-rulesmd.golden
@@ -39,11 +39,8 @@ Format for `mem_save`:
 - **scope**: `project` (default) | `personal`
 - **topic_key** (recommended for evolving topics): stable key like `architecture/auth-model`
 - **capture_prompt**: optional; default `true`. Do not set this for normal human/proactive saves. Set `false` only for automated artifacts such as SDD proposal/spec/design/tasks/apply/verify/archive/init reports, testing-capabilities caches, onboarding/state artifacts, or skill-registry output.
-- **content**:
-  - **What**: One sentence — what was done
-  - **Why**: What motivated it (user request, bug, performance, etc.)
-  - **Where**: Files or paths affected
-  - **Learned**: Gotchas, edge cases, things that surprised you (omit if none)
+- **content**: one plain string with labeled lines, for example:
+  `What: One sentence — what was done\nWhy: What motivated it\nWhere: Files or paths affected\nLearned: Gotchas or edge cases (omit if none)`
 
 Prompt capture behavior (Engram v1.15.3+):
 - `mem_save` captures the user prompt best-effort when the MCP process already has prompt context for the same `project + session_id`.

--- a/testdata/golden/engram-codex-instructions.golden
+++ b/testdata/golden/engram-codex-instructions.golden
@@ -38,11 +38,8 @@ Format for `mem_save`:
 - **scope**: `project` (default) | `personal`
 - **topic_key** (recommended for evolving topics): stable key like `architecture/auth-model`
 - **capture_prompt**: optional; default `true`. Do not set this for normal human/proactive saves. Set `false` only for automated artifacts such as SDD proposal/spec/design/tasks/apply/verify/archive/init reports, testing-capabilities caches, onboarding/state artifacts, or skill-registry output.
-- **content**:
-  - **What**: One sentence — what was done
-  - **Why**: What motivated it (user request, bug, performance, etc.)
-  - **Where**: Files or paths affected
-  - **Learned**: Gotchas, edge cases, things that surprised you (omit if none)
+- **content**: one plain string with labeled lines, for example:
+  `What: One sentence — what was done\nWhy: What motivated it\nWhere: Files or paths affected\nLearned: Gotchas or edge cases (omit if none)`
 
 Prompt capture behavior (Engram v1.15.3+):
 - `mem_save` captures the user prompt best-effort when the MCP process already has prompt context for the same `project + session_id`.


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #3698

---

## 🏷️ PR Type

- [x] `type:bug` — Bug fix (non-breaking change that fixes an issue)
- [ ] `type:feature` — New feature (non-breaking change that adds functionality)
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring (no functional changes)
- [ ] `type:chore` — Build, CI, or tooling changes
- [ ] `type:breaking-change` — Breaking change (fix or feature that changes existing behavior)

---

## 📝 Summary

The shared Engram protocol rendered `mem_save.content` as a nested Markdown list. OpenCode agents could interpret that shape as an object even though Engram accepts a string.

This change describes `content` as one plain string and shows the labeled lines inside an escaped string example. The OpenCode injection regression now requires that contract and rejects the former object-shaped guidance.

---

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/assets/engram/protocol.md` | Defines `mem_save.content` as one plain string with labeled lines |
| `internal/components/engram/inject_test.go` | Verifies generated OpenCode guidance states the string contract and excludes the nested-list shape |
| Engram fixtures and golden outputs | Updates generated guidance snapshots for Codex, Antigravity, and Windsurf |

---

## 🤖 AI Assistance

- [ ] **None** — No material AI assistance was used.
- [x] **Material assistance used** — Complete all applicable declaration fields below.

**Tool/model (if known):** OpenAI Codex, GPT-6

**Material scope:** Issue analysis, protocol wording, regression-test implementation, fixture updates, and PR drafting.

**Verification performed:** Reviewed the complete diff; proved the new OpenCode assertion failed before the protocol change; ran the focused Engram and affected golden tests, the repository formatter, the complete Docker E2E matrix, and the full Go suite. The full Go suite reached unrelated existing environment-sensitive failures in CLI/review transaction, process-signaling, and external MCP discovery tests; the changed Engram paths passed.

---

## 🧪 Test Plan

**Unit Tests**
```bash
go test ./internal/components/engram -run '^(TestInjectOpenCodeMergesEngramToSettings|TestProtocolFullByteEqualsPreConsolidationClaudeAsset|TestCodexInstructionsIsFullPlusPassiveCaptureInOrder)$'
go test ./internal/components -run 'TestGolden.*(Engram|Windsurf)'
```

**Go Format**
```bash
go run ./internal/gofmtcheck
```

**E2E Tests**
```bash
cd e2e && ./docker-test.sh
```

**Benchmark Validation**

N/A. This changes generated Engram guidance and its snapshots; it does not affect review lifecycle, gates, recovery, delivery, benchmark code, corpus, classifiers, or benchmark claims.

- [x] Changed-path unit tests pass
- [x] Go format passes (`go run ./internal/gofmtcheck`)
- [x] E2E tests pass (`cd e2e && ./docker-test.sh`): Ubuntu, Arch, and Fedora; 79 enabled assertions per platform
- [x] Manually reviewed generated guidance and the complete diff

The repository-wide `go test ./...` command was also attempted. It failed in unrelated environment-sensitive tests: CLI/review transaction tests timed out or rejected this host's temporary/TTY conditions, the existing Engram handshake signal test returned `operation not permitted`, and native Claude MCP discovery could not connect to Context7. The focused Engram package and all affected golden tests pass.

---

## ✅ Contributor Checklist

- [x] PR is linked to an issue with `status:approved`
- [x] PR stays within 400 changed lines
- [ ] A maintainer or repository automation still needs to apply the declared `type:bug` label
- [x] Changed-path unit tests pass
- [x] Go format passes (`go run ./internal/gofmtcheck`)
- [x] E2E tests pass (`cd e2e && ./docker-test.sh`)
- [x] Benchmark validation is not applicable, as explained above
- [x] Documentation is updated at the canonical shared protocol source
- [x] Commits follow Conventional Commits
- [x] I understand, reviewed, and take responsibility for the complete submission
- [x] I selected exactly one AI-assistance option and completed the declaration fields
- [x] Commits do not include `Co-Authored-By` trailers

---

## 💬 Notes for Reviewers

The source protocol, full-protocol fixture, and every affected generated golden output carry the same string-shaped example. The historical pre-consolidation Codex fixture remains unchanged because it documents old behavior.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the `mem_save` content format to use a single plain-text string with labeled lines.
  * Simplified guidance for describing what was done, why it was motivated, and relevant gotchas or edge cases.
  * Clarified the expected formatting for consistent, readable saved memories.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->