### PR TITLE
feat(review): expose the candidate risk assessment as a read-only command

### DIFF
--- a/contracts/review-integration/v2/schemas/assess.schema.json
+++ b/contracts/review-integration/v2/schemas/assess.schema.json
@@ -1,0 +1,36 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://gentle-ai.dev/contracts/review-integration/v2/schemas/assess.schema.json",
+  "title": "Gentle AI read-only review candidate risk assessment",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema", "risk", "reasons", "changed_paths", "changed_lines", "candidate"],
+  "properties": {
+    "schema": {"const": "gentle-ai.review-assessment/v1"},
+    "risk": {"enum": ["passive", "medium", "high"]},
+    "reasons": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["code"],
+        "properties": {
+          "code": {"type": "string", "minLength": 1},
+          "path": {"type": "string", "minLength": 1},
+          "detail": {"type": "string", "minLength": 1}
+        }
+      }
+    },
+    "changed_paths": {"type": "integer", "minimum": 0},
+    "changed_lines": {"type": "integer", "minimum": 0},
+    "candidate": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["kind"],
+      "properties": {
+        "kind": {"enum": ["current-changes", "base-diff"]},
+        "base_ref": {"type": "string", "minLength": 1}
+      }
+    }
+  }
+}

--- a/docs/review-integration.md
+++ b/docs/review-integration.md
@@ -94,6 +94,29 @@ Native Go alone selects lenses, classifies candidate causality, performs refutat
 
 Medium and high-risk START may return the typed `gentle-ai.review-integration.consent/v3` envelope. Relay the complete choice envelope losslessly, preserve machine tokens and invocations exactly, and run only the invocation selected by the human. Global RDD mode permits review; it never grants per-candidate consent. A decline is not the kill switch.
 
+## Read-only risk assessment (`gentle-ai review assess`)
+
+`gentle-ai review assess --cwd <repo> [--base-ref <ref> --committed-only] [--untracked-scope exclude|select --intended-untracked <path> --expected-untracked-inventory <digest>] [--json]` prints the same candidate risk classification START uses to select lenses (`reviewtransaction.AssessSnapshotRisk`), without creating any review authority, lineage, or store mutation. It works identically with receipt-driven development on or off, so a host can gate delegated verification on the result before ever calling `review start`.
+
+It builds the exact same candidate `review start` would: current changes by default, or an immutable base-to-HEAD comparison with `--base-ref` (which requires `--committed-only` to acknowledge dirty tracked changes, exactly like `review start`). The untracked-scope flags accept the same values `review start` does.
+
+With `--json`, it prints the typed `gentle-ai.review-assessment/v1` envelope:
+
+```json
+{
+  "schema": "gentle-ai.review-assessment/v1",
+  "risk": "medium",
+  "reasons": [{"code": "executable_change", "path": "notes/scratch.txt"}],
+  "changed_paths": 1,
+  "changed_lines": 1,
+  "candidate": {"kind": "current-changes"}
+}
+```
+
+`risk` is `passive`, `medium`, or `high`. `passive` is exactly the tier START selects zero reviewer lenses for (every authored path proven passive documentation by its own frozen bytes); `medium` and `high` keep the same vocabulary and evidence codes START's own `risk_reasons` already publishes, so this projection can never disagree with the classification a review of the same candidate would use. Without `--json`, it prints the same information as human-readable text.
+
+When the candidate cannot be built or classified (for example an unresolvable `--base-ref`), the command fails closed and names a runnable `gentle-ai review assess ...` continuation. A host that cannot resolve the named continuation should treat the failure exactly as it would treat a `"high"` result.
+
 ## Delivery remains human-owned
 
 `gentle-ai review validate` and named gates (`post-apply`, `pre-commit`, `pre-push`, `pre-pr`, and `release`) are compatibility/informational commands. They never discover authority or decide delivery:

--- a/docs/review-integration.md
+++ b/docs/review-integration.md
@@ -115,7 +115,7 @@ With `--json`, it prints the typed `gentle-ai.review-assessment/v1` envelope:
 
 `risk` is `passive`, `medium`, or `high`. `passive` is exactly the tier START selects zero reviewer lenses for (every authored path proven passive documentation by its own frozen bytes); `medium` and `high` keep the same vocabulary and evidence codes START's own `risk_reasons` already publishes, so this projection can never disagree with the classification a review of the same candidate would use. Without `--json`, it prints the same information as human-readable text.
 
