### PR TITLE
fix(review): retry transient Darwin lock creation

### DIFF
--- a/internal/reviewtransaction/secure_open_leaf_darwin.go
+++ b/internal/reviewtransaction/secure_open_leaf_darwin.go
@@ -1,0 +1,27 @@
+//go:build darwin
+
+package reviewtransaction
+
+import (
+	"errors"
+
+	"golang.org/x/sys/unix"
+)
+
+type secureOpenLeafOperation func(parentFD int, name string, flags int, mode uint32) (int, error)
+
+func secureOpenLocalStoreLockLeaf(parentFD int, name string, flags int, mode uint32) (int, error) {
+	return secureOpenLocalStoreLockLeafWith(parentFD, name, flags, mode, unix.Openat)
+}
+
+func secureOpenLocalStoreLockLeafWith(parentFD int, name string, flags int, mode uint32, openat secureOpenLeafOperation) (int, error) {
+	var fd int
+	var err error
+	for attempt := 0; attempt < 3; attempt++ {
+		fd, err = openat(parentFD, name, flags, mode)
+		if err == nil || !errors.Is(err, unix.ENOENT) || attempt == 2 {
+			return fd, err
+		}
+	}
+	return fd, err
+}

--- a/internal/reviewtransaction/secure_open_leaf_darwin_test.go
+++ b/internal/reviewtransaction/secure_open_leaf_darwin_test.go
@@ -1,0 +1,330 @@
+//go:build darwin
+
+package reviewtransaction
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"golang.org/x/sys/unix"
+)
+
+func TestSecureOpenLocalStoreLockLeafRetriesENOENT(t *testing.T) {
+	const (
+		parentFD = 17
+		name     = "LOCK"
+		flags    = unix.O_RDWR | unix.O_CREAT | unix.O_CLOEXEC | unix.O_NOFOLLOW | unix.O_NONBLOCK
+		mode     = 0o600
+	)
+
+	tests := []struct {
+		name      string
+		results   []secureOpenLeafResult
+		wantFD    int
+		wantErr   error
+		wantCalls int
+	}{
+		{
+			name:    "transient ENOENT succeeds on retry",
+			results: []secureOpenLeafResult{{fd: -1, err: unix.ENOENT}, {fd: 41}},
+			wantFD:  41, wantCalls: 2,
+		},
+		{
+			name:    "persistent ENOENT stops after three attempts",
+			results: []secureOpenLeafResult{{fd: -1, err: unix.ENOENT}, {fd: -1, err: unix.ENOENT}, {fd: -1, err: unix.ENOENT}, {fd: 41}},
+			wantFD:  -1, wantErr: unix.ENOENT, wantCalls: 3,
+		},
+		{
+			name:    "wrapped ENOENT retries",
+			results: []secureOpenLeafResult{{fd: -1, err: fmt.Errorf("open lock: %w", unix.ENOENT)}, {fd: 41}},
+			wantFD:  41, wantCalls: 2,
+		},
+		{
+			name:    "non ENOENT is returned immediately",
+			results: []secureOpenLeafResult{{fd: -1, err: unix.EACCES}, {fd: 41}},
+			wantFD:  -1, wantErr: unix.EACCES, wantCalls: 1,
+		},
+		{
+			name:    "immediate success opens once",
+			results: []secureOpenLeafResult{{fd: 41}},
+			wantFD:  41, wantCalls: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var calls []secureOpenLeafCall
+			fd, err := secureOpenLocalStoreLockLeafWith(parentFD, name, flags, mode, func(gotParentFD int, gotName string, gotFlags int, gotMode uint32) (int, error) {
+				calls = append(calls, secureOpenLeafCall{gotParentFD, gotName, gotFlags, gotMode})
+				result := tt.results[len(calls)-1]
+				return result.fd, result.err
+			})
+			if fd != tt.wantFD || !errors.Is(err, tt.wantErr) {
+				t.Fatalf("secure open leaf = (%d, %v), want (%d, %v)", fd, err, tt.wantFD, tt.wantErr)
+			}
+			if len(calls) != tt.wantCalls {
+				t.Fatalf("open calls = %d, want %d", len(calls), tt.wantCalls)
+			}
+			for _, call := range calls {
+				if call != (secureOpenLeafCall{parentFD, name, flags, mode}) {
+					t.Fatalf("open arguments = %#v, want parent=%d name=%q flags=%#x mode=%#o", call, parentFD, name, flags, mode)
+				}
+			}
+		})
+	}
+}
+
+type secureOpenLeafResult struct {
+	fd  int
+	err error
+}
+
+type secureOpenLeafCall struct {
+	parentFD int
+	name     string
+	flags    int
+	mode     uint32
+}
+
+const (
+	secureOpenLeafStuckBeforeEntryEnv  = "GENTLE_AI_SECURE_OPEN_LEAF_STUCK_BEFORE_ENTRY"
+	secureOpenLeafConcurrentLifeline   = 5 * time.Second
+	secureOpenLeafInjectedFailureBound = 100 * time.Millisecond
+)
+
+func TestSecureOpenLocalStoreLockLeafConcurrentPersistentENOENTStuckWorkerFailsPromptly(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	command := exec.CommandContext(ctx, os.Args[0], "-test.run=^TestSecureOpenLocalStoreLockLeafConcurrentPersistentENOENT$", "-test.timeout=1s")
+	command.Env = append(os.Environ(), secureOpenLeafStuckBeforeEntryEnv+"=1")
+	output, err := command.CombinedOutput()
+	if ctx.Err() != nil {
+		t.Fatalf("stuck worker child test exceeded its outer bound: %v\n%s", ctx.Err(), output)
+	}
+	if err == nil {
+		t.Fatalf("stuck worker child test passed, want bounded entry failure\n%s", output)
+	}
+	if strings.Contains(string(output), "test timed out") {
+		t.Fatalf("stuck worker child test timed out instead of reporting bounded entry failure\n%s", output)
+	}
+	if !strings.Contains(string(output), "second worker did not enter the first open attempt") {
+		t.Fatalf("stuck worker child test output missing bounded entry failure\n%s", output)
+	}
+}
+
+func TestSecureOpenLocalStoreLockLeafConcurrentPersistentENOENT(t *testing.T) {
+	entered := make(chan struct{}, 2)
+	release := make(chan struct{})
+	results := make(chan secureOpenLeafResult, 2)
+	var releaseOnce sync.Once
+	releaseWorkers := func() { releaseOnce.Do(func() { close(release) }) }
+	var calls struct {
+		sync.Mutex
+		byParent map[int]int
+	}
+	calls.byParent = make(map[int]int)
+	var workers sync.WaitGroup
+	for _, parentFD := range []int{17, 18} {
+		workers.Add(1)
+		go func(parentFD int) {
+			defer workers.Done()
+			fd, err := secureOpenLocalStoreLockLeafWith(parentFD, "LOCK", unix.O_RDWR|unix.O_CREAT|unix.O_CLOEXEC|unix.O_NOFOLLOW|unix.O_NONBLOCK, 0o600, func(parentFD int, name string, flags int, mode uint32) (int, error) {
+				calls.Lock()
+				calls.byParent[parentFD]++
+				attempt := calls.byParent[parentFD]
+				calls.Unlock()
+				if attempt == 1 {
+					if os.Getenv(secureOpenLeafStuckBeforeEntryEnv) == "1" && parentFD == 18 {
+						return -1, unix.ENOENT
+					}
+					entered <- struct{}{}
+					<-release
+				}
+				return -1, unix.ENOENT
+			})
+			results <- secureOpenLeafResult{fd: fd, err: err}
+		}(parentFD)
+	}
+	finished := make(chan struct{})
+	go func() {
+		workers.Wait()
+		close(finished)
+	}()
+	workersFinished := false
+	t.Cleanup(func() {
+		releaseWorkers()
+		if !workersFinished && !waitForSecureOpenLeafCompletion(finished, secureOpenLeafConcurrentLifeline) {
+			t.Errorf("persistent ENOENT workers did not finish during cleanup within %s", secureOpenLeafConcurrentLifeline)
+		}
+	})
+
+	entryBound := secureOpenLeafConcurrentLifeline
+	if os.Getenv(secureOpenLeafStuckBeforeEntryEnv) == "1" {
+		entryBound = secureOpenLeafInjectedFailureBound
+	}
+	if !waitForSecureOpenLeafEntries(entered, 2, entryBound) {
+		releaseWorkers()
+		if !waitForSecureOpenLeafCompletion(finished, secureOpenLeafConcurrentLifeline) {
+			t.Errorf("persistent ENOENT workers did not finish after entry failure within %s", secureOpenLeafConcurrentLifeline)
+		}
+		t.Errorf("second worker did not enter the first open attempt within %s", entryBound)
+		return
+	}
+	releaseWorkers()
+	if !waitForSecureOpenLeafCompletion(finished, secureOpenLeafConcurrentLifeline) {
+		t.Errorf("persistent ENOENT retries did not complete within %s after releasing first attempts", secureOpenLeafConcurrentLifeline)
+		return
+	}
+	workersFinished = true
+	close(results)
+	for result := range results {
+		if result.fd != -1 || !errors.Is(result.err, unix.ENOENT) {
+			t.Fatalf("persistent ENOENT result = (%d, %v), want (-1, ENOENT)", result.fd, result.err)
+		}
+	}
+	calls.Lock()
+	defer calls.Unlock()
+	for _, parentFD := range []int{17, 18} {
+		if calls.byParent[parentFD] != 3 {
+			t.Fatalf("parent fd %d calls = %d, want 3", parentFD, calls.byParent[parentFD])
+		}
+	}
+}
+
+func TestSecureOpenLocalStoreLockLeafConcurrentFirstCreate(t *testing.T) {
+	parent := canonicalTempDir(t)
+	parentFDs := make([]int, 2)
+	parentStats := make([]unix.Stat_t, 2)
+	for i := range parentFDs {
+		fd, err := unix.Open(parent, secureDirectoryOpenFlags(), 0)
+		if err != nil {
+			t.Fatal(err)
+		}
+		parentFDs[i] = fd
+		t.Cleanup(func() { _ = unix.Close(fd) })
+		if err := unix.Fstat(fd, &parentStats[i]); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if parentStats[0].Dev != parentStats[1].Dev || parentStats[0].Ino != parentStats[1].Ino {
+		t.Fatalf("independent parent descriptors opened different inodes: %#v", parentStats)
+	}
+
+	entered := make(chan struct{}, 2)
+	release := make(chan struct{})
+	results := make(chan secureOpenLeafResult, 2)
+	var releaseOnce sync.Once
+	releaseWorkers := func() { releaseOnce.Do(func() { close(release) }) }
+	var workers sync.WaitGroup
+	for _, parentFD := range parentFDs {
+		workers.Add(1)
+		go func(parentFD int) {
+			defer workers.Done()
+			var firstAttempt sync.Once
+			fd, err := secureOpenLocalStoreLockLeafWith(parentFD, "LOCK", unix.O_RDWR|unix.O_CREAT|unix.O_CLOEXEC|unix.O_NOFOLLOW|unix.O_NONBLOCK, 0o600, func(parentFD int, name string, flags int, mode uint32) (int, error) {
+				firstAttempt.Do(func() {
+					entered <- struct{}{}
+					<-release
+				})
+				return unix.Openat(parentFD, name, flags, mode)
+			})
+			results <- secureOpenLeafResult{fd: fd, err: err}
+		}(parentFD)
+	}
+	finished := make(chan struct{})
+	go func() {
+		workers.Wait()
+		close(finished)
+	}()
+	workersFinished := false
+	t.Cleanup(func() {
+		releaseWorkers()
+		if !workersFinished && !waitForSecureOpenLeafCompletion(finished, secureOpenLeafConcurrentLifeline) {
+			t.Errorf("first create workers did not finish during cleanup within %s", secureOpenLeafConcurrentLifeline)
+		}
+		for {
+			select {
+			case result, ok := <-results:
+				if !ok {
+					return
+				}
+				if result.fd >= 0 {
+					_ = unix.Close(result.fd)
+				}
+			default:
+				return
+			}
+		}
+	})
+
+	if !waitForSecureOpenLeafEntries(entered, len(parentFDs), secureOpenLeafConcurrentLifeline) {
+		releaseWorkers()
+		if !waitForSecureOpenLeafCompletion(finished, secureOpenLeafConcurrentLifeline) {
+			t.Errorf("first create workers did not finish after entry failure within %s", secureOpenLeafConcurrentLifeline)
+		}
+		t.Errorf("concurrent first create workers did not enter the first open attempt within %s", secureOpenLeafConcurrentLifeline)
+		return
+	}
+	releaseWorkers()
+	if !waitForSecureOpenLeafCompletion(finished, secureOpenLeafConcurrentLifeline) {
+		t.Errorf("concurrent first create workers did not complete within %s after releasing first attempts", secureOpenLeafConcurrentLifeline)
+		return
+	}
+	workersFinished = true
+	close(results)
+
+	var stats []unix.Stat_t
+	for result := range results {
+		if result.err != nil {
+			t.Fatalf("concurrent first create: %v", result.err)
+		}
+		var stat unix.Stat_t
+		if err := unix.Fstat(result.fd, &stat); err != nil {
+			_ = unix.Close(result.fd)
+			t.Fatal(err)
+		}
+		if stat.Mode&unix.S_IFMT != unix.S_IFREG {
+			_ = unix.Close(result.fd)
+			t.Fatalf("concurrent first create mode = %#o, want regular file", stat.Mode)
+		}
+		if err := unix.Close(result.fd); err != nil {
+			t.Fatal(err)
+		}
+		stats = append(stats, stat)
+	}
+	if len(stats) != 2 || stats[0].Dev != stats[1].Dev || stats[0].Ino != stats[1].Ino {
+		t.Fatalf("concurrent first create opened different inodes: %#v", stats)
+	}
+}
+
+func waitForSecureOpenLeafEntries(entered <-chan struct{}, count int, timeout time.Duration) bool {
+	timer := time.NewTimer(timeout)
+	defer timer.Stop()
+	for range count {
+		select {
+		case <-entered:
+		case <-timer.C:
+			return false
+		}
+	}
+	return true
+}
+
+func waitForSecureOpenLeafCompletion(finished <-chan struct{}, timeout time.Duration) bool {
+	timer := time.NewTimer(timeout)
+	defer timer.Stop()
+	select {
+	case <-finished:
+		return true
+	case <-timer.C:
+		return false
+	}
+}

--- a/internal/reviewtransaction/secure_open_leaf_other_unix.go
+++ b/internal/reviewtransaction/secure_open_leaf_other_unix.go
@@ -1,0 +1,9 @@
+//go:build unix && !darwin
+
+package reviewtransaction
+
+import "golang.org/x/sys/unix"
+
+func secureOpenLocalStoreLockLeaf(parentFD int, name string, flags int, mode uint32) (int, error) {
+	return unix.Openat(parentFD, name, flags, mode)
+}

--- a/internal/reviewtransaction/secure_open_unix.go
+++ b/internal/reviewtransaction/secure_open_unix.go
@@ -28,7 +28,7 @@ func secureOpenLocalStoreLock(path string) (*os.File, error) {
 	}
 	defer unix.Close(parentFD)
 
-	fd, err := unix.Openat(parentFD, filepath.Base(absPath), unix.O_RDWR|unix.O_CREAT|unix.O_CLOEXEC|unix.O_NOFOLLOW|unix.O_NONBLOCK, 0o600)
+	fd, err := secureOpenLocalStoreLockLeaf(parentFD, filepath.Base(absPath), unix.O_RDWR|unix.O_CREAT|unix.O_CLOEXEC|unix.O_NOFOLLOW|unix.O_NONBLOCK, 0o600)
 	if err != nil {
 		return nil, err
 	}

--- a/scripts/darwin-release-blockers.manifest
+++ b/scripts/darwin-release-blockers.manifest
@@ -56,6 +56,11 @@
 ./internal/reviewtransaction TestAcquireLocalStoreLockRejectsNonRegularUnixObject              # non-regular-object errnos differ on Darwin
 ./internal/reviewtransaction TestBusyStoreLockProbePreservesExistingUnixInodeAndMetadata       # inode identity of a live lock under Darwin stat semantics
 
+# --- #4276: local store lock leaf first-create ENOENT -------------------------
+./internal/reviewtransaction TestSecureOpenLocalStoreLockLeafRetriesENOENT
+./internal/reviewtransaction TestSecureOpenLocalStoreLockLeafConcurrentFirstCreate
+./internal/reviewtransaction TestSecureOpenLocalStoreLockLeafConcurrentPersistentENOENT
+
 # --- #1804: reviewer-result publication on macOS ExFAT ------------------------
 # These are //go:build darwin — no CI lane has EVER executed them. On ExFAT the
 # exclusive-rename primitive is missing (ENOTSUP) and publication falls back to


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #4276

---

## 🏷️ PR Type

- [x] `type:bug` — Bug fix (non-breaking change that fixes an issue)
- [ ] `type:feature` — New feature
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring
- [ ] `type:chore` — Build, CI, or tooling changes
- [ ] `type:breaking-change` — Breaking change

---

## 📝 Summary

- Retry Darwin's transient `openat(O_CREAT)` `ENOENT` at the shared secure lock-leaf boundary.
- Preserve the validated parent descriptor, security flags, persistent errors, and single-call behavior on other Unix systems.
- Add deterministic, concurrency, liveness, wrapped-error, and Darwin release-blocker coverage.

---

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/reviewtransaction/secure_open_unix.go` | Routes the final lock-leaf open through a platform helper. |
| `internal/reviewtransaction/secure_open_leaf_darwin.go` | Retries only `ENOENT`, with three total attempts against the same validated parent FD. |
| `internal/reviewtransaction/secure_open_leaf_other_unix.go` | Preserves one direct `openat` call outside Darwin. |
| `internal/reviewtransaction/secure_open_leaf_darwin_test.go` | Covers retry bounds, preserved arguments, persistent and wrapped errors, concurrent first-create, and bounded worker cleanup. |
| `scripts/darwin-release-blockers.manifest` | Adds the three stable regression selectors to the native Darwin CI lane. |

---

## 🤖 AI Assistance

- [ ] **None** — No material AI assistance was used.
- [x] **Material assistance used** — Complete all applicable declaration fields below.

**Tool/model (if known):** Pi coding-agent harness; OpenAI Codex model.

**Material scope:** Root-cause investigation, implementation, test authoring, verification orchestration, and advisory review.

**Verification performed:** Behavior-first RED/GREEN tests; the original concurrent exact-START regression; deterministic retry, persistent-error, wrapped-error, and liveness tests; focused race run; Darwin release-blocker manifest verification; Windows/amd64 build; Linux/amd64 build with `CGO_ENABLED=0`; default Docker E2E; four-lens native RDD review approved and acknowledged as `review-67948c031ac046f4`.

---

## 🧪 Test Plan

- [x] Focused tests pass under `-race`:
  `go test -race -timeout=90s ./internal/reviewtransaction -run '^(TestSecureOpenLocalStoreLockLeaf.*|TestCompactStoreCreateOrReplayAtomicStartConvergesConcurrentExactRequests)$' -count=1`
- [x] Darwin release-blocker manifest verifies: `./scripts/darwin-release-blockers.sh verify`
- [x] Windows cross-build passes: `GOOS=windows GOARCH=amd64 go build ./internal/reviewtransaction`
- [x] Linux non-CGo cross-build passes: `CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build ./internal/reviewtransaction`
- [x] Default Docker E2E passes: `cd e2e && ./docker-test.sh`
- [ ] Repository-wide unit suite: running separately on the exact prerequisite integration candidate; CI remains authoritative for this PR.
- [x] Benchmark validation: the repository has no driven journey for concurrent Darwin first-create. Native Darwin regression tests and the curated Darwin release-blocker lane exercise the actual platform boundary; the sequential j59 journey is not claimed as proof.

---

## ✅ Contributor Checklist

- [x] PR is linked to issue #4276 with `status:approved`
- [x] PR stays within 400 changed lines (373 total)
- [x] Exactly one PR label, `type:bug`, is requested
- [ ] Full repository unit tests pass
- [x] Go formatting and `git diff --check` pass
- [x] E2E tests pass
- [x] Applicable native Darwin validation is documented above
- [x] Documentation changes are not required for this bounded platform fix
- [x] Commit follows Conventional Commits
- [x] I reviewed and accept responsibility for every change
- [x] Material AI assistance is disclosed
- [x] Commit contains no `Co-Authored-By` trailer

---

## 💬 Notes for Reviewers

The retry is Darwin-only, bounded to three total attempts, and applies only to `ENOENT` from the final leaf `openat`. It reuses the already-validated parent descriptor and leaves persistent missing-path and all non-`ENOENT` failures observable. The existing SDD caller-level retry remains unchanged in this work unit.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when creating local store lock files concurrently on Darwin.
  * Added retry handling for transient file-not-found conditions during lock-file creation.
  * Preserved prompt failure behavior for persistent or unexpected errors.

* **Tests**
  * Added coverage for concurrent creation, retry limits, error handling, and successful lock-file access across supported Unix platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->