### PR TITLE
fix(engram): skip direct Claude MCP when plugin is enabled

### DIFF
--- a/internal/components/engram/healthprobe_test.go
+++ b/internal/components/engram/healthprobe_test.go
@@ -107,7 +107,9 @@ func TestHelperEngramMCPProcess(t *testing.T) {
 			// A single small pipe write makes both frames available before the
 			// parent can terminate this helper.
 			_, _ = os.Stdout.WriteString(healthyResponse + "\nengram mcp stopped\n")
-			return
+			// Remain alive so the parent, rather than a natural helper exit,
+			// terminates the process before it drains buffered stdout.
+			select {}
 		case "descendant-holds-stdout", "descendant-holds-stdout-before-response":
 			// -test.timeout: same pending-timer lifeline as setStdioHelperProcess.
 			descendant := exec.Command(os.Args[0], "-test.run=TestHelperEngramMCPProcess", "-test.timeout=1m", "--", "descendant")

--- a/internal/components/engram/inject.go
+++ b/internal/components/engram/inject.go
@@ -567,6 +567,13 @@ func injectWithOptions(configHomeDir, promptDir string, adapter agents.Adapter, 
 }
 
 func injectClaudeUserConfig(homeDir string, adapter agents.Adapter) (InjectionResult, error) {
+	// The plugin and direct MCP entry expose the same Engram tools. When the
+	// plugin is enabled, suppress direct registration without deleting any
+	// existing entry: matching config shape is not proof that gentle-ai owns it.
+	if claudeEngramPluginEnabled(homeDir) {
+		return InjectionResult{}, nil
+	}
+
 	legacyPath := adapter.MCPConfigPath(homeDir, "engram")
 	command := stableEngramCommandForMergedConfig(claude.UserConfigPath(homeDir), model.AgentClaudeCode)
 	legacyManaged := false
@@ -597,6 +604,22 @@ func injectClaudeUserConfig(homeDir string, adapter agents.Adapter) (InjectionRe
 	result.Changed = true
 	result.Files = append(result.Files, legacyPath)
 	return result, nil
+}
+
+func claudeEngramPluginEnabled(homeDir string) bool {
+	settingsPath := filepath.Join(homeDir, ".claude", "settings.json")
+	raw, err := os.ReadFile(settingsPath)
+	if err != nil {
+		return false
+	}
+
+	var settings struct {
+		EnabledPlugins map[string]bool `json:"enabledPlugins"`
+	}
+	if err := json.Unmarshal(raw, &settings); err != nil {
+		return false
+	}
+	return settings.EnabledPlugins["engram@engram"]
 }
 
 func validateOpenClawWorkspacePath(workspaceDir string, adapter agents.Adapter) error {

--- a/internal/components/engram/inject_test.go
+++ b/internal/components/engram/inject_test.go
@@ -852,6 +852,158 @@ func TestInjectClaudePreservesAbsoluteCommandFromEngramSetup(t *testing.T) {
 	}
 }
 
+// TestInjectClaudeSkipsMCPServersEngramWhenPluginEnabled reproduces issue
+// #4188: gentle-ai sync must not add mcpServers.engram to ~/.claude.json
+// when the Engram plugin is already enabled via
+// ~/.claude/settings.json's enabledPlugins["engram@engram"], because the
+// plugin already exposes the same 18 tools under a different prefix.
+func TestInjectClaudeSkipsMCPServersEngramWhenPluginEnabled(t *testing.T) {
+	home := t.TempDir()
+	mockEngramLookPath(t, "/opt/homebrew/bin/engram", "")
+	writeClaudeEngramPluginEnabled(t, home)
+
+	registryPath := claude.UserConfigPath(home)
+	registrySeed := []byte(`{"mcpServers":{"context7":{"command":"npx"}}}`)
+	if err := os.WriteFile(registryPath, registrySeed, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Repeated syncs must leave the user registry byte-for-byte unchanged.
+	for run := 1; run <= 2; run++ {
+		if _, err := Inject(home, claudeAdapter()); err != nil {
+			t.Fatalf("Inject() run %d error = %v", run, err)
+		}
+		if got, err := os.ReadFile(registryPath); err != nil || !bytes.Equal(got, registrySeed) {
+			t.Fatalf("Inject() run %d changed registry: got=%q error=%v", run, got, err)
+		}
+	}
+
+	registry := readJSONFile(t, registryPath)
+	mcpServers, _ := registry["mcpServers"].(map[string]any)
+	if _, exists := mcpServers["engram"]; exists {
+		t.Fatalf("mcpServers.engram must not be added when the Engram plugin is enabled; registry = %#v", registry)
+	}
+	assertNestedString(t, registry, "npx", "mcpServers", "context7", "command")
+}
+
+// TestInjectClaudePreservesIdenticalManualRegistrationsWhenPluginEnabled
+// verifies that sync never infers ownership from an Engram registration's
+// shape. A user can author exactly the same registry and legacy entries that
+// gentle-ai would write, so plugin detection must only suppress new writes.
+func TestInjectClaudePreservesIdenticalManualRegistrationsWhenPluginEnabled(t *testing.T) {
+	home := t.TempDir()
+	mockEngramLookPath(t, "/opt/homebrew/bin/engram", "")
+	writeClaudeEngramPluginEnabled(t, home)
+
+	registryPath := claude.UserConfigPath(home)
+	registrySeed := []byte(`{"mcpServers":{"context7":{"command":"npx"},"engram":{"command":"/opt/homebrew/bin/engram","args":["mcp","--tools=agent"]}}}`)
+	if err := os.WriteFile(registryPath, registrySeed, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	legacyPath := filepath.Join(home, ".claude", "mcp", "engram.json")
+	legacySeed := []byte(`{"command":"/opt/homebrew/bin/engram","args":["mcp","--tools=agent"]}`)
+	if err := os.MkdirAll(filepath.Dir(legacyPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(legacyPath, legacySeed, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	for run := 1; run <= 2; run++ {
+		if _, err := Inject(home, claudeAdapter()); err != nil {
+			t.Fatalf("Inject() run %d error = %v", run, err)
+		}
+	}
+	if got, err := os.ReadFile(registryPath); err != nil || !bytes.Equal(got, registrySeed) {
+		t.Fatalf("manual registry changed: got=%q error=%v", got, err)
+	}
+	if got, err := os.ReadFile(legacyPath); err != nil || !bytes.Equal(got, legacySeed) {
+		t.Fatalf("manual legacy config changed: got=%q error=%v", got, err)
+	}
+}
+
+// TestInjectClaudePreservesUserAuthoredMCPServersEngramWhenPluginEnabled
+// verifies that plugin detection only suppresses new direct registration and
+// never alters an existing customized mcpServers.engram entry.
+func TestInjectClaudePreservesUserAuthoredMCPServersEngramWhenPluginEnabled(t *testing.T) {
+	home := t.TempDir()
+	mockEngramLookPath(t, "/opt/homebrew/bin/engram", "")
+	writeClaudeEngramPluginEnabled(t, home)
+
+	registryPath := claude.UserConfigPath(home)
+	seed := `{"mcpServers":{"engram":{"command":"/custom/path/engram","args":["mcp","--tools=agent"],"env":{"FOO":"bar"}}}}`
+	if err := os.WriteFile(registryPath, []byte(seed), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Inject() also bootstraps CLAUDE.md's protocol section on a fresh
+	// tempdir, so overall Changed being true here is expected and not the
+	// behavior under test; only the registry content matters (issue #4188).
+	if _, err := Inject(home, claudeAdapter()); err != nil {
+		t.Fatalf("Inject() error = %v", err)
+	}
+
+	registry := readJSONFile(t, registryPath)
+	assertNestedString(t, registry, "/custom/path/engram", "mcpServers", "engram", "command")
+	assertNestedString(t, registry, "bar", "mcpServers", "engram", "env", "FOO")
+}
+
+func TestInjectClaudeUsesDirectMCPWhenPluginIsNotEnabled(t *testing.T) {
+	for _, tt := range []struct {
+		name     string
+		settings string
+	}{
+		{name: "plugin disabled", settings: `{"enabledPlugins":{"engram@engram":false}}`},
+		{name: "malformed settings", settings: `{not-json`},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			home := t.TempDir()
+			mockEngramLookPath(t, "/opt/homebrew/bin/engram", "")
+			settingsPath := filepath.Join(home, ".claude", "settings.json")
+			if err := os.MkdirAll(filepath.Dir(settingsPath), 0o755); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.WriteFile(settingsPath, []byte(tt.settings), 0o644); err != nil {
+				t.Fatal(err)
+			}
+
+			if _, err := Inject(home, claudeAdapter()); err != nil {
+				t.Fatalf("Inject() error = %v", err)
+			}
+			registry := readJSONFile(t, claude.UserConfigPath(home))
+			assertNestedString(t, registry, "/opt/homebrew/bin/engram", "mcpServers", "engram", "command")
+		})
+	}
+}
+
+func TestInjectClaudePreservesMalformedRegistryWhenPluginEnabled(t *testing.T) {
+	home := t.TempDir()
+	writeClaudeEngramPluginEnabled(t, home)
+	registryPath := claude.UserConfigPath(home)
+	registrySeed := []byte(`{not-json`)
+	if err := os.WriteFile(registryPath, registrySeed, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := Inject(home, claudeAdapter()); err != nil {
+		t.Fatalf("Inject() error = %v", err)
+	}
+	if got, err := os.ReadFile(registryPath); err != nil || !bytes.Equal(got, registrySeed) {
+		t.Fatalf("malformed user registry changed: got=%q error=%v", got, err)
+	}
+}
+
+func writeClaudeEngramPluginEnabled(t *testing.T, home string) {
+	t.Helper()
+	settingsPath := filepath.Join(home, ".claude", "settings.json")
+	if err := os.MkdirAll(filepath.Dir(settingsPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(settingsPath, []byte(`{"enabledPlugins":{"engram@engram":true}}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
 func TestInjectClaudePreservesManagedLegacyParentLayouts(t *testing.T) {
 	for _, symlinkParent := range []bool{true, false} {
 		name := "non-empty real parent"


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #4188

---

## 🏷️ PR Type

- [x] `type:bug` — Bug fix (non-breaking change that fixes an issue)
- [ ] `type:feature` — New feature
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring
- [ ] `type:chore` — Build, CI, or tooling changes
- [ ] `type:breaking-change` — Breaking change

---

## 📝 Summary

- Avoid adding `mcpServers.engram` when Claude's Engram plugin is enabled.
- Preserve existing manual and legacy Engram registrations instead of deleting configuration without ownership proof.
- Stabilize the buffered-stdout health-probe fixture used by the repository-wide suite.

---

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/components/engram/inject.go` | Detects the enabled Claude Engram plugin and suppresses only new direct MCP registration. |
| `internal/components/engram/inject_test.go` | Adds enabled, disabled, malformed, idempotent, and preservation coverage. |
| `internal/components/engram/healthprobe_test.go` | Keeps the helper alive until parent termination so the intended drain sequence is deterministic. |

---

## 🤖 AI Assistance

- [ ] **None** — No material AI assistance was used.
- [x] **Material assistance used**

**Tool/model (if known):** Pi coding-agent harness; OpenAI Codex model.

**Material scope:** Investigation, implementation, test authoring, verification orchestration, and advisory review.

**Verification performed:** Focused fixture RED/GREEN; full Engram package; three isolated-HOME public `sync --agent claude-code` scenarios; exact source-hash comparison; four-lens native RDD review approved and acknowledged as `review-538982a78293f15c`.

---

## 🧪 Test Plan

- [x] Buffered-stdout fixture fails on the baseline and passes with the candidate.
- [x] `go test ./internal/components/engram` passes.
- [x] Public sync behavior passes in three isolated HOME scenarios: enabled plugin suppresses new direct registration; existing registration is preserved; absent plugin creates direct registration.
- [ ] Repository-wide `go test ./...`: running on the exact prerequisite integration candidate; CI remains authoritative for this PR.
- [ ] Default Docker E2E: CI remains authoritative for this PR.
- [x] Benchmark validation: N/A — this is Engram injection behavior, not a benchmark or review-lifecycle surface; public sync scenarios exercise its runtime boundary.

---

## ✅ Contributor Checklist

- [x] PR is linked to issue #4188 with `status:approved`
- [x] PR stays within 400 changed lines (179 total)
- [x] Exactly one PR label, `type:bug`, is requested
- [ ] Full repository unit tests pass
- [x] Go formatting and `git diff --check` pass
- [ ] E2E tests pass
- [x] Applicable runtime verification is documented above
- [x] Documentation changes are not required for this focused behavior fix
- [x] Commit follows Conventional Commits
- [x] I reviewed and accept responsibility for every change
- [x] Material AI assistance is disclosed
- [x] Commit contains no `Co-Authored-By` trailer

---

## 💬 Notes for Reviewers

The plugin and direct MCP entry expose the same Engram tools. The change suppresses only new direct registration when the plugin is enabled. It deliberately preserves existing entries because matching configuration shape does not establish ownership.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented duplicate Engram MCP registration when the Engram Claude plugin is enabled.
  * Preserved existing user-configured Engram registrations and custom MCP settings without modification.
  * Continued direct MCP registration when the plugin is disabled or Claude settings cannot be read or parsed.
  * Improved health-probe handling so processes remain available long enough for probe termination and output draining.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->