-When the candidate cannot be built or classified (for example an unresolvable `--base-ref`), the command fails closed and names a runnable `gentle-ai review assess ...` continuation. A host that cannot resolve the named continuation should treat the failure exactly as it would treat a `"high"` result.
+When the candidate cannot be built or classified (for example an unresolvable `--base-ref`), the command fails closed and names a runnable continuation of the same command with a resolvable `--base-ref`. A host that cannot resolve the named continuation should treat the failure exactly as it would treat a `"high"` result.
 
 ## Delivery remains human-owned
 

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -455,7 +455,7 @@ func TestRunArgsDispatchesCompactReviewFacadeBeforePlatformValidation(t *testing
 	if err := RunArgs([]string{"review", "--help"}, &output); err != nil {
 		t.Fatalf("RunArgs(review --help) error = %v", err)
 	}
-	if !strings.Contains(output.String(), "review <acknowledge-approved|capture-result|capture-correction-plan|capture-refuter|capture-unachievable|capture-validation|lens-context|capabilities|start|validate|status|repair|invalidate|abandon|recover|reclaim|store-reset|inspect-authority|inspect-candidate|reopen-results|schema|opencode-transport>") {
+	if !strings.Contains(output.String(), "review <acknowledge-approved|capture-result|capture-correction-plan|capture-refuter|capture-unachievable|capture-validation|lens-context|capabilities|assess|start|validate|status|repair|invalidate|abandon|recover|reclaim|store-reset|inspect-authority|inspect-candidate|reopen-results|schema|opencode-transport>") {
 		t.Fatalf("compact review help missing:\n%s", output.String())
 	}
 	for _, retired := range []string{"preserve-result", "dispose-result"} {

--- a/internal/cli/review_assess.go
+++ b/internal/cli/review_assess.go
@@ -1,0 +1,226 @@
+package cli
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/gentleman-programming/gentle-ai/v2/internal/reviewtransaction"
+)
+
+// ReviewAssessmentSchema is the typed envelope gentle-ai review assess prints
+// with --json. It is a read-only projection of the same candidate risk
+// assessment START uses to choose lenses (reviewtransaction.AssessSnapshotRisk),
+// so a host can gate delegated verification on it before deciding whether to
+// start a review at all, with or without receipt-driven development enabled
+// (issue #4295).
+const ReviewAssessmentSchema = "gentle-ai.review-assessment/v1"
+const ReviewAssessmentSchemaID = "https://gentle-ai.dev/contracts/review-integration/v2/schemas/assess.schema.json"
+
+// ReviewAssessmentReason is the public projection of one
+// reviewtransaction.RiskReason: the same evidence code and path START already
+// carries in its own risk_reasons, plus an optional human-readable detail for
+// the signal or mode-change evidence a bare code does not spell out.
+type ReviewAssessmentReason struct {
+	Code   string `json:"code"`
+	Path   string `json:"path,omitempty"`
+	Detail string `json:"detail,omitempty"`
+}
+
+// ReviewAssessmentCandidate names the exact candidate the assessment was
+// computed over, so a caller can tell a current-changes candidate from a named
+// base comparison without re-deriving it.
+type ReviewAssessmentCandidate struct {
+	Kind    string `json:"kind"`
+	BaseRef string `json:"base_ref,omitempty"`
+}
+
+// ReviewAssessmentResult is the complete gentle-ai.review-assessment/v1
+// envelope. Risk is the public vocabulary: "passive" is exactly the tier
+// reviewtransaction.RiskLow names -- the same zero-lens, structural-readback
+// tier START selects for it -- and "medium"/"high" are unchanged so this
+// projection can never disagree with START's own classification of the same
+// candidate.
+type ReviewAssessmentResult struct {
+	Schema       string                    `json:"schema"`
+	Risk         string                    `json:"risk"`
+	Reasons      []ReviewAssessmentReason  `json:"reasons"`
+	ChangedPaths int                       `json:"changed_paths"`
+	ChangedLines int                       `json:"changed_lines"`
+	Candidate    ReviewAssessmentCandidate `json:"candidate"`
+}
+
+// reviewAssessPublicRisk maps the internal risk tier to the public
+// gentle-ai.review-assessment/v1 vocabulary. RiskLow is renamed to "passive"
+// because that is exactly the condition it names: every authored path proven
+// passive documentation by its own frozen bytes, the one tier START selects
+// zero reviewer lenses for. Medium and high keep their internal spelling
+// unchanged.
+func reviewAssessPublicRisk(level reviewtransaction.RiskLevel) (string, error) {
+	switch level {
+	case reviewtransaction.RiskLow:
+		return "passive", nil
+	case reviewtransaction.RiskMedium:
+		return "medium", nil
+	case reviewtransaction.RiskHigh:
+		return "high", nil
+	default:
+		return "", fmt.Errorf("review assess computed an unsupported risk level %q; this is a defect in gentle-ai itself, not a request error -- file it and retry with gentle-ai review assess --help", level)
+	}
+}
+
+// reviewAssessmentReasons projects the internal risk reasons onto the public
+// envelope shape, folding the signal and mode-change evidence a bare code
+// does not carry into an optional human-readable detail string.
+func reviewAssessmentReasons(reasons []reviewtransaction.RiskReason) []ReviewAssessmentReason {
+	public := make([]ReviewAssessmentReason, 0, len(reasons))
+	for _, reason := range reasons {
+		var detail []string
+		if reason.Signal != "" {
+			detail = append(detail, "signal: "+string(reason.Signal))
+		}
+		if reason.OldMode != "" || reason.NewMode != "" {
+			detail = append(detail, fmt.Sprintf("mode %s -> %s", reason.OldMode, reason.NewMode))
+		}
+		public = append(public, ReviewAssessmentReason{
+			Code: string(reason.Code), Path: reason.Path, Detail: strings.Join(detail, "; "),
+		})
+	}
+	return public
+}
+
+// RunReviewAssess is the read-only `gentle-ai review assess` command. It
+// builds the exact same candidate review start would (current changes, or a
+// named --base-ref comparison), runs the shared risk assessment, and prints
+// it: no authority, no lineage, no store mutation, and no lock beyond an
+// ordinary read. It works identically whether or not receipt-driven
+// development is enabled, so a host can gate delegated verification on the
+// result before ever calling review start (issue #4295).
+//
+// When the candidate cannot be built or assessed, this command fails closed:
+// every returned error names a runnable `gentle-ai review assess ...`
+// continuation (or an unambiguous %w propagation of the underlying native
+// failure). Hosts that cannot resolve the named continuation should treat the
+// failure exactly as they would treat a "high" result.
+func RunReviewAssess(args []string, stdout io.Writer) error {
+	ctx := context.Background()
+	flags := newReviewFlagSet("review assess", stdout,
+		"Print the read-only candidate risk assessment review start would use to select lenses, without creating any review authority.")
+	cwd := flags.String("cwd", ".", "repository path")
+	baseRef := flags.String("base-ref", "", "optional base revision for an immutable base-to-HEAD assessment")
+	committedOnly := flags.Bool("committed-only", false, "acknowledge that --base-ref excludes dirty tracked changes")
+	jsonOutput := flags.Bool("json", false, "print the gentle-ai.review-assessment/v1 envelope as JSON instead of human-readable text")
+	untrackedScope := reviewSingleValueFlag{}
+	intendedUntracked := reviewRepeatedPathFlag{}
+	expectedUntrackedInventory := reviewSingleValueFlag{}
+	flags.Var(&untrackedScope, "untracked-scope", "explicit untracked scope: exclude or select")
+	flags.Var(&intendedUntracked, "intended-untracked", "repo-relative untracked path to include; repeat for each path")
+	flags.Var(&expectedUntrackedInventory, "expected-untracked-inventory", "sha256 inventory digest from review status")
+	if err := parseReviewFlags(flags, args); err != nil {
+		return err
+	}
+	if reviewHelpRequested(args) {
+		return nil
+	}
+	if flags.NArg() != 0 {
+		return reviewPreflightError(fmt.Errorf("unexpected review assess argument %q; run `gentle-ai review assess --help` for the closed command form", flags.Arg(0)))
+	}
+
+	root, err := reviewtransaction.PrepareReviewRepositoryRoot(ctx, *cwd)
+	if err != nil {
+		return fmt.Errorf("review assess: resolve repository root: %w", err)
+	}
+	builder := reviewtransaction.SnapshotBuilder{Repo: root}
+
+	trimmedBaseRef := strings.TrimSpace(*baseRef)
+	target := reviewtransaction.Target{
+		Kind: reviewtransaction.TargetCurrentChanges, Projection: reviewtransaction.ProjectionWorkspace,
+		IntendedUntracked: []string{},
+	}
+	if trimmedBaseRef != "" {
+		target.Kind = reviewtransaction.TargetBaseDiff
+		target.BaseRef = trimmedBaseRef
+		dirtyTracked, dirtyErr := builder.HasDirtyTrackedChanges(ctx)
+		if dirtyErr != nil {
+			return fmt.Errorf("review assess: detect dirty tracked changes: %w", dirtyErr)
+		}
+		if dirtyTracked && !*committedOnly {
+			return reviewPreflightError(fmt.Errorf(
+				"review assess with --base-ref omits dirty tracked changes; rerun `gentle-ai review assess --base-ref %s --committed-only` to acknowledge committed-only scope",
+				trimmedBaseRef))
+		}
+	}
+
+	intendedScope, err := intendedUntrackedScopeForTarget(ctx, builder, untrackedScope, intendedUntracked, expectedUntrackedInventory,
+		reviewIntendedUntrackedInventoryCommand, "gentle-ai review assess")
+	if err != nil {
+		return reviewPreflightError(err)
+	}
+	if intendedScope.NeedsSelection {
+		return reviewPreflightError(intendedUntrackedSelectionRequired(intendedScope, reviewIntendedUntrackedInventoryCommand, "gentle-ai review assess"))
+	}
+	target.IntendedUntracked = intendedScope.Intended
+
+	snapshot, err := builder.Build(ctx, target)
+	if err != nil {
+		return fmt.Errorf("review assess could not build the candidate; correct --cwd or --base-ref and retry with `gentle-ai review assess --help`: %w", err)
+	}
+	if reviewStartEmptyCandidateScope(snapshot) {
+		return reviewPreflightError(errors.New(
+			"the review assess candidate has no pending changes; already-committed work can be assessed by rerunning `gentle-ai review assess --base-ref <commit>` naming the base to compare against"))
+	}
+
+	assessment, err := builder.AssessSnapshotRisk(ctx, snapshot)
+	if err != nil {
+		return fmt.Errorf("review assess could not classify the candidate; retry with `gentle-ai review assess --help` or a narrower --base-ref: %w", err)
+	}
+	publicRisk, err := reviewAssessPublicRisk(assessment.Level)
+	if err != nil {
+		return err
+	}
+
+	result := ReviewAssessmentResult{
+		Schema: ReviewAssessmentSchema, Risk: publicRisk, Reasons: reviewAssessmentReasons(assessment.Reasons),
+		ChangedPaths: len(snapshot.Paths), ChangedLines: assessment.ChangedLines,
+		Candidate: ReviewAssessmentCandidate{Kind: string(snapshot.Kind), BaseRef: trimmedBaseRef},
+	}
+
+	if *jsonOutput {
+		return encodeReviewJSON(stdout, result)
+	}
+	return writeReviewAssessmentHuman(stdout, result)
+}
+
+// writeReviewAssessmentHuman renders the same assessment as readable text,
+// for a caller that has not asked for the JSON envelope.
+func writeReviewAssessmentHuman(stdout io.Writer, result ReviewAssessmentResult) error {
+	candidate := result.Candidate.Kind
+	if result.Candidate.BaseRef != "" {
+		candidate = fmt.Sprintf("%s (base-ref %s)", candidate, result.Candidate.BaseRef)
+	}
+	if _, err := fmt.Fprintf(stdout, "Risk: %s\nCandidate: %s\nChanged paths: %d\nChanged lines: %d\n",
+		result.Risk, candidate, result.ChangedPaths, result.ChangedLines); err != nil {
+		return err
+	}
+	if len(result.Reasons) == 0 {
+		return nil
+	}
+	if _, err := fmt.Fprintln(stdout, "Reasons:"); err != nil {
+		return err
+	}
+	for _, reason := range result.Reasons {
+		line := "  - " + reason.Code
+		if reason.Path != "" {
+			line += " (" + reason.Path + ")"
+		}
+		if reason.Detail != "" {
+			line += ": " + reason.Detail
+		}
+		if _, err := fmt.Fprintln(stdout, line); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/internal/cli/review_assess_test.go
+++ b/internal/cli/review_assess_test.go
@@ -1,0 +1,206 @@
+package cli
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/gentleman-programming/gentle-ai/v2/internal/reviewtransaction"
+)
+
+// TestReviewAssessPassiveDocumentationCandidate proves review assess reports
+// the same zero-lens tier START would select for a candidate whose only
+// authored bytes are ordinary prose, without creating any review authority.
+// It deliberately does not assert an empty reasons array: the shared
+// assessor's own fallback reason (non_executable_only) is exactly what
+// explains the "passive" tier, and review assess reuses that assessor rather
+// than forking it, so this envelope carries the same evidence START does.
+func TestReviewAssessPassiveDocumentationCandidate(t *testing.T) {
+	repo := initReviewCLIRepo(t)
+	writeReviewStartCandidate(t, repo, "docs/guide.md", "ordinary documentation prose.\n", 0o644)
+
+	var output bytes.Buffer
+	if err := RunReview([]string{"assess", "--cwd", repo, "--json"}, &output); err != nil {
+		t.Fatalf("review assess: %v\n%s", err, output.String())
+	}
+	var result ReviewAssessmentResult
+	if err := json.Unmarshal(output.Bytes(), &result); err != nil {
+		t.Fatalf("decode review assess envelope: %v\n%s", err, output.String())
+	}
+	if result.Schema != ReviewAssessmentSchema || result.Risk != "passive" || result.ChangedPaths != 1 ||
+		result.Candidate.Kind != string(reviewtransaction.TargetCurrentChanges) || result.Candidate.BaseRef != "" {
+		t.Fatalf("passive review assess = %#v\n%s", result, output.String())
+	}
+	if len(result.Reasons) != 1 || result.Reasons[0].Code != string(reviewtransaction.RiskReasonNonExecutableOnly) {
+		t.Fatalf("passive review assess reasons = %#v", result.Reasons)
+	}
+}
+
+// TestReviewAssessExecutableChangeCandidate proves an ordinary but
+// non-passive change (a plain-text file, which no passive-document extension
+// admits) is reported as medium with the executable-change reason, exactly
+// as the shared assessor's fallback classifies it for START.
+func TestReviewAssessExecutableChangeCandidate(t *testing.T) {
+	repo := initReviewCLIRepo(t)
+	writeReviewStartCandidate(t, repo, "notes/scratch.txt", "some plain scratch content\n", 0o644)
+
+	var output bytes.Buffer
+	if err := RunReview([]string{"assess", "--cwd", repo, "--json"}, &output); err != nil {
+		t.Fatalf("review assess: %v\n%s", err, output.String())
+	}
+	var result ReviewAssessmentResult
+	if err := json.Unmarshal(output.Bytes(), &result); err != nil {
+		t.Fatalf("decode review assess envelope: %v\n%s", err, output.String())
+	}
+	if result.Risk != "medium" {
+		t.Fatalf("executable-change review assess risk = %q, want medium: %#v", result.Risk, result)
+	}
+	if len(result.Reasons) != 1 || result.Reasons[0].Code != string(reviewtransaction.RiskReasonExecutableChange) ||
+		result.Reasons[0].Path != "notes/scratch.txt" {
+		t.Fatalf("executable-change review assess reasons = %#v", result.Reasons)
+	}
+}
+
+// TestReviewAssessProcessBoundaryCandidate proves a change touching an
+// authentication-pattern path is reported as high with a matching reason
+// code, exactly as START's own hot-path classification would.
+func TestReviewAssessProcessBoundaryCandidate(t *testing.T) {
+	repo := initReviewCLIRepo(t)
+	writeReviewStartCandidate(t, repo, "internal/auth/login.go", "package auth\n", 0o644)
+
+	var output bytes.Buffer
+	if err := RunReview([]string{"assess", "--cwd", repo, "--json"}, &output); err != nil {
+		t.Fatalf("review assess: %v\n%s", err, output.String())
+	}
+	var result ReviewAssessmentResult
+	if err := json.Unmarshal(output.Bytes(), &result); err != nil {
+		t.Fatalf("decode review assess envelope: %v\n%s", err, output.String())
+	}
+	if result.Risk != "high" {
+		t.Fatalf("auth-path review assess risk = %q, want high: %#v", result.Risk, result)
+	}
+	found := false
+	for _, reason := range result.Reasons {
+		if reason.Code == string(reviewtransaction.RiskReasonHotPath) && strings.Contains(reason.Detail, "signal: auth") {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("auth-path review assess reasons missing hot_path/auth evidence: %#v", result.Reasons)
+	}
+}
+
+// TestReviewAssessCommittedOnlyBaseDiffMatchesStart proves a --base-ref
+// candidate is classified by review assess exactly the way a negotiated
+// review start records it in its own authority state, for the identical
+// fixture. review assess must never disagree with the classifier START uses
+// to select lenses.
+func TestReviewAssessCommittedOnlyBaseDiffMatchesStart(t *testing.T) {
+	reviewEnabledHome(t)
+	repo := initReviewCLIRepo(t)
+	baseRef := strings.TrimSpace(runReviewCLIGit(t, repo, "rev-parse", "HEAD"))
+	writeReviewStartCandidate(t, repo, "scripts/deploy.sh", "echo deploy\n", 0o644)
+	runReviewCLIGit(t, repo, "commit", "-qm", "add deploy script")
+
+	var assessOutput bytes.Buffer
+	if err := RunReview([]string{"assess", "--cwd", repo, "--base-ref", baseRef, "--committed-only", "--json"}, &assessOutput); err != nil {
+		t.Fatalf("review assess --base-ref: %v\n%s", err, assessOutput.String())
+	}
+	var assessed ReviewAssessmentResult
+	if err := json.Unmarshal(assessOutput.Bytes(), &assessed); err != nil {
+		t.Fatalf("decode review assess envelope: %v\n%s", err, assessOutput.String())
+	}
+	if assessed.Candidate.Kind != string(reviewtransaction.TargetBaseDiff) || assessed.Candidate.BaseRef != baseRef {
+		t.Fatalf("base-diff review assess candidate = %#v", assessed.Candidate)
+	}
+
+	started := runNegotiatedReviewStartWith(t, repo, "review-assess-equivalence", "--base-ref", baseRef)
+	wantRisk, err := reviewAssessPublicRisk(started.RiskLevel)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if assessed.Risk != wantRisk || assessed.ChangedLines != started.ChangedLines {
+		t.Fatalf("review assess (%q, %d changed lines) does not match review start's own classification (%q, %d changed lines)",
+			assessed.Risk, assessed.ChangedLines, wantRisk, started.ChangedLines)
+	}
+}
+
+// TestReviewAssessUnbuildableCandidateNamesResolution proves an unbuildable
+// candidate (an unresolvable --base-ref) fails closed with a message naming a
+// literal `gentle-ai review assess ...` resolution, per the refusal ratchet
+// and issue #4295's fail-closed requirement. Hosts that cannot resolve the
+// named continuation are documented to treat this exactly like a "high"
+// result.
+func TestReviewAssessUnbuildableCandidateNamesResolution(t *testing.T) {
+	repo := initReviewCLIRepo(t)
+
+	var output bytes.Buffer
+	err := RunReview([]string{"assess", "--cwd", repo, "--base-ref", "not-a-real-ref-4295"}, &output)
+	if err == nil {
+		t.Fatalf("review assess with an unresolvable --base-ref unexpectedly succeeded: %s", output.String())
+	}
+	if !strings.Contains(err.Error(), "gentle-ai review assess") {
+		t.Fatalf("unbuildable review assess error does not name a gentle-ai review assess resolution: %v", err)
+	}
+}
+
+// TestReviewAssessJSONEnvelopeValidatesAgainstPublishedSchema proves the
+// --json envelope validates against the published
+// gentle-ai.review-assessment/v1 schema for a representative candidate of
+// each public risk word.
+func TestReviewAssessJSONEnvelopeValidatesAgainstPublishedSchema(t *testing.T) {
+	schema := compileWholePublishedReviewSchema(t, "v2", "assess.schema.json")
+
+	for _, fixture := range []struct {
+		name string
+		path string
+		body string
+	}{
+		{name: "passive", path: "docs/guide.md", body: "ordinary documentation prose.\n"},
+		{name: "medium", path: "notes/scratch.txt", body: "some plain scratch content\n"},
+		{name: "high", path: "internal/auth/login.go", body: "package auth\n"},
+	} {
+		t.Run(fixture.name, func(t *testing.T) {
+			repo := initReviewCLIRepo(t)
+			writeReviewStartCandidate(t, repo, fixture.path, fixture.body, 0o644)
+
+			var output bytes.Buffer
+			if err := RunReview([]string{"assess", "--cwd", repo, "--json"}, &output); err != nil {
+				t.Fatalf("review assess: %v\n%s", err, output.String())
+			}
+			validatePublishedReviewSchema(t, schema, output.Bytes())
+		})
+	}
+}
+
+// TestReviewAssessHumanReadableOutputOmitsJSON proves the default (no --json)
+// output is human-readable text, not the machine envelope, and still reports
+// the risk and candidate shape.
+func TestReviewAssessHumanReadableOutputOmitsJSON(t *testing.T) {
+	repo := initReviewCLIRepo(t)
+	writeReviewStartCandidate(t, repo, "docs/guide.md", "ordinary documentation prose.\n", 0o644)
+
+	var output bytes.Buffer
+	if err := RunReview([]string{"assess", "--cwd", repo}, &output); err != nil {
+		t.Fatalf("review assess: %v\n%s", err, output.String())
+	}
+	rendered := output.String()
+	if strings.Contains(rendered, "{") || !strings.Contains(rendered, "Risk: passive") || !strings.Contains(rendered, "Candidate: current-changes") {
+		t.Fatalf("human-readable review assess output = %q", rendered)
+	}
+}
+
+// TestReviewAssessDispatchedFromReviewCommand proves the verb is reachable
+// through the plain review facade dispatch, the same route
+// docs/review-integration.md's guard requires.
+func TestReviewAssessDispatchedFromReviewCommand(t *testing.T) {
+	source, err := os.ReadFile("review_facade.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reviewCommandDispatchVerbsFromSource(t, source)["assess"] {
+		t.Fatal("review assess is not dispatched by review_facade.go")
+	}
+}

--- a/internal/cli/review_facade.go
+++ b/internal/cli/review_facade.go
@@ -594,7 +594,7 @@ func (err *reviewStartContextError) Unwrap() error { return err.Cause }
 
 func RunReview(args []string, stdout io.Writer) error {
 	if len(args) == 0 || args[0] == "help" || args[0] == "-h" || args[0] == "--help" {
-		_, _ = fmt.Fprintln(stdout, "Usage: gentle-ai review <acknowledge-approved|capture-result|capture-correction-plan|capture-refuter|capture-unachievable|capture-validation|lens-context|capabilities|start|validate|status|repair|invalidate|abandon|recover|reclaim|store-reset|inspect-authority|inspect-candidate|reopen-results|schema|opencode-transport> [flags]\n\nOrdinary review facade; repository scope, authority, canonical artifacts, and lifecycle transitions are derived by Go. Provider transports relay opaque bytes only; Go materializes, admits, captures, and closes review on its final causal event. Generic review recover remains unchanged. Use review repair --preflight for provider-owned classified authority repair.")
+		_, _ = fmt.Fprintln(stdout, "Usage: gentle-ai review <acknowledge-approved|capture-result|capture-correction-plan|capture-refuter|capture-unachievable|capture-validation|lens-context|capabilities|assess|start|validate|status|repair|invalidate|abandon|recover|reclaim|store-reset|inspect-authority|inspect-candidate|reopen-results|schema|opencode-transport> [flags]\n\nOrdinary review facade; repository scope, authority, canonical artifacts, and lifecycle transitions are derived by Go. Provider transports relay opaque bytes only; Go materializes, admits, captures, and closes review on its final causal event. Generic review recover remains unchanged. Use review repair --preflight for provider-owned classified authority repair.")
 		return nil
 	}
 	operation, negotiated, preflightFailure := reviewIntegrationFailureRoute(args)
@@ -726,6 +726,8 @@ func runReviewCommandContext(ctx context.Context, args []string, stdout io.Write
 
 func runReviewCommand(args []string, stdout io.Writer) error {
 	switch args[0] {
+	case "assess":
+		return RunReviewAssess(args[1:], stdout)
 	case "capture-result":
 		return RunReviewCaptureResult(args[1:], stdout)
 	case "capture-correction-plan":

--- a/internal/cli/review_operation_contract.go
+++ b/internal/cli/review_operation_contract.go
@@ -79,6 +79,13 @@ type reviewIntegrationOperationMetadata struct {
 // the verb; see the field's own comment for why the difference is load-bearing.
 var reviewIntegrationOperationRegistry = []reviewIntegrationOperationMetadata{
 	{Command: "capabilities", Operation: "review.capabilities", Label: "Review CAPABILITIES", Negotiated: true},
+	// review.assess owns a verb without joining the published negotiated
+	// surface (see Negotiated above). It is a read-only projection of the same
+	// candidate risk assessment START uses to select lenses: no authority, no
+	// lineage, no store mutation, so it declares no flag or timeout metadata --
+	// those fields are consumed only on the negotiated and collect-capture
+	// routes this row does not take (issue #4295).
+	{Command: "assess", Operation: "review.assess", Label: "Review ASSESS"},
 	// CollectCapture rows carry the exact flag sets their Run functions define,
 	// so a refusal envelope never silently drops the bound lineage.
 	{Command: "capture-correction-plan", Operation: reviewCaptureCorrectionPlanOperation, Label: "Review CAPTURE-CORRECTION-PLAN", CollectCapture: true, ValueFlags: []string{"cwd", "repository-context", "lineage", "target", "expected-revision", "request-hash"}, IntFlags: []string{"correction-lines"}, MutatesAuthority: true},


### PR DESCRIPTION
Closes #4295

## Summary
- New read-only verb `gentle-ai review assess --cwd <repo> [--base-ref <ref> --committed-only] [--untracked-scope …] [--json]` that builds the candidate exactly as `review start` would and runs the shared `AssessSnapshotRisk`, so the command and START can never disagree.
- Typed envelope `gentle-ai.review-assessment/v1`: `risk` (`passive|medium|high`, the internal low level surfaces as `passive`), `reasons[]` with the existing reason codes, `changed_paths`, `changed_lines`, `candidate {kind, base_ref}`. Human-readable output without `--json`.
- No authority, no lineage, no store mutation. An unbuildable candidate fails closed with a typed refusal naming the `gentle-ai …` resolution; hosts treat that as `high`.
- Phase two of Gentleman-Programming/gentle-pi#661: gentle-pi#662 gates the separate verifier on this tier when RDD is off; #4296 projects the rule into every runtime asset.

## Changes
| File | Change |
|------|--------|
| `internal/cli/review_assess.go` (+test) | `RunReviewAssess`, envelope, human output |
| `contracts/review-integration/v2/schemas/assess.schema.json` | Strict schema |
| `internal/cli/review_facade.go`, `review_operation_contract.go` | Dispatch and registry row |
| `internal/app/app_test.go` | Facade usage line |
| `docs/review-integration.md` | "Read-only risk assessment" section |

## Size exception
504 lines, mostly the behavior tests (passive, executable, process boundary, committed-only parity with START, unbuildable candidate, schema validation, dispatch).

## Test plan
- [x] `go test ./internal/cli/ -run 'Assess|TestReviewProviderArtifact|TestRunArgs' -count=1`
- [x] `go test ./internal/reviewtransaction/ -run 'Risk|Assess' -count=1`, `go test ./internal/components/ -count=1`, `internal/app` facade test
- [x] Refusal and deadcode ratchets pass
- [x] Native review approved (lineage review-fac2f442f389c6ad, four lenses), acknowledged

https://claude.ai/code/session_01SYqbaaqyJcAv1FYtSJXx6M

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added the read-only `gentle-ai review assess` command.
  - Assessments can target current changes or a base-reference comparison.
  - Results are available as human-readable text or validated JSON, including risk level, reasons, and change statistics.
  - Added fail-closed guidance when a candidate cannot be built or assessed.

- **Documentation**
  - Documented the assessment command, options, output schema, risk levels, and failure behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->