### PR TITLE
fix(sdd): project canonical preflight into Claude workflow

### DIFF
--- a/internal/assets/assets_test.go
+++ b/internal/assets/assets_test.go
@@ -1083,33 +1083,12 @@ func TestClaudeSDDWorkflowRequiresSessionPreflight(t *testing.T) {
 	content := MustRead("claude/sdd-orchestrator-workflow.md")
 
 	for _, required := range []string{
-		"### SDD Session Preflight (HARD GATE)",
-		"Before executing ANY SDD command or natural-language SDD request",
-		"**Execution mode**",
-		"**Artifact store**",
-		"**Chained PR strategy**",
-		"**Review budget**",
-		"`openspec/config.yaml`, existing SDD artifacts, previous `sdd-init` results, or installed SDD assets do NOT satisfy session preflight",
-		"Use the built-in `AskUserQuestion` tool for SDD Session Preflight",
-		"only when it is available in the current interactive runtime and all four groups are exactly representable",
-		"follow the Lossless Blocking Prompts fallback in the orchestrator rule and STOP",
-		"When the native route is representable, ask all four preflight groups in one single `AskUserQuestion` tool call",
-		"Do NOT run this as a sequential wizard",
-		"Do NOT issue four separate `AskUserQuestion` tool calls",
-		"Match the user's current language and active persona",
-		"Do NOT show option codes",
-		"Do NOT show canonical values",
-		"map the selected human labels to canonical values internally",
-		"1. Pace: Interactive, Automatic.",
-		"2. Artifacts: OpenSpec, Engram, Both.",
-		"3. PRs: Ask me, Single PR, Auto.",
-		"4. Review: 400 lines, 800 lines, Other.",
+		"Session preflight is projected here by the installer from the shared canonical authority",
+		"### SDD Init Guard (MANDATORY)",
 		"### SDD Entry Routing (MANDATORY)",
 		"Never launch `sdd-apply` just because the user asked to implement a feature",
 		"Only launch `sdd-apply` when all are true",
 		"If any dependency is missing, STOP and propose `/gentle-sdd-new` or `/gentle-sdd-ff`; do not implement",
-		"or `hybrid` when Engram is callable",
-		"Both -> `hybrid`",
 	} {
 		if !strings.Contains(content, required) {
 			t.Fatalf("claude/sdd-orchestrator-workflow.md missing required preflight wording %q", required)
@@ -1117,8 +1096,10 @@ func TestClaudeSDDWorkflowRequiresSessionPreflight(t *testing.T) {
 	}
 
 	for _, forbidden := range []string{
-		"`question` tool",
-		"groups as tabs",
+		"`question` tool", "AskUserQuestion", "groups as tabs",
+		"### SDD Session Preflight (HARD GATE)",
+		"gentle-ai:sdd-session-preflight", "Required preflight choices:",
+		"1. Pace:", "Both ->", "800 lines", "Other", "all four",
 	} {
 		if strings.Contains(content, forbidden) {
 			t.Fatalf("claude/sdd-orchestrator-workflow.md must use Claude Code's AskUserQuestion mechanics, not OpenCode wording %q", forbidden)
@@ -1143,11 +1124,10 @@ func TestClaudeSDDWorkflowRequiresSessionPreflight(t *testing.T) {
 		}
 	}
 
-	preflight := strings.Index(content, "### SDD Session Preflight (HARD GATE)")
-	routing := strings.Index(content, "### SDD Entry Routing (MANDATORY)")
-	initGuard := strings.Index(content, "### SDD Init Guard (MANDATORY)")
-	if !(preflight < routing && routing < initGuard) {
-		t.Fatalf("claude/sdd-orchestrator-workflow.md section order must be preflight (%d) < entry routing (%d) < init guard (%d)", preflight, routing, initGuard)
+	routing := "### SDD Entry Routing (MANDATORY)"
+	initGuard := "### SDD Init Guard (MANDATORY)"
+	if strings.Count(content, routing) != 1 || strings.Count(content, initGuard) != 1 || strings.Index(content, routing) >= strings.Index(content, initGuard) {
+		t.Fatal("Claude projection template requires unique routing then init anchors")
 	}
 }
 
@@ -1203,7 +1183,6 @@ func TestSDDOrchestratorAssetsDefaultToAutomatic(t *testing.T) {
 func TestSDDFFCommandsHonorInteractiveMode(t *testing.T) {
 	for _, path := range []string{
 		"opencode/commands/sdd-ff.md",
-		"claude/commands/gentle-sdd-ff.md",
 	} {
 		t.Run(path, func(t *testing.T) {
 			content := MustRead(path)

--- a/internal/assets/claude/commands/gentle-sdd-continue.md
+++ b/internal/assets/claude/commands/gentle-sdd-continue.md
@@ -2,34 +2,8 @@
 description: Continue the next SDD phase in the dependency chain
 ---
 
-Read the SDD workflow FIRST: `.claude/skills/_shared/sdd-orchestrator-workflow.md` under the workspace when a workspace-scope install wrote it there, otherwise `~/.claude/skills/_shared/sdd-orchestrator-workflow.md`. Then treat it as the authoritative SDD workflow instructions for this command.
-The Claude Code session model is controlled by Claude Code; Gentle AI's always-on Model Assignments policy resolves every Agent tool call, including generic/organic delegation through `default`.
+Intent: Continue the active SDD change.
+Change name (optional): $ARGUMENTS
 
-WORKFLOW:
-
-1. If the `gentle-ai` binary is available, run `gentle-ai sdd-continue [change] --cwd <repo>` and treat its dispatcher/status output as authoritative — but only when the session artifact store is `openspec` or `hybrid`. When the session artifact store is `engram`, do NOT invoke the native dispatcher at all — it cannot see the change (it reads only `openspec/changes/`); resolve status entirely from Engram (`mem_search` + `mem_get_observation` on the change's topic keys) using the manual status schema in `~/.claude/skills/_shared/sdd-status-contract.md` (the same schema used when the binary is unavailable). The dispatcher is authoritative only for `openspec`/`hybrid`. If unavailable, read `~/.claude/skills/_shared/sdd-status-contract.md` and produce structured status before acting.
-2. Resolve the active change. If `$ARGUMENTS` is missing and more than one active change exists, ask the user to choose and STOP. Do not guess.
-3. Check which artifacts already exist for the active change (proposal, specs, design, tasks)
-4. Determine the next phase needed based on the dependency graph:
-   proposal → [specs ∥ design] → tasks → apply → verify → archive
-5. Launch the appropriate sub-agent(s) for the next phase only if authoritative status says the dependency is ready. Route only by `nextRecommended` and dependency states; never infer from free text. If `blockedReasons` is non-empty, do not proceed to apply, archive, or terminal work. If `nextRecommended` is `verify`, verification/remediation may run only to refresh evidence; if `nextRecommended` is `resolve-blockers`, report `blockedReasons` and stop; if `nextRecommended` is a planning token (`propose`, `spec`, `design`, or `tasks`), launch the corresponding planning phase. Carry `actionContext` and allowed edit roots into any sub-agent launch.
-6. Present the result and ask the user to proceed
-
-CONTEXT:
-
-- Working directory: Detect agent-side before proceeding by running `git rev-parse --show-toplevel` with the Bash tool; if that fails, run `pwd` with the Bash tool.
-- Current project: Derive agent-side from the detected working directory basename. Do not use slash-command shell interpolation for this value.
-- Change name: $ARGUMENTS
-- Execution mode: ask/cache per orchestrator
-- Artifact store mode: ask/cache per orchestrator
-- Delivery strategy: ask/cache per orchestrator
-
-ENGRAM NOTE:
-To check which artifacts exist, search: mem_search(query: "sdd/$ARGUMENTS/", project: "{project}") to list all artifacts for this change.
-Sub-agents handle persistence automatically with topic_key "sdd/$ARGUMENTS/{type}".
-
-Use the lazy workflow instructions to coordinate this workflow. Do NOT execute phase work inline when a native sub-agent is available.
-
-STATUS CONTRACT:
-
-Prefer `gentle-ai sdd-continue [change] --cwd <repo>` when available — but only when the session artifact store is `openspec` or `hybrid`; when the store is `engram`, do NOT invoke the binary and resolve status from Engram using the manual status schema. Otherwise read `~/.claude/skills/_shared/sdd-status-contract.md` and follow it. If status reports `workspace-planning` with no allowed edit roots, do not launch apply/verify/archive work that would infer repo-local ownership.
+Read `.claude/skills/_shared/sdd-orchestrator-workflow.md` under the workspace first; if absent, read `~/.claude/skills/_shared/sdd-orchestrator-workflow.md`.
+Delegate this intent and arguments to that authoritative lazy workflow; follow its instructions rather than defining command-local policy.

--- a/internal/assets/claude/commands/gentle-sdd-ff.md
+++ b/internal/assets/claude/commands/gentle-sdd-ff.md
@@ -2,32 +2,8 @@
 description: Fast-forward all SDD planning phases — proposal through tasks
 ---
 
-Read the SDD workflow FIRST: `.claude/skills/_shared/sdd-orchestrator-workflow.md` under the workspace when a workspace-scope install wrote it there, otherwise `~/.claude/skills/_shared/sdd-orchestrator-workflow.md`. Then treat it as the authoritative SDD workflow instructions for this command.
-The Claude Code session model is controlled by Claude Code; Gentle AI's always-on Model Assignments policy resolves every Agent tool call, including generic/organic delegation through `default`.
+Intent: Fast-forward planning for an SDD change.
+Change name: $ARGUMENTS
 
-WORKFLOW:
-Honor the cached execution mode from SDD Session Preflight.
-
-Planning phases:
-
-1. `sdd-propose` — create the proposal
-2. `sdd-spec` — write specifications
-3. `sdd-design` — create technical design
-4. `sdd-tasks` — break down into implementation tasks
-
-- In `interactive` mode: run only the next planning phase, present its summary and artifact path(s), ask whether to adjust or continue, then STOP. Do not launch the following phase until the user confirms.
-- In `auto` mode: run all planning phases back-to-back and present a combined summary after all phases complete.
-
-CONTEXT:
-
-- Working directory: Detect agent-side before proceeding by running `git rev-parse --show-toplevel` with the Bash tool; if that fails, run `pwd` with the Bash tool.
-- Current project: Derive agent-side from the detected working directory basename. Do not use slash-command shell interpolation for this value.
-- Change name: $ARGUMENTS
-- Execution mode: ask/cache per orchestrator
-- Artifact store mode: ask/cache per orchestrator
-- Delivery strategy: ask/cache per orchestrator
-
-ENGRAM NOTE:
-Sub-agents handle persistence automatically. Each phase saves its artifact to engram with topic_key "sdd/$ARGUMENTS/{type}" where type is: proposal, spec, design, tasks.
-
-Use the lazy workflow instructions to coordinate this workflow. Do NOT execute phase work inline when a native sub-agent is available.
+Read `.claude/skills/_shared/sdd-orchestrator-workflow.md` under the workspace first; if absent, read `~/.claude/skills/_shared/sdd-orchestrator-workflow.md`.
+Delegate this intent and arguments to that authoritative lazy workflow; follow its instructions rather than defining command-local policy.

--- a/internal/assets/claude/commands/gentle-sdd-new.md
+++ b/internal/assets/claude/commands/gentle-sdd-new.md
@@ -2,26 +2,8 @@
 description: Start a new SDD change — runs exploration then creates a proposal
 ---
 
-Read the SDD workflow FIRST: `.claude/skills/_shared/sdd-orchestrator-workflow.md` under the workspace when a workspace-scope install wrote it there, otherwise `~/.claude/skills/_shared/sdd-orchestrator-workflow.md`. Then treat it as the authoritative SDD workflow instructions for this command.
-The Claude Code session model is controlled by Claude Code; Gentle AI's always-on Model Assignments policy resolves every Agent tool call, including generic/organic delegation through `default`.
+Intent: Start a new SDD change.
+Change name: $ARGUMENTS
 
-WORKFLOW:
-
-1. Launch `sdd-explore` to investigate the codebase for this change
-2. Present the exploration summary to the user
-3. Launch `sdd-propose` to create a proposal based on the exploration
-4. Present the proposal summary and ask the user if they want to continue with specs and design
-
-CONTEXT:
-
-- Working directory: Detect agent-side before proceeding by running `git rev-parse --show-toplevel` with the Bash tool; if that fails, run `pwd` with the Bash tool.
-- Current project: Derive agent-side from the detected working directory basename. Do not use slash-command shell interpolation for this value.
-- Change name: $ARGUMENTS
-- Execution mode: ask/cache per orchestrator
-- Artifact store mode: ask/cache per orchestrator
-- Delivery strategy: ask/cache per orchestrator
-
-ENGRAM NOTE:
-Sub-agents handle persistence automatically. Each phase saves its artifact to engram with topic_key "sdd/$ARGUMENTS/{type}".
-
-Use the lazy workflow instructions to coordinate this workflow. Do NOT execute phase work inline when a native sub-agent is available.
+Read `.claude/skills/_shared/sdd-orchestrator-workflow.md` under the workspace first; if absent, read `~/.claude/skills/_shared/sdd-orchestrator-workflow.md`.
+Delegate this intent and arguments to that authoritative lazy workflow; follow its instructions rather than defining command-local policy.

--- a/internal/assets/claude/sdd-orchestrator-workflow.md
+++ b/internal/assets/claude/sdd-orchestrator-workflow.md
@@ -36,57 +36,7 @@ Before routing, continuing, applying, verifying, or archiving an SDD change, inv
 - Route only by structured `nextRecommended`, dependency states, and `blockedReasons`; never infer from free text.
 - If blocked, stop and report the blocker. Do not proceed to apply, archive, or terminal work.
 
-### SDD Session Preflight (HARD GATE)
-
-Before executing ANY SDD command or natural-language SDD request, ensure this session has an explicit `SDD Session Preflight` decision block.
-
-This applies to `/gentle-sdd-new`, `/gentle-sdd-ff`, `/gentle-sdd-continue`, `/gentle-sdd-explore`, `/gentle-sdd-status`, `/gentle-sdd-apply`, `/gentle-sdd-verify`, `/gentle-sdd-archive`, and natural-language equivalents such as "use SDD to add dark mode" / "do it with SDD".
-
-Required preflight choices:
-
-1. **Execution mode**: `interactive` or `auto`.
-2. **Artifact store**: `openspec`, `engram`, or `hybrid` when Engram is callable. If Engram is unavailable, offer only file/inline-safe choices.
-3. **Chained PR strategy**: the canonical `delivery_strategy` — `ask-on-risk`, `auto-chain`, `single-pr`, or `exception-ok`. The preflight menu offers the first three; `exception-ok` is reachable only when the user explicitly accepts `size:exception`.
-4. **Review budget**: maximum changed lines before stopping for reviewer-burden approval.
-
-User-facing preflight question format:
-
-Use the built-in `AskUserQuestion` tool for SDD Session Preflight only when it is available in the current interactive runtime and all four groups are exactly representable. While that native route is usable, do NOT render a duplicate plain-chat menu. If the tool is unavailable, denied, the runtime is noninteractive, or the prompt is unrepresentable, follow the Lossless Blocking Prompts fallback in the orchestrator rule and STOP.
-
-When the native route is representable, ask all four preflight groups in one single `AskUserQuestion` tool call so Claude Code can render the groups as one interactive prompt. Do NOT run this as a sequential wizard. Do NOT issue four separate `AskUserQuestion` tool calls.
-
-The single `AskUserQuestion` tool call must contain these four localized groups in this order:
-
-1. Pace: Interactive, Automatic.
-2. Artifacts: OpenSpec, Engram, Both.
-3. PRs: Ask me, Single PR, Auto.
-4. Review: 400 lines, 800 lines, Other.
-
-Match the user's current language and active persona for question labels and descriptions. Treat the preflight UI as direct orchestrator conversation, not as a generated technical artifact. Technical artifacts still default to English, but this UI follows the user's conversation language/persona. Do NOT mix languages inside one grouped question.
-
-Do NOT show option codes in the interactive UI. Do NOT show canonical values or other internal values in the interactive UI labels or descriptions.
-
-After the single grouped `AskUserQuestion` tool call returns, map the selected human labels to canonical values internally. Do not reveal the canonical values in the UI.
-
-If Other is selected for review budget, ask one follow-up question for the numeric budget.
-
-Only after all four preflight choices are collected, summarize them as the `SDD Session Preflight` decision block and continue with the SDD init guard/requested phase.
-
-Map answers to canonical values:
-
-- Pace: Interactive -> `interactive`; Automatic -> `auto`.
-- Artifacts: OpenSpec -> `openspec`; Engram -> `engram`; Both -> `hybrid`.
-- PRs: Ask me -> `ask-on-risk`; Single PR -> `single-pr`; Auto -> `auto-chain`.
-- Review: 400 lines -> `review_budget_lines: 400`; 800 lines -> `review_budget_lines: 800`; Other -> ask one follow-up for the number.
-
-The PR canonical values are exactly the `delivery_strategy` domain `sdd-tasks` and `sdd-apply` accept; never emit a value outside it. The preflight offers no separate chained option because `delivery_strategy` is only consulted once the tasks forecast flags review-budget risk: below that line there is nothing to chain, and above it `Auto` already resolves to `auto-chain` without asking again.
-
-Hard gate rules:
-
-- `openspec/config.yaml`, existing SDD artifacts, previous `sdd-init` results, or installed SDD assets do NOT satisfy session preflight.
-- If the session has no preflight block, ask the single grouped `AskUserQuestion` preflight above. Do not run init, delegate phases, edit files, or apply tasks until all four choices are collected.
-- Cache the choices for this session and include them in later phase prompts.
-- If the user explicitly provided all four choices in the current conversation, summarize them as the session preflight block and continue.
+<!-- Session preflight is projected here by the installer from the shared canonical authority. -->
 
 ### SDD Entry Routing (MANDATORY)
 
@@ -160,7 +110,7 @@ Pass the artifact store mode to every SDD phase agent.
 
 ### Delivery Strategy
 
-On the first SDD chain request in a session, ask once for delivery strategy and cache it:
+Use the delivery strategy cached by SDD Session Preflight; do not ask a separate strategy question:
 
 - `ask-on-risk` — default; ask only when the tasks forecast detects review-budget risk.
 - `auto-chain` — automatically split into chained/stacked PR slices when needed.

--- a/internal/assets/sdd_exits_wording_test.go
+++ b/internal/assets/sdd_exits_wording_test.go
@@ -18,6 +18,24 @@ func TestClaudeWorkflowPointersNameWorkspaceAndHomeLocations(t *testing.T) {
 	}
 }
 
+func TestClaudeMetaCommandsDelegatePolicy(t *testing.T) {
+	for _, name := range []string{"new", "continue", "ff"} {
+		t.Run(name, func(t *testing.T) {
+			content := MustRead("claude/commands/gentle-sdd-" + name + ".md")
+			for _, required := range []string{"description:", "Intent:", "$ARGUMENTS", "under the workspace first; if absent", "authoritative lazy workflow"} {
+				if !strings.Contains(content, required) {
+					t.Errorf("entrypoint missing %q", required)
+				}
+			}
+			for _, forbidden := range []string{"WORKFLOW:", "STATUS CONTRACT:", "preflight", "sdd-init", "sdd-propose", "sdd-spec", "sdd-apply", "nextRecommended", "blockedReasons", "artifact store", "review", "400", "mem_search", "AskUserQuestion", "`interactive`", "`auto`"} {
+				if strings.Contains(content, forbidden) {
+					t.Errorf("entrypoint duplicates policy %q", forbidden)
+				}
+			}
+		})
+	}
+}
+
 // #2480: regenerating tasks.md must keep the existing list and numbering.
 func TestTasksSkillPreservesExistingTaskListOnRegeneration(t *testing.T) {
 	if content := MustRead("skills/sdd-tasks/SKILL.md"); !strings.Contains(content, "never rewrite") || !strings.Contains(content, "numbering") {

--- a/internal/components/sdd/delivery_strategy_vocabulary_test.go
+++ b/internal/components/sdd/delivery_strategy_vocabulary_test.go
@@ -17,10 +17,9 @@ import (
 
 // SDD delivery strategy has a producer and a consumer. The producer is the
 // session-preflight label->canonical mapping; the consumer is every phase skill
-// and orchestrator branch that reads `delivery_strategy`. In the Claude and
-// OpenCode orchestrators both halves live in the same document about a hundred
-// lines apart. Preserved OpenCode prompts receive the same canonical block from
-// the marker-owned session-preflight migration.
+// and orchestrator branch that reads `delivery_strategy`. Claude and OpenCode
+// receive the same canonical producer at render time; raw assets are templates.
+// Preserved OpenCode prompts receive it through marker-owned migration.
 //
 // Nothing asserted the halves agreed, so the preflight emitted `ask-always`,
 // `single-pr-default`, `force-chained`, and `auto-forecast` into a consumer
@@ -32,8 +31,8 @@ import (
 // Both halves below are derived from shipped artifacts, never from a list
 // restated here: the domain from the phase skills that declare it as their
 // input contract, the producer from the preflight UI label list plus the
-// mapping block in the same document, and the producer sites from walking the
-// embedded assets tree. A renamed label, a fifth canonical value, or a typo on
+// mapping block in the installed document. Walking the embedded assets rejects
+// a second producer. A renamed label, a fifth canonical value, or a typo on
 // either side fails here instead of drifting silently.
 
 // deliveryDomainDeclaration matches a phase skill's declared input domain for
@@ -43,12 +42,8 @@ import (
 var deliveryDomainDeclaration = regexp.MustCompile("`(ask-on-risk(?: \\| [a-z][a-z0-9-]*)+)`")
 
 // preflightPRGroupLabels matches the user-facing PR option list the preflight
-// renders, e.g. "3. PRs: Ask me, Single PR, Auto."
-var preflightPRGroupLabels = regexp.MustCompile(`(?m)^\s*3\. PRs: (.+?)\.[ \t]*\r?$`)
-
-// preflightStrategyChoiceDeclaration matches the preflight requirement line that
-// names the canonical values the chained-PR question collects.
-var preflightStrategyChoiceDeclaration = regexp.MustCompile(`(?m)^\s*3\. \*\*Chained PR strategy\*\*[^:]*: (.+?)[ \t]*\r?$`)
+// renders, e.g. "3. **PR strategy**: Ask me, Single PR, or Auto."
+var preflightPRGroupLabels = regexp.MustCompile(`(?m)^\s*3\. \*\*PR strategy\*\*: (.+?)\.[ \t]*\r?$`)
 
 var backtickSpan = regexp.MustCompile("`([^`]+)`")
 
@@ -116,30 +111,40 @@ func splitDeclaredDomain(declaration string) []string {
 	return values
 }
 
-// preflightMappingSources returns every shipped asset that carries the
-// label->canonical preflight mapping, discovered by walking the embedded tree so
-// a new runtime that grows a preflight is covered without editing this guard.
+// preflightMappingSources reads the actual installed Claude authority and rejects
+// any raw asset that reintroduces a separately authored mapping producer.
 func preflightMappingSources(t *testing.T) map[string]string {
 	t.Helper()
 
-	sources := map[string]string{}
-	err := fs.WalkDir(assets.FS, ".", func(path string, entry fs.DirEntry, walkErr error) error {
+	home := t.TempDir()
+	if _, err := writeClaudeLazySDDWorkflow(home, claudeAdapter()); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(home, ".claude", "skills", "_shared", "sdd-orchestrator-workflow.md")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	content := string(data)
+	if err := validateSDDSessionPreflightProjection(content, testSDDSessionPreflightEntryAnchor, "AskUserQuestion"); err != nil {
+		t.Fatal(err)
+	}
+	sources := map[string]string{"installed Claude": content}
+	err = fs.WalkDir(assets.FS, ".", func(path string, entry fs.DirEntry, walkErr error) error {
 		if walkErr != nil || entry.IsDir() || !strings.HasSuffix(path, ".md") {
 			return walkErr
 		}
 		content := assets.MustRead(path)
-		if strings.Contains(content, "Map answers to canonical values") {
-			sources[path] = content
+		for _, producer := range []string{"Map answers to canonical values", "Canonical mappings:", "Ask me ->", sddSessionPreflightMarker} {
+			if strings.Contains(content, producer) {
+				t.Errorf("raw asset %s owns a second preflight producer: %q", path, producer)
+			}
 		}
 		return nil
 	})
 	if err != nil {
 		t.Fatalf("walk embedded assets: %v", err)
 	}
-	if len(sources) == 0 {
-		t.Fatal("no shipped asset carries a preflight label->canonical mapping; the guard has lost its subject")
-	}
-
 	return sources
 }
 
@@ -164,12 +169,12 @@ func mappedCanonicalValue(mapping, label string) (string, bool) {
 func canonicalMappingBlock(t *testing.T, path, content string) string {
 	t.Helper()
 
-	start := strings.Index(content, "Map answers to canonical values")
+	start := strings.Index(content, "Canonical mappings:")
 	if start < 0 {
 		t.Fatalf("%s lost its canonical mapping block", path)
 	}
 	block := content[start:]
-	if end := strings.Index(block, "Hard gate rules:"); end >= 0 {
+	if end := strings.Index(block, sddSessionPreflightEnd); end >= 0 {
 		block = block[:end]
 	}
 	return block
@@ -190,7 +195,7 @@ func TestSDDPreflightDeliveryStrategyMappingStaysInsideConsumerDomain(t *testing
 
 		mapping := canonicalMappingBlock(t, path, content)
 		for _, rawLabel := range strings.Split(labelMatch[1], ",") {
-			label := strings.TrimSpace(rawLabel)
+			label := strings.TrimPrefix(strings.TrimSpace(rawLabel), "or ")
 			if label == "" {
 				continue
 			}
@@ -224,13 +229,16 @@ func TestSDDPreflightStrategyChoicesStayInsideConsumerDomain(t *testing.T) {
 
 	checked := 0
 	for path, content := range preflightMappingSources(t) {
-		match := preflightStrategyChoiceDeclaration.FindStringSubmatch(content)
-		if match == nil {
-			continue
+		mapping := canonicalMappingBlock(t, path, content)
+		// Inspect every emitted mapping, including one accidentally added outside
+		// the declared UI choices. Pace/artifact mappings are not PR strategies.
+		start := strings.Index(mapping, "- Ask me ->")
+		if start < 0 {
+			t.Fatalf("%s missing PR strategy mappings", path)
 		}
 		checked++
 
-		for _, span := range backtickSpan.FindAllStringSubmatch(match[1], -1) {
+		for _, span := range backtickSpan.FindAllStringSubmatch(mapping[start:], -1) {
 			for _, value := range splitDeclaredDomain(span[1]) {
 				if !canonicalValueShape.MatchString(value) {
 					continue
@@ -395,7 +403,7 @@ func TestSDDPreflightNoLongerOffersRetiredChainedPRLabel(t *testing.T) {
 		}
 
 		for _, rawLabel := range strings.Split(labelMatch[1], ",") {
-			if strings.TrimSpace(rawLabel) != retired {
+			if strings.TrimPrefix(strings.TrimSpace(rawLabel), "or ") != retired {
 				continue
 			}
 			t.Errorf(

--- a/internal/components/sdd/inject.go
+++ b/internal/components/sdd/inject.go
@@ -2890,6 +2890,10 @@ func writeClaudeLazySDDWorkflow(homeDir string, adapter agents.Adapter) (Injecti
 	}
 
 	content := renderBoundedReviewAsset(model.AgentClaudeCode, "claude/sdd-orchestrator-workflow.md")
+	content, err := projectSDDSessionPreflightWithTool(content, "### SDD Entry Routing (MANDATORY)", "AskUserQuestion")
+	if err != nil {
+		return InjectionResult{}, fmt.Errorf("project Claude session preflight: %w", err)
+	}
 
 	path := filepath.Join(skillDir, "_shared", "sdd-orchestrator-workflow.md")
 	writeResult, err := filemerge.WriteFileAtomic(path, []byte(content), 0o644)

--- a/internal/components/sdd/inject_test.go
+++ b/internal/components/sdd/inject_test.go
@@ -302,6 +302,33 @@ func TestInjectClaudeKeepsHeavySDDWorkflowLazy(t *testing.T) {
 	}
 }
 
+func TestClaudeLazyPreflightCanonicalInstall(t *testing.T) {
+	home := t.TempDir()
+	if _, err := writeClaudeLazySDDWorkflow(home, claudeAdapter()); err != nil {
+		t.Fatal(err)
+	}
+	data, err := os.ReadFile(filepath.Join(home, ".claude", "skills", "_shared", "sdd-orchestrator-workflow.md"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	content := string(data)
+	want := strings.ReplaceAll(sddSessionPreflightBlock(), "`question`", "`AskUserQuestion`")
+	if strings.Count(content, want) != 1 || strings.Count(content, sddSessionPreflightMarker) != 1 {
+		t.Fatal("installed Claude workflow must contain exactly one Claude-native canonical block")
+	}
+	if strings.Index(content, sddSessionPreflightEnd) > strings.Index(content, testSDDSessionPreflightEntryAnchor) {
+		t.Fatal("preflight must precede entry routing")
+	}
+	for _, forbidden := range []string{"all four", "800 lines", "Other", "numeric budget", "`question`"} {
+		if strings.Contains(content, forbidden) {
+			t.Errorf("installed workflow retains %q", forbidden)
+		}
+	}
+	if result, err := writeClaudeLazySDDWorkflow(home, claudeAdapter()); err != nil || result.Changed {
+		t.Fatalf("second install = %+v, %v; want unchanged", result, err)
+	}
+}
+
 func TestInjectClaudePreservesExistingSections(t *testing.T) {
 	home := t.TempDir()
 	claudeDir := filepath.Join(home, ".claude")
@@ -492,7 +519,16 @@ func TestInjectClaudeCommandModelAssignmentsApplyToEveryDelegation(t *testing.T)
 	}
 
 	const stale = "Gentle AI only configures models for Agent tool calls to phase sub-agents."
-	const want = "The Claude Code session model is controlled by Claude Code; Gentle AI's always-on Model Assignments policy resolves every Agent tool call, including generic/organic delegation through `default`."
+	prompt, err := os.ReadFile(filepath.Join(home, ".claude", "CLAUDE.md"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{"Every Claude Agent tool call MUST include `model`", "organic explorer/mapper/writer/verifier and other generic delegations use the `default` assignment"} {
+		if !strings.Contains(string(prompt), want) {
+			t.Fatalf("always-on model authority missing %q", want)
+		}
+	}
+	const want = "Delegate this intent and arguments to that authoritative lazy workflow"
 	for _, name := range []string{"gentle-sdd-new.md", "gentle-sdd-ff.md", "gentle-sdd-continue.md"} {
 		t.Run(name, func(t *testing.T) {
 			content, err := os.ReadFile(filepath.Join(home, ".claude", "commands", name))
@@ -500,11 +536,11 @@ func TestInjectClaudeCommandModelAssignmentsApplyToEveryDelegation(t *testing.T)
 				t.Fatalf("ReadFile(%s) error = %v", name, err)
 			}
 			text := string(content)
-			if strings.Contains(text, stale) {
-				t.Fatalf("installed command retains phase-only model wording %q", stale)
+			if strings.Contains(text, stale) || strings.Contains(text, "Model Assignments") || strings.Contains(text, "STATUS CONTRACT:") {
+				t.Fatal("installed thin command owns model/status policy")
 			}
 			if !strings.Contains(text, want) {
-				t.Fatalf("installed command missing always-on model wording %q", want)
+				t.Fatalf("installed command missing policy delegation %q", want)
 			}
 		})
 	}

--- a/internal/components/sdd/session_preflight.go
+++ b/internal/components/sdd/session_preflight.go
@@ -15,7 +15,13 @@ const (
 )
 
 func sddSessionPreflightBlock() string {
-	return sddSessionPreflightMarker + "\n" + sddSessionPreflightBody + "\n" + sddSessionPreflightEnd
+	return sddSessionPreflightBlockWithTool("question")
+}
+
+// Only native interaction vocabulary varies; all runtimes share one policy body.
+func sddSessionPreflightBlockWithTool(tool string) string {
+	body := strings.ReplaceAll(sddSessionPreflightBody, "`question`", "`"+tool+"`")
+	return sddSessionPreflightMarker + "\n" + body + "\n" + sddSessionPreflightEnd
 }
 
 // migratePreservedSDDSessionPreflight is the only migration path for a
@@ -70,6 +76,10 @@ func migratePreservedSDDSessionPreflight(rendered string) (string, error) {
 }
 
 func projectSDDSessionPreflight(rendered, preInitAnchor string) (string, error) {
+	return projectSDDSessionPreflightWithTool(rendered, preInitAnchor, "question")
+}
+
+func projectSDDSessionPreflightWithTool(rendered, preInitAnchor, tool string) (string, error) {
 	anchor, err := sddSessionPreflightAnchorIndex(rendered, preInitAnchor)
 	if err != nil {
 		return "", err
@@ -85,18 +95,22 @@ func projectSDDSessionPreflight(rendered, preInitAnchor string) (string, error) 
 	if err != nil {
 		return "", err
 	}
-	block := strings.ReplaceAll(sddSessionPreflightBlock(), "\n", newline)
+	block := strings.ReplaceAll(sddSessionPreflightBlockWithTool(tool), "\n", newline)
 	if open >= 0 {
 		rendered = rendered[:open] + block + rendered[closeEnd:]
 	} else {
 		rendered = rendered[:anchor] + block + newline + rendered[anchor:]
 	}
-	if err := validateSDDSessionPreflightProjection(rendered, preInitAnchor); err != nil {
+	if err := validateSDDSessionPreflightProjection(rendered, preInitAnchor, tool); err != nil {
 		return "", fmt.Errorf("validate projected SDD session preflight: %w", err)
 	}
 	return rendered, nil
 }
-func validateSDDSessionPreflightProjection(rendered, preInitAnchor string) error {
+func validateSDDSessionPreflightProjection(rendered, preInitAnchor string, nativeTool ...string) error {
+	tool := "question"
+	if len(nativeTool) > 0 {
+		tool = nativeTool[0]
+	}
 	anchor, err := sddSessionPreflightAnchorIndex(rendered, preInitAnchor)
 	if err != nil {
 		return err
@@ -125,7 +139,7 @@ func validateSDDSessionPreflightProjection(rendered, preInitAnchor string) error
 	if strings.Contains(actual, "Both -> `both`") {
 		return fmt.Errorf("legacy SDD session preflight mapping Both -> both is rejected")
 	}
-	if actual != sddSessionPreflightBlock() {
+	if actual != sddSessionPreflightBlockWithTool(tool) {
 		return fmt.Errorf("sdd session preflight block is not exact canonical content")
 	}
 	return nil

--- a/internal/components/sdd/session_preflight_test.go
+++ b/internal/components/sdd/session_preflight_test.go
@@ -10,6 +10,42 @@ import (
 const testSDDSessionPreflightInitAnchor = "### SDD Init Guard (MANDATORY)"
 const testSDDSessionPreflightEntryAnchor = "### SDD Entry Routing (MANDATORY)"
 
+func TestClaudeSessionPreflightProjectionStructure(t *testing.T) {
+	const tool = "AskUserQuestion"
+	anchor := testSDDSessionPreflightEntryAnchor
+	template := "prefix\n" + anchor + "\n" + sddSessionPreflightInit + "\nsuffix"
+	got, err := projectSDDSessionPreflightWithTool(template, anchor, tool)
+	if err != nil {
+		t.Fatal(err)
+	}
+	block := strings.ReplaceAll(sddSessionPreflightBlock(), "`question`", "`AskUserQuestion`")
+	for _, tc := range []struct {
+		name, content string
+		valid         bool
+	}{
+		{"canonical", got, true},
+		{"CRLF", strings.ReplaceAll(got, "\n", "\r\n"), true},
+		{"missing", template, false},
+		{"duplicate", block + "\n" + got, false},
+		{"after init", template + "\n" + block, false},
+		{"after routing", strings.Replace(template, anchor, anchor+"\n"+block, 1), false},
+		{"missing close", strings.Replace(got, sddSessionPreflightEnd, "", 1), false},
+		{"wrong tool", strings.ReplaceAll(got, "`AskUserQuestion`", "`question`"), false},
+		{"legacy mapping", strings.ReplaceAll(got, "Both -> `hybrid`", "Both -> `both`"), false},
+		{"duplicate init", got + "\n" + sddSessionPreflightInit, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateSDDSessionPreflightProjection(tc.content, anchor, tool)
+			if (err == nil) != tc.valid {
+				t.Fatalf("validation = %v; valid = %v", err, tc.valid)
+			}
+		})
+	}
+	if again, err := projectSDDSessionPreflightWithTool(got, anchor, tool); err != nil || again != got {
+		t.Fatalf("projection not idempotent: %v", err)
+	}
+}
+
 func TestOpenCodeSessionPreflightCompositionIsRuntimeScoped(t *testing.T) {
 	for _, agent := range []model.AgentID{model.AgentOpenCode, model.AgentKilocode} {
 		content, err := composeOpenCodeOrchestratorPrompt(agent)

--- a/testdata/golden/sdd-claude-cmd-gentle-sdd-continue.golden
+++ b/testdata/golden/sdd-claude-cmd-gentle-sdd-continue.golden
@@ -2,34 +2,8 @@
 description: Continue the next SDD phase in the dependency chain
 ---
 
-Read the SDD workflow FIRST: `.claude/skills/_shared/sdd-orchestrator-workflow.md` under the workspace when a workspace-scope install wrote it there, otherwise `~/.claude/skills/_shared/sdd-orchestrator-workflow.md`. Then treat it as the authoritative SDD workflow instructions for this command.
-The Claude Code session model is controlled by Claude Code; Gentle AI's always-on Model Assignments policy resolves every Agent tool call, including generic/organic delegation through `default`.
+Intent: Continue the active SDD change.
+Change name (optional): $ARGUMENTS
 
-WORKFLOW:
-
-1. If the `gentle-ai` binary is available, run `gentle-ai sdd-continue [change] --cwd <repo>` and treat its dispatcher/status output as authoritative — but only when the session artifact store is `openspec` or `hybrid`. When the session artifact store is `engram`, do NOT invoke the native dispatcher at all — it cannot see the change (it reads only `openspec/changes/`); resolve status entirely from Engram (`mem_search` + `mem_get_observation` on the change's topic keys) using the manual status schema in `~/.claude/skills/_shared/sdd-status-contract.md` (the same schema used when the binary is unavailable). The dispatcher is authoritative only for `openspec`/`hybrid`. If unavailable, read `~/.claude/skills/_shared/sdd-status-contract.md` and produce structured status before acting.
-2. Resolve the active change. If `$ARGUMENTS` is missing and more than one active change exists, ask the user to choose and STOP. Do not guess.
-3. Check which artifacts already exist for the active change (proposal, specs, design, tasks)
-4. Determine the next phase needed based on the dependency graph:
-   proposal → [specs ∥ design] → tasks → apply → verify → archive
-5. Launch the appropriate sub-agent(s) for the next phase only if authoritative status says the dependency is ready. Route only by `nextRecommended` and dependency states; never infer from free text. If `blockedReasons` is non-empty, do not proceed to apply, archive, or terminal work. If `nextRecommended` is `verify`, verification/remediation may run only to refresh evidence; if `nextRecommended` is `resolve-blockers`, report `blockedReasons` and stop; if `nextRecommended` is a planning token (`propose`, `spec`, `design`, or `tasks`), launch the corresponding planning phase. Carry `actionContext` and allowed edit roots into any sub-agent launch.
-6. Present the result and ask the user to proceed
-
-CONTEXT:
-
-- Working directory: Detect agent-side before proceeding by running `git rev-parse --show-toplevel` with the Bash tool; if that fails, run `pwd` with the Bash tool.
-- Current project: Derive agent-side from the detected working directory basename. Do not use slash-command shell interpolation for this value.
-- Change name: $ARGUMENTS
-- Execution mode: ask/cache per orchestrator
-- Artifact store mode: ask/cache per orchestrator
-- Delivery strategy: ask/cache per orchestrator
-
-ENGRAM NOTE:
-To check which artifacts exist, search: mem_search(query: "sdd/$ARGUMENTS/", project: "{project}") to list all artifacts for this change.
-Sub-agents handle persistence automatically with topic_key "sdd/$ARGUMENTS/{type}".
-
-Use the lazy workflow instructions to coordinate this workflow. Do NOT execute phase work inline when a native sub-agent is available.
-
-STATUS CONTRACT:
-
-Prefer `gentle-ai sdd-continue [change] --cwd <repo>` when available — but only when the session artifact store is `openspec` or `hybrid`; when the store is `engram`, do NOT invoke the binary and resolve status from Engram using the manual status schema. Otherwise read `~/.claude/skills/_shared/sdd-status-contract.md` and follow it. If status reports `workspace-planning` with no allowed edit roots, do not launch apply/verify/archive work that would infer repo-local ownership.
+Read `.claude/skills/_shared/sdd-orchestrator-workflow.md` under the workspace first; if absent, read `~/.claude/skills/_shared/sdd-orchestrator-workflow.md`.
+Delegate this intent and arguments to that authoritative lazy workflow; follow its instructions rather than defining command-local policy.

--- a/testdata/golden/sdd-claude-cmd-gentle-sdd-ff.golden
+++ b/testdata/golden/sdd-claude-cmd-gentle-sdd-ff.golden
@@ -2,32 +2,8 @@
 description: Fast-forward all SDD planning phases — proposal through tasks
 ---
 
-Read the SDD workflow FIRST: `.claude/skills/_shared/sdd-orchestrator-workflow.md` under the workspace when a workspace-scope install wrote it there, otherwise `~/.claude/skills/_shared/sdd-orchestrator-workflow.md`. Then treat it as the authoritative SDD workflow instructions for this command.
-The Claude Code session model is controlled by Claude Code; Gentle AI's always-on Model Assignments policy resolves every Agent tool call, including generic/organic delegation through `default`.
+Intent: Fast-forward planning for an SDD change.
+Change name: $ARGUMENTS
 
-WORKFLOW:
-Honor the cached execution mode from SDD Session Preflight.
-
-Planning phases:
-
-1. `sdd-propose` — create the proposal
-2. `sdd-spec` — write specifications
-3. `sdd-design` — create technical design
-4. `sdd-tasks` — break down into implementation tasks
-
-- In `interactive` mode: run only the next planning phase, present its summary and artifact path(s), ask whether to adjust or continue, then STOP. Do not launch the following phase until the user confirms.
-- In `auto` mode: run all planning phases back-to-back and present a combined summary after all phases complete.
-
-CONTEXT:
-
-- Working directory: Detect agent-side before proceeding by running `git rev-parse --show-toplevel` with the Bash tool; if that fails, run `pwd` with the Bash tool.
-- Current project: Derive agent-side from the detected working directory basename. Do not use slash-command shell interpolation for this value.
-- Change name: $ARGUMENTS
-- Execution mode: ask/cache per orchestrator
-- Artifact store mode: ask/cache per orchestrator
-- Delivery strategy: ask/cache per orchestrator
-
-ENGRAM NOTE:
-Sub-agents handle persistence automatically. Each phase saves its artifact to engram with topic_key "sdd/$ARGUMENTS/{type}" where type is: proposal, spec, design, tasks.
-
-Use the lazy workflow instructions to coordinate this workflow. Do NOT execute phase work inline when a native sub-agent is available.
+Read `.claude/skills/_shared/sdd-orchestrator-workflow.md` under the workspace first; if absent, read `~/.claude/skills/_shared/sdd-orchestrator-workflow.md`.
+Delegate this intent and arguments to that authoritative lazy workflow; follow its instructions rather than defining command-local policy.

--- a/testdata/golden/sdd-claude-cmd-gentle-sdd-new.golden
+++ b/testdata/golden/sdd-claude-cmd-gentle-sdd-new.golden
@@ -2,26 +2,8 @@
 description: Start a new SDD change — runs exploration then creates a proposal
 ---
 
-Read the SDD workflow FIRST: `.claude/skills/_shared/sdd-orchestrator-workflow.md` under the workspace when a workspace-scope install wrote it there, otherwise `~/.claude/skills/_shared/sdd-orchestrator-workflow.md`. Then treat it as the authoritative SDD workflow instructions for this command.
-The Claude Code session model is controlled by Claude Code; Gentle AI's always-on Model Assignments policy resolves every Agent tool call, including generic/organic delegation through `default`.
+Intent: Start a new SDD change.
+Change name: $ARGUMENTS
 
-WORKFLOW:
-
-1. Launch `sdd-explore` to investigate the codebase for this change
-2. Present the exploration summary to the user
-3. Launch `sdd-propose` to create a proposal based on the exploration
-4. Present the proposal summary and ask the user if they want to continue with specs and design
-
-CONTEXT:
-
-- Working directory: Detect agent-side before proceeding by running `git rev-parse --show-toplevel` with the Bash tool; if that fails, run `pwd` with the Bash tool.
-- Current project: Derive agent-side from the detected working directory basename. Do not use slash-command shell interpolation for this value.
-- Change name: $ARGUMENTS
-- Execution mode: ask/cache per orchestrator
-- Artifact store mode: ask/cache per orchestrator
-- Delivery strategy: ask/cache per orchestrator
-
-ENGRAM NOTE:
-Sub-agents handle persistence automatically. Each phase saves its artifact to engram with topic_key "sdd/$ARGUMENTS/{type}".
-
-Use the lazy workflow instructions to coordinate this workflow. Do NOT execute phase work inline when a native sub-agent is available.
+Read `.claude/skills/_shared/sdd-orchestrator-workflow.md` under the workspace first; if absent, read `~/.claude/skills/_shared/sdd-orchestrator-workflow.md`.
+Delegate this intent and arguments to that authoritative lazy workflow; follow its instructions rather than defining command-local policy.


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #3501

Part of #3336, work unit 3. Dependencies #3499 and #3500 are merged. This PR does not close the parent tracker.

## 🏷️ PR Type

- [x] `type:bug` — Bug fix

## 📝 Summary

- Project the single canonical session-preflight policy into Claude's installed lazy workflow using native `AskUserQuestion` vocabulary.
- Remove the independent four-choice producer and make new/continue/ff commands thin workspace-first, home-fallback entrypoints.
- Validate canonical structure, installed authority, model-policy delegation, idempotence, and exact command goldens.

## 📂 Changes

| File / Area | What Changed |
|---|---|
| `internal/components/sdd/session_preflight.go`, `inject.go` | Shared policy projection and Claude installation |
| `internal/assets/claude/` | Lazy projection template and thin commands |
| `internal/assets/*_test.go`, `internal/components/sdd/*_test.go` | Structural negatives, native vocabulary, installed policy and regression coverage |
| `testdata/golden/sdd-claude-cmd-gentle-sdd-*.golden` | Three exact thin-command expectations |

## 🤖 AI Assistance

- [x] **Material assistance used**

**Tool/model (if known):** Pi coding-agent harness with delegated workers and verifiers.

**Material scope:** Implementation, regression tests, three golden updates, and review preparation.

**Verification performed:** Observed RED/GREEN, independent diff review, full Go validation, and four native RDD lenses.

## 🧪 Test Plan

- [x] `go test -timeout=20m ./...`
- [x] `go vet ./...`
- [x] `go run ./internal/gofmtcheck`
- [x] `./scripts/deadcode-ratchet.sh`
- [x] `git diff --check`
- [x] Complete candidate before/after hash matched during global validation
- [ ] Docker E2E, pending before merge

Global evidence: `/private/tmp/3501-global-ikxmfpur/terminal-result.json` (all five commands exit 0).

RDD: `review-a6aa9574e58639a8`, four lenses admitted, approved and acknowledged. One informational non-blocking advisory at `internal/assets/claude/commands/gentle-sdd-ff.md:9` remains separate follow-up.

Benchmark scope: no corpus or review-lifecycle change; existing runtime/benchmark CI remains required. This PR does not claim a new driven journey.

## ✅ Contributor Checklist

- [x] Linked issue has `status:approved`
- [x] Exactly one `type:*` label
- [x] Maintainer explicitly authorized `size:exception` through 600 changed lines; this cohesive PR has 475
- [x] Unit tests, formatting, vet and deadcode checks pass
- [ ] E2E tests pass, pending execution
- [x] Conventional commit with no `Co-Authored-By` trailers
- [x] Material AI assistance declared
- [x] Complete submission reviewed; remaining delivery gates are recorded above

## 💬 Notes for Reviewers

Review policy remains fixed at 400 in generated product output. The maintainer-authorized 475-line delivery exception does not change that policy. Goldens account for 92 of the changed lines. Other runtime families, Windsurf integration and final pre-write matrix validation remain in #3502/#3503.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Claude SDD commands now delegate to a shared workflow for consistent handling of new, continue, and fast-forward operations.
  - Installation now adds a standardized session preflight and initialization guard to the Claude workflow.
  - Delivery strategy choices are reused from the session preflight.

- **Improvements**
  - Reduced duplicated command-specific workflow and policy instructions.
  - Improved consistency and reliability when installing or re-installing Claude SDD workflows.
  - Updated delivery-strategy handling to support current options and retire outdated mappings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->