### PR TITLE
fix(tui): persist OpenCode SDD profiles and isolate default model assignments

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -829,6 +829,13 @@ func applyOverrides(selection *model.Selection, overrides *model.SyncOverrides) 
 			selection.SDDMode = model.SDDModeMulti
 		}
 	}
+	// A persisted component selection loaded earlier via loadPersistedAssignments
+	// may omit the SDD component (e.g. an install that predates profiles). When
+	// the caller explicitly asked for profile or model assignment work through
+	// this override, that request must not be silently dropped — see issue #3430.
+	if model.CarriesSDDWork(overrides.Profiles, overrides.ModelAssignments) {
+		selection.EnsureComponent(model.ComponentSDD)
+	}
 }
 
 // loadPersistedAssignments reads previously-saved model assignments from

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -637,6 +637,56 @@ func TestTuiSyncSelectionPreservesCustomPermissionExclusion(t *testing.T) {
 	}
 }
 
+// TestTuiSyncProfilePersistsWhenSDDComponentMissingFromState reproduces
+// https://github.com/Gentleman-Programming/gentle-ai/issues/3430 through the
+// TUI sync entry point: a machine that installed without the SDD component
+// (state.json's persisted Components list omits "sdd") must still get its
+// OpenCode SDD profile written when the "Edit Profile" flow explicitly
+// requests it via SyncOverrides.Profiles — loadPersistedAssignments restores
+// Components from state before applyOverrides sets Profiles, so without the
+// fix ComponentSDD is dropped and the profile write silently never runs.
+func TestTuiSyncProfilePersistsWhenSDDComponentMissingFromState(t *testing.T) {
+	home := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(home, ".config", "opencode"), 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	settingsPath := filepath.Join(home, ".config", "opencode", "opencode.json")
+	if err := os.WriteFile(settingsPath, []byte(`{"$schema":"https://opencode.ai/config.json"}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := state.Write(home, state.InstallState{
+		InstalledAgents:     []string{"opencode"},
+		SelectionConfigured: true,
+		Components:          []model.ComponentID{model.ComponentEngram},
+		SDDMode:             model.SDDModeSingle,
+	}); err != nil {
+		t.Fatalf("state.Write: %v", err)
+	}
+
+	profile := model.Profile{
+		Name:              "demo",
+		OrchestratorModel: model.ModelAssignment{ProviderID: "anthropic", ModelID: "claude-sonnet-4-5"},
+	}
+	changed, err := tuiSync(home)(&model.SyncOverrides{
+		TargetAgents: []model.AgentID{model.AgentOpenCode},
+		Profiles:     []model.Profile{profile},
+	})
+	if err != nil {
+		t.Fatalf("tuiSync() error = %v", err)
+	}
+	if len(changed) == 0 {
+		t.Fatal("tuiSync() changed 0 files, want the profile written to opencode.json")
+	}
+
+	settingsData, err := os.ReadFile(settingsPath)
+	if err != nil {
+		t.Fatalf("ReadFile(%q): %v", settingsPath, err)
+	}
+	if !strings.Contains(string(settingsData), "sdd-orchestrator-demo") {
+		t.Fatalf("opencode.json missing profile agent key %q; the explicitly requested profile was silently dropped. Got: %s", "sdd-orchestrator-demo", settingsData)
+	}
+}
+
 func TestTUIExecutePersistsConfiguredSelection(t *testing.T) {
 	home := t.TempDir()
 	setupMockHome(t, home)

--- a/internal/cli/sync.go
+++ b/internal/cli/sync.go
@@ -425,6 +425,13 @@ func RestorePersistedSelection(selection *model.Selection, persisted state.Insta
 	}
 	setSelectionComponent(selection, model.ComponentPermission, flags.permissionsSet, flags.IncludePermissions)
 	setSelectionComponent(selection, model.ComponentTheme, flags.themeSet, flags.IncludeTheme)
+	// The persisted component list above may predate the caller ever choosing
+	// the SDD component (e.g. an install that ran before profiles existed).
+	// When the caller explicitly asked for profile or model assignment work,
+	// that request must not be silently dropped — see issue #3430.
+	if model.CarriesSDDWork(explicit.Profiles, explicit.ModelAssignments) {
+		selection.EnsureComponent(model.ComponentSDD)
+	}
 }
 
 func setSelectionComponent(selection *model.Selection, component model.ComponentID, configured, included bool) {

--- a/internal/cli/sync_test.go
+++ b/internal/cli/sync_test.go
@@ -4143,6 +4143,115 @@ func TestBuildSyncSelectionSDDProfileStrategyForwarded(t *testing.T) {
 	}
 }
 
+// ─── Issue #3430: persisted component selection must not drop explicit SDD
+// profile/model-assignment work ───────────────────────────────────────────
+
+// TestRunSyncProfilePersistsWhenSDDComponentMissingFromState reproduces
+// https://github.com/Gentleman-Programming/gentle-ai/issues/3430: a machine
+// that installed without the SDD component (state.json's persisted
+// Components list omits "sdd") never gets its OpenCode SDD profile written
+// by `gentle-ai sync --profile ...`, even though the sync reports success.
+//
+// RestorePersistedSelection replaces selection.Components wholesale with the
+// persisted list, dropping ComponentSDD, so the componentSyncStep that writes
+// profiles into opencode.json never runs — but the sync still exits 0.
+func TestRunSyncProfilePersistsWhenSDDComponentMissingFromState(t *testing.T) {
+	home := t.TempDir()
+	restoreHome := osUserHomeDir
+	restoreBackupHome := backup.UserHomeDirFn
+	restoreCommand := runCommand
+	restoreLookPath := cmdLookPath
+	t.Cleanup(func() {
+		osUserHomeDir = restoreHome
+		backup.UserHomeDirFn = restoreBackupHome
+		runCommand = restoreCommand
+		cmdLookPath = restoreLookPath
+	})
+
+	osUserHomeDir = func() (string, error) { return home, nil }
+	backup.UserHomeDirFn = func() (string, error) { return home, nil }
+	runCommand = func(string, ...string) error { return nil }
+	cmdLookPath = func(name string) (string, error) { return "/usr/local/bin/" + name, nil }
+
+	if err := os.MkdirAll(filepath.Join(home, ".config", "opencode"), 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	settingsPath := filepath.Join(home, ".config", "opencode", "opencode.json")
+	if err := os.WriteFile(settingsPath, []byte(`{"$schema":"https://opencode.ai/config.json"}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Persisted state shape from an install that never selected the SDD
+	// component — the normal shape for anyone who installed without it.
+	if err := state.Write(home, state.InstallState{
+		InstalledAgents:     []string{"opencode"},
+		SelectionConfigured: true,
+		Components:          []model.ComponentID{model.ComponentEngram},
+		SDDMode:             model.SDDModeSingle,
+	}); err != nil {
+		t.Fatalf("state.Write: %v", err)
+	}
+
+	result, err := RunSync([]string{"--agents", "opencode", "--profile", "demo:anthropic/claude-sonnet-4-5"})
+	if err != nil {
+		t.Fatalf("RunSync() error = %v", err)
+	}
+
+	if !result.Selection.HasComponent(model.ComponentSDD) {
+		t.Fatalf("Selection.Components = %v, want ComponentSDD present because a profile was explicitly requested", result.Selection.Components)
+	}
+
+	settingsData, err := os.ReadFile(settingsPath)
+	if err != nil {
+		t.Fatalf("ReadFile(%q): %v", settingsPath, err)
+	}
+	if !bytes.Contains(settingsData, []byte("sdd-orchestrator-demo")) {
+		t.Fatalf("opencode.json missing profile agent key %q for the explicitly requested profile; sync silently dropped the write. Got: %s", "sdd-orchestrator-demo", settingsData)
+	}
+}
+
+// TestRunSyncPlainSyncHonoursPersistedComponentsWithoutProfile verifies that a
+// plain sync (no --profile / --profile-phase flags) still honours a persisted
+// component selection that omits "sdd" — the fix for #3430 must only re-add
+// ComponentSDD when the caller explicitly asked for profile or model
+// assignment work, not on every sync.
+func TestRunSyncPlainSyncHonoursPersistedComponentsWithoutProfile(t *testing.T) {
+	home := t.TempDir()
+	restoreHome := osUserHomeDir
+	restoreBackupHome := backup.UserHomeDirFn
+	restoreCommand := runCommand
+	restoreLookPath := cmdLookPath
+	t.Cleanup(func() {
+		osUserHomeDir = restoreHome
+		backup.UserHomeDirFn = restoreBackupHome
+		runCommand = restoreCommand
+		cmdLookPath = restoreLookPath
+	})
+
+	osUserHomeDir = func() (string, error) { return home, nil }
+	backup.UserHomeDirFn = func() (string, error) { return home, nil }
+	runCommand = func(string, ...string) error { return nil }
+	cmdLookPath = func(name string) (string, error) { return "/usr/local/bin/" + name, nil }
+
+	if err := state.Write(home, state.InstallState{
+		InstalledAgents:     []string{"opencode"},
+		SelectionConfigured: true,
+		Components:          []model.ComponentID{model.ComponentEngram},
+		SDDMode:             model.SDDModeSingle,
+	}); err != nil {
+		t.Fatalf("state.Write: %v", err)
+	}
+
+	result, err := RunSync([]string{"--agents", "opencode"})
+	if err != nil {
+		t.Fatalf("RunSync() error = %v", err)
+	}
+
+	if result.Selection.HasComponent(model.ComponentSDD) {
+		t.Fatalf("Selection.Components = %v, want ComponentSDD absent — a plain sync with no explicit profile/model-assignment request must honour the persisted component list", result.Selection.Components)
+	}
+}
+
 // ─── Persist model assignments across sync runs ─────────────────────────────
 
 // TestRunSyncLoadsPersistedModelAssignments verifies that when state.json

--- a/internal/model/selection.go
+++ b/internal/model/selection.go
@@ -53,6 +53,35 @@ func (s Selection) HasComponent(component ComponentID) bool {
 	return false
 }
 
+// EnsureComponent appends component to s.Components when it is not already
+// present. Used to re-enable a component that a persisted selection would
+// otherwise drop, once the caller has explicitly requested work that only
+// that component's sync stage can perform.
+func (s *Selection) EnsureComponent(component ComponentID) {
+	if s.HasComponent(component) {
+		return
+	}
+	s.Components = append(s.Components, component)
+}
+
+// CarriesSDDWork reports whether the caller explicitly asked for OpenCode SDD
+// profile or per-agent model assignment work: named profiles to write, or a
+// model assignment override (including a non-nil empty map, which means
+// "reset to defaults" and still requires a write).
+//
+// This is the shared rule used by both the CLI (RestorePersistedSelection)
+// and the TUI (applyOverrides) sync entry points: a persisted component
+// selection that omits "sdd" must not silently swallow that explicit
+// request. See https://github.com/Gentleman-Programming/gentle-ai/issues/3430 —
+// both entry points restore Components from state.json, dropping ComponentSDD
+// whenever the persisted selection predates that component being chosen; the
+// componentSyncStep that writes profiles/model assignments into
+// ~/.config/opencode/opencode.json then never runs, yet the sync still
+// reports success.
+func CarriesSDDWork(profiles []Profile, modelAssignments map[string]ModelAssignment) bool {
+	return len(profiles) > 0 || modelAssignments != nil
+}
+
 // SyncOverrides holds optional overrides applied to the sync selection.
 // Used when the TUI "Configure Models" flow needs to persist model assignments
 // without re-running the full install pipeline.

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -721,6 +721,22 @@ type Model struct {
 	ProfileNameCollision bool            // true when name collides with existing profile (awaiting second enter to overwrite)
 	ProfileDeleteErr     error           // error from the last RemoveProfileAgents call, displayed on ScreenProfiles
 
+	// DefaultModelAssignmentsStash holds a copy of the default (non-profile)
+	// Selection.ModelAssignments captured on entering the profile flow
+	// (ScreenProfiles/ScreenProfileCreate) from any other screen, and restored
+	// when the flow returns to a non-profile, non-picker screen. See setScreen.
+	DefaultModelAssignmentsStash map[string]model.ModelAssignment
+
+	// ProfileFlowActive is true from the moment a profile edit is entered
+	// (ScreenProfiles/ScreenProfileCreate reached from outside the flow) until
+	// it returns to a screen that is neither a profile screen nor the shared
+	// model picker. It defines the profile flow by origin rather than by a
+	// fixed screen set, so a mid-edit detour into ScreenModelPicker (or any
+	// other screen a profile edit may open to display/edit its assignments)
+	// keeps carrying the profile's live assignments instead of having them
+	// silently swapped for the stashed default. See setScreen.
+	ProfileFlowActive bool
+
 	// UninstallMode holds the selected uninstall mode (partial, full, full-remove).
 	UninstallMode model.UninstallMode
 
@@ -3960,7 +3976,61 @@ func (m Model) goBack(cmd *tea.Cmd) Model {
 	return m
 }
 
+// copyModelAssignments returns a shallow copy of a model assignment map so
+// stashing/restoring it (see setScreen) can never alias the caller's live
+// map — a nil source returns nil, preserving the "no assignments yet"
+// nil-guard semantics used by ScreenModelConfig's pre-population check.
+func copyModelAssignments(src map[string]model.ModelAssignment) map[string]model.ModelAssignment {
+	if src == nil {
+		return nil
+	}
+	dst := make(map[string]model.ModelAssignment, len(src))
+	for k, v := range src {
+		dst[k] = v
+	}
+	return dst
+}
+
+// profileFlowScreen reports whether screen is one of the two dedicated
+// profile screens (the list, and create/edit).
+func profileFlowScreen(screen Screen) bool {
+	return screen == ScreenProfiles || screen == ScreenProfileCreate
+}
+
 func (m *Model) setScreen(next Screen) {
+	// Isolate the default OpenCode model config from custom SDD profile model
+	// assignments (issue #950). Editing a profile loads its own phase
+	// assignments (plus its orchestrator model) into m.Selection.ModelAssignments
+	// so the shared model picker can display and edit them — keyed by the same
+	// "gentle-orchestrator" constant the default config screen uses for its own
+	// base row.
+	//
+	// The profile flow is defined by origin (ProfileFlowActive), not by a fixed
+	// screen set: entering ScreenProfiles/ScreenProfileCreate from outside the
+	// flow stashes a copy of the caller's current (default) assignments and
+	// marks the flow active. While active, a detour into ScreenModelPicker (or
+	// any other screen a profile edit may open to display/edit its own
+	// assignments) keeps carrying the profile's live data — it does NOT get
+	// swapped for the stash, because ScreenModelPicker while ProfileFlowActive
+	// is still "inside" the flow. Only when the flow returns to a screen that
+	// is neither a profile screen nor the picker does it end: the stash (a
+	// copy, never the profile's data) is restored and the flag clears.
+	//
+	// Outside the profile flow (ProfileFlowActive false and next isn't a
+	// profile screen), ScreenModelPicker is reached and left exactly like any
+	// other screen — the default config's own edits are never touched here.
+	enteringProfileFlow := !m.ProfileFlowActive && profileFlowScreen(next)
+	stillInProfileFlow := m.ProfileFlowActive && (profileFlowScreen(next) || next == ScreenModelPicker)
+	leavingProfileFlow := m.ProfileFlowActive && !stillInProfileFlow
+
+	if enteringProfileFlow {
+		m.DefaultModelAssignmentsStash = copyModelAssignments(m.Selection.ModelAssignments)
+		m.ProfileFlowActive = true
+	} else if leavingProfileFlow {
+		m.Selection.ModelAssignments = copyModelAssignments(m.DefaultModelAssignmentsStash)
+		m.DefaultModelAssignmentsStash = nil
+		m.ProfileFlowActive = false
+	}
 	m.PreviousScreen = m.Screen
 	m.Screen = next
 	m.Cursor = 0

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -4937,6 +4937,224 @@ func TestModelConfigOpenCodeNoPrePopulationWhenFileEmpty(t *testing.T) {
 	}
 }
 
+// ─── Issue #950: isolate default OpenCode model config from custom SDD
+// profiles ───────────────────────────────────────────────────────────────
+
+// TestModelAssignmentsIsolatedBetweenProfilesAndDefaultConfig is a table test
+// for issue #950. A custom SDD profile edit loads its own OrchestratorModel
+// and PhaseAssignments into m.Selection.ModelAssignments — keyed by the same
+// "gentle-orchestrator" constant the default OpenCode model config screen
+// uses for its own base row — because both screens share one ModelPicker.
+// Without resetting that map on entry/exit of the profile flow:
+//   - a profile's assignments bleed into the default gentle-orchestrator
+//     config (a custom profile overwrites the default), and
+//   - the default config's nil guard (`if ModelAssignments == nil`) never
+//     fires, so opening it after visiting a profile shows/persists stale
+//     profile-specific phase keys (e.g. "sdd-apply") instead of just the
+//     real default.
+//
+// Each case drives the model through a sequence of screens and asserts the
+// final m.Selection.ModelAssignments contents.
+func TestModelAssignmentsIsolatedBetweenProfilesAndDefaultConfig(t *testing.T) {
+	defaultAssignment := model.ModelAssignment{ProviderID: "anthropic", ModelID: "claude-sonnet-4-20250514"}
+	profileOrchestrator := model.ModelAssignment{ProviderID: "openai", ModelID: "o3"}
+	profilePhase := model.ModelAssignment{ProviderID: "openai", ModelID: "gpt-4o"}
+
+	profile := model.Profile{
+		Name:              "high-performance",
+		OrchestratorModel: profileOrchestrator,
+		PhaseAssignments:  map[string]model.ModelAssignment{"sdd-apply": profilePhase},
+	}
+
+	origAssignments := readCurrentAssignmentsFn
+	readCurrentAssignmentsFn = func(_ string) (map[string]model.ModelAssignment, error) {
+		return map[string]model.ModelAssignment{"gentle-orchestrator": defaultAssignment}, nil
+	}
+	t.Cleanup(func() { readCurrentAssignmentsFn = origAssignments })
+
+	origProfiles := readProfilesFn
+	readProfilesFn = func(_ string) ([]model.Profile, error) {
+		return []model.Profile{profile}, nil
+	}
+	t.Cleanup(func() { readProfilesFn = origProfiles })
+
+	openDefaultModelConfig := func(m *Model) {
+		m.setScreen(ScreenModelConfig)
+		m.Cursor = 1 // "Configure OpenCode models"
+		updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+		*m = updated.(Model)
+		if m.Screen != ScreenModelPicker {
+			t.Fatalf("expected ScreenModelPicker, got %v", m.Screen)
+		}
+	}
+
+	editProfile := func(m *Model) {
+		m.setScreen(ScreenProfiles)
+		m.Cursor = 0 // the only entry: "high-performance"
+		updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+		*m = updated.(Model)
+		if m.Screen != ScreenProfileCreate {
+			t.Fatalf("expected ScreenProfileCreate, got %v", m.Screen)
+		}
+	}
+
+	tests := []struct {
+		name        string
+		drive       func(m *Model)
+		wantAssign  map[string]model.ModelAssignment
+		wantMissing []string // keys that must be absent from the final map
+
+		// checkStash, when true, additionally asserts m.DefaultModelAssignmentsStash
+		// equals wantStash exactly (nil-safe via reflect.DeepEqual semantics).
+		checkStash bool
+		wantStash  map[string]model.ModelAssignment
+	}{
+		{
+			name: "fresh default OpenCode model config loads only the real default",
+			drive: func(m *Model) {
+				openDefaultModelConfig(m)
+			},
+			wantAssign:  map[string]model.ModelAssignment{"gentle-orchestrator": defaultAssignment},
+			wantMissing: []string{"sdd-apply"},
+		},
+		{
+			name: "editing a profile loads only that profile's own assignments",
+			drive: func(m *Model) {
+				editProfile(m)
+			},
+			wantAssign: map[string]model.ModelAssignment{
+				"gentle-orchestrator": profileOrchestrator,
+				"sdd-apply":           profilePhase,
+			},
+		},
+		{
+			name: "leaving a profile edit then opening default config loads real defaults, not the profile's",
+			drive: func(m *Model) {
+				editProfile(m)
+				m.setScreen(ScreenWelcome) // abandon the profile edit
+				openDefaultModelConfig(m)
+			},
+			wantAssign:  map[string]model.ModelAssignment{"gentle-orchestrator": defaultAssignment},
+			wantMissing: []string{"sdd-apply"},
+		},
+		{
+			name: "opening default config then editing a profile does not carry default fields into the profile",
+			drive: func(m *Model) {
+				openDefaultModelConfig(m)
+				editProfile(m)
+			},
+			wantAssign: map[string]model.ModelAssignment{
+				"gentle-orchestrator": profileOrchestrator,
+				"sdd-apply":           profilePhase,
+			},
+		},
+		{
+			// Regression for a review finding: an earlier version of this fix
+			// nil'd m.Selection.ModelAssignments unconditionally on entering
+			// ScreenProfiles, which wiped in-session default edits the user had
+			// not synced yet just by visiting the Profiles screen. The default
+			// must be stashed and restored intact instead of discarded.
+			name: "configuring defaults then visiting Profiles and leaving without editing leaves defaults intact",
+			drive: func(m *Model) {
+				openDefaultModelConfig(m)
+				m.setScreen(ScreenProfiles)
+				m.setScreen(ScreenWelcome)
+			},
+			wantAssign:  map[string]model.ModelAssignment{"gentle-orchestrator": defaultAssignment},
+			wantMissing: []string{"sdd-apply"},
+		},
+		{
+			// Regression for the same finding: editing a profile and leaving
+			// must restore the stashed default, not the profile's edited data
+			// nor an empty map.
+			name: "configuring defaults then editing a profile and leaving restores the defaults, not the profile edit",
+			drive: func(m *Model) {
+				openDefaultModelConfig(m)
+				editProfile(m)
+				m.setScreen(ScreenWelcome)
+			},
+			wantAssign:  map[string]model.ModelAssignment{"gentle-orchestrator": defaultAssignment},
+			wantMissing: []string{"sdd-apply"},
+		},
+		{
+			// Regression for a second review finding (R4-profile-picker-wipe):
+			// the exit-side restore fired on every transition out of
+			// {ScreenProfiles, ScreenProfileCreate}, including a detour into the
+			// shared ScreenModelPicker that a profile edit may open to display/
+			// edit its own assignments — swapping the profile's live data for
+			// the stashed default mid-edit and clearing the stash early. The
+			// profile flow must be tracked by origin (ProfileFlowActive) so a
+			// picker detour stays "inside" the flow: the profile's assignments
+			// must survive the round trip, and the stash must be untouched.
+			name: "detouring through the model picker mid-profile-edit keeps the profile's own assignments and leaves the stash untouched",
+			drive: func(m *Model) {
+				openDefaultModelConfig(m)      // configure a real default first
+				editProfile(m)                 // stash := copy(default); ModelAssignments := profile's own data
+				m.setScreen(ScreenModelPicker) // detour reachable from a profile edit — must NOT restore/clear
+				m.setScreen(ScreenProfileCreate)
+			},
+			wantAssign: map[string]model.ModelAssignment{
+				"gentle-orchestrator": profileOrchestrator,
+				"sdd-apply":           profilePhase,
+			},
+			checkStash: true,
+			wantStash:  map[string]model.ModelAssignment{"gentle-orchestrator": defaultAssignment},
+		},
+		{
+			// Companion case for the same finding: ordinary navigation within
+			// the default config flow (never having entered the profile flow)
+			// must never touch the stash at all.
+			name: "opening the default config, editing it, then bouncing through the picker leaves defaults intact with no stash involvement",
+			drive: func(m *Model) {
+				openDefaultModelConfig(m) // ProfileFlowActive stays false throughout
+				m.Selection.ModelAssignments["sdd-onboard"] = model.ModelAssignment{ProviderID: "anthropic", ModelID: "claude-haiku-4-5"}
+				m.setScreen(ScreenModelConfig) // back out of the picker
+				m.setScreen(ScreenModelPicker) // and back in
+			},
+			wantAssign: map[string]model.ModelAssignment{
+				"gentle-orchestrator": defaultAssignment,
+				"sdd-onboard":         {ProviderID: "anthropic", ModelID: "claude-haiku-4-5"},
+			},
+			wantMissing: []string{"sdd-apply"},
+			checkStash:  true,
+			wantStash:   nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := NewModel(system.DetectionResult{}, "dev")
+			tt.drive(&m)
+
+			for key, want := range tt.wantAssign {
+				got, ok := m.Selection.ModelAssignments[key]
+				if !ok {
+					t.Errorf("ModelAssignments[%q] missing, want %+v", key, want)
+					continue
+				}
+				if got != want {
+					t.Errorf("ModelAssignments[%q] = %+v, want %+v", key, got, want)
+				}
+			}
+			for _, key := range tt.wantMissing {
+				if got, ok := m.Selection.ModelAssignments[key]; ok {
+					t.Errorf("ModelAssignments[%q] = %+v, want absent (isolation leak)", key, got)
+				}
+			}
+			// Exact-size check: catches a stray extra key (from either side)
+			// that the per-key checks above would otherwise miss — important
+			// for the "defaults are intact and unchanged" regression cases.
+			if tt.wantAssign != nil && len(m.Selection.ModelAssignments) != len(tt.wantAssign) {
+				t.Errorf("ModelAssignments = %+v (%d entries), want exactly %+v (%d entries)",
+					m.Selection.ModelAssignments, len(m.Selection.ModelAssignments), tt.wantAssign, len(tt.wantAssign))
+			}
+			if tt.checkStash && !reflect.DeepEqual(m.DefaultModelAssignmentsStash, tt.wantStash) {
+				t.Errorf("DefaultModelAssignmentsStash = %+v, want %+v", m.DefaultModelAssignmentsStash, tt.wantStash)
+			}
+		})
+	}
+}
+
 // TestCustomSkillPickerBackGoesToStrictTDD verifies that in the custom preset,
 // with OpenCode + SDD + Skills, pressing Back on ScreenSkillPicker goes to ScreenStrictTDD
 // and NOT directly to ScreenSDDMode. StrictTDD must come before SDDMode in the back chain.


### PR DESCRIPTION
Closes #3430
Closes #950

## Summary
- SDD profile and model-assignment edits made in the TUI are persisted again: restoring the persisted selection no longer drops the SDD component for installs that predate it, so the sync step that writes `opencode.json` runs. The "config directory disappears" claim in #3430 is not reproducible; no code path removes it.
- Default OpenCode model assignments and custom SDD profile assignments are isolated: the default map is stashed when the profile flow begins (tracked by origin, so a detour through the shared model picker stays inside the flow) and restored when the flow ends. Unsaved default edits survive a visit to Profiles; profile edits never reach the default map.

## Changes
| File | Change |
|------|--------|
| `internal/model/selection.go` | `EnsureComponent`, `CarriesSDDWork` |
| `internal/cli/sync.go`, `internal/app/app.go` | Re-add the SDD component when the selection carries SDD work |
| `internal/tui/model.go` | `ProfileFlowActive`, `DefaultModelAssignmentsStash`, stash/restore in `setScreen` |
| tests | CLI and TUI persistence reproductions; eight-case isolation table |

## Size exception
514 lines, most of them reproduction tests for both entry points and the isolation table; the two fixes share the selection model.

## Test plan
- [x] `go test ./internal/tui/ ./internal/model/ ./internal/app/ -count=1`
- [x] `go test ./internal/cli/ -run 'TestRunSync|Profile|Selection' -count=1`
- [x] Refusal and deadcode ratchets pass
- [x] Native review: correction (104/200 lines) validated and approved (lineage review-14b4a9e3875aafef), acknowledged

https://claude.ai/code/session_01SYqbaaqyJcAv1FYtSJXx6M

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Explicit profile and model-assignment requests now persist correctly during sync, even when older saved settings do not include the SDD component.
  - Regular syncs continue to respect saved component selections when no profile or model-assignment options are provided.
  - Improved TUI behavior keeps default model settings separate from custom profile edits, preventing unintended changes when switching between configuration screens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->