### PR TITLE
fix(sdd): canonical fallback preflight for VSCode, Cursor and Gemini

### DIFF
--- a/internal/components/sdd/inject_test.go
+++ b/internal/components/sdd/inject_test.go
@@ -40,6 +40,34 @@ func mockNoPackageManager(t *testing.T) {
 	t.Helper()
 }
 
+func TestInjectFallbackSessionPreflight(t *testing.T) {
+	for _, agent := range []model.AgentID{model.AgentVSCodeCopilot, model.AgentCursor, model.AgentGeminiCLI} {
+		t.Run(string(agent), func(t *testing.T) {
+			home := t.TempDir()
+			t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
+			t.Setenv("APPDATA", filepath.Join(home, "AppData", "Roaming"))
+			adapter := mustAdapter(t, agent)
+			if _, err := Inject(home, adapter, ""); err != nil {
+				t.Fatal(err)
+			}
+			path := adapter.SystemPromptFile(home)
+			before, err := os.ReadFile(path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			assertFallbackSessionPreflight(t, string(before))
+			if result, err := Inject(home, adapter, ""); err != nil || result.Changed {
+				t.Fatalf("repeat install = %+v, %v; want unchanged", result, err)
+			}
+			after, err := os.ReadFile(path)
+			if err != nil || !bytes.Equal(before, after) {
+				t.Fatalf("repeat install changed prompt bytes: %v", err)
+			}
+			assertFallbackSessionPreflight(t, string(after))
+		})
+	}
+}
+
 func TestSDDOrchestratorAssetSelectionCoversSupportedAgents(t *testing.T) {
 	tests := []struct {
 		agent model.AgentID

--- a/internal/components/sdd/orchestrator.go
+++ b/internal/components/sdd/orchestrator.go
@@ -73,7 +73,11 @@ func substituteSharedOrchestratorSections(content string) string {
 // bounded-review and runtime-identity substitutions.
 func composeOrchestratorPrompt(agent model.AgentID, options ...OrchestratorRenderOptions) string {
 	path := sddOrchestratorAsset(agent)
-	content := substituteSharedOrchestratorSections(assets.MustRead(path))
+	content := assets.MustRead(path)
+	if usesFallbackSessionPreflight(agent) {
+		content = composeFallbackSessionPreflight(content, agent)
+	}
+	content = substituteSharedOrchestratorSections(content)
 	var renderOptions OrchestratorRenderOptions
 	if len(options) > 0 {
 		renderOptions = options[0]
@@ -84,6 +88,74 @@ func composeOrchestratorPrompt(agent model.AgentID, options ...OrchestratorRende
 	content = replacePiClosedSingleSelectRoute(content, agent)
 	content = renderBoundedReviewAssetBodyFromContent(agent, path, content)
 	return bindRuntimeAgentIdentity(content, agent)
+}
+
+// Generic is also consumed by Pi, OpenClaw, and Trae. Select by identity,
+// not asset path, so this cohort cannot change deferred runtime prompts.
+func usesFallbackSessionPreflight(agent model.AgentID) bool {
+	return agent == model.AgentVSCodeCopilot || agent == model.AgentCursor || agent == model.AgentGeminiCLI
+}
+
+// Replace only owned session-choice producers before composing shared sections.
+// Historical assets remain intact for runtimes outside the migrated cohort.
+func composeFallbackSessionPreflight(content string, agent model.AgentID) string {
+	// Validate cardinality before removing any range: a duplicate nested in an
+	// earlier range must not disappear before its own validation runs.
+	for _, heading := range []string{"### Artifact Store Policy", "### Commands", "### Execution Mode", "### Artifact Store Mode", "### Delivery Strategy", "### Chain Strategy"} {
+		if _, err := sddSessionPreflightAnchorIndex(content, heading); err != nil {
+			panic(fmt.Sprintf("sdd: fallback source %s: %v", heading, err))
+		}
+	}
+	for _, section := range []struct{ start, end, body string }{
+		{"### Artifact Store Policy", "### Commands", "Use the artifact store resolved by SDD Session Preflight; never detect or default a separate choice."},
+		{"### Artifact Store Mode", "### Delivery Strategy", "Pass the preflight artifact choice as `artifact_store.mode` to every sub-agent launch."},
+		{"### Delivery Strategy", "### Chain Strategy", "Pass the preflight PR strategy as `delivery_strategy` to `sdd-tasks` and `sdd-apply`. `exception-ok` is never a preflight choice; it requires explicit maintainer-approved `size:exception`."},
+	} {
+		start := strings.Index(content, section.start+"\n")
+		end := strings.Index(content, section.end+"\n")
+		if start < 0 || end <= start {
+			panic("sdd: missing fallback session policy section: " + section.start)
+		}
+		content = content[:start] + section.start + "\n\n" + section.body + "\n\n" + content[end:]
+	}
+	// Keep runtime-specific execution semantics and phase approval rules.
+	for _, bounds := range [][2]string{
+		{"When the user invokes `/sdd-new`", "- **Automatic**"},
+		{"If the user doesn't specify, default to **Automatic**.", "In **Interactive** mode, between phases:"},
+	} {
+		start := strings.Index(content, bounds[0])
+		end := strings.Index(content, bounds[1])
+		if strings.Count(content, bounds[0]) != 1 || strings.Count(content, bounds[1]) != 1 || end <= start {
+			panic("sdd: missing or ambiguous fallback execution choice producer")
+		}
+		content = content[:start] + "Use the execution mode cached by SDD Session Preflight.\n\n" + content[end:]
+	}
+	for _, replacement := range []struct {
+		agent    model.AgentID
+		old, new string
+	}{
+		{model.AgentCursor, "**Interactive** is the default behavior", "**Interactive** uses the preflight choice"},
+		{model.AgentVSCodeCopilot, "Artifact store: default `engram` when available.", "Artifact store: use the SDD Session Preflight choice."},
+	} {
+		want := 0
+		if agent == replacement.agent {
+			want = 1
+		}
+		if strings.Count(content, replacement.old) != want {
+			panic("sdd: missing or ambiguous fallback source clause: " + replacement.old)
+		}
+		content = strings.Replace(content, replacement.old, replacement.new, want)
+	}
+	const legacyInitLookup = "1. Search Engram: `mem_search(query: \"sdd-init/{project}\", project: \"{project}\")`\n2. If found → init was done, proceed normally\n3. If NOT found → run `sdd-init` FIRST (delegate to sdd-init sub-agent), THEN proceed with the requested command"
+	if strings.Count(content, legacyInitLookup) != 1 {
+		panic("sdd: missing or ambiguous fallback init lookup")
+	}
+	content = strings.Replace(content, legacyInitLookup, "1. Use the artifact store resolved by SDD Session Preflight. In `openspec` mode, check project context and testing capabilities in `openspec/config.yaml` without calling Engram. In `engram` mode, search `sdd-init/{project}` in Engram. In `hybrid` mode, check both stores.\n2. If the selected store contains initialized project context and testing capabilities, proceed normally; a directory alone is not initialization evidence.\n3. If initialization is missing, delegate to `sdd-init` with the cached `artifact_store.mode`, then proceed. If a selected backend is unavailable, STOP and report it; never silently change the user's artifact choice.", 1)
+	projected, err := projectSDDSessionPreflightWithTool(content, "### Native SDD Dispatcher Guard", "")
+	if err != nil {
+		panic(err)
+	}
+	return projected
 }
 
 const genericFallbackOnlyNativeRoute = "- Native route: This variant has no classified native question UI for this contract; always use the plain chat or terminal fallback below. When the closed domain of a single-select envelope is unrepresentable here, fall through to the Fallback clause below."

--- a/internal/components/sdd/orchestrator_composition_test.go
+++ b/internal/components/sdd/orchestrator_composition_test.go
@@ -18,8 +18,8 @@ const testGenericFallbackOnlyNativeRoute = "- Native route: This variant has no 
 const testPiClosedSingleSelectNativeRoute = "- Native route: For every strictly closed single-select envelope, use ask_user_choice only when the interactive Pi TUI can represent its complete one-question 2-4 ordered-option domain. Pass each user-facing label and description with the envelope-owned canonical option token as value. The selector returns exactly one value; map it to the exact envelope-owned choice once, then select any envelope-owned continuation or invocation once where present. It has no custom/free-text or multi-select path. If the native TUI is unavailable or the envelope is not exactly representable, use the complete chat fallback. ask_user_question is the external open/free-text questionnaire and must not be used for a closed domain; open/free-text questionnaires may use ask_user_question when exactly representable. For gentle-ai.review-integration.consent/v3, the chosen continuation is still the exact captured provider-owned choice invocation, used once without synthesis."
 
 // TestCanonicalCompositionAddsOnlyItsKnownSteps proves that composition is
-// bounded-review rendering plus the shared-section substitution plus the Pi
-// route, and nothing else. It deliberately no longer claims to preserve
+// bounded-review rendering plus shared-section substitution, cohort preflight,
+// and the Pi route. Non-cohort runtimes retain their historical composition. It deliberately no longer claims to preserve
 // historical bytes: #3817 moved five section bodies into a shared asset, so
 // this test's expected side must apply the same substitution, which means it
 // cannot detect a substitution defect. Byte preservation across that move is
@@ -32,7 +32,12 @@ func TestCanonicalCompositionAddsOnlyItsKnownSteps(t *testing.T) {
 			// #3817 adds shared-section substitution to the composition. The
 			// invariant is unchanged in spirit: composition is bounded review
 			// plus the shared sections plus the Pi route, and nothing else.
-			content := substituteSharedOrchestratorSections(assets.MustRead(path))
+			content := assets.MustRead(path)
+			if agent.ID == model.AgentVSCodeCopilot || agent.ID == model.AgentCursor || agent.ID == model.AgentGeminiCLI {
+				assertFallbackSessionPreflight(t, composeOrchestratorPrompt(agent.ID))
+				return
+			}
+			content = substituteSharedOrchestratorSections(content)
 			if agent.ID == model.AgentPi {
 				content = strings.Replace(content, testGenericFallbackOnlyNativeRoute, testPiClosedSingleSelectNativeRoute, 1)
 			}
@@ -42,6 +47,41 @@ func TestCanonicalCompositionAddsOnlyItsKnownSteps(t *testing.T) {
 				t.Fatalf("canonical composition changed %s orchestrator bytes", agent.ID)
 			}
 		})
+	}
+}
+
+func TestFallbackSessionPreflightRejectsAmbiguousSource(t *testing.T) {
+	for _, agent := range []model.AgentID{model.AgentVSCodeCopilot, model.AgentCursor, model.AgentGeminiCLI} {
+		source := assets.MustRead(sddOrchestratorAsset(agent))
+		for _, heading := range []string{"### Artifact Store Policy", "### Commands", "### Execution Mode", "### Artifact Store Mode", "### Delivery Strategy", "### Chain Strategy"} {
+			t.Run(string(agent)+"/duplicate/"+heading, func(t *testing.T) {
+				defer func() {
+					if recover() == nil {
+						t.Fatal("ambiguous source did not fail closed")
+					}
+				}()
+				composeFallbackSessionPreflight(source+"\n"+heading+"\n", agent)
+			})
+		}
+	}
+	for _, tc := range []struct {
+		agent  model.AgentID
+		clause string
+	}{
+		{model.AgentCursor, "**Interactive** is the default behavior"},
+		{model.AgentVSCodeCopilot, "Artifact store: default `engram` when available."},
+	} {
+		for _, mutation := range []string{"drifted default", tc.clause + "\n" + tc.clause} {
+			t.Run(string(tc.agent)+"/"+mutation, func(t *testing.T) {
+				defer func() {
+					if recover() == nil {
+						t.Fatal("drifted or duplicate replacement clause did not fail closed")
+					}
+				}()
+				source := assets.MustRead(sddOrchestratorAsset(tc.agent))
+				composeFallbackSessionPreflight(strings.Replace(source, tc.clause, mutation, 1), tc.agent)
+			})
+		}
 	}
 }
 

--- a/internal/components/sdd/session_preflight.go
+++ b/internal/components/sdd/session_preflight.go
@@ -18,9 +18,14 @@ func sddSessionPreflightBlock() string {
 	return sddSessionPreflightBlockWithTool("question")
 }
 
-// Only native interaction vocabulary varies; all runtimes share one policy body.
+// Only interaction transport varies; all runtimes share one policy body.
 func sddSessionPreflightBlockWithTool(tool string) string {
 	body := strings.ReplaceAll(sddSessionPreflightBody, "`question`", "`"+tool+"`")
+	if tool == "" {
+		start := strings.Index(sddSessionPreflightBody, "Use the `question` tool")
+		end := strings.Index(sddSessionPreflightBody, "Match labels")
+		body = sddSessionPreflightBody[:start] + "This runtime has no classified native question UI. Present ONE complete blocking prompt in plain chat or terminal with all three groups below, in order, and explain that their answers are required before init. Each group is single-select; its listed labels are the complete allowed-answer domain. Include every label and description, the fixed review policy, and this answer syntax: `Pace: <label>; Artifacts: <label>; PR strategy: <label>`. Then STOP; never default, infer, or launch dependent work. Validate all three answers under the Lossless Blocking Prompts contract before caching their canonical mappings.\n\n" + sddSessionPreflightBody[end:]
+	}
 	return sddSessionPreflightMarker + "\n" + body + "\n" + sddSessionPreflightEnd
 }
 

--- a/internal/components/sdd/session_preflight_test.go
+++ b/internal/components/sdd/session_preflight_test.go
@@ -10,6 +10,90 @@ import (
 const testSDDSessionPreflightInitAnchor = "### SDD Init Guard (MANDATORY)"
 const testSDDSessionPreflightEntryAnchor = "### SDD Entry Routing (MANDATORY)"
 
+func assertFallbackSessionPreflight(t *testing.T, got string) {
+	t.Helper()
+	open, close := "<!-- gentle-ai:sdd-session-preflight -->", "<!-- /gentle-ai:sdd-session-preflight -->"
+	if strings.Count(got, open) != 1 || strings.Count(got, close) != 1 {
+		t.Fatal("installed prompt requires exactly one bounded preflight")
+	}
+	start, end := strings.Index(got, open), strings.Index(got, close)
+	if end <= start || end >= strings.Index(got, "### SDD Init Guard (MANDATORY)") {
+		t.Fatal("complete preflight must precede init")
+	}
+	for _, want := range []string{"Interactive or Automatic", "OpenSpec, Engram, or Both", "Ask me, Single PR, or Auto", "Both -> `hybrid`", "fixed at 400", "NEVER ask it as a fourth group", "plain chat or terminal", "STOP", "Pace: <label>; Artifacts: <label>; PR strategy: <label>"} {
+		if !strings.Contains(got[start:end], want) {
+			t.Errorf("preflight missing %q", want)
+		}
+	}
+	for _, stale := range []string{"`question`", "AskUserQuestion", "ALSO ASK", "ASK which execution mode", "default to **Automatic**", "default when available", "default `engram`", "ask once for and cache delivery strategy", "**Interactive** is the default behavior"} {
+		if strings.Contains(got, stale) {
+			t.Errorf("contradictory installed producer %q", stale)
+		}
+	}
+	init := got[strings.Index(got, "### SDD Init Guard (MANDATORY)"):strings.Index(got, "### Execution Mode")]
+	if !strings.Contains(init, "In `openspec` mode") || !strings.Contains(init, "without calling Engram") || !strings.Contains(init, "openspec/config.yaml") {
+		t.Error("OpenSpec init lookup must not require Engram")
+	}
+}
+
+func TestFallbackSessionPreflightCohort(t *testing.T) {
+	for _, agent := range []model.AgentID{model.AgentVSCodeCopilot, model.AgentCursor, model.AgentGeminiCLI} {
+		t.Run(string(agent), func(t *testing.T) {
+			got := composeOrchestratorPrompt(agent)
+			for _, marker := range []string{sddSessionPreflightMarker, sddSessionPreflightEnd} {
+				if strings.Count(got, marker) != 1 {
+					t.Fatalf("expected exactly one %s", marker)
+				}
+			}
+			end := strings.Index(got, sddSessionPreflightEnd)
+			if end > strings.Index(got, testSDDSessionPreflightInitAnchor) {
+				t.Fatal("preflight follows init")
+			}
+			block := got[strings.Index(got, sddSessionPreflightMarker):end]
+			for _, want := range []string{"Interactive or Automatic", "OpenSpec, Engram, or Both", "Ask me, Single PR, or Auto", "Both -> `hybrid`", "Interactive -> `interactive`", "Automatic -> `auto`", "OpenSpec -> `openspec`", "Engram -> `engram`", "Ask me -> `ask-on-risk`", "Single PR -> `single-pr`", "Auto -> `auto-chain`", "fixed at 400", "NEVER ask it as a fourth group", "plain chat or terminal", "STOP", "Pace: <label>; Artifacts: <label>; PR strategy: <label>"} {
+				if !strings.Contains(block, want) {
+					t.Errorf("preflight missing %q", want)
+				}
+			}
+			for _, stale := range []string{"`question`", "AskUserQuestion", "ALSO ASK", "ASK which execution mode", "default to **Automatic**", "default when available", "default `engram`", "ask once for and cache delivery strategy", "**Interactive** is the default behavior"} {
+				if strings.Contains(got, stale) {
+					t.Errorf("stale producer or native vocabulary %q", stale)
+				}
+			}
+		})
+	}
+}
+
+func TestFallbackSessionPreflightProjectionBoundaries(t *testing.T) {
+	anchor := testSDDSessionPreflightInitAnchor
+	template := "prefix\n" + anchor + "\nsuffix"
+	got, err := projectSDDSessionPreflightWithTool(template, anchor, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, tc := range []struct {
+		name, content string
+		valid         bool
+	}{
+		{"canonical", got, true},
+		{"CRLF", strings.ReplaceAll(got, "\n", "\r\n"), true},
+		{"missing", template, false},
+		{"duplicate", sddSessionPreflightBlockWithTool("") + "\n" + got, false},
+		{"after init", template + "\n" + sddSessionPreflightBlockWithTool(""), false},
+		{"native transport", strings.Replace(got, sddSessionPreflightBlockWithTool(""), sddSessionPreflightBlock(), 1), false},
+		{"wrong mapping", strings.ReplaceAll(got, "Both -> `hybrid`", "Both -> `both`"), false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if err := validateSDDSessionPreflightProjection(tc.content, anchor, ""); (err == nil) != tc.valid {
+				t.Fatalf("validation = %v; valid = %v", err, tc.valid)
+			}
+		})
+	}
+	if again, err := projectSDDSessionPreflightWithTool(got, anchor, ""); err != nil || again != got {
+		t.Fatalf("projection not idempotent: %v", err)
+	}
+}
+
 func TestClaudeSessionPreflightProjectionStructure(t *testing.T) {
 	const tool = "AskUserQuestion"
 	anchor := testSDDSessionPreflightEntryAnchor

--- a/testdata/golden/sdd-cursor-rules.golden
+++ b/testdata/golden/sdd-cursor-rules.golden
@@ -144,10 +144,7 @@ SDD is the structured planning layer for substantial changes.
 
 ### Artifact Store Policy
 
-- `engram` — default when available; persistent memory across sessions
-- `openspec` — file-based artifacts; use only when user explicitly requests
-- `hybrid` — both backends; cross-session recovery + local files; more tokens per op
-- `none` — return results inline only; recommend enabling engram or openspec
+Use the artifact store resolved by SDD Session Preflight; never detect or default a separate choice.
 
 ### Commands
 
@@ -169,6 +166,31 @@ Meta-commands (type directly — orchestrator handles them, won't appear in auto
 
 `/sdd-new`, `/sdd-continue`, and `/sdd-ff` are meta-commands handled by YOU. Do NOT invoke them as skills. You orchestrate the subagent sequence yourself.
 
+<!-- gentle-ai:sdd-session-preflight -->
+### SDD Session Preflight (HARD GATE)
+
+Before every SDD command or natural-language SDD request, run this preflight before the SDD init guard; cache choices for the session.
+
+This runtime has no classified native question UI. Present ONE complete blocking prompt in plain chat or terminal with all three groups below, in order, and explain that their answers are required before init. Each group is single-select; its listed labels are the complete allowed-answer domain. Include every label and description, the fixed review policy, and this answer syntax: `Pace: <label>; Artifacts: <label>; PR strategy: <label>`. Then STOP; never default, infer, or launch dependent work. Validate all three answers under the Lossless Blocking Prompts contract before caching their canonical mappings.
+
+Match labels and descriptions to the conversation language and persona; do not expose canonical/internal codes.
+
+1. **Pace**: Interactive or Automatic.
+2. **Artifacts**: OpenSpec, Engram, or Both (user-facing Both maps only to internal `hybrid`).
+3. **PR strategy**: Ask me, Single PR, or Auto.
+
+Review policy is fixed at 400 changed lines per PR; above 400, split the PR or require maintainer-approved `size:exception`; NEVER ask it as a fourth group or selectable budget.
+
+Canonical mappings:
+- Interactive -> `interactive`
+- Automatic -> `auto`
+- OpenSpec -> `openspec`
+- Engram -> `engram`
+- Both -> `hybrid`
+- Ask me -> `ask-on-risk`
+- Single PR -> `single-pr`
+- Auto -> `auto-chain`
+<!-- /gentle-ai:sdd-session-preflight -->
 ### Native SDD Dispatcher Guard
 
 Before routing, continuing, applying, verifying, or archiving an SDD change, **invoke the native dispatcher** (`gentle-ai sdd-continue [change] --cwd <repo>` or `gentle-ai sdd-status [change] --cwd <repo> --json --instructions`). It resolves the artifact store the workspace DECLARES, reports it in `artifactStore`, and returns that store's locators in `artifactPaths`. **Do NOT determine the artifact store yourself, and do NOT branch on it** — an actor that re-derives the store disagrees with the authority that launched it, which is how a phase ends up reading a store the workspace never declared. Use the dispatcher for every store when `gentle-ai` is available and treat its native status JSON as authoritative over prompt inference. Route only by `nextRecommended` and dependency states; never infer from free text. If `blockedReasons` is non-empty, do not proceed to apply, archive, or terminal work. If `nextRecommended` is `verify`, verification/remediation may run only to refresh evidence; if `nextRecommended` is `resolve-blockers`, report `blockedReasons` and stop; if `nextRecommended` is a planning token (`propose`, `spec`, `design`, or `tasks`), launch the corresponding planning phase. If the binary is unavailable, fall back to the existing prompt contract and manual status schema.
@@ -177,9 +199,9 @@ Before routing, continuing, applying, verifying, or archiving an SDD change, **i
 
 Before executing ANY SDD command (`/sdd-new`, `/sdd-ff`, `/sdd-continue`, `/sdd-explore`, `/sdd-status`, `/sdd-apply`, `/sdd-verify`, `/sdd-archive`), check if `sdd-init` has been run for this project:
 
-1. Search Engram: `mem_search(query: "sdd-init/{project}", project: "{project}")`
-2. If found → init was done, proceed normally
-3. If NOT found → run `sdd-init` FIRST (delegate to sdd-init sub-agent), THEN proceed with the requested command
+1. Use the artifact store resolved by SDD Session Preflight. In `openspec` mode, check project context and testing capabilities in `openspec/config.yaml` without calling Engram. In `engram` mode, search `sdd-init/{project}` in Engram. In `hybrid` mode, check both stores.
+2. If the selected store contains initialized project context and testing capabilities, proceed normally; a directory alone is not initialization evidence.
+3. If initialization is missing, delegate to `sdd-init` with the cached `artifact_store.mode`, then proceed. If a selected backend is unavailable, STOP and report it; never silently change the user's artifact choice.
 
 This ensures:
 
@@ -191,14 +213,12 @@ Do NOT skip this check. Do NOT ask the user — just run init silently if needed
 
 ### Execution Mode
 
-When the user invokes `/sdd-new`, `/sdd-ff`, or `/sdd-continue` (or an equivalent natural-language request, e.g. "create an SDD for X" / "do SDD for X") for the first time in a session, ASK which execution mode they prefer:
+Use the execution mode cached by SDD Session Preflight.
 
 - **Automatic** (`auto`): Run all phases back-to-back without pausing. Phases still run back-to-back WITHOUT interrupting the user, BUT the orchestrator runs a gatekeeper validation after every phase before invoking the next inline subagent — the user only sees an interruption when the gatekeeper catches a real problem. Otherwise only the final result is shown. Use this when the user wants speed and trusts the process.
 - **Interactive** (`interactive`): After each phase completes, show the result summary and ASK: "Want to adjust anything or continue?" before proceeding to the next phase. Use this when the user wants to review and steer each step.
 
-If the user doesn't specify, default to **Automatic**. After scope approval, expect zero further prompts on the happy path and at most one actionable prompt per recoverable failure; the gatekeeper summarizes phase progress instead of interrupting except on a second consecutive gate failure or a genuine scope/product decision.
-
-Cache the mode choice for the session — don't ask again unless the user explicitly requests a mode change.
+Use the execution mode cached by SDD Session Preflight.
 
 In **Interactive** mode, between phases:
 
@@ -207,7 +227,7 @@ In **Interactive** mode, between phases:
 3. Ask: "¿Continuamos? / Continue?" — accept YES/continue, NO/stop, or specific feedback to adjust
 4. If the user gives feedback, incorporate it before running the next phase
 
-For this agent (inline subagents): phases already run with user visibility between invocations. **Interactive** is the default behavior — show results between subagent calls and ask before proceeding. **Automatic** means invoke subagents sequentially without pausing to ask between phases.
+For this agent (inline subagents): phases already run with user visibility between invocations. **Interactive** uses the preflight choice — show results between subagent calls and ask before proceeding. **Automatic** means invoke subagents sequentially without pausing to ask between phases.
 
 Interactive approval is phase-scoped. Words like "continue", "dale", or "go on" approve only the immediate next phase, not the rest of the SDD pipeline. Do not treat a generated artifact as approved until the user has had a chance to review or explicitly delegate that review.
 
@@ -249,19 +269,11 @@ Use the provider-owned Git-common-dir runtime ledger for every runtime-bearing `
 
 ### Artifact Store Mode
 
-When the user invokes `/sdd-new`, `/sdd-ff`, or `/sdd-continue` (or an equivalent natural-language request) for the first time in a session, ALSO ASK which artifact store they want for this change:
-
-- **`engram`**: Fast, no files created. Artifacts live in engram only. Best for solo work and quick iteration. Note: re-running a phase overwrites the previous version (no history).
-- **`openspec`**: File-based. Creates `openspec/` directory with full artifact trail. Committable, shareable with team, full git history.
-- **`hybrid`**: Both — files for team sharing + engram for cross-session recovery. Higher token cost.
-
-If the user doesn't specify, detect: if engram is available → default to `engram`. Otherwise → `none`.
-
-Cache the artifact store choice for the session. Pass it as `artifact_store.mode` to every sub-agent launch.
+Pass the preflight artifact choice as `artifact_store.mode` to every sub-agent launch.
 
 ### Delivery Strategy
 
-On the first `/sdd-new`, `/sdd-ff`, or `/sdd-continue` (or an equivalent natural-language request) in a session, ask once for and cache delivery strategy: `ask-on-risk` (default), `auto-chain`, `single-pr`, or `exception-ok`. Pass it as `delivery_strategy` to `sdd-tasks` and `sdd-apply` prompts.
+Pass the preflight PR strategy as `delivery_strategy` to `sdd-tasks` and `sdd-apply`. `exception-ok` is never a preflight choice; it requires explicit maintainer-approved `size:exception`.
 
 ### Chain Strategy
 

--- a/testdata/golden/sdd-gemini-geminimd.golden
+++ b/testdata/golden/sdd-gemini-geminimd.golden
@@ -124,10 +124,7 @@ SDD is the structured planning layer for substantial changes.
 
 ### Artifact Store Policy
 
-- `engram` — default when available; persistent memory across sessions
-- `openspec` — file-based artifacts; use only when user explicitly requests
-- `hybrid` — both backends; cross-session recovery + local files; more tokens per op
-- `none` — return results inline only; recommend enabling engram or openspec
+Use the artifact store resolved by SDD Session Preflight; never detect or default a separate choice.
 
 ### Commands
 
@@ -149,6 +146,31 @@ Meta-commands (type directly — orchestrator handles them, won't appear in auto
 
 `/sdd-new`, `/sdd-continue`, and `/sdd-ff` are meta-commands handled by YOU. Do NOT invoke them as skills.
 
+<!-- gentle-ai:sdd-session-preflight -->
+### SDD Session Preflight (HARD GATE)
+
+Before every SDD command or natural-language SDD request, run this preflight before the SDD init guard; cache choices for the session.
+
+This runtime has no classified native question UI. Present ONE complete blocking prompt in plain chat or terminal with all three groups below, in order, and explain that their answers are required before init. Each group is single-select; its listed labels are the complete allowed-answer domain. Include every label and description, the fixed review policy, and this answer syntax: `Pace: <label>; Artifacts: <label>; PR strategy: <label>`. Then STOP; never default, infer, or launch dependent work. Validate all three answers under the Lossless Blocking Prompts contract before caching their canonical mappings.
+
+Match labels and descriptions to the conversation language and persona; do not expose canonical/internal codes.
+
+1. **Pace**: Interactive or Automatic.
+2. **Artifacts**: OpenSpec, Engram, or Both (user-facing Both maps only to internal `hybrid`).
+3. **PR strategy**: Ask me, Single PR, or Auto.
+
+Review policy is fixed at 400 changed lines per PR; above 400, split the PR or require maintainer-approved `size:exception`; NEVER ask it as a fourth group or selectable budget.
+
+Canonical mappings:
+- Interactive -> `interactive`
+- Automatic -> `auto`
+- OpenSpec -> `openspec`
+- Engram -> `engram`
+- Both -> `hybrid`
+- Ask me -> `ask-on-risk`
+- Single PR -> `single-pr`
+- Auto -> `auto-chain`
+<!-- /gentle-ai:sdd-session-preflight -->
 ### Native SDD Dispatcher Guard
 
 Before routing, continuing, applying, verifying, or archiving an SDD change, **invoke the native dispatcher** (`gentle-ai sdd-continue [change] --cwd <repo>` or `gentle-ai sdd-status [change] --cwd <repo> --json --instructions`). It resolves the artifact store the workspace DECLARES, reports it in `artifactStore`, and returns that store's locators in `artifactPaths`. **Do NOT determine the artifact store yourself, and do NOT branch on it** — an actor that re-derives the store disagrees with the authority that launched it, which is how a phase ends up reading a store the workspace never declared. Use the dispatcher for every store when `gentle-ai` is available and treat its native status JSON as authoritative over prompt inference. Route only by `nextRecommended` and dependency states; never infer from free text. If `blockedReasons` is non-empty, do not proceed to apply, archive, or terminal work. If `nextRecommended` is `verify`, verification/remediation may run only to refresh evidence; if `nextRecommended` is `resolve-blockers`, report `blockedReasons` and stop; if `nextRecommended` is a planning token (`propose`, `spec`, `design`, or `tasks`), launch the corresponding planning phase. If the binary is unavailable, fall back to the existing prompt contract and manual status schema.
@@ -157,9 +179,9 @@ Before routing, continuing, applying, verifying, or archiving an SDD change, **i
 
 Before executing ANY SDD command (`/sdd-new`, `/sdd-ff`, `/sdd-continue`, `/sdd-explore`, `/sdd-status`, `/sdd-apply`, `/sdd-verify`, `/sdd-archive`), check if `sdd-init` has been run for this project:
 
-1. Search Engram: `mem_search(query: "sdd-init/{project}", project: "{project}")`
-2. If found → init was done, proceed normally
-3. If NOT found → run `sdd-init` FIRST (delegate to sdd-init sub-agent), THEN proceed with the requested command
+1. Use the artifact store resolved by SDD Session Preflight. In `openspec` mode, check project context and testing capabilities in `openspec/config.yaml` without calling Engram. In `engram` mode, search `sdd-init/{project}` in Engram. In `hybrid` mode, check both stores.
+2. If the selected store contains initialized project context and testing capabilities, proceed normally; a directory alone is not initialization evidence.
+3. If initialization is missing, delegate to `sdd-init` with the cached `artifact_store.mode`, then proceed. If a selected backend is unavailable, STOP and report it; never silently change the user's artifact choice.
 
 This ensures:
 
@@ -171,14 +193,12 @@ Do NOT skip this check. Do NOT ask the user — just run init silently if needed
 
 ### Execution Mode
 
-When the user invokes `/sdd-new`, `/sdd-ff`, or `/sdd-continue` (or an equivalent natural-language request, e.g. "create an SDD for X" / "do SDD for X") for the first time in a session, ASK which execution mode they prefer:
+Use the execution mode cached by SDD Session Preflight.
 
 - **Automatic** (`auto`): Run all phases back-to-back without pausing. Phases still run back-to-back WITHOUT interrupting the user, BUT the orchestrator runs a gatekeeper validation after every phase before launching the next sub-agent — the user only sees an interruption when the gatekeeper catches a real problem. Otherwise only the final result is shown. Use this when the user wants speed and trusts the process.
 - **Interactive** (`interactive`): After each phase completes, show the result summary and ASK: "Want to adjust anything or continue?" before proceeding to the next phase. Use this when the user wants to review and steer each step.
 
-If the user doesn't specify, default to **Automatic**. After scope approval, expect zero further prompts on the happy path and at most one actionable prompt per recoverable failure; the gatekeeper summarizes phase progress instead of interrupting except on a second consecutive gate failure or a genuine scope/product decision.
-
-Cache the mode choice for the session — don't ask again unless the user explicitly requests a mode change.
+Use the execution mode cached by SDD Session Preflight.
 
 In **Interactive** mode, between phases:
 
@@ -229,19 +249,11 @@ Use the provider-owned Git-common-dir runtime ledger for every runtime-bearing `
 
 ### Artifact Store Mode
 
-When the user invokes `/sdd-new`, `/sdd-ff`, or `/sdd-continue` (or an equivalent natural-language request) for the first time in a session, ALSO ASK which artifact store they want for this change:
-
-- **`engram`**: Fast, no files created. Artifacts live in engram only. Best for solo work and quick iteration. Note: re-running a phase overwrites the previous version (no history).
-- **`openspec`**: File-based. Creates `openspec/` directory with full artifact trail. Committable, shareable with team, full git history.
-- **`hybrid`**: Both — files for team sharing + engram for cross-session recovery. Higher token cost.
-
-If the user doesn't specify, detect: if engram is available → default to `engram`. Otherwise → `none`.
-
-Cache the artifact store choice for the session. Pass it as `artifact_store.mode` to every sub-agent launch.
+Pass the preflight artifact choice as `artifact_store.mode` to every sub-agent launch.
 
 ### Delivery Strategy
 
-On the first `/sdd-new`, `/sdd-ff`, or `/sdd-continue` (or an equivalent natural-language request) in a session, ask once for and cache delivery strategy: `ask-on-risk` (default), `auto-chain`, `single-pr`, or `exception-ok`. Pass it as `delivery_strategy` to `sdd-tasks` and `sdd-apply` prompts.
+Pass the preflight PR strategy as `delivery_strategy` to `sdd-tasks` and `sdd-apply`. `exception-ok` is never a preflight choice; it requires explicit maintainer-approved `size:exception`.
 
 ### Chain Strategy
 

--- a/testdata/golden/sdd-vscode-instructions.golden
+++ b/testdata/golden/sdd-vscode-instructions.golden
@@ -132,10 +132,7 @@ SDD is the structured planning layer for substantial changes.
 
 ### Artifact Store Policy
 
-- `engram` — default when available; persistent memory across sessions
-- `openspec` — file-based artifacts; use only when user explicitly requests
-- `hybrid` — both backends; cross-session recovery + local files; more tokens per op
-- `none` — return results inline only; recommend enabling engram or openspec
+Use the artifact store resolved by SDD Session Preflight; never detect or default a separate choice.
 
 ### Commands
 
@@ -157,6 +154,31 @@ Meta-commands (type directly — orchestrator handles them, won't appear in auto
 
 `/sdd-new`, `/sdd-continue`, and `/sdd-ff` are meta-commands handled by YOU. Do NOT invoke them as skills.
 
+<!-- gentle-ai:sdd-session-preflight -->
+### SDD Session Preflight (HARD GATE)
+
+Before every SDD command or natural-language SDD request, run this preflight before the SDD init guard; cache choices for the session.
+
+This runtime has no classified native question UI. Present ONE complete blocking prompt in plain chat or terminal with all three groups below, in order, and explain that their answers are required before init. Each group is single-select; its listed labels are the complete allowed-answer domain. Include every label and description, the fixed review policy, and this answer syntax: `Pace: <label>; Artifacts: <label>; PR strategy: <label>`. Then STOP; never default, infer, or launch dependent work. Validate all three answers under the Lossless Blocking Prompts contract before caching their canonical mappings.
+
+Match labels and descriptions to the conversation language and persona; do not expose canonical/internal codes.
+
+1. **Pace**: Interactive or Automatic.
+2. **Artifacts**: OpenSpec, Engram, or Both (user-facing Both maps only to internal `hybrid`).
+3. **PR strategy**: Ask me, Single PR, or Auto.
+
+Review policy is fixed at 400 changed lines per PR; above 400, split the PR or require maintainer-approved `size:exception`; NEVER ask it as a fourth group or selectable budget.
+
+Canonical mappings:
+- Interactive -> `interactive`
+- Automatic -> `auto`
+- OpenSpec -> `openspec`
+- Engram -> `engram`
+- Both -> `hybrid`
+- Ask me -> `ask-on-risk`
+- Single PR -> `single-pr`
+- Auto -> `auto-chain`
+<!-- /gentle-ai:sdd-session-preflight -->
 ### Native SDD Dispatcher Guard
 
 Before routing, continuing, applying, verifying, or archiving an SDD change, **invoke the native dispatcher** (`gentle-ai sdd-continue [change] --cwd <repo>` or `gentle-ai sdd-status [change] --cwd <repo> --json --instructions`). It resolves the artifact store the workspace DECLARES, reports it in `artifactStore`, and returns that store's locators in `artifactPaths`. **Do NOT determine the artifact store yourself, and do NOT branch on it** — an actor that re-derives the store disagrees with the authority that launched it, which is how a phase ends up reading a store the workspace never declared. Use the dispatcher for every store when `gentle-ai` is available and treat its native status JSON as authoritative over prompt inference. Route only by `nextRecommended` and dependency states; never infer from free text. If `blockedReasons` is non-empty, do not proceed to apply, archive, or terminal work. If `nextRecommended` is `verify`, verification/remediation may run only to refresh evidence; if `nextRecommended` is `resolve-blockers`, report `blockedReasons` and stop; if `nextRecommended` is a planning token (`propose`, `spec`, `design`, or `tasks`), launch the corresponding planning phase. If the binary is unavailable, fall back to the existing prompt contract and manual status schema.
@@ -165,9 +187,9 @@ Before routing, continuing, applying, verifying, or archiving an SDD change, **i
 
 Before executing ANY SDD command (`/sdd-new`, `/sdd-ff`, `/sdd-continue`, `/sdd-explore`, `/sdd-status`, `/sdd-apply`, `/sdd-verify`, `/sdd-archive`), check if `sdd-init` has been run for this project:
 
-1. Search Engram: `mem_search(query: "sdd-init/{project}", project: "{project}")`
-2. If found → init was done, proceed normally
-3. If NOT found → run `sdd-init` FIRST (delegate to sdd-init sub-agent), THEN proceed with the requested command
+1. Use the artifact store resolved by SDD Session Preflight. In `openspec` mode, check project context and testing capabilities in `openspec/config.yaml` without calling Engram. In `engram` mode, search `sdd-init/{project}` in Engram. In `hybrid` mode, check both stores.
+2. If the selected store contains initialized project context and testing capabilities, proceed normally; a directory alone is not initialization evidence.
+3. If initialization is missing, delegate to `sdd-init` with the cached `artifact_store.mode`, then proceed. If a selected backend is unavailable, STOP and report it; never silently change the user's artifact choice.
 
 This ensures:
 
@@ -179,14 +201,12 @@ Do NOT skip this check. Do NOT ask the user — just run init silently if needed
 
 ### Execution Mode
 
-When the user invokes `/sdd-new`, `/sdd-ff`, or `/sdd-continue` (or an equivalent natural-language request, e.g. "create an SDD for X" / "do SDD for X") for the first time in a session, ASK which execution mode they prefer:
+Use the execution mode cached by SDD Session Preflight.
 
 - **Automatic** (`auto`): Run all phases back-to-back without pausing. Phases still run back-to-back WITHOUT interrupting the user, BUT the orchestrator runs a gatekeeper validation after every phase before launching the next sub-agent — the user only sees an interruption when the gatekeeper catches a real problem. Otherwise only the final result is shown. Use this when the user wants speed and trusts the process.
 - **Interactive** (`interactive`): After each phase completes, show the result summary and ASK: "Want to adjust anything or continue?" before proceeding to the next phase. Use this when the user wants to review and steer each step.
 
-If the user doesn't specify, default to **Automatic**. After scope approval, expect zero further prompts on the happy path and at most one actionable prompt per recoverable failure; the gatekeeper summarizes phase progress instead of interrupting except on a second consecutive gate failure or a genuine scope/product decision.
-
-Cache the mode choice for the session — don't ask again unless the user explicitly requests a mode change.
+Use the execution mode cached by SDD Session Preflight.
 
 In **Interactive** mode, between phases:
 
@@ -237,19 +257,11 @@ Use the provider-owned Git-common-dir runtime ledger for every runtime-bearing `
 
 ### Artifact Store Mode
 
-When the user invokes `/sdd-new`, `/sdd-ff`, or `/sdd-continue` (or an equivalent natural-language request) for the first time in a session, ALSO ASK which artifact store they want for this change:
-
-- **`engram`**: Fast, no files created. Artifacts live in engram only. Best for solo work and quick iteration. Note: re-running a phase overwrites the previous version (no history).
-- **`openspec`**: File-based. Creates `openspec/` directory with full artifact trail. Committable, shareable with team, full git history.
-- **`hybrid`**: Both — files for team sharing + engram for cross-session recovery. Higher token cost.
-
-If the user doesn't specify, detect: if engram is available → default to `engram`. Otherwise → `none`.
-
-Cache the artifact store choice for the session. Pass it as `artifact_store.mode` to every sub-agent launch.
+Pass the preflight artifact choice as `artifact_store.mode` to every sub-agent launch.
 
 ### Delivery Strategy
 
-On the first `/sdd-new`, `/sdd-ff`, or `/sdd-continue` (or an equivalent natural-language request) in a session, ask once for and cache delivery strategy: `ask-on-risk` (default), `auto-chain`, `single-pr`, or `exception-ok`. Pass it as `delivery_strategy` to `sdd-tasks` and `sdd-apply` prompts.
+Pass the preflight PR strategy as `delivery_strategy` to `sdd-tasks` and `sdd-apply`. `exception-ok` is never a preflight choice; it requires explicit maintainer-approved `size:exception`.
 
 ### Chain Strategy
 
@@ -315,7 +327,7 @@ Model hints:
 
 - If your assigned model tier is `small`, load only up to 3 relevant `SKILL.md` paths and prefer numbered step instructions instead of long paragraphs.
 
-Artifact store: default `engram` when available.
+Artifact store: use the SDD Session Preflight choice.
 
 When delegating to sub-agents, pass `## Skills to load before work` followed by exact `SKILL.md` paths. Sub-agents must `mem_save` important discoveries before returning.
 <!-- /section:model-small -->


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #4301

Part of #3502; references #3336. This first cohort does not close either issue: seven runtime families remain deferred.

Approved cohort issue #4301 provides the closing reference; #3502 and #3336 remain open for the remaining work.

## 🏷️ PR Type

- [x] `type:bug` — Bug fix

## 📝 Summary

- Project one canonical preflight into VSCode, Cursor and Gemini using truthful chat/terminal fallback.
- Reject ambiguous legacy producers and select init lookup by the chosen artifact backend.
- Preserve deferred runtime consumers and validate installed output plus repeat-install idempotence.

## 📂 Changes

| Area | Change |
|---|---|
| SDD composer/preflight | Identity-scoped fallback projection, fail-closed legacy removal, backend-aware init |
| SDD tests | Independent semantics, malformed-source regressions and installed idempotence |
| Three goldens | Exact installed cohort output |

## 🤖 AI Assistance

- [x] **Material assistance used**

**Tool/model:** Pi harness with delegated writer and verification.
**Material scope:** Implementation, tests, golden refresh and delivery preparation.
**Verification performed:** Observed RED/GREEN, boundary regressions, full global suite, parent focused spot check, native consolidated RDD review.

## 🧪 Test Plan

- [x] `go test -timeout=20m ./...` (921.61s)
- [x] `go vet ./...`
- [x] `go run ./internal/gofmtcheck`
- [x] `./scripts/deadcode-ratchet.sh`
- [x] `git diff --check`
- [x] Complete before/after candidate byte identity unchanged
- [x] Focused tests and three installed golden tests
- [x] Docker E2E: Ubuntu, Arch and Fedora passed; exact head and tracked bytes unchanged.

Benchmark: no new benchmark claim or review lifecycle code change; runtime CI remains required. Generated prompt tests do not prove live client conversations.

RDD `review-ed33d9a3c9084d96`: approved and acknowledged. Informational R3-001 at cursor golden lines 172–174 is separate follow-up, not a correction request.

## ✅ Contributor Checklist

- [x] Parent issue #3502 has `status:approved`
- [x] Exactly one `type:*` label
- [x] Explicit maintainer exception up to 600 lines; this cohesive candidate is 405 actual changed lines
- [x] Tests/format/vet/deadcode passed
- [x] Conventional commit, no co-author trailers
- [x] AI assistance declared
- [x] Slice-level closing linkage resolved through approved #4301 without closing parent
- [ ] Required remote checks and Docker pass before merge

## 💬 Notes for Reviewers

Only VSCode/Generic, Cursor and Gemini migrate here. Historical asset prose remains for deferred consumers and is removed fail-closed during cohort rendering. Rollback is limited to these eight changed files. Product review policy remains fixed at 400; the delivery exception does not alter generated policy.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a fallback session preflight for VS Code Copilot, Cursor, and Gemini CLI.
  - Prompts now request explicit answers for required session choices before proceeding.
  - Fallback flows validate responses and avoid applying defaults or inferred values.

- **Bug Fixes**
  - Improved session setup when no interaction tool is available.
  - Repeated setup runs now preserve the existing prompt without duplicating preflight instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->