### PR TITLE
test(review): stabilize refuter deadline fixture

### DIFF
--- a/internal/cli/review_provider_role_materialize_test.go
+++ b/internal/cli/review_provider_role_materialize_test.go
@@ -2,13 +2,17 @@ package cli
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
+	"fmt"
 	"io"
 	"os"
 	"path/filepath"
 	goruntime "runtime"
 	"slices"
+	"strconv"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -138,6 +142,74 @@ func overrideProviderRoleHostAdapter(t *testing.T, adapter reviewerprovider.Adap
 	reviewProviderRoleHostAdapter = func() reviewerprovider.Adapter { return adapter }
 }
 
+type controlledDeadlineContext struct {
+	context.Context
+	done chan struct{}
+	once sync.Once
+	mu   sync.RWMutex
+	err  error
+}
+
+func (ctx *controlledDeadlineContext) Done() <-chan struct{} { return ctx.done }
+
+func (ctx *controlledDeadlineContext) Err() error {
+	ctx.mu.RLock()
+	defer ctx.mu.RUnlock()
+	return ctx.err
+}
+
+func (ctx *controlledDeadlineContext) expire(err error) {
+	ctx.once.Do(func() {
+		ctx.mu.Lock()
+		ctx.err = err
+		ctx.mu.Unlock()
+		close(ctx.done)
+	})
+}
+
+type deadlineAfterReadyAdapter struct {
+	adapter   reviewerprovider.Adapter
+	readyPath string
+}
+
+type providerReviewResult struct {
+	raw []byte
+	err error
+}
+
+func (adapter deadlineAfterReadyAdapter) Review(ctx context.Context, invocation reviewerprovider.Invocation) ([]byte, error) {
+	controlled := &controlledDeadlineContext{Context: ctx, done: make(chan struct{})}
+	results := make(chan providerReviewResult, 1)
+	go func() {
+		raw, err := adapter.adapter.Review(controlled, invocation)
+		results <- providerReviewResult{raw: raw, err: err}
+	}()
+	ticker := time.NewTicker(time.Millisecond)
+	defer ticker.Stop()
+	lifeline := time.NewTimer(5 * time.Second)
+	defer lifeline.Stop()
+	for {
+		select {
+		case result := <-results:
+			return result.raw, result.err
+		case <-ticker.C:
+			if _, err := os.Stat(adapter.readyPath); err == nil {
+				controlled.expire(context.DeadlineExceeded)
+				returnResult := <-results
+				return returnResult.raw, returnResult.err
+			}
+		case <-ctx.Done():
+			controlled.expire(ctx.Err())
+			returnResult := <-results
+			return returnResult.raw, returnResult.err
+		case <-lifeline.C:
+			controlled.expire(context.Canceled)
+			returnResult := <-results
+			return returnResult.raw, fmt.Errorf("fake pi did not signal readiness: %w", returnResult.err)
+		}
+	}
+}
+
 func TestReviewCaptureRefuterExecutesGoOwnedPiAndClosesOnTheRefuterEvent(t *testing.T) {
 	reviewEnabledHome(t)
 	t.Setenv(reviewPiHostRelayContractEnvironment, reviewPiHostRelayContract)
@@ -187,15 +259,20 @@ func TestReviewCaptureRefuterExecuteDeadlineFailsClosedWithoutCapture(t *testing
 	repo, store, record, handle := piRefuterReview(t)
 	previous := reviewProviderRoleCaptureTimeout
 	t.Cleanup(func() { reviewProviderRoleCaptureTimeout = previous })
-	reviewProviderRoleCaptureTimeout = 100 * time.Millisecond
+	reviewProviderRoleCaptureTimeout = 10 * time.Second
+	ready := filepath.Join(t.TempDir(), "pi-ready")
 	stalled := filepath.Join(t.TempDir(), "stalled-pi")
-	if err := os.WriteFile(stalled, []byte("#!/bin/sh\nsleep 10\n"), 0o700); err != nil {
+	if err := os.WriteFile(stalled, []byte("#!/bin/sh\n: > "+strconv.Quote(ready)+"\nexec sleep 10\n"), 0o700); err != nil {
 		t.Fatal(err)
 	}
-	overrideProviderRoleHostAdapter(t, &reviewerprovider.PiAdapter{LookPath: func(string) (string, error) { return stalled, nil }})
+	realPi := &reviewerprovider.PiAdapter{LookPath: func(string) (string, error) { return stalled, nil }}
+	overrideProviderRoleHostAdapter(t, deadlineAfterReadyAdapter{adapter: realPi, readyPath: ready})
 	err := RunReview(append(append([]string{"capture-refuter"}, piRefuterBinding(repo, record, handle)...), "--agent", string(model.AgentPi), "--execute=true"), io.Discard)
 	if err == nil || !strings.Contains(err.Error(), "pi reviewer transport failed") || !strings.Contains(err.Error(), "context deadline exceeded") {
 		t.Fatalf("stalled pi deadline refusal = %v", err)
+	}
+	if _, readinessErr := os.Stat(ready); readinessErr != nil {
+		t.Fatalf("fake pi did not announce readiness before deadline: %v", readinessErr)
 	}
 	current, loadErr := store.Load()
 	if loadErr != nil || recordHasAdmittedRole(current.State, reviewtransaction.CompactRoleRefuter) {


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #3948

---

## 🏷️ PR Type

- [ ] `type:bug` — Bug fix
- [ ] `type:feature` — New feature
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring
- [x] `type:chore` — Build, CI, or tooling changes
- [ ] `type:breaking-change` — Breaking change

---

## 📝 Summary

- Wait until the fake Pi process is ready before expiring the controlled deadline.
- Preserve the real adapter path and fail-closed transport assertions.
- Remove dependence on a short wall-clock timeout that could fire before subprocess startup.

---

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/cli/review_provider_role_materialize_test.go` | Adds readiness-aware deadline control and updates the stalled-Pi fixture to signal readiness before expiration. |

---

## 🤖 AI Assistance

- [ ] **None** — No material AI assistance was used.
- [x] **Material assistance used**

**Tool/model (if known):** Pi coding-agent harness; OpenAI Codex model.

**Material scope:** Investigation, test implementation, verification orchestration, and advisory review.

**Verification performed:** Behavior-first RED/GREEN; 11 role checks; complete `internal/cli` package suite with 2,483 test-level pass events and no failures; default Docker E2E; native RDD review approved and acknowledged as `review-546f32249e5eda1d`.

---

## 🧪 Test Plan

- [x] Targeted RED/GREEN fixture coverage passes.
- [x] Eleven provider-role checks pass.
- [x] `go test -timeout=15m -json ./internal/cli -count=1` passes in 570.03 seconds.
- [x] Default `cd e2e && ./docker-test.sh` passes.
- [ ] Repository-wide `go test ./...`: running on the exact prerequisite integration candidate; CI remains authoritative.
- [x] Go format and `git diff --check` pass.
- [x] Benchmark validation: N/A — this is a test-fixture-only change and does not alter product or benchmark behavior.

---

## ✅ Contributor Checklist

- [x] PR is linked to issue #3948 with `status:approved`
- [x] PR stays within 400 changed lines (83 total)
- [x] Exactly one PR label, `type:chore`, is requested
- [ ] Full repository unit tests pass
- [x] Go formatting passes
- [x] E2E tests pass
- [x] Benchmark applicability is documented
- [x] Documentation changes are not required for this test-only fix
- [x] Commit follows Conventional Commits
- [x] I reviewed and accept responsibility for every change
- [x] Material AI assistance is disclosed
- [x] Commit contains no `Co-Authored-By` trailer

---

## 💬 Notes for Reviewers

Deadline expiration now occurs only after the fake Pi process signals readiness. The test continues to prove that transport failure does not admit compact authority.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved deadline handling test coverage for reviewer provider readiness.
  * Added validation that readiness is reported before the configured deadline.
  * Increased test capture timeout to support the readiness verification flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->