### PR TITLE
fix(sdd): migrate preserved OpenCode preflight

### DIFF
--- a/bench/journeys.go
+++ b/bench/journeys.go
@@ -841,6 +841,7 @@ func Journeys() []Journey {
 	journeys = append(journeys, issue2906Journeys()...)
 	journeys = append(journeys, issue2138Journeys()...)
 	journeys = append(journeys, issue3336Journeys()...)
+	journeys = append(journeys, issue3500Journeys()...)
 	journeys = append(journeys, issue3043Journeys()...)
 	journeys = append(journeys, issue3557Journeys()...)
 	journeys = append(journeys, issue3561Journeys()...)

--- a/bench/journeys_id_collision_test.go
+++ b/bench/journeys_id_collision_test.go
@@ -58,6 +58,7 @@ func journeySources() []journeySource {
 		{"journeys_issue2906.go", issue2906Journeys()},
 		{"journeys_issue_2138.go", issue2138Journeys()},
 		{"journeys_issue_3336.go", issue3336Journeys()},
+		{"journeys_issue_3500.go", issue3500Journeys()},
 		{"journeys_issue_3043.go", issue3043Journeys()},
 		{"journeys_issue_3557.go", issue3557Journeys()},
 		{"journeys_issue_3561.go", issue3561Journeys()},

--- a/bench/journeys_issue_3500.go
+++ b/bench/journeys_issue_3500.go
@@ -1,0 +1,81 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+const issue3500ExternalPrompt = "EXTERNAL_3500_PREFIX\nKeep these external policy bytes exactly.\nEXTERNAL_3500_SUFFIX"
+
+func issue3500SeedExternalOpenCodePrompt(sandbox *Sandbox) error {
+	path := filepath.Join(sandbox.Home, ".config", "opencode", "opencode.json")
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return err
+	}
+	settings := map[string]any{"agent": map[string]any{"gentle-orchestrator": map[string]any{"prompt": issue3500ExternalPrompt}}}
+	content, err := json.Marshal(settings)
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(path, content, 0o644)
+}
+
+func issue3500PreservedPrompt(sandbox *Sandbox) (string, error) {
+	content, err := os.ReadFile(filepath.Join(sandbox.Home, ".config", "opencode", "opencode.json"))
+	if err != nil {
+		return "", err
+	}
+	var settings struct {
+		Agent map[string]struct {
+			Prompt string `json:"prompt"`
+		} `json:"agent"`
+	}
+	if err := json.Unmarshal(content, &settings); err != nil {
+		return "", err
+	}
+	return settings.Agent["gentle-orchestrator"].Prompt, nil
+}
+
+func issue3500AssertFirstSync(sandbox *Sandbox, observation Observation) error {
+	prompt, err := issue3500PreservedPrompt(sandbox)
+	if err != nil || observation.ExitCode != 0 || !strings.Contains(prompt, issue3500ExternalPrompt) ||
+		strings.Count(prompt, "<!-- gentle-ai:sdd-session-preflight -->") != 1 ||
+		strings.Count(prompt, "<!-- /gentle-ai:sdd-session-preflight -->") != 1 ||
+		!strings.Contains(prompt, "Both -> `hybrid`") || strings.Contains(prompt, "Both -> `both`") {
+		return fmt.Errorf("external OpenCode sync did not preserve user bytes and compose one canonical hybrid preflight: %q (%v)", prompt, err)
+	}
+	sandbox.Scratch["issue3500-first-prompt"] = prompt
+	return nil
+}
+
+func issue3500AssertSecondSync(sandbox *Sandbox, observation Observation) error {
+	prompt, err := issue3500PreservedPrompt(sandbox)
+	if err != nil || observation.ExitCode != 0 || prompt != sandbox.Scratch["issue3500-first-prompt"] {
+		return fmt.Errorf("second external OpenCode sync changed the preserved prompt: %q (%v)", prompt, err)
+	}
+	return nil
+}
+
+func issue3500Journeys() []Journey {
+	return []Journey{{
+		ID:     "j3500-preserved-external-opencode-sync",
+		Review: reviewUntouched,
+		Title:  "#3500: external OpenCode sync preserves user prompt bytes and canonicalizes preflight once",
+		Source: "#3500: the external-single-active public sync owns only the canonical preflight block",
+		Steps: []Step{
+			{Name: "fixture: repository", Fixture: baseRepo},
+			{Name: "fixture: external OpenCode prompt", Fixture: issue3500SeedExternalOpenCodePrompt},
+			{Name: "public external OpenCode sync", Requires: issue3500SyncCapability, Args: issue3500SyncArgs, After: issue3500AssertFirstSync},
+			{Name: "second public external OpenCode sync is idempotent", Requires: issue3500SyncCapability, Args: issue3500SyncArgs, After: issue3500AssertSecondSync},
+		},
+	}}
+}
+
+var issue3500SyncCapability = &Capability{Verb: []string{"sync"}, Flags: []string{"--agents", "--sdd-mode", "--sdd-profile-strategy"}}
+
+func issue3500SyncArgs(*Sandbox) ([]string, error) {
+	return []string{"sync", "--agents", "opencode", "--sdd-mode", "multi", "--sdd-profile-strategy", "external-single-active"}, nil
+}

--- a/bench/review_declarations.go
+++ b/bench/review_declarations.go
@@ -56,6 +56,7 @@ var coreJourneyReviewModes = map[string]ReviewPrecondition{
 	"j32-recovery-of-a-recovery":                                                reviewOptedIn,
 	"j33-escalate-then-recover":                                                 reviewOptedIn,
 	"j3336-opencode-sdd-fresh-default-preflight":                                reviewUntouched,
+	"j3500-preserved-external-opencode-sync":                                    reviewUntouched,
 	"j34-abandon-then-start-again":                                              reviewOptedIn,
 	"j35-correction-budget-exactly-zero":                                        reviewOptedIn,
 	"j36-contract-right-name-wrong-version":                                     reviewOptedIn,

--- a/bench/testdata/journeys.manifest
+++ b/bench/testdata/journeys.manifest
@@ -32,6 +32,7 @@ j3043-opencode-managed-background-activation
 j31-nonsense-mode-value
 j3336-opencode-sdd-fresh-default-preflight
 j34-abandon-then-start-again
+j3500-preserved-external-opencode-sync
 j36-contract-right-name-wrong-version
 j40-sdd-attempt-reset-after-drift
 j4040-untracked-inventory-recovery-loop

--- a/internal/components/sdd/delivery_strategy_vocabulary_test.go
+++ b/internal/components/sdd/delivery_strategy_vocabulary_test.go
@@ -19,9 +19,8 @@ import (
 // session-preflight label->canonical mapping; the consumer is every phase skill
 // and orchestrator branch that reads `delivery_strategy`. In the Claude and
 // OpenCode orchestrators both halves live in the same document about a hundred
-// lines apart, and OpenCode carries a third copy of the producer compiled into
-// ensurePreservedOpenCodeOrchestratorPreflight, which re-injects it into
-// installed configs on every sync.
+// lines apart. Preserved OpenCode prompts receive the same canonical block from
+// the marker-owned session-preflight migration.
 //
 // Nothing asserted the halves agreed, so the preflight emitted `ask-always`,
 // `single-pr-default`, `force-chained`, and `auto-forecast` into a consumer
@@ -140,12 +139,6 @@ func preflightMappingSources(t *testing.T) map[string]string {
 	if len(sources) == 0 {
 		t.Fatal("no shipped asset carries a preflight label->canonical mapping; the guard has lost its subject")
 	}
-
-	// The OpenCode installer re-injects its own copy of the mapping into
-	// existing configs, so a markdown-only fix would be reverted on the next
-	// sync. Check the compiled literal through the same derivation.
-	sources["internal/components/sdd/inject.go (ensurePreservedOpenCodeOrchestratorPreflight)"] =
-		ensurePreservedOpenCodeOrchestratorPreflight("")
 
 	return sources
 }
@@ -332,11 +325,8 @@ func TestSDDReviewWorkloadGuardsRejectUnrecognisedDeliveryStrategy(t *testing.T)
 	}
 }
 
-// A preserved OpenCode prompt that already carries a well-formed preflight
-// satisfies every other freshness clause in
-// ensurePreservedOpenCodeOrchestratorPreflight, so before this the retired
-// mapping survived every sync and a markdown-only fix would have been reverted
-// on the user's next install.
+// A preserved OpenCode prompt with a legacy owned block must replace that block,
+// so retired delivery mappings cannot survive a sync.
 func TestInjectOpenCodeMigratesRetiredDeliveryStrategyMapping(t *testing.T) {
 	home := t.TempDir()
 	mockNoPackageManager(t)
@@ -346,11 +336,10 @@ func TestInjectOpenCodeMigratesRetiredDeliveryStrategyMapping(t *testing.T) {
 		t.Fatalf("MkdirAll(settings dir) error = %v", err)
 	}
 
-	stalePrompt := strings.ReplaceAll(
-		ensurePreservedOpenCodeOrchestratorPreflight(""),
-		"Ask me -> `ask-on-risk`; Single PR -> `single-pr`; Auto -> `auto-chain`",
-		"Ask me -> `ask-always`; Single PR -> `single-pr-default`; Auto -> `auto-forecast`",
-	)
+	stalePrompt := legacySDDSessionPreflightMarker + "\n" +
+		"3. PRs: Ask me, Single PR, Auto.\n" +
+		"Ask me -> `ask-always`; Single PR -> `single-pr-default`; Auto -> `auto-forecast`\n" +
+		legacySDDSessionPreflightEnd
 	if !strings.Contains(stalePrompt, "Ask me -> `ask-always`") {
 		t.Fatal("test seed did not reproduce the retired mapping; the literal shape changed")
 	}
@@ -462,14 +451,11 @@ func TestInjectOpenCodeMigratesRetiredChainedPRPreflightOption(t *testing.T) {
 	// Rebuild the exact prompt the previous release injected by reversing this
 	// change on the current literal, so the seed tracks the literal instead of
 	// freezing a copy of it that could drift.
-	stalePrompt := strings.NewReplacer(
-		"3. PRs: Ask me, Single PR, Auto.",
-		"3. PRs: Ask me, Single PR, Chained, Auto.",
-		"Ask me -> `ask-on-risk`; Single PR -> `single-pr`; Auto -> `auto-chain`",
-		"Ask me -> `ask-on-risk`; Single PR -> `single-pr`; Chained -> `auto-chain`; Auto -> `auto-chain`",
-		"The preflight offers no separate chained option because `delivery_strategy` is only consulted once the tasks forecast flags review-budget risk: below that line there is nothing to chain, and above it `Auto` already resolves to `auto-chain`.",
-		"Chained and Auto both resolve to `auto-chain` because `delivery_strategy` is only consulted once the tasks forecast flags review-budget risk.",
-	).Replace(ensurePreservedOpenCodeOrchestratorPreflight(""))
+	stalePrompt := legacySDDSessionPreflightMarker + "\n" +
+		"3. PRs: Ask me, Single PR, Chained, Auto.\n" +
+		"Chained -> `auto-chain`\n" +
+		"Chained and Auto both resolve to `auto-chain` because `delivery_strategy` is only consulted once the tasks forecast flags review-budget risk.\n" +
+		legacySDDSessionPreflightEnd
 
 	for _, seeded := range []string{
 		"3. PRs: Ask me, Single PR, Chained, Auto.",
@@ -510,8 +496,8 @@ func TestInjectOpenCodeMigratesRetiredChainedPRPreflightOption(t *testing.T) {
 			t.Errorf("opencode.json kept retired preflight fragment %q after sync", residue)
 		}
 	}
-	if !strings.Contains(text, "3. PRs: Ask me, Single PR, Auto.") {
-		t.Error("opencode.json did not receive the three-option PR preflight list")
+	if !strings.Contains(text, "3. **PR strategy**: Ask me, Single PR, or Auto.") {
+		t.Error("opencode.json did not receive the canonical three-option PR preflight list")
 	}
 	if !strings.Contains(text, "Auto -> `auto-chain`") {
 		t.Error("opencode.json lost the `auto-chain` canonical value; only the `Chained` label was retired")
@@ -519,8 +505,8 @@ func TestInjectOpenCodeMigratesRetiredChainedPRPreflightOption(t *testing.T) {
 	if !strings.Contains(text, "# Custom prompt") {
 		t.Error("migration discarded the user's own prompt content")
 	}
-	if count := strings.Count(text, "3. PRs: "); count != 1 {
-		t.Errorf("migrated prompt carries %d PR option lists; the retired menu must be replaced, not appended to", count)
+	if count := strings.Count(text, sddSessionPreflightMarker); count != 1 {
+		t.Errorf("migrated prompt carries %d canonical preflight blocks; the retired menu must be replaced, not appended to", count)
 	}
 
 	// The freshness clause that fires this migration must also stop firing once

--- a/internal/components/sdd/inject.go
+++ b/internal/components/sdd/inject.go
@@ -1586,20 +1586,6 @@ func replacePreservedPromptSection(prompt string, start, end int, replacement st
 	return b.String()
 }
 
-func containsOpenCodeOrchestratorLanguageLeak(prompt string) bool {
-	for _, leak := range []string{
-		"elegí",
-		"Respondé",
-		"¿Querés ajustar algo o continuamos?",
-		"If the current language is Spanish, use the Spanish localized shape below verbatim",
-	} {
-		if strings.Contains(prompt, leak) {
-			return true
-		}
-	}
-	return false
-}
-
 func readOpenCodeAgentPrompt(settingsPath, agentKey string) (string, error) {
 	if strings.TrimSpace(settingsPath) == "" || strings.TrimSpace(agentKey) == "" {
 		return "", nil

--- a/internal/components/sdd/inject.go
+++ b/internal/components/sdd/inject.go
@@ -390,6 +390,15 @@ func Inject(homeDir string, adapter agents.Adapter, sddMode model.SDDModeID, opt
 		opts = options[0]
 	}
 	settingsPath := openCodeSettingsPath(homeDir, adapter, opts.OpenCodeSettingsPath)
+	if opts.PreserveOpenCodeOrchestratorPrompt && AgentReceivesManagedOpenCodePlugins(adapter.Agent()) {
+		prompt, err := readPreservedOpenCodeOrchestratorPrompt(settingsPath)
+		if err != nil {
+			return InjectionResult{}, err
+		}
+		if err := validatePreservedSDDSessionPreflight(prompt); err != nil {
+			return InjectionResult{}, fmt.Errorf("validate preserved OpenCode session preflight: %w", err)
+		}
+	}
 	var defaultPlan *opencodedefault.InstallPlan
 	if adapter.Agent() == model.AgentOpenCode {
 		var err error
@@ -931,6 +940,16 @@ func Inject(homeDir string, adapter agents.Adapter, sddMode model.SDDModeID, opt
 	return InjectionResult{Changed: changed, Files: files}, nil
 }
 
+func readPreservedOpenCodeOrchestratorPrompt(settingsPath string) (string, error) {
+	for _, agentKey := range []string{"gentle-orchestrator", "sdd-orchestrator"} {
+		prompt, err := readOpenCodeAgentPrompt(settingsPath, agentKey)
+		if err != nil || prompt != "" {
+			return prompt, err
+		}
+	}
+	return readMisnamedOpenCodeGentlemanSDDPrompt(settingsPath)
+}
+
 func openCodeSettingsPath(homeDir string, adapter agents.Adapter, effectivePath string) string {
 	if effectivePath != "" {
 		return effectivePath
@@ -975,21 +994,9 @@ func inlineOpenCodeSDDPrompts(overlayBytes []byte, homeDir, settingsPath string,
 		return overlayBytes, nil
 	}
 	if preserveExistingOrchestratorPrompt {
-		existingPrompt, err := readOpenCodeAgentPrompt(settingsPath, "gentle-orchestrator")
+		existingPrompt, err := readPreservedOpenCodeOrchestratorPrompt(settingsPath)
 		if err != nil {
 			return nil, err
-		}
-		if existingPrompt == "" {
-			existingPrompt, err = readOpenCodeAgentPrompt(settingsPath, "sdd-orchestrator")
-			if err != nil {
-				return nil, err
-			}
-		}
-		if existingPrompt == "" {
-			existingPrompt, err = readMisnamedOpenCodeGentlemanSDDPrompt(settingsPath)
-			if err != nil {
-				return nil, err
-			}
 		}
 		if existingPrompt != "" {
 			if strings.Contains(existingPrompt, openCodeBackgroundPolicyMarker) || strings.Contains(existingPrompt, openCodeBackgroundPolicyEnd) {
@@ -997,14 +1004,13 @@ func inlineOpenCodeSDDPrompts(overlayBytes []byte, homeDir, settingsPath string,
 					return nil, fmt.Errorf("validate preserved OpenCode background policy: %w", err)
 				}
 			}
-			prompt := renderPreservedOpenCodeOrchestratorPrompt(existingPrompt, agent, renderOptions)
-			if strings.Count(prompt, "### SDD Entry Routing (MANDATORY)") == 1 && strings.Count(prompt, sddSessionPreflightInit) == 1 {
-				prompt, err = projectSDDSessionPreflight(filemerge.InjectMarkdownSection(prompt, "sdd-session-preflight-migration", ""), "### SDD Entry Routing (MANDATORY)")
-				if err != nil {
-					return nil, fmt.Errorf("project preserved OpenCode session preflight: %w", err)
-				}
+			preservedPrompt, err := migratePreservedSDDSessionPreflight(existingPrompt)
+			if err != nil {
+				return nil, fmt.Errorf("migrate preserved OpenCode session preflight: %w", err)
 			}
-			orchestratorMap["prompt"] = prompt
+			prompt := renderPreservedOpenCodeOrchestratorPrompt(strings.ReplaceAll(preservedPrompt, "\r\n", "\n"), agent, renderOptions)
+			newline, _ := sddSessionPreflightNewline(preservedPrompt)
+			orchestratorMap["prompt"] = normalizeSDDSessionPreflightPromptLineEndings(prompt, newline)
 		} else {
 			orchestratorPrompt, err := composeOpenCodeOrchestratorPrompt(agent, renderOptions)
 			if err != nil {
@@ -1270,7 +1276,6 @@ func migratePreservedOpenCodeOrchestratorPrompt(prompt string) string {
 		"",
 	)
 	migrated := removeLegacyOpenCodePlainChatPreflightLines(replacer.Replace(prompt))
-	migrated = ensurePreservedOpenCodeOrchestratorPreflight(migrated)
 	migrated = ensurePreservedOpenCodeDelegationHardGates(migrated)
 	migrated = ensurePreservedOpenCodeResearchLifecycle(migrated)
 	return ensurePreservedOpenCodeReviewExecutionContract(migrated)
@@ -1579,92 +1584,6 @@ func replacePreservedPromptSection(prompt string, start, end int, replacement st
 		b.WriteString("\n")
 	}
 	return b.String()
-}
-
-func ensurePreservedOpenCodeOrchestratorPreflight(prompt string) string {
-	preflight := `
-
-<!-- gentle-ai:sdd-session-preflight-migration -->
-### SDD Session Preflight (HARD GATE)
-
-Before executing ANY SDD command or natural-language SDD request, ensure this session has an explicit ` + "`SDD Session Preflight`" + ` decision block.
-
-Required preflight choices: execution mode, artifact store, chained PR strategy, and review budget.
-
-Use the ` + "`question`" + ` tool for SDD Session Preflight. Do NOT render the full preflight menu as plain chat text.
-
-Ask all four preflight groups in one single ` + "`question`" + ` tool call so OpenCode can render the groups as tabs. Do NOT run this as a sequential wizard. Do NOT issue four separate ` + "`question`" + ` tool calls.
-
-The single ` + "`question`" + ` tool call must contain these four localized groups in this order:
-
-1. Pace: Interactive, Automatic.
-2. Artifacts: OpenSpec, Engram, Both.
-3. PRs: Ask me, Single PR, Auto.
-4. Review: 400 lines, 800 lines, Other.
-
-Match the user's current language and active persona for question labels and descriptions. Treat the preflight UI as direct orchestrator conversation, not as a generated technical artifact. Technical artifacts still default to English, but this UI follows the user's conversation language/persona. Do NOT mix languages inside one grouped question.
-
-Do NOT show option codes in the interactive UI. Do NOT show canonical values or other internal values in the interactive UI labels or descriptions.
-
-After the single grouped ` + "`question`" + ` tool call returns, map the selected human labels to canonical values internally. Do not reveal the canonical values in the UI.
-
-If Other is selected for review budget, ask one follow-up question for the numeric budget.
-
-Only after all four preflight choices are collected, summarize them as the ` + "`SDD Session Preflight`" + ` decision block and continue with the SDD init guard/requested phase.
-
-Map answers to canonical values: Interactive -> ` + "`interactive`" + `; Automatic -> ` + "`auto`" + `; OpenSpec -> ` + "`openspec`" + `; Engram -> ` + "`engram`" + `; Both -> ` + "`both`" + `; Ask me -> ` + "`ask-on-risk`" + `; Single PR -> ` + "`single-pr`" + `; Auto -> ` + "`auto-chain`" + `; 400 lines -> ` + "`review_budget_lines: 400`" + `; 800 lines -> ` + "`review_budget_lines: 800`" + `; Other -> ask one follow-up for the number.
-
-The PR canonical values are exactly the ` + "`delivery_strategy`" + ` domain ` + "`sdd-tasks`" + ` and ` + "`sdd-apply`" + ` accept (` + "`ask-on-risk | auto-chain | single-pr | exception-ok`" + `); never emit a value outside it. The preflight offers no separate chained option because ` + "`delivery_strategy`" + ` is only consulted once the tasks forecast flags review-budget risk: below that line there is nothing to chain, and above it ` + "`Auto`" + ` already resolves to ` + "`auto-chain`" + `.
-
-Hard gate rules:
-
-- ` + "`openspec/config.yaml`" + `, existing SDD artifacts, previous ` + "`sdd-init`" + ` results, or installed SDD assets do NOT satisfy session preflight.
-- If the session has no preflight block, ask the single grouped ` + "`question`" + ` tool preflight above. Do not run init, delegate phases, edit files, or apply tasks until all four choices are collected.
-- For a new feature request that says to use SDD, start at preflight -> init guard -> explore/proposal. Never launch ` + "`sdd-apply`" + ` just because the user asked to implement a feature.
-- In ` + "`interactive`" + ` mode, pause after each delegated phase returns, summarize the phase, then ask before launching the next phase via the ` + "`question`" + ` tool, and STOP. Use the ` + "`question`" + ` tool for this between-phase decision: present the proceed/adjust/stop options through a single ` + "`question`" + ` tool call; do NOT render the options as a plain markdown bullet list or plain chat text. Match the user's language and active persona for the question labels; for Spanish neutral fallback frame it as: "¿Quiere ajustar algo o continuamos?". Do not run /sdd-ff phases back-to-back unless execution mode is ` + "`auto`" + `.
-- Interactive approval is phase-scoped. Words like "continue", "dale", or "go on" approve only the immediate next phase, not the rest of the SDD pipeline. Do not treat a generated artifact as approved until the user has had a chance to review or explicitly delegate that review.
-<!-- /gentle-ai:sdd-session-preflight-migration -->
-`
-
-	if strings.Contains(prompt, "### SDD Session Preflight (HARD GATE)") &&
-		strings.Contains(prompt, "openspec/config.yaml") &&
-		strings.Contains(prompt, "Never launch `sdd-apply`") &&
-		strings.Contains(prompt, "Match the user's current language") &&
-		strings.Contains(prompt, "Ask all four preflight groups in one single `question` tool call") &&
-		strings.Contains(prompt, "groups as tabs") &&
-		strings.Contains(prompt, "Do NOT run this as a sequential wizard") &&
-		strings.Contains(prompt, "Do NOT mix languages inside one grouped question") &&
-		strings.Contains(prompt, "map the selected human labels to canonical values internally") &&
-		// A preserved prompt written before the delivery-strategy vocabularies
-		// were reconciled still maps the PR options to `ask-always`,
-		// `single-pr-default`, `force-chained`, and `auto-forecast`, none of
-		// which any consumer branch matches. Every other clause here is
-		// satisfied by that stale text, so without this the broken mapping
-		// would survive every future sync.
-		strings.Contains(prompt, "Ask me -> `ask-on-risk`") &&
-		// The retired `Chained` PR option shipped alongside that corrected
-		// mapping, so a prompt still offering it satisfies every clause above,
-		// including the one directly overhead. Without this the four-option menu
-		// would survive every future sync and the asset-only removal would be
-		// reverted on the operator's next install.
-		strings.Contains(prompt, "3. PRs: Ask me, Single PR, Auto.") &&
-		strings.Contains(prompt, "pause after each delegated phase returns") &&
-		strings.Contains(prompt, "ask before launching the next phase via the `question` tool") &&
-		strings.Contains(prompt, "approve only the immediate next phase") &&
-		!containsOpenCodeOrchestratorLanguageLeak(prompt) {
-		return prompt
-	}
-
-	start := "<!-- gentle-ai:sdd-session-preflight-migration -->"
-	end := "<!-- /gentle-ai:sdd-session-preflight-migration -->"
-	if startIdx := strings.Index(prompt, start); startIdx >= 0 {
-		if relEndIdx := strings.Index(prompt[startIdx:], end); relEndIdx >= 0 {
-			endIdx := startIdx + relEndIdx + len(end)
-			return strings.TrimRight(prompt[:startIdx], "\n") + preflight + prompt[endIdx:]
-		}
-	}
-
-	return strings.TrimRight(prompt, "\n") + preflight
 }
 
 func containsOpenCodeOrchestratorLanguageLeak(prompt string) bool {

--- a/internal/components/sdd/inject_test.go
+++ b/internal/components/sdd/inject_test.go
@@ -755,6 +755,134 @@ func TestInjectOpenCodePreservesExistingOrchestratorPromptWhenRequested(t *testi
 	}
 }
 
+func TestInjectOpenCodeAndKilocodeRejectMalformedPreservedPreflightBeforeAnyWrite(t *testing.T) {
+	adapters := []struct {
+		name    string
+		adapter agents.Adapter
+	}{
+		{name: "opencode", adapter: opencodeAdapter()},
+		{name: "kilocode", adapter: kilocodeAdapter()},
+	}
+	markers := []struct {
+		name, prompt string
+	}{
+		{name: "duplicate canonical", prompt: sddSessionPreflightMarker + "\n" + sddSessionPreflightEnd + "\n" + sddSessionPreflightMarker + "\n" + sddSessionPreflightEnd},
+		{name: "reversed canonical", prompt: sddSessionPreflightEnd + "\n" + sddSessionPreflightMarker},
+		{name: "duplicate legacy", prompt: legacySDDSessionPreflightMarker + "\n" + legacySDDSessionPreflightEnd + "\n" + legacySDDSessionPreflightMarker + "\n" + legacySDDSessionPreflightEnd},
+		{name: "reversed legacy", prompt: legacySDDSessionPreflightEnd + "\n" + legacySDDSessionPreflightMarker},
+		{name: "canonical and legacy", prompt: sddSessionPreflightMarker + "\n" + sddSessionPreflightEnd + "\n" + legacySDDSessionPreflightMarker + "\n" + legacySDDSessionPreflightEnd},
+	}
+	for _, adapterCase := range adapters {
+		for _, markerCase := range markers {
+			t.Run(adapterCase.name+"/"+markerCase.name, func(t *testing.T) {
+				home := t.TempDir()
+				settingsPath := adapterCase.adapter.SettingsPath(home)
+				if err := os.MkdirAll(filepath.Dir(settingsPath), 0o755); err != nil {
+					t.Fatal(err)
+				}
+				beforeSettings := []byte(`{"agent":{"gentle-orchestrator":{"prompt":` + strconv.Quote(markerCase.prompt) + `}}}`)
+				if err := os.WriteFile(settingsPath, beforeSettings, 0o644); err != nil {
+					t.Fatal(err)
+				}
+				commandPath := filepath.Join(adapterCase.adapter.CommandsDir(home), "sdd-init.md")
+				beforeCommand := []byte("external sentinel must remain untouched\n")
+				if err := os.MkdirAll(filepath.Dir(commandPath), 0o755); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.WriteFile(commandPath, beforeCommand, 0o644); err != nil {
+					t.Fatal(err)
+				}
+
+				if _, err := Inject(home, adapterCase.adapter, model.SDDModeMulti, InjectOptions{PreserveOpenCodeOrchestratorPrompt: true}); err == nil {
+					t.Fatal("Inject() accepted malformed preserved preflight markers")
+				}
+				for path, before := range map[string][]byte{settingsPath: beforeSettings, commandPath: beforeCommand} {
+					after, err := os.ReadFile(path)
+					if err != nil || !bytes.Equal(after, before) {
+						t.Fatalf("Inject() wrote %q before rejecting malformed markers: after=%q err=%v", path, after, err)
+					}
+				}
+			})
+		}
+	}
+}
+
+func TestInjectOpenCodeAndKilocodePreservedExternalPreflightUsesCanonicalOwnedBlock(t *testing.T) {
+	adapters := []struct {
+		name    string
+		adapter agents.Adapter
+	}{
+		{name: "opencode", adapter: opencodeAdapter()},
+		{name: "kilocode", adapter: kilocodeAdapter()},
+	}
+	for _, adapterCase := range adapters {
+		for _, lineEnding := range []struct {
+			name, value string
+		}{{name: "lf", value: "\n"}, {name: "crlf", value: "\r\n"}} {
+			for _, promptCase := range []struct {
+				name, prompt string
+			}{
+				{name: "unmarked", prompt: "CUSTOM_SENTINEL_A" + lineEnding.value + "CUSTOM_SENTINEL_B"},
+				{name: "legacy-owned-markers", prompt: "CUSTOM_SENTINEL_A" + lineEnding.value + "<!-- gentle-ai:sdd-session-preflight-migration -->" + lineEnding.value + "### SDD Session Preflight (HARD GATE)" + lineEnding.value + "Both -> `both`" + lineEnding.value + "<!-- /gentle-ai:sdd-session-preflight-migration -->" + lineEnding.value + "CUSTOM_SENTINEL_B"},
+			} {
+				t.Run(adapterCase.name+"/"+lineEnding.name+"/"+promptCase.name, func(t *testing.T) {
+					home := t.TempDir()
+					settingsPath := adapterCase.adapter.SettingsPath(home)
+					if err := os.MkdirAll(filepath.Dir(settingsPath), 0o755); err != nil {
+						t.Fatal(err)
+					}
+					seed := `{"agent":{"gentle-orchestrator":{"prompt":` + strconv.Quote(promptCase.prompt) + `}}}`
+					if err := os.WriteFile(settingsPath, []byte(seed), 0o644); err != nil {
+						t.Fatal(err)
+					}
+
+					opts := InjectOptions{PreserveOpenCodeOrchestratorPrompt: true}
+					if _, err := Inject(home, adapterCase.adapter, model.SDDModeMulti, opts); err != nil {
+						t.Fatalf("first Inject() error = %v", err)
+					}
+					first := readGentleOrchestratorPrompt(t, settingsPath)
+					if strings.Contains(promptCase.prompt, legacySDDSessionPreflightMarker) {
+						legacyStart := strings.Index(promptCase.prompt, legacySDDSessionPreflightMarker)
+						legacyEnd := strings.Index(promptCase.prompt, legacySDDSessionPreflightEnd) + len(legacySDDSessionPreflightEnd)
+						open, closeEnd, rangeErr := sddSessionPreflightMarkerRange(first)
+						if rangeErr != nil {
+							t.Fatalf("canonical preflight markers are malformed: %v", rangeErr)
+						}
+						if first[:open] != promptCase.prompt[:legacyStart] || !strings.HasPrefix(first[closeEnd:], promptCase.prompt[legacyEnd:]) {
+							t.Fatalf("legacy migration changed user-owned prefix or suffix:\n got: %q\nwant prefix: %q\nwant suffix: %q", first, promptCase.prompt[:legacyStart], promptCase.prompt[legacyEnd:])
+						}
+					} else if !strings.HasPrefix(first, promptCase.prompt+lineEnding.value+lineEnding.value) {
+						t.Fatalf("unmarked migration changed user-owned prompt bytes:\n got: %q\nwant prefix: %q", first, promptCase.prompt+lineEnding.value+lineEnding.value)
+					}
+					for _, marker := range []string{sddSessionPreflightMarker, sddSessionPreflightEnd} {
+						if got := strings.Count(first, marker); got != 1 {
+							t.Fatalf("canonical marker %q count = %d, want 1: %q", marker, got, first)
+						}
+					}
+					open, closeEnd, err := sddSessionPreflightMarkerRange(first)
+					if err != nil {
+						t.Fatalf("canonical preflight marker range: %v", err)
+					}
+					canonical, err := normalizeSDDSessionPreflightLineEndings(first[open:closeEnd])
+					if err != nil || canonical != sddSessionPreflightBlock() {
+						t.Fatalf("preserved prompt did not emit the exact canonical block: %q, err=%v", canonical, err)
+					}
+					if lineEnding.value == "\r\n" && strings.Contains(strings.ReplaceAll(first, "\r\n", ""), "\n") {
+						t.Fatalf("preserved CRLF prompt has mixed line endings: %q", first)
+					}
+
+					if _, err := Inject(home, adapterCase.adapter, model.SDDModeMulti, opts); err != nil {
+						t.Fatalf("second Inject() error = %v", err)
+					}
+					if second := readGentleOrchestratorPrompt(t, settingsPath); second != first {
+						t.Fatalf("second sync changed preserved prompt\nfirst:  %q\nsecond: %q", first, second)
+					}
+				})
+			}
+		}
+	}
+}
+
 func TestInjectOpenCodeMigratesPreservedLegacyOrchestratorPromptReferences(t *testing.T) {
 	home := t.TempDir()
 	mockNoPackageManager(t)
@@ -810,27 +938,11 @@ func TestInjectOpenCodeMigratesPreservedLegacyOrchestratorPromptReferences(t *te
 		"Bind this to the dedicated `gentle-orchestrator` agent only.",
 		"agent.gentle-orchestrator.model",
 		"### SDD Session Preflight (HARD GATE)",
-		"Use the `question` tool for SDD Session Preflight",
-		"Ask all four preflight groups in one single `question` tool call",
-		"OpenCode can render the groups as tabs",
-		"Do NOT run this as a sequential wizard",
-		"Do NOT issue four separate `question` tool calls",
-		"Match the user's current language and active persona",
-		"Treat the preflight UI as direct orchestrator conversation",
-		"not as a generated technical artifact",
-		"Technical artifacts still default to English",
-		"this UI follows the user's conversation language/persona",
-		"Do NOT mix languages inside one grouped question",
-		"Do NOT show option codes",
-		"Do NOT show canonical values or other internal values",
-		"map the selected human labels to canonical values internally",
-		"pause after each delegated phase returns",
-		"ask before launching the next phase via the `question` tool",
-		"present the proceed/adjust/stop options through a single `question` tool call",
-		"approve only the immediate next phase",
+		"all three groups (Pace, Artifacts, and PR strategy)",
+		"3. **PR strategy**: Ask me, Single PR, or Auto.",
+		"fixed at 400 changed lines",
 		"### Research and Pre-Proposal Gate (MANDATORY)",
 		"confirmed pre-proposal handoff",
-		"Never launch `sdd-apply` just because the user asked to implement a feature",
 		"### Mandatory Delegation Triggers (Non-Skippable)",
 		"fully mandatory",
 		"Bounded read rule",
@@ -1319,27 +1431,11 @@ Map answers to canonical values: A1/Interactive -> interactive.
 	for _, wanted := range []string{
 		"# Custom prompt",
 		"### SDD Session Preflight (HARD GATE)",
-		"openspec/config.yaml",
-		"Use the `question` tool for SDD Session Preflight",
-		"Ask all four preflight groups in one single `question` tool call",
-		"OpenCode can render the groups as tabs",
-		"Do NOT run this as a sequential wizard",
-		"Match the user's current language and active persona",
-		"Treat the preflight UI as direct orchestrator conversation",
-		"not as a generated technical artifact",
-		"Technical artifacts still default to English",
-		"this UI follows the user's conversation language/persona",
-		"Do NOT mix languages inside one grouped question",
-		"Do NOT show option codes",
-		"Do NOT show canonical values or other internal values",
-		"map the selected human labels to canonical values internally",
-		"pause after each delegated phase returns",
-		"ask before launching the next phase via the `question` tool",
-		"present the proceed/adjust/stop options through a single `question` tool call",
-		"approve only the immediate next phase",
+		"all three groups (Pace, Artifacts, and PR strategy)",
+		"3. **PR strategy**: Ask me, Single PR, or Auto.",
+		"fixed at 400 changed lines",
 		"### Research and Pre-Proposal Gate (MANDATORY)",
 		"confirmed pre-proposal handoff",
-		"Never launch `sdd-apply` just because the user asked to implement a feature",
 	} {
 		if !strings.Contains(text, wanted) {
 			t.Fatalf("opencode.json missing migrated partial prompt content %q", wanted)
@@ -1429,23 +1525,10 @@ Hard gate rules:
 	}
 	for _, wanted := range []string{
 		"# Custom prompt",
-		"Use the `question` tool for SDD Session Preflight",
-		"Ask all four preflight groups in one single `question` tool call",
-		"OpenCode can render the groups as tabs",
-		"Do NOT run this as a sequential wizard",
-		"Do NOT issue four separate `question` tool calls",
-		"Do NOT mix languages inside one grouped question",
-		"Do NOT show option codes",
-		"Do NOT show canonical values or other internal values",
-		"map the selected human labels to canonical values internally",
-		"Treat the preflight UI as direct orchestrator conversation",
-		"not as a generated technical artifact",
-		"Technical artifacts still default to English",
-		"this UI follows the user's conversation language/persona",
-		"for Spanish neutral fallback frame it as",
-		"ask before launching the next phase via the `question` tool",
-		"present the proceed/adjust/stop options through a single `question` tool call",
-		"approve only the immediate next phase",
+		"### SDD Session Preflight (HARD GATE)",
+		"all three groups (Pace, Artifacts, and PR strategy)",
+		"3. **PR strategy**: Ask me, Single PR, or Auto.",
+		"fixed at 400 changed lines",
 		"### Research and Pre-Proposal Gate (MANDATORY)",
 		"confirmed pre-proposal handoff",
 	} {

--- a/internal/components/sdd/session_preflight.go
+++ b/internal/components/sdd/session_preflight.go
@@ -6,15 +6,69 @@ import (
 )
 
 const (
-	sddSessionPreflightMarker = "<!-- gentle-ai:sdd-session-preflight -->"
-	sddSessionPreflightEnd    = "<!-- /gentle-ai:sdd-session-preflight -->"
-	sddSessionPreflightInit   = "### SDD Init Guard (MANDATORY)"
-	sddSessionPreflightBody   = "### SDD Session Preflight (HARD GATE)\n\nBefore every SDD command or natural-language SDD request, run this preflight before the SDD init guard; cache choices for the session.\n\nUse the `question` tool only when available and all three groups (Pace, Artifacts, and PR strategy) are exactly representable; otherwise use the lossless blocking fallback and STOP.\nAsk Pace, Artifacts, and PR strategy in ONE `question` tool call; no sequential wizard and no three separate calls.\nMatch labels and descriptions to the conversation language and persona; do not expose canonical/internal codes.\n\n1. **Pace**: Interactive or Automatic.\n2. **Artifacts**: OpenSpec, Engram, or Both (user-facing Both maps only to internal `hybrid`).\n3. **PR strategy**: Ask me, Single PR, or Auto.\n\nReview policy is fixed at 400 changed lines per PR; above 400, split the PR or require maintainer-approved `size:exception`; NEVER ask it as a fourth group or selectable budget.\n\nCanonical mappings:\n- Interactive -> `interactive`\n- Automatic -> `auto`\n- OpenSpec -> `openspec`\n- Engram -> `engram`\n- Both -> `hybrid`\n- Ask me -> `ask-on-risk`\n- Single PR -> `single-pr`\n- Auto -> `auto-chain`"
+	sddSessionPreflightMarker       = "<!-- gentle-ai:sdd-session-preflight -->"
+	sddSessionPreflightEnd          = "<!-- /gentle-ai:sdd-session-preflight -->"
+	sddSessionPreflightInit         = "### SDD Init Guard (MANDATORY)"
+	legacySDDSessionPreflightMarker = "<!-- gentle-ai:sdd-session-preflight-migration -->"
+	legacySDDSessionPreflightEnd    = "<!-- /gentle-ai:sdd-session-preflight-migration -->"
+	sddSessionPreflightBody         = "### SDD Session Preflight (HARD GATE)\n\nBefore every SDD command or natural-language SDD request, run this preflight before the SDD init guard; cache choices for the session.\n\nUse the `question` tool only when available and all three groups (Pace, Artifacts, and PR strategy) are exactly representable; otherwise use the lossless blocking fallback and STOP.\nAsk Pace, Artifacts, and PR strategy in ONE `question` tool call; no sequential wizard and no three separate calls.\nMatch labels and descriptions to the conversation language and persona; do not expose canonical/internal codes.\n\n1. **Pace**: Interactive or Automatic.\n2. **Artifacts**: OpenSpec, Engram, or Both (user-facing Both maps only to internal `hybrid`).\n3. **PR strategy**: Ask me, Single PR, or Auto.\n\nReview policy is fixed at 400 changed lines per PR; above 400, split the PR or require maintainer-approved `size:exception`; NEVER ask it as a fourth group or selectable budget.\n\nCanonical mappings:\n- Interactive -> `interactive`\n- Automatic -> `auto`\n- OpenSpec -> `openspec`\n- Engram -> `engram`\n- Both -> `hybrid`\n- Ask me -> `ask-on-risk`\n- Single PR -> `single-pr`\n- Auto -> `auto-chain`"
 )
 
 func sddSessionPreflightBlock() string {
 	return sddSessionPreflightMarker + "\n" + sddSessionPreflightBody + "\n" + sddSessionPreflightEnd
 }
+
+// migratePreservedSDDSessionPreflight is the only migration path for a
+// preserved external OpenCode or Kilo prompt. It replaces owned legacy ranges
+// in place and otherwise appends the canonical block without interpreting any
+// unmarked user-authored prompt text.
+func validatePreservedSDDSessionPreflight(rendered string) error {
+	canonicalStart, _, err := sddSessionPreflightMarkerRange(rendered)
+	if err != nil {
+		return err
+	}
+	legacyStart, _, err := sddSessionPreflightOwnedMarkerRange(rendered, legacySDDSessionPreflightMarker, legacySDDSessionPreflightEnd)
+	if err != nil {
+		return err
+	}
+	if canonicalStart >= 0 && legacyStart >= 0 {
+		return fmt.Errorf("sdd session preflight cannot contain canonical and legacy marker pairs")
+	}
+	return nil
+}
+
+func migratePreservedSDDSessionPreflight(rendered string) (string, error) {
+	if err := validatePreservedSDDSessionPreflight(rendered); err != nil {
+		return "", err
+	}
+	newline, err := sddSessionPreflightNewline(rendered)
+	if err != nil {
+		return "", err
+	}
+	legacyStart, legacyEnd, err := sddSessionPreflightOwnedMarkerRange(rendered, legacySDDSessionPreflightMarker, legacySDDSessionPreflightEnd)
+	if err != nil {
+		return "", err
+	}
+	block := strings.ReplaceAll(sddSessionPreflightBlock(), "\n", newline)
+	if legacyStart >= 0 {
+		rendered = rendered[:legacyStart] + block + rendered[legacyEnd:]
+	}
+	open, closeEnd, err := sddSessionPreflightMarkerRange(rendered)
+	if err != nil {
+		return "", err
+	}
+	if open >= 0 {
+		return rendered[:open] + block + rendered[closeEnd:], nil
+	}
+	if rendered == "" {
+		return block, nil
+	}
+	if strings.HasSuffix(rendered, newline) {
+		return rendered + newline + block, nil
+	}
+	return rendered + newline + newline + block, nil
+}
+
 func projectSDDSessionPreflight(rendered, preInitAnchor string) (string, error) {
 	anchor, err := sddSessionPreflightAnchorIndex(rendered, preInitAnchor)
 	if err != nil {
@@ -27,9 +81,9 @@ func projectSDDSessionPreflight(rendered, preInitAnchor string) (string, error) 
 	if open >= 0 && (open >= anchor || closeEnd > anchor) {
 		return "", fmt.Errorf("sdd session preflight is not at the supplied pre-init anchor")
 	}
-	newline := "\n"
-	if strings.Contains(rendered, "\r\n") {
-		newline = "\r\n"
+	newline, err := sddSessionPreflightNewline(rendered)
+	if err != nil {
+		return "", err
 	}
 	block := strings.ReplaceAll(sddSessionPreflightBlock(), "\n", newline)
 	if open >= 0 {
@@ -91,24 +145,46 @@ func sddSessionPreflightAnchorIndex(rendered, anchor string) (int, error) {
 }
 
 func sddSessionPreflightMarkerRange(rendered string) (int, int, error) {
-	openCount := strings.Count(rendered, sddSessionPreflightMarker)
-	closeCount := strings.Count(rendered, sddSessionPreflightEnd)
+	return sddSessionPreflightOwnedMarkerRange(rendered, sddSessionPreflightMarker, sddSessionPreflightEnd)
+}
+
+func sddSessionPreflightOwnedMarkerRange(rendered, openMarker, closeMarker string) (int, int, error) {
+	openCount := strings.Count(rendered, openMarker)
+	closeCount := strings.Count(rendered, closeMarker)
 	if openCount == 0 && closeCount == 0 {
 		return -1, -1, nil
 	}
 	if openCount != 1 || closeCount != 1 {
 		return 0, 0, fmt.Errorf("sdd session preflight markers must contain exactly one pair")
 	}
-	open := strings.Index(rendered, sddSessionPreflightMarker)
-	close := strings.Index(rendered, sddSessionPreflightEnd)
+	open := strings.Index(rendered, openMarker)
+	close := strings.Index(rendered, closeMarker)
 	if close <= open {
 		return 0, 0, fmt.Errorf("sdd session preflight markers are orphaned or reversed")
 	}
-	closeEnd := close + len(sddSessionPreflightEnd)
+	closeEnd := close + len(closeMarker)
 	if !sddSessionPreflightLineStart(rendered, open) || !sddSessionPreflightLineEnd(rendered, closeEnd) {
 		return 0, 0, fmt.Errorf("sdd session preflight markers must occupy complete lines")
 	}
 	return open, closeEnd, nil
+}
+
+func sddSessionPreflightNewline(value string) (string, error) {
+	withoutCRLF := strings.ReplaceAll(value, "\r\n", "")
+	if strings.Contains(withoutCRLF, "\r") || (strings.Contains(value, "\r\n") && strings.Contains(withoutCRLF, "\n")) {
+		return "", fmt.Errorf("sdd session preflight contains mixed or unsupported line endings")
+	}
+	if strings.Contains(value, "\r\n") {
+		return "\r\n", nil
+	}
+	return "\n", nil
+}
+
+func normalizeSDDSessionPreflightPromptLineEndings(value, newline string) string {
+	if newline == "\n" {
+		return value
+	}
+	return strings.ReplaceAll(strings.ReplaceAll(value, "\r\n", "\n"), "\n", newline)
 }
 
 func normalizeSDDSessionPreflightLineEndings(value string) (string, error) {

--- a/internal/components/sdd/session_preflight_test.go
+++ b/internal/components/sdd/session_preflight_test.go
@@ -28,6 +28,33 @@ func TestOpenCodeSessionPreflightCompositionIsRuntimeScoped(t *testing.T) {
 		t.Fatal("Claude composition unexpectedly received the OpenCode session preflight projection")
 	}
 }
+func TestMigratePreservedSDDSessionPreflightReplacesOnlyOwnedBytes(t *testing.T) {
+	for _, newline := range []string{"\n", "\r\n"} {
+		for _, testCase := range []struct {
+			name, prompt, want string
+		}{
+			{name: "unmarked", prompt: "PREFIX" + newline + "SUFFIX", want: "PREFIX" + newline + "SUFFIX" + newline + newline},
+			{name: "legacy", prompt: "PREFIX" + newline + legacySDDSessionPreflightMarker + newline + "Both -> `both`" + newline + legacySDDSessionPreflightEnd + newline + "SUFFIX", want: "PREFIX" + newline},
+			{name: "canonical", prompt: "PREFIX" + newline + sddSessionPreflightMarker + newline + "Both -> `both`" + newline + sddSessionPreflightEnd + newline + "SUFFIX", want: "PREFIX" + newline},
+		} {
+			t.Run(testCase.name+"/"+strings.ReplaceAll(newline, "\r", "cr"), func(t *testing.T) {
+				got, err := migratePreservedSDDSessionPreflight(testCase.prompt)
+				if err != nil {
+					t.Fatal(err)
+				}
+				block := strings.ReplaceAll(sddSessionPreflightBlock(), "\n", newline)
+				want := testCase.want + block
+				if testCase.name != "unmarked" {
+					want += newline + "SUFFIX"
+				}
+				if got != want || strings.Contains(got, "Both -> `both`") {
+					t.Fatalf("migration = %q, want %q", got, want)
+				}
+			})
+		}
+	}
+}
+
 func TestSDDSessionPreflightProjectionCanonicalAndBounded(t *testing.T) {
 	block := sddSessionPreflightBlock()
 	for _, want := range []string{"<!-- gentle-ai:sdd-session-preflight -->", "### SDD Session Preflight (HARD GATE)", "1. **Pace**", "2. **Artifacts**", "3. **PR strategy**", "Both -> `hybrid`", "fixed at 400 changed lines", "<!-- /gentle-ai:sdd-session-preflight -->"} {


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #3500

---

## 🏷️ PR Type

- [x] `type:bug` — Bug fix (non-breaking change that fixes an issue)

---

## 📝 Summary

Migrates preserved OpenCode and Kilo orchestrator prompts through the canonical marker-owned session-preflight authority. User-controlled bytes outside owned ranges are preserved across LF and CRLF inputs, malformed owned markers fail before any overlay write, and the obsolete second producer is removed.

This is work unit 2 of #3336 and does not close the parent tracker.

---

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/components/sdd/session_preflight.go` | Canonical preserved-marker migration and validation |
| `internal/components/sdd/inject.go` | Pre-write validation and canonical OpenCode/Kilo projection |
| `internal/components/sdd/*_test.go` | Preservation, malformed-marker, CRLF, vocabulary, and idempotence regressions |
| `bench/journeys_issue_3500.go` | Public external OpenCode sync journey |
| `bench/` registries | Journey ownership, manifest, and `reviewUntouched` declaration |

---

## 🤖 AI Assistance

- [x] **Material assistance used**

**Tool/model (if known):** Pi coding-agent harness with delegated worker/verifier agents.

**Material scope:** Root-cause mapping, implementation, tests, benchmark journey, and review preparation.

**Verification performed:** Strict TDD, independent diff review, full Go suite, vet, formatting, driven benchmark, and native RDD.

---

## 🧪 Test Plan

- [x] `go test -timeout=20m ./...` — PASS (672s, physical macOS TMPDIR)
- [x] `go vet ./...` — PASS
- [x] `go run ./internal/gofmtcheck` — PASS
- [x] `cd bench && go test ./... -count=1` — PASS
- [x] Driven `j3500-preserved-external-opencode-sync` — 1 completed, 0 unsupported, 0 failed
- [ ] Docker E2E — CI/local gate before merge

RDD: `review-59ea29bf7ef56781`, approved and acknowledged.

---

## ✅ Contributor Checklist

- [x] Linked issue has `status:approved`
- [x] Maintainer authorized `size:exception` up to 600 changed lines; this PR has 586
- [x] Appropriate `type:*` label requested
- [x] Unit tests and Go format pass
- [x] Benchmark validation completed in driven mode
- [x] Commit follows Conventional Commits
- [x] I understand, reviewed, and take responsibility for the complete submission
- [x] Material AI assistance declared
- [x] No `Co-Authored-By` trailers

---

## 💬 Notes for Reviewers

Review focus: canonical marker ownership in `session_preflight.go`, the pre-write rejection boundary in `Inject`, and byte-preserving external sync behavior. The 586-line cohesive diff is covered by the explicit maintainer `size:exception` granted for this work unit.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved externally authored OpenCode and Kilo prompts during SDD synchronization.
  * Migrated legacy session preflight content to the current format while retaining user-authored text.
  * Prevented malformed or duplicate preflight sections from being written.
  * Ensured repeated synchronization remains stable without altering already-migrated prompts.
  * Improved compatibility with prompts using LF or CRLF line endings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->