### PR TITLE
fix(providercontractbundle): verify accepts bundles published before the runtimes and orchestration fields

### DIFF
--- a/internal/cli/review_validate_nondeciding_test.go
+++ b/internal/cli/review_validate_nondeciding_test.go
@@ -10,6 +10,7 @@ import (
 	"reflect"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/gentleman-programming/gentle-ai/v2/internal/reviewtransaction"
 )
@@ -137,6 +138,59 @@ func assertEnabledUnmanagedGatePayload(t *testing.T, payload []byte, gate review
 		if strings.Contains(compact, forbidden) {
 			t.Fatalf("enabled unmanaged output contains forbidden %q:\n%s", forbidden, payload)
 		}
+	}
+}
+
+// TestShippedReviewValidatePrePushIgnoresExplicitBaseRefAndNeverTouchesNetwork
+// pins the resolution of issue #2893 (advertised-remote credential prompting
+// misclassifying an existing branch as missing/ambiguous during pre-push
+// validation). Since #3417's Gate Cutover, `review validate` is the shipped
+// non-deciding route: it accepts --lineage and --base-ref for historical
+// syntax compatibility but never reads authority, a receipt, or a candidate,
+// and therefore never derives an advertised remote boundary. This test
+// replays the issue's exact invocation shape against an HTTPS remote that
+// cannot be dialed, so any reintroduced remote-derivation call would either
+// error or block past the bound instead of returning the fixed unmanaged
+// envelope.
+func TestShippedReviewValidatePrePushIgnoresExplicitBaseRefAndNeverTouchesNetwork(t *testing.T) {
+	reviewModeHome(t)
+	repo := initReviewCLIRepo(t)
+	if err := RunReviewMode([]string{"enable", "--scope", "global", "--cwd", repo}, io.Discard); err != nil {
+		t.Fatalf("enable receipt-driven development: %v", err)
+	}
+	// A reserved, non-routable TEST-NET-2 address (RFC 5737): a real network
+	// attempt or an interactive credential prompt would block well past this
+	// test's bound, while the shipped non-deciding route never dials out.
+	runReviewCLIGit(t, repo, "remote", "add", "origin", "https://198.51.100.1/unreachable/issue-2893.git")
+
+	type result struct {
+		payload []byte
+		err     error
+	}
+	done := make(chan result, 1)
+	go func() {
+		var output bytes.Buffer
+		err := RunReview([]string{
+			"validate", "--cwd", repo, "--gate", "pre-push",
+			"--lineage", "issue-2893-approved-lineage", "--base-ref", "origin/main",
+		}, &output)
+		done <- result{payload: append([]byte(nil), output.Bytes()...), err: err}
+	}()
+
+	select {
+	case outcome := <-done:
+		if outcome.err != nil {
+			t.Fatalf("shipped review validate --gate pre-push --lineage --base-ref: %v", outcome.err)
+		}
+		assertEnabledUnmanagedGatePayload(t, outcome.payload, reviewtransaction.GatePrePush)
+		compact := strings.ToLower(string(outcome.payload))
+		for _, forbidden := range []string{"ls-remote", "username", "password", "credential", "origin/main", "missing or ambiguous"} {
+			if strings.Contains(compact, forbidden) {
+				t.Fatalf("pre-push non-deciding output leaked remote-derivation vocabulary %q:\n%s", forbidden, outcome.payload)
+			}
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("shipped review validate --gate pre-push blocked past 5s: it must never query the remote or prompt for credentials (issue #2893)")
 	}
 }
 

--- a/internal/providercontractbundle/bundle.go
+++ b/internal/providercontractbundle/bundle.go
@@ -48,6 +48,64 @@ const (
 
 var bundleTimestamp = time.Unix(0, 0).UTC()
 
+// contractSemverIntroducingRuntimesField is the first contract_semver whose
+// manifest carries a "runtimes" inventory (issue #3249, PR #3254 bumped
+// CONTRACT_SEMVER to 1.1.0). Every bundle published before it never had the
+// field, so its own manifest correctly decodes Runtimes as nil: that absence
+// is not corruption, it is exactly what a contract at that version promised
+// (#3256).
+var contractSemverIntroducingRuntimesField = contractSemverComponents{major: 1, minor: 1, patch: 0}
+
+// contractSemverIntroducingOrchestrationField is the first contract_semver
+// whose manifest carries an "orchestration" inventory (issue #4056, PR that
+// bumped CONTRACT_SEMVER to 1.2.0). The same backward-compatibility rule
+// applies: a bundle published before it never shipped an orchestration/*.md
+// file, so an empty inventory there is correct, not incomplete.
+var contractSemverIntroducingOrchestrationField = contractSemverComponents{major: 1, minor: 2, patch: 0}
+
+type contractSemverComponents struct{ major, minor, patch int }
+
+// parseContractSemver decomposes an already-pattern-validated MAJOR.MINOR.PATCH
+// string. It is not itself the format check -- contractSemverPattern in
+// validateEntries and ReadContractSemver already reject anything else -- so a
+// parse failure here can only mean the pattern and this parser disagree, which
+// fails closed rather than silently treating an unparseable semver as the
+// oldest possible contract.
+func parseContractSemver(semver string) (contractSemverComponents, bool) {
+	parts := strings.SplitN(semver, ".", 3)
+	if len(parts) != 3 {
+		return contractSemverComponents{}, false
+	}
+	values := make([]int, 3)
+	for index, part := range parts {
+		value, err := strconv.Atoi(part)
+		if err != nil {
+			return contractSemverComponents{}, false
+		}
+		values[index] = value
+	}
+	return contractSemverComponents{major: values[0], minor: values[1], patch: values[2]}, true
+}
+
+// contractSemverAtLeast reports whether semver names a contract at or after
+// introduced. It is the single comparison every field-introduction
+// compatibility rule in validateEntries uses, so a bundle whose contract
+// predates a field is excused from that field's exact-match check instead of
+// being rejected for lacking a promise its own contract version never made.
+func contractSemverAtLeast(semver string, introduced contractSemverComponents) bool {
+	got, ok := parseContractSemver(semver)
+	if !ok {
+		return false
+	}
+	if got.major != introduced.major {
+		return got.major > introduced.major
+	}
+	if got.minor != introduced.minor {
+		return got.minor > introduced.minor
+	}
+	return got.patch >= introduced.patch
+}
+
 var (
 	// refusal:by-design input: an untrusted bundle never becomes an activation candidate.
 	errInvalidBundle = errors.New("invalid provider contract bundle")
@@ -520,8 +578,12 @@ func validateEntries(entries map[string][]byte) error {
 	if decoded.Schema != bundleSchema || !contractSemverPattern.MatchString(decoded.ContractSemver) || decoded.TransportCapability != reviewerprovider.TransportCapability {
 		return fmt.Errorf("%w: manifest identity is unsupported", errInvalidBundle)
 	}
-	if !slices.Equal(decoded.Runtimes, reviewerprovider.RegisteredRuntimeIdentities()) {
-		return fmt.Errorf("%w: manifest runtime inventory does not match the registered runtime identities", errInvalidBundle)
+	if contractSemverAtLeast(decoded.ContractSemver, contractSemverIntroducingRuntimesField) {
+		if !slices.Equal(decoded.Runtimes, reviewerprovider.RegisteredRuntimeIdentities()) {
+			return fmt.Errorf("%w: manifest runtime inventory does not match the registered runtime identities", errInvalidBundle)
+		}
+	} else if len(decoded.Runtimes) != 0 {
+		return fmt.Errorf("%w: manifest runtime inventory is not empty for a contract older than the field it names", errInvalidBundle)
 	}
 	contracts, err := canonicalContracts()
 	if err != nil {
@@ -565,29 +627,33 @@ func validateEntries(entries map[string][]byte) error {
 		expected[schemaPath] = struct{}{}
 		expected[vectorPath] = struct{}{}
 	}
-	orchestrationSources, err := canonicalOrchestrationEntries()
-	if err != nil {
-		return err
-	}
-	if len(decoded.Orchestration) != len(orchestrationSources) {
-		return fmt.Errorf("%w: manifest orchestration inventory is incomplete", errInvalidBundle)
-	}
-	for index, source := range orchestrationSources {
-		entry := decoded.Orchestration[index]
-		if index > 0 && decoded.Orchestration[index-1].Runtime >= entry.Runtime {
-			return fmt.Errorf("%w: manifest orchestration entries are not strictly sorted", errInvalidBundle)
-		}
-		if entry.Runtime != source.runtime {
-			return fmt.Errorf("%w: manifest orchestration runtime %q does not match the canonical registry", errInvalidBundle, entry.Runtime)
-		}
-		if !reviewerprovider.RegisteredRuntime(model.AgentID(entry.Runtime)) {
-			return fmt.Errorf("%w: manifest orchestration runtime %q is not a registered review runtime", errInvalidBundle, entry.Runtime)
-		}
-		filePath := path.Join("orchestration", entry.Runtime+".md")
-		if err := validateFileReference(entries, entry.File, filePath, source.content); err != nil {
+	if contractSemverAtLeast(decoded.ContractSemver, contractSemverIntroducingOrchestrationField) {
+		orchestrationSources, err := canonicalOrchestrationEntries()
+		if err != nil {
 			return err
 		}
-		expected[filePath] = struct{}{}
+		if len(decoded.Orchestration) != len(orchestrationSources) {
+			return fmt.Errorf("%w: manifest orchestration inventory is incomplete", errInvalidBundle)
+		}
+		for index, source := range orchestrationSources {
+			entry := decoded.Orchestration[index]
+			if index > 0 && decoded.Orchestration[index-1].Runtime >= entry.Runtime {
+				return fmt.Errorf("%w: manifest orchestration entries are not strictly sorted", errInvalidBundle)
+			}
+			if entry.Runtime != source.runtime {
+				return fmt.Errorf("%w: manifest orchestration runtime %q does not match the canonical registry", errInvalidBundle, entry.Runtime)
+			}
+			if !reviewerprovider.RegisteredRuntime(model.AgentID(entry.Runtime)) {
+				return fmt.Errorf("%w: manifest orchestration runtime %q is not a registered review runtime", errInvalidBundle, entry.Runtime)
+			}
+			filePath := path.Join("orchestration", entry.Runtime+".md")
+			if err := validateFileReference(entries, entry.File, filePath, source.content); err != nil {
+				return err
+			}
+			expected[filePath] = struct{}{}
+		}
+	} else if len(decoded.Orchestration) != 0 {
+		return fmt.Errorf("%w: manifest orchestration inventory is not empty for a contract older than the field it names", errInvalidBundle)
 	}
 	if len(entries) != len(expected) {
 		return fmt.Errorf("%w: archive inventory has %d files, want %d", errInvalidBundle, len(entries), len(expected))

--- a/internal/providercontractbundle/bundle_test.go
+++ b/internal/providercontractbundle/bundle_test.go
@@ -19,11 +19,23 @@ import (
 	"github.com/gentleman-programming/gentle-ai/v2/internal/model"
 )
 
+// currentShapeContractSemver labels fixtures built by generatedFiles/Generate
+// in tests that are not about historical-contract compatibility. Both
+// functions always emit the full current manifest shape (runtimes and
+// orchestration populated) regardless of the semver string passed in, so the
+// label here must be at or after every field's own introduction version
+// (contractSemverIntroducingRuntimesField, contractSemverIntroducingOrchestrationField)
+// -- otherwise validateEntries correctly refuses a manifest that claims an
+// older contract while still carrying fields that contract never promised
+// (#3256). Tests that exercise pre-1.1.0/pre-1.2.0 compatibility build their
+// own minimal legacy-shaped manifest instead of using this label.
+const currentShapeContractSemver = "1.2.0"
+
 func TestGenerateIsDeterministicAndVerifiable(t *testing.T) {
 	first := filepath.Join(t.TempDir(), "first")
 	second := filepath.Join(t.TempDir(), "second")
 	for _, directory := range []string{first, second} {
-		if err := Generate(directory, "1.0.0"); err != nil {
+		if err := Generate(directory, currentShapeContractSemver); err != nil {
 			t.Fatalf("Generate(%s): %v", directory, err)
 		}
 	}
@@ -132,7 +144,7 @@ func TestVerifyArchiveRejectsUnsafeTarEntries(t *testing.T) {
 }
 
 func TestVerifyArchiveAcceptsTypeRegA(t *testing.T) {
-	files, err := generatedFiles("1.0.0")
+	files, err := generatedFiles(currentShapeContractSemver)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -692,5 +704,58 @@ func TestVerifyArchiveRejectsAnUnregisteredOrchestrationRuntime(t *testing.T) {
 	writeArchive(t, archive, tampered, nil, false)
 	if err := VerifyArchive(archive); err == nil {
 		t.Fatal("VerifyArchive accepted an unregistered orchestration runtime")
+	}
+}
+
+// TestVerifyArchiveAcceptsAGenuinePre110PublishedBundleWithoutRuntimesOrOrchestrationFields
+// pins the fix for issue #3256: `providercontractbundle verify` used to reject
+// every bundle published before the 1.1.0 contract bump unconditionally,
+// because validateEntries required decoded.Runtimes to equal the registered
+// runtime identities regardless of contract_semver. A genuine pre-1.1.0
+// manifest never had a "runtimes" key at all (and a genuine pre-1.2.0
+// manifest never had "orchestration" either), so it correctly decodes both as
+// nil -- that is not corruption, it is exactly what the contract at that
+// version promised.
+func TestVerifyArchiveAcceptsAGenuinePre110PublishedBundleWithoutRuntimesOrOrchestrationFields(t *testing.T) {
+	files, err := generatedFiles("1.0.0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var decoded manifest
+	if err := json.Unmarshal(files["manifest.json"], &decoded); err != nil {
+		t.Fatal(err)
+	}
+	// legacyManifest is the exact pre-#3254 manifest shape: no "runtimes" key,
+	// no "orchestration" key. Marshaling this struct (rather than deleting
+	// keys from a generic map) guarantees the fixture cannot accidentally
+	// carry either field.
+	type legacyManifest struct {
+		Schema              string         `json:"schema"`
+		ContractSemver      string         `json:"contract_semver"`
+		TransportCapability string         `json:"transport_capability"`
+		README              fileReference  `json:"readme"`
+		Roles               []roleManifest `json:"roles"`
+	}
+	legacyPayload, err := json.MarshalIndent(legacyManifest{
+		Schema:              decoded.Schema,
+		ContractSemver:      decoded.ContractSemver,
+		TransportCapability: decoded.TransportCapability,
+		README:              decoded.README,
+		Roles:               decoded.Roles,
+	}, "", "  ")
+	if err != nil {
+		t.Fatal(err)
+	}
+	files["manifest.json"] = append(legacyPayload, '\n')
+	delete(files, "orchestration/pi.md")
+
+	if strings.Contains(string(files["manifest.json"]), "runtime") {
+		t.Fatalf("legacy fixture manifest unexpectedly mentions runtimes:\n%s", files["manifest.json"])
+	}
+
+	archive := filepath.Join(t.TempDir(), "legacy-1.0.0.tar.gz")
+	writeArchive(t, archive, files, nil, false)
+	if err := VerifyArchive(archive); err != nil {
+		t.Fatalf("VerifyArchive rejected a genuine pre-1.1.0 published bundle: %v", err)
 	}
 }


### PR DESCRIPTION
Closes #3256
Closes #2893

## Summary
- `providercontractbundle verify` no longer rejects every published 1.0.0 bundle: the `runtimes` (1.1.0) and `orchestration` (1.2.0) inventory checks are gated on the contract revision that introduced each field, and pre-introduction contracts must carry the field empty rather than matching.
- `review validate --gate pre-push` is pinned by a regression test as never touching the network or credentials: it discards `--base-ref`/`--lineage` and reports the non-deciding outcome from the review switch alone, which is the #3417 gate cutover behavior the reporter of #2893 predates.

## Changes
| File | Change |
|------|--------|
| `internal/providercontractbundle/bundle.go` | `contractSemverAtLeast`, field-introduction gates |
| `internal/providercontractbundle/bundle_test.go` | Genuine pre-1.1.0 bundle accepted; fixture labels corrected |
| `internal/cli/review_validate_nondeciding_test.go` | Pre-push validate against an unroutable HTTPS remote completes offline |

## Test plan
- [x] `go test ./internal/providercontractbundle/... -count=1`
- [x] `go test ./internal/cli/ -run 'TestShippedReviewValidatePrePush' -count=1`
- [x] Refusal and deadcode ratchets pass
- [x] Native review approved (lineage review-dcd9d2c406c05d18), acknowledged

https://claude.ai/code/session_01SYqbaaqyJcAv1FYtSJXx6M

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Provider contract bundle validation now correctly supports bundles created under older contract versions.
  - Genuine pre-1.1.0 bundles without newer runtime and orchestration fields are accepted.
  - Validation only requires fields supported by the bundle’s declared contract version.
  - Pre-push review validation avoids contacting unreachable remotes or prompting for credentials when explicit base references are supplied.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->