### PR TITLE
fix(sdd): complete canonical fallback runtime projections

### DIFF
--- a/internal/components/sdd/inject_test.go
+++ b/internal/components/sdd/inject_test.go
@@ -41,7 +41,7 @@ func mockNoPackageManager(t *testing.T) {
 }
 
 func TestInjectFallbackSessionPreflight(t *testing.T) {
-	for _, agent := range []model.AgentID{model.AgentVSCodeCopilot, model.AgentCursor, model.AgentGeminiCLI} {
+	for _, agent := range []model.AgentID{model.AgentVSCodeCopilot, model.AgentCursor, model.AgentGeminiCLI, model.AgentAntigravity, model.AgentQwenCode, model.AgentHermes, model.AgentKimi, model.AgentKiroIDE, model.AgentCodex, model.AgentWindsurf} {
 		t.Run(string(agent), func(t *testing.T) {
 			home := t.TempDir()
 			t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
@@ -51,6 +51,9 @@ func TestInjectFallbackSessionPreflight(t *testing.T) {
 				t.Fatal(err)
 			}
 			path := adapter.SystemPromptFile(home)
+			if agent == model.AgentKimi {
+				path = filepath.Join(home, ".kimi", "sdd-orchestrator.md")
+			}
 			before, err := os.ReadFile(path)
 			if err != nil {
 				t.Fatal(err)
@@ -2201,6 +2204,21 @@ func TestInjectKimiKiroWindsurfAntigravityPreserveNativeChainStrategyWording(t *
 				t.Fatalf("ReadFile(%s prompt) error = %v", tt.name, readErr)
 			}
 			text := string(content)
+
+			// Chain topology is a later, independent choice, not an initial
+			// delivery-strategy producer.
+			assertFallbackSessionPreflight(t, text)
+			chainStart := strings.Index(text, "### Chain Strategy\n")
+			chainEnd := strings.Index(text, "### Review Workload Guard (MANDATORY)")
+			if chainStart < 0 || chainEnd <= chainStart {
+				t.Fatal("missing bounded chain strategy section")
+			}
+			chain := text[chainStart:chainEnd]
+			for _, want := range []string{"When `delivery_strategy` results in chained PRs", "ask the user which chain strategy to use", "Cache the chain strategy for the session", "`chain_strategy`", "`delivery_strategy`"} {
+				if !strings.Contains(chain, want) {
+					t.Errorf("native chain strategy missing independent semantics %q", want)
+				}
+			}
 
 			for _, required := range tt.required {
 				if !strings.Contains(text, required) {
@@ -7645,6 +7663,38 @@ func containsPath(paths []string, want string) bool {
 		}
 	}
 	return false
+}
+
+func TestInjectCodexFallbackProfilesRemainIdempotent(t *testing.T) {
+	for name, opts := range map[string]InjectOptions{
+		"recommended": {CodexModelAssignments: model.CodexModelPresetRecommended()},
+		"low-cost":    {CodexModelAssignments: model.CodexModelPresetLowCost()},
+		"powerful":    {CodexModelAssignments: model.CodexModelPresetPowerful()},
+		"custom":      {CodexModelAssignments: model.CodexModelPresetRecommended(), CodexPhaseModelAssignments: map[string]string{"sdd-propose": "gpt-5.4"}},
+	} {
+		t.Run(name, func(t *testing.T) {
+			home := t.TempDir()
+			adapter := codexInjectAdapter()
+			if _, err := Inject(home, adapter, "", opts); err != nil {
+				t.Fatal(err)
+			}
+			before, err := os.ReadFile(adapter.SystemPromptFile(home))
+			if err != nil {
+				t.Fatal(err)
+			}
+			assertFallbackSessionPreflight(t, string(before))
+			if strings.Contains(string(before), "{{CODEX_PHASE_EFFORTS}}") || !strings.Contains(string(before), "reasoning_effort") {
+				t.Fatal("preflight projection lost phase-effort substitution")
+			}
+			if result, err := Inject(home, adapter, "", opts); err != nil || result.Changed {
+				t.Fatalf("repeat profile install = %+v, %v", result, err)
+			}
+			after, err := os.ReadFile(adapter.SystemPromptFile(home))
+			if err != nil || !bytes.Equal(before, after) {
+				t.Fatalf("repeat profile install changed bytes: %v", err)
+			}
+		})
+	}
 }
 
 func TestInject_CodexSubstitutesPhaseEfforts(t *testing.T) {

--- a/internal/components/sdd/orchestrator.go
+++ b/internal/components/sdd/orchestrator.go
@@ -93,7 +93,13 @@ func composeOrchestratorPrompt(agent model.AgentID, options ...OrchestratorRende
 // Generic is also consumed by Pi, OpenClaw, and Trae. Select by identity,
 // not asset path, so this cohort cannot change deferred runtime prompts.
 func usesFallbackSessionPreflight(agent model.AgentID) bool {
-	return agent == model.AgentVSCodeCopilot || agent == model.AgentCursor || agent == model.AgentGeminiCLI
+	switch agent {
+	case model.AgentVSCodeCopilot, model.AgentCursor, model.AgentGeminiCLI,
+		model.AgentAntigravity, model.AgentQwenCode, model.AgentHermes, model.AgentKimi, model.AgentKiroIDE, model.AgentCodex, model.AgentWindsurf:
+		return true
+	default:
+		return false
+	}
 }
 
 // Replace only owned session-choice producers before composing shared sections.
@@ -101,7 +107,11 @@ func usesFallbackSessionPreflight(agent model.AgentID) bool {
 func composeFallbackSessionPreflight(content string, agent model.AgentID) string {
 	// Validate cardinality before removing any range: a duplicate nested in an
 	// earlier range must not disappear before its own validation runs.
-	for _, heading := range []string{"### Artifact Store Policy", "### Commands", "### Execution Mode", "### Artifact Store Mode", "### Delivery Strategy", "### Chain Strategy"} {
+	policyHeading := "### Artifact Store Policy"
+	if agent == model.AgentCodex {
+		policyHeading = "### Artifact store (engram default)"
+	}
+	for _, heading := range []string{policyHeading, "### Commands", "### Execution Mode", "### Artifact Store Mode", "### Delivery Strategy", "### Chain Strategy"} {
 		if _, err := sddSessionPreflightAnchorIndex(content, heading); err != nil {
 			panic(fmt.Sprintf("sdd: fallback source %s: %v", heading, err))
 		}
@@ -111,6 +121,11 @@ func composeFallbackSessionPreflight(content string, agent model.AgentID) string
 		{"### Artifact Store Mode", "### Delivery Strategy", "Pass the preflight artifact choice as `artifact_store.mode` to every sub-agent launch."},
 		{"### Delivery Strategy", "### Chain Strategy", "Pass the preflight PR strategy as `delivery_strategy` to `sdd-tasks` and `sdd-apply`. `exception-ok` is never a preflight choice; it requires explicit maintainer-approved `size:exception`."},
 	} {
+		if agent == model.AgentCodex && section.start == "### Artifact Store Policy" {
+			const tableHeading = "### Artifact store (engram default)\n"
+			content = strings.Replace(content, tableHeading, "### Artifact store (preflight-selected backend)\n\nUse the following topic keys and retrieval calls only in `engram` or `hybrid` mode. In `openspec` mode, use OpenSpec artifacts instead; do not call Engram for this table.\n", 1)
+			continue
+		}
 		start := strings.Index(content, section.start+"\n")
 		end := strings.Index(content, section.end+"\n")
 		if start < 0 || end <= start {
@@ -119,9 +134,13 @@ func composeFallbackSessionPreflight(content string, agent model.AgentID) string
 		content = content[:start] + section.start + "\n\n" + section.body + "\n\n" + content[end:]
 	}
 	// Keep runtime-specific execution semantics and phase approval rules.
+	executionEnd := "In **Interactive** mode, between phases:"
+	if agent == model.AgentKimi || agent == model.AgentKiroIDE {
+		executionEnd = "Interactive approval is phase-scoped."
+	}
 	for _, bounds := range [][2]string{
 		{"When the user invokes `/sdd-new`", "- **Automatic**"},
-		{"If the user doesn't specify, default to **Automatic**.", "In **Interactive** mode, between phases:"},
+		{"If the user doesn't specify, default to **Automatic**.", executionEnd},
 	} {
 		start := strings.Index(content, bounds[0])
 		end := strings.Index(content, bounds[1])
@@ -146,11 +165,31 @@ func composeFallbackSessionPreflight(content string, agent model.AgentID) string
 		}
 		content = strings.Replace(content, replacement.old, replacement.new, want)
 	}
-	const legacyInitLookup = "1. Search Engram: `mem_search(query: \"sdd-init/{project}\", project: \"{project}\")`\n2. If found → init was done, proceed normally\n3. If NOT found → run `sdd-init` FIRST (delegate to sdd-init sub-agent), THEN proceed with the requested command"
+	// Match each runtime's complete source clause, never a permissive substring.
+	legacyInitAction := "run `sdd-init` FIRST (delegate to sdd-init sub-agent)"
+	initAction := "delegate to `sdd-init`"
+	switch agent {
+	case model.AgentVSCodeCopilot, model.AgentCursor, model.AgentGeminiCLI, model.AgentQwenCode, model.AgentHermes, model.AgentCodex:
+	case model.AgentWindsurf:
+		legacyInitAction = "run the `sdd-init` phase inline FIRST"
+		initAction = "run the `sdd-init` phase inline"
+	case model.AgentAntigravity:
+		legacyInitAction = "invoke the `sdd-init` phase subagent FIRST"
+		initAction = "invoke the `sdd-init` phase subagent"
+	case model.AgentKimi:
+		legacyInitAction = "run `sdd-init` FIRST by launching the `sdd-init` custom agent"
+		initAction = "launch the `sdd-init` custom agent"
+	case model.AgentKiroIDE:
+		legacyInitAction = "run `sdd-init` FIRST (load the sdd-init skill and execute it)"
+		initAction = "load the `sdd-init` skill and execute it in the native Kiro phase context"
+	default:
+		panic("sdd: unsupported fallback runtime: " + string(agent))
+	}
+	legacyInitLookup := "1. Search Engram: `mem_search(query: \"sdd-init/{project}\", project: \"{project}\")`\n2. If found → init was done, proceed normally\n3. If NOT found → " + legacyInitAction + ", THEN proceed with the requested command"
 	if strings.Count(content, legacyInitLookup) != 1 {
 		panic("sdd: missing or ambiguous fallback init lookup")
 	}
-	content = strings.Replace(content, legacyInitLookup, "1. Use the artifact store resolved by SDD Session Preflight. In `openspec` mode, check project context and testing capabilities in `openspec/config.yaml` without calling Engram. In `engram` mode, search `sdd-init/{project}` in Engram. In `hybrid` mode, check both stores.\n2. If the selected store contains initialized project context and testing capabilities, proceed normally; a directory alone is not initialization evidence.\n3. If initialization is missing, delegate to `sdd-init` with the cached `artifact_store.mode`, then proceed. If a selected backend is unavailable, STOP and report it; never silently change the user's artifact choice.", 1)
+	content = strings.Replace(content, legacyInitLookup, "1. Use the artifact store resolved by SDD Session Preflight. In `openspec` mode, check project context and testing capabilities in `openspec/config.yaml` without calling Engram. In `engram` mode, search `sdd-init/{project}` in Engram. In `hybrid` mode, check both stores.\n2. If the selected store contains initialized project context and testing capabilities, proceed normally; a directory alone is not initialization evidence.\n3. If initialization is missing, "+initAction+" with the cached `artifact_store.mode`, then proceed. If a selected backend is unavailable, STOP and report it; never silently change the user's artifact choice.", 1)
 	projected, err := projectSDDSessionPreflightWithTool(content, "### Native SDD Dispatcher Guard", "")
 	if err != nil {
 		panic(err)

--- a/internal/components/sdd/orchestrator_composition_test.go
+++ b/internal/components/sdd/orchestrator_composition_test.go
@@ -33,7 +33,8 @@ func TestCanonicalCompositionAddsOnlyItsKnownSteps(t *testing.T) {
 			// invariant is unchanged in spirit: composition is bounded review
 			// plus the shared sections plus the Pi route, and nothing else.
 			content := assets.MustRead(path)
-			if agent.ID == model.AgentVSCodeCopilot || agent.ID == model.AgentCursor || agent.ID == model.AgentGeminiCLI {
+			if agent.ID == model.AgentVSCodeCopilot || agent.ID == model.AgentCursor || agent.ID == model.AgentGeminiCLI ||
+				agent.ID == model.AgentAntigravity || agent.ID == model.AgentQwenCode || agent.ID == model.AgentHermes || agent.ID == model.AgentKimi || agent.ID == model.AgentKiroIDE || agent.ID == model.AgentCodex || agent.ID == model.AgentWindsurf {
 				assertFallbackSessionPreflight(t, composeOrchestratorPrompt(agent.ID))
 				return
 			}
@@ -51,17 +52,30 @@ func TestCanonicalCompositionAddsOnlyItsKnownSteps(t *testing.T) {
 }
 
 func TestFallbackSessionPreflightRejectsAmbiguousSource(t *testing.T) {
-	for _, agent := range []model.AgentID{model.AgentVSCodeCopilot, model.AgentCursor, model.AgentGeminiCLI} {
+	for _, agent := range []model.AgentID{model.AgentVSCodeCopilot, model.AgentCursor, model.AgentGeminiCLI, model.AgentAntigravity, model.AgentQwenCode, model.AgentHermes, model.AgentKimi, model.AgentKiroIDE, model.AgentCodex, model.AgentWindsurf} {
 		source := assets.MustRead(sddOrchestratorAsset(agent))
-		for _, heading := range []string{"### Artifact Store Policy", "### Commands", "### Execution Mode", "### Artifact Store Mode", "### Delivery Strategy", "### Chain Strategy"} {
-			t.Run(string(agent)+"/duplicate/"+heading, func(t *testing.T) {
-				defer func() {
-					if recover() == nil {
-						t.Fatal("ambiguous source did not fail closed")
+		initStart := strings.Index(source, "1. Search Engram:")
+		initEnd := strings.Index(source[initStart:], "\n\n") + initStart
+		initLookup := source[initStart:initEnd]
+		policyHeading := "### Artifact Store Policy"
+		if agent == model.AgentCodex {
+			policyHeading = "### Artifact store (engram default)"
+		}
+		for _, heading := range []string{initLookup, policyHeading, "### Commands", "### Execution Mode", "### Artifact Store Mode", "### Delivery Strategy", "### Chain Strategy", "### Native SDD Dispatcher Guard", "### SDD Init Guard (MANDATORY)", "If the user doesn't specify, default to **Automatic**."} {
+			for _, mutation := range []string{"missing", "duplicate"} {
+				t.Run(string(agent)+"/"+mutation+"/"+heading, func(t *testing.T) {
+					defer func() {
+						if recover() == nil {
+							t.Fatal("ambiguous source did not fail closed")
+						}
+					}()
+					mutated := source + "\n" + heading + "\n"
+					if mutation == "missing" {
+						mutated = strings.Replace(source, heading, "drifted source", 1)
 					}
-				}()
-				composeFallbackSessionPreflight(source+"\n"+heading+"\n", agent)
-			})
+					composeFallbackSessionPreflight(mutated, agent)
+				})
+			}
 		}
 	}
 	for _, tc := range []struct {

--- a/internal/components/sdd/session_preflight_test.go
+++ b/internal/components/sdd/session_preflight_test.go
@@ -37,9 +37,19 @@ func assertFallbackSessionPreflight(t *testing.T, got string) {
 }
 
 func TestFallbackSessionPreflightCohort(t *testing.T) {
-	for _, agent := range []model.AgentID{model.AgentVSCodeCopilot, model.AgentCursor, model.AgentGeminiCLI} {
+	for _, agent := range []model.AgentID{model.AgentVSCodeCopilot, model.AgentCursor, model.AgentGeminiCLI, model.AgentAntigravity, model.AgentQwenCode, model.AgentHermes, model.AgentKimi, model.AgentKiroIDE, model.AgentCodex, model.AgentWindsurf} {
 		t.Run(string(agent), func(t *testing.T) {
 			got := composeOrchestratorPrompt(agent)
+			if agent == model.AgentCodex {
+				for _, want := range []string{"{{CODEX_PHASE_EFFORTS}}", "only in `engram` or `hybrid` mode", "In `openspec` mode, use OpenSpec artifacts instead; do not call Engram for this table."} {
+					if !strings.Contains(got, want) {
+						t.Errorf("Codex projection missing %q", want)
+					}
+				}
+				if strings.Contains(got, "engram default") || strings.Contains(got, "Default: `engram`") {
+					t.Error("Codex projection retained an independent artifact default")
+				}
+			}
 			for _, marker := range []string{sddSessionPreflightMarker, sddSessionPreflightEnd} {
 				if strings.Count(got, marker) != 1 {
 					t.Fatalf("expected exactly one %s", marker)

--- a/testdata/golden/combined-windsurf-global-rules.golden
+++ b/testdata/golden/combined-windsurf-global-rules.golden
@@ -202,10 +202,7 @@ SDD is the structured planning layer for substantial changes.
 
 ### Artifact Store Policy
 
-- `engram` — default when available; persistent memory across sessions via MCP
-- `openspec` — file-based artifacts; use only when user explicitly requests
-- `hybrid` — both backends; cross-session recovery + local files; more tokens per op
-- `none` — return results inline only; recommend enabling engram or openspec
+Use the artifact store resolved by SDD Session Preflight; never detect or default a separate choice.
 
 ### Commands
 
@@ -227,6 +224,31 @@ Meta-commands (type directly — orchestrator handles them, will not appear in a
 
 `/sdd-new`, `/sdd-continue`, and `/sdd-ff` are meta-commands handled by YOU. Do NOT invoke them as skills. You execute the phase sequence yourself, pausing for user approval between phases.
 
+<!-- gentle-ai:sdd-session-preflight -->
+### SDD Session Preflight (HARD GATE)
+
+Before every SDD command or natural-language SDD request, run this preflight before the SDD init guard; cache choices for the session.
+
+This runtime has no classified native question UI. Present ONE complete blocking prompt in plain chat or terminal with all three groups below, in order, and explain that their answers are required before init. Each group is single-select; its listed labels are the complete allowed-answer domain. Include every label and description, the fixed review policy, and this answer syntax: `Pace: <label>; Artifacts: <label>; PR strategy: <label>`. Then STOP; never default, infer, or launch dependent work. Validate all three answers under the Lossless Blocking Prompts contract before caching their canonical mappings.
+
+Match labels and descriptions to the conversation language and persona; do not expose canonical/internal codes.
+
+1. **Pace**: Interactive or Automatic.
+2. **Artifacts**: OpenSpec, Engram, or Both (user-facing Both maps only to internal `hybrid`).
+3. **PR strategy**: Ask me, Single PR, or Auto.
+
+Review policy is fixed at 400 changed lines per PR; above 400, split the PR or require maintainer-approved `size:exception`; NEVER ask it as a fourth group or selectable budget.
+
+Canonical mappings:
+- Interactive -> `interactive`
+- Automatic -> `auto`
+- OpenSpec -> `openspec`
+- Engram -> `engram`
+- Both -> `hybrid`
+- Ask me -> `ask-on-risk`
+- Single PR -> `single-pr`
+- Auto -> `auto-chain`
+<!-- /gentle-ai:sdd-session-preflight -->
 ### Native SDD Dispatcher Guard
 
 Before routing, continuing, applying, verifying, or archiving an SDD change, **invoke the native dispatcher** (`gentle-ai sdd-continue [change] --cwd <repo>` or `gentle-ai sdd-status [change] --cwd <repo> --json --instructions`). It resolves the artifact store the workspace DECLARES, reports it in `artifactStore`, and returns that store's locators in `artifactPaths`. **Do NOT determine the artifact store yourself, and do NOT branch on it** — an actor that re-derives the store disagrees with the authority that launched it, which is how a phase ends up reading a store the workspace never declared. Use the dispatcher for every store when `gentle-ai` is available and treat its native status JSON as authoritative over prompt inference. Route only by `nextRecommended` and dependency states; never infer from free text. If `blockedReasons` is non-empty, do not proceed to apply, archive, or terminal work. If `nextRecommended` is `verify`, verification/remediation may run only to refresh evidence; if `nextRecommended` is `resolve-blockers`, report `blockedReasons` and stop; if `nextRecommended` is a planning token (`propose`, `spec`, `design`, or `tasks`), launch the corresponding planning phase. If the binary is unavailable, fall back to the existing prompt contract and manual status schema.
@@ -235,9 +257,9 @@ Before routing, continuing, applying, verifying, or archiving an SDD change, **i
 
 Before executing ANY SDD command (`/sdd-new`, `/sdd-ff`, `/sdd-continue`, `/sdd-explore`, `/sdd-status`, `/sdd-apply`, `/sdd-verify`, `/sdd-archive`), check if `sdd-init` has been run for this project:
 
-1. Search Engram: `mem_search(query: "sdd-init/{project}", project: "{project}")`
-2. If found → init was done, proceed normally
-3. If NOT found → run the `sdd-init` phase inline FIRST, THEN proceed with the requested command
+1. Use the artifact store resolved by SDD Session Preflight. In `openspec` mode, check project context and testing capabilities in `openspec/config.yaml` without calling Engram. In `engram` mode, search `sdd-init/{project}` in Engram. In `hybrid` mode, check both stores.
+2. If the selected store contains initialized project context and testing capabilities, proceed normally; a directory alone is not initialization evidence.
+3. If initialization is missing, run the `sdd-init` phase inline with the cached `artifact_store.mode`, then proceed. If a selected backend is unavailable, STOP and report it; never silently change the user's artifact choice.
 
 This ensures:
 
@@ -251,14 +273,12 @@ Native Windsurf Workflow: `/sdd-new` is also available as a native Windsurf work
 
 ### Execution Mode
 
-When the user invokes `/sdd-new`, `/sdd-ff`, or `/sdd-continue` (or an equivalent natural-language request, e.g. "create an SDD for X" / "do SDD for X") for the first time in a session, ASK which execution mode they prefer:
+Use the execution mode cached by SDD Session Preflight.
 
 - **Automatic** (`auto`): Run all phases sequentially without pausing. Phases still run sequentially WITHOUT interrupting the user, BUT the orchestrator runs a gatekeeper validation after every phase before advancing — the user only sees an interruption when the gatekeeper catches a real problem. Otherwise only the final result is shown. Use this when the user wants speed and trusts the process.
 - **Interactive** (`interactive`): After each phase completes, show the result summary and ASK: "Want to adjust anything or continue?" before proceeding to the next phase. Use this when the user wants to review and steer each step.
 
-If the user doesn't specify, default to **Automatic**. After scope approval, expect zero further prompts on the happy path and at most one actionable prompt per recoverable failure; the gatekeeper summarizes phase progress instead of interrupting except on a second consecutive gate failure or a genuine scope/product decision.
-
-Cache the mode choice for the session — don't ask again unless the user explicitly requests a mode change.
+Use the execution mode cached by SDD Session Preflight.
 
 In **Interactive** mode, between phases:
 
@@ -309,19 +329,11 @@ Use the provider-owned Git-common-dir runtime ledger for every runtime-bearing `
 
 ### Artifact Store Mode
 
-When the user invokes `/sdd-new`, `/sdd-ff`, or `/sdd-continue` (or an equivalent natural-language request) for the first time in a session, ALSO ASK which artifact store they want for this change:
-
-- **`engram`**: Fast, no files created. Artifacts live in engram only. Best for solo work and quick iteration. Note: re-running a phase overwrites the previous version (no history).
-- **`openspec`**: File-based. Creates `openspec/` directory with full artifact trail. Committable, shareable with team, full git history.
-- **`hybrid`**: Both — files for team sharing + engram for cross-session recovery. Higher token cost.
-
-If the user doesn't specify, detect: if engram is available → default to `engram`. Otherwise → `none`.
-
-Cache the artifact store choice for the session. Add it to every inline phase context.
+Pass the preflight artifact choice as `artifact_store.mode` to every sub-agent launch.
 
 ### Delivery Strategy
 
-On the first `/sdd-new`, `/sdd-ff`, or `/sdd-continue` (or an equivalent natural-language request) in a session, ask once for and cache delivery strategy: `ask-on-risk` (default), `auto-chain`, `single-pr`, or `exception-ok`. Pass it as `delivery_strategy` to `sdd-tasks` and `sdd-apply` prompts.
+Pass the preflight PR strategy as `delivery_strategy` to `sdd-tasks` and `sdd-apply`. `exception-ok` is never a preflight choice; it requires explicit maintainer-approved `size:exception`.
 
 ### Chain Strategy
 

--- a/testdata/golden/sdd-antigravity-rulesmd.golden
+++ b/testdata/golden/sdd-antigravity-rulesmd.golden
@@ -142,10 +142,7 @@ SDD is the structured planning layer for substantial changes.
 
 ### Artifact Store Policy
 
-- `engram` — default when available; persistent memory across sessions via MCP
-- `openspec` — file-based artifacts; use only when user explicitly requests
-- `hybrid` — both backends; cross-session recovery + local files; more tokens per op
-- `none` — return results inline only; recommend enabling engram or openspec
+Use the artifact store resolved by SDD Session Preflight; never detect or default a separate choice.
 
 ### Commands
 
@@ -167,6 +164,31 @@ Meta-commands (type directly — orchestrator handles them, will not appear in a
 
 `/sdd-new`, `/sdd-continue`, and `/sdd-ff` are meta-commands handled by YOU. Do NOT invoke them as skills. You orchestrate the phase sequence through dynamic subagents, pausing for user approval between phases when required.
 
+<!-- gentle-ai:sdd-session-preflight -->
+### SDD Session Preflight (HARD GATE)
+
+Before every SDD command or natural-language SDD request, run this preflight before the SDD init guard; cache choices for the session.
+
+This runtime has no classified native question UI. Present ONE complete blocking prompt in plain chat or terminal with all three groups below, in order, and explain that their answers are required before init. Each group is single-select; its listed labels are the complete allowed-answer domain. Include every label and description, the fixed review policy, and this answer syntax: `Pace: <label>; Artifacts: <label>; PR strategy: <label>`. Then STOP; never default, infer, or launch dependent work. Validate all three answers under the Lossless Blocking Prompts contract before caching their canonical mappings.
+
+Match labels and descriptions to the conversation language and persona; do not expose canonical/internal codes.
+
+1. **Pace**: Interactive or Automatic.
+2. **Artifacts**: OpenSpec, Engram, or Both (user-facing Both maps only to internal `hybrid`).
+3. **PR strategy**: Ask me, Single PR, or Auto.
+
+Review policy is fixed at 400 changed lines per PR; above 400, split the PR or require maintainer-approved `size:exception`; NEVER ask it as a fourth group or selectable budget.
+
+Canonical mappings:
+- Interactive -> `interactive`
+- Automatic -> `auto`
+- OpenSpec -> `openspec`
+- Engram -> `engram`
+- Both -> `hybrid`
+- Ask me -> `ask-on-risk`
+- Single PR -> `single-pr`
+- Auto -> `auto-chain`
+<!-- /gentle-ai:sdd-session-preflight -->
 ### Native SDD Dispatcher Guard
 
 Before routing, continuing, applying, verifying, or archiving an SDD change, **invoke the native dispatcher** (`gentle-ai sdd-continue [change] --cwd <repo>` or `gentle-ai sdd-status [change] --cwd <repo> --json --instructions`). It resolves the artifact store the workspace DECLARES, reports it in `artifactStore`, and returns that store's locators in `artifactPaths`. **Do NOT determine the artifact store yourself, and do NOT branch on it** — an actor that re-derives the store disagrees with the authority that launched it, which is how a phase ends up reading a store the workspace never declared. Use the dispatcher for every store when `gentle-ai` is available and treat its native status JSON as authoritative over prompt inference. Route only by `nextRecommended` and dependency states; never infer from free text. If `blockedReasons` is non-empty, do not proceed to apply, archive, or terminal work. If `nextRecommended` is `verify`, verification/remediation may run only to refresh evidence; if `nextRecommended` is `resolve-blockers`, report `blockedReasons` and stop; if `nextRecommended` is a planning token (`propose`, `spec`, `design`, or `tasks`), launch the corresponding planning phase. If the binary is unavailable, fall back to the existing prompt contract and manual status schema.
@@ -175,9 +197,9 @@ Before routing, continuing, applying, verifying, or archiving an SDD change, **i
 
 Before executing ANY SDD command (`/sdd-new`, `/sdd-ff`, `/sdd-continue`, `/sdd-explore`, `/sdd-status`, `/sdd-apply`, `/sdd-verify`, `/sdd-archive`), check if `sdd-init` has been run for this project:
 
-1. Search Engram: `mem_search(query: "sdd-init/{project}", project: "{project}")`
-2. If found → init was done, proceed normally
-3. If NOT found → invoke the `sdd-init` phase subagent FIRST, THEN proceed with the requested command
+1. Use the artifact store resolved by SDD Session Preflight. In `openspec` mode, check project context and testing capabilities in `openspec/config.yaml` without calling Engram. In `engram` mode, search `sdd-init/{project}` in Engram. In `hybrid` mode, check both stores.
+2. If the selected store contains initialized project context and testing capabilities, proceed normally; a directory alone is not initialization evidence.
+3. If initialization is missing, invoke the `sdd-init` phase subagent with the cached `artifact_store.mode`, then proceed. If a selected backend is unavailable, STOP and report it; never silently change the user's artifact choice.
 
 This ensures:
 
@@ -189,14 +211,12 @@ Do NOT skip this check. Do NOT ask the user — just run init silently if needed
 
 ### Execution Mode
 
-When the user invokes `/sdd-new`, `/sdd-ff`, or `/sdd-continue` (or an equivalent natural-language request, e.g. "create an SDD for X" / "do SDD for X") for the first time in a session, ASK which execution mode they prefer:
+Use the execution mode cached by SDD Session Preflight.
 
 - **Automatic** (`auto`): Run all phases sequentially without pausing. Phases still run back-to-back WITHOUT interrupting the user, BUT the orchestrator runs a gatekeeper validation after every phase before invoking the next dynamic subagent — the user only sees an interruption when the gatekeeper catches a real problem. Otherwise only the final result is shown. Use this when the user wants speed and trusts the process.
 - **Interactive** (`interactive`): After each phase completes, show the result summary and ASK: "Want to adjust anything or continue?" before proceeding to the next phase. Use this when the user wants to review and steer each step.
 
-If the user doesn't specify, default to **Automatic**. After scope approval, expect zero further prompts on the happy path and at most one actionable prompt per recoverable failure; the gatekeeper summarizes phase progress instead of interrupting except on a second consecutive gate failure or a genuine scope/product decision.
-
-Cache the mode choice for the session — don't ask again unless the user explicitly requests a mode change.
+Use the execution mode cached by SDD Session Preflight.
 
 In **Interactive** mode, between phases:
 
@@ -247,19 +267,11 @@ Use the provider-owned Git-common-dir runtime ledger for every runtime-bearing `
 
 ### Artifact Store Mode
 
-When the user invokes `/sdd-new`, `/sdd-ff`, or `/sdd-continue` (or an equivalent natural-language request) for the first time in a session, ALSO ASK which artifact store they want for this change:
-
-- **`engram`**: Fast, no files created. Artifacts live in engram only. Best for solo work and quick iteration. Note: re-running a phase overwrites the previous version (no history).
-- **`openspec`**: File-based. Creates `openspec/` directory with full artifact trail. Committable, shareable with team, full git history.
-- **`hybrid`**: Both — files for team sharing + engram for cross-session recovery. Higher token cost.
-
-If the user doesn't specify, detect: if engram is available → default to `engram`. Otherwise → `none`.
-
-Cache the artifact store choice for the session. Add it to every dynamic subagent context.
+Pass the preflight artifact choice as `artifact_store.mode` to every sub-agent launch.
 
 ### Delivery Strategy
 
-On the first `/sdd-new`, `/sdd-ff`, or `/sdd-continue` (or an equivalent natural-language request) in a session, ask once for and cache delivery strategy: `ask-on-risk` (default), `auto-chain`, `single-pr`, or `exception-ok`. Pass it as `delivery_strategy` to `sdd-tasks` and `sdd-apply` prompts.
+Pass the preflight PR strategy as `delivery_strategy` to `sdd-tasks` and `sdd-apply`. `exception-ok` is never a preflight choice; it requires explicit maintainer-approved `size:exception`.
 
 ### Chain Strategy
 

--- a/testdata/golden/sdd-codex-agentsmd-lowcost.golden
+++ b/testdata/golden/sdd-codex-agentsmd-lowcost.golden
@@ -371,6 +371,31 @@ Meta-commands (type directly — orchestrator handles them, won't appear in auto
 
 `/sdd-new`, `/sdd-continue`, and `/sdd-ff` are meta-commands handled by YOU. Do NOT invoke them as skills.
 
+<!-- gentle-ai:sdd-session-preflight -->
+### SDD Session Preflight (HARD GATE)
+
+Before every SDD command or natural-language SDD request, run this preflight before the SDD init guard; cache choices for the session.
+
+This runtime has no classified native question UI. Present ONE complete blocking prompt in plain chat or terminal with all three groups below, in order, and explain that their answers are required before init. Each group is single-select; its listed labels are the complete allowed-answer domain. Include every label and description, the fixed review policy, and this answer syntax: `Pace: <label>; Artifacts: <label>; PR strategy: <label>`. Then STOP; never default, infer, or launch dependent work. Validate all three answers under the Lossless Blocking Prompts contract before caching their canonical mappings.
+
+Match labels and descriptions to the conversation language and persona; do not expose canonical/internal codes.
+
+1. **Pace**: Interactive or Automatic.
+2. **Artifacts**: OpenSpec, Engram, or Both (user-facing Both maps only to internal `hybrid`).
+3. **PR strategy**: Ask me, Single PR, or Auto.
+
+Review policy is fixed at 400 changed lines per PR; above 400, split the PR or require maintainer-approved `size:exception`; NEVER ask it as a fourth group or selectable budget.
+
+Canonical mappings:
+- Interactive -> `interactive`
+- Automatic -> `auto`
+- OpenSpec -> `openspec`
+- Engram -> `engram`
+- Both -> `hybrid`
+- Ask me -> `ask-on-risk`
+- Single PR -> `single-pr`
+- Auto -> `auto-chain`
+<!-- /gentle-ai:sdd-session-preflight -->
 ### Native SDD Dispatcher Guard
 
 Before routing, continuing, applying, verifying, or archiving an SDD change, **invoke the native dispatcher** (`gentle-ai sdd-continue [change] --cwd <repo>` or `gentle-ai sdd-status [change] --cwd <repo> --json --instructions`). It resolves the artifact store the workspace DECLARES, reports it in `artifactStore`, and returns that store's locators in `artifactPaths`. **Do NOT determine the artifact store yourself, and do NOT branch on it** — an actor that re-derives the store disagrees with the authority that launched it, which is how a phase ends up reading a store the workspace never declared. Use the dispatcher for every store when `gentle-ai` is available and treat its native status JSON as authoritative over prompt inference. Route only by `nextRecommended` and dependency states; never infer from free text. If `blockedReasons` is non-empty, do not proceed to apply, archive, or terminal work. If `nextRecommended` is `verify`, verification/remediation may run only to refresh evidence; if `nextRecommended` is `resolve-blockers`, report `blockedReasons` and stop; if `nextRecommended` is a planning token (`propose`, `spec`, `design`, or `tasks`), launch the corresponding planning phase. If the binary is unavailable, fall back to the existing prompt contract and manual status schema.
@@ -379,9 +404,9 @@ Before routing, continuing, applying, verifying, or archiving an SDD change, **i
 
 Before executing ANY SDD command (`/sdd-new`, `/sdd-ff`, `/sdd-continue`, `/sdd-explore`, `/sdd-status`, `/sdd-apply`, `/sdd-verify`, `/sdd-archive`), check if `sdd-init` has been run for this project:
 
-1. Search Engram: `mem_search(query: "sdd-init/{project}", project: "{project}")`
-2. If found → init was done, proceed normally
-3. If NOT found → run `sdd-init` FIRST (delegate to sdd-init sub-agent), THEN proceed with the requested command
+1. Use the artifact store resolved by SDD Session Preflight. In `openspec` mode, check project context and testing capabilities in `openspec/config.yaml` without calling Engram. In `engram` mode, search `sdd-init/{project}` in Engram. In `hybrid` mode, check both stores.
+2. If the selected store contains initialized project context and testing capabilities, proceed normally; a directory alone is not initialization evidence.
+3. If initialization is missing, delegate to `sdd-init` with the cached `artifact_store.mode`, then proceed. If a selected backend is unavailable, STOP and report it; never silently change the user's artifact choice.
 
 This ensures:
 
@@ -393,12 +418,12 @@ Do NOT skip this check. Do NOT ask the user — just run init silently if needed
 
 ### Execution Mode
 
-When the user invokes `/sdd-new`, `/sdd-ff`, or `/sdd-continue` for the first time in a session, ask which execution mode they prefer:
+Use the execution mode cached by SDD Session Preflight.
 
 - **Automatic** (`auto`): Run all phases back-to-back. The orchestrator runs a gatekeeper validation after every phase before launching the next sub-agent — the user only sees an interruption when the gatekeeper catches a problem. Final result only.
 - **Interactive** (`interactive`): After each phase, show the result summary and ask before proceeding.
 
-If the user doesn't specify, default to **Automatic**. After scope approval, expect zero further prompts on the happy path and at most one actionable prompt per recoverable failure; the gatekeeper summarizes phase progress instead of interrupting except on a second consecutive gate failure or a genuine scope/product decision.
+Use the execution mode cached by SDD Session Preflight.
 
 In **Interactive** mode, between phases:
 
@@ -449,17 +474,11 @@ Use the provider-owned Git-common-dir runtime ledger for every runtime-bearing `
 
 ### Artifact Store Mode
 
-When the user invokes `/sdd-new`, `/sdd-ff`, or `/sdd-continue` for the first time in a session, also ask which artifact store they want:
-
-- **`engram`**: Fast, no files created. Best for solo work.
-- **`openspec`**: File-based. Creates `openspec/` directory. Committable, shareable.
-- **`hybrid`**: Both — files for team sharing + engram for cross-session recovery.
-
-Default: `engram` when available. Cache the choice for the session.
+Pass the preflight artifact choice as `artifact_store.mode` to every sub-agent launch.
 
 ### Delivery Strategy
 
-On the first `/sdd-new`, `/sdd-ff`, or `/sdd-continue` in a session, ask once for and cache delivery strategy: `ask-on-risk` (default), `auto-chain`, `single-pr`, or `exception-ok`. Pass it as `delivery_strategy` to `sdd-tasks` and `sdd-apply` prompts.
+Pass the preflight PR strategy as `delivery_strategy` to `sdd-tasks` and `sdd-apply`. `exception-ok` is never a preflight choice; it requires explicit maintainer-approved `size:exception`.
 
 ### Chain Strategy
 
@@ -499,7 +518,9 @@ The phase result must prove that persistence contract. Refresh prior progress be
 
 When launching `sdd-archive`, forward explicit final-state facts for any work completed after `apply-progress` or `verify-report` were persisted — verify warnings fixed in later commits, blockers resolved, tasks finished, updated test or issue counts — with commit or evidence references where available. Those two artifacts are intermediate snapshots, valid at the time they were written; the archive report records the state at close, and explicit final-state facts in the `sdd-archive` launch prompt outrank stale snapshot claims.
 
-### Artifact store (engram default)
+### Artifact store (preflight-selected backend)
+
+Use the following topic keys and retrieval calls only in `engram` or `hybrid` mode. In `openspec` mode, use OpenSpec artifacts instead; do not call Engram for this table.
 
 | Artifact | Topic key |
 |----------|-----------|

--- a/testdata/golden/sdd-codex-agentsmd-powerful.golden
+++ b/testdata/golden/sdd-codex-agentsmd-powerful.golden
@@ -371,6 +371,31 @@ Meta-commands (type directly — orchestrator handles them, won't appear in auto
 
 `/sdd-new`, `/sdd-continue`, and `/sdd-ff` are meta-commands handled by YOU. Do NOT invoke them as skills.
 
+<!-- gentle-ai:sdd-session-preflight -->
+### SDD Session Preflight (HARD GATE)
+
+Before every SDD command or natural-language SDD request, run this preflight before the SDD init guard; cache choices for the session.
+
+This runtime has no classified native question UI. Present ONE complete blocking prompt in plain chat or terminal with all three groups below, in order, and explain that their answers are required before init. Each group is single-select; its listed labels are the complete allowed-answer domain. Include every label and description, the fixed review policy, and this answer syntax: `Pace: <label>; Artifacts: <label>; PR strategy: <label>`. Then STOP; never default, infer, or launch dependent work. Validate all three answers under the Lossless Blocking Prompts contract before caching their canonical mappings.
+
+Match labels and descriptions to the conversation language and persona; do not expose canonical/internal codes.
+
+1. **Pace**: Interactive or Automatic.
+2. **Artifacts**: OpenSpec, Engram, or Both (user-facing Both maps only to internal `hybrid`).
+3. **PR strategy**: Ask me, Single PR, or Auto.
+
+Review policy is fixed at 400 changed lines per PR; above 400, split the PR or require maintainer-approved `size:exception`; NEVER ask it as a fourth group or selectable budget.
+
+Canonical mappings:
+- Interactive -> `interactive`
+- Automatic -> `auto`
+- OpenSpec -> `openspec`
+- Engram -> `engram`
+- Both -> `hybrid`
+- Ask me -> `ask-on-risk`
+- Single PR -> `single-pr`
+- Auto -> `auto-chain`
+<!-- /gentle-ai:sdd-session-preflight -->
 ### Native SDD Dispatcher Guard
 
 Before routing, continuing, applying, verifying, or archiving an SDD change, **invoke the native dispatcher** (`gentle-ai sdd-continue [change] --cwd <repo>` or `gentle-ai sdd-status [change] --cwd <repo> --json --instructions`). It resolves the artifact store the workspace DECLARES, reports it in `artifactStore`, and returns that store's locators in `artifactPaths`. **Do NOT determine the artifact store yourself, and do NOT branch on it** — an actor that re-derives the store disagrees with the authority that launched it, which is how a phase ends up reading a store the workspace never declared. Use the dispatcher for every store when `gentle-ai` is available and treat its native status JSON as authoritative over prompt inference. Route only by `nextRecommended` and dependency states; never infer from free text. If `blockedReasons` is non-empty, do not proceed to apply, archive, or terminal work. If `nextRecommended` is `verify`, verification/remediation may run only to refresh evidence; if `nextRecommended` is `resolve-blockers`, report `blockedReasons` and stop; if `nextRecommended` is a planning token (`propose`, `spec`, `design`, or `tasks`), launch the corresponding planning phase. If the binary is unavailable, fall back to the existing prompt contract and manual status schema.
@@ -379,9 +404,9 @@ Before routing, continuing, applying, verifying, or archiving an SDD change, **i
 
 Before executing ANY SDD command (`/sdd-new`, `/sdd-ff`, `/sdd-continue`, `/sdd-explore`, `/sdd-status`, `/sdd-apply`, `/sdd-verify`, `/sdd-archive`), check if `sdd-init` has been run for this project:
 
-1. Search Engram: `mem_search(query: "sdd-init/{project}", project: "{project}")`
-2. If found → init was done, proceed normally
-3. If NOT found → run `sdd-init` FIRST (delegate to sdd-init sub-agent), THEN proceed with the requested command
+1. Use the artifact store resolved by SDD Session Preflight. In `openspec` mode, check project context and testing capabilities in `openspec/config.yaml` without calling Engram. In `engram` mode, search `sdd-init/{project}` in Engram. In `hybrid` mode, check both stores.
+2. If the selected store contains initialized project context and testing capabilities, proceed normally; a directory alone is not initialization evidence.
+3. If initialization is missing, delegate to `sdd-init` with the cached `artifact_store.mode`, then proceed. If a selected backend is unavailable, STOP and report it; never silently change the user's artifact choice.
 
 This ensures:
 
@@ -393,12 +418,12 @@ Do NOT skip this check. Do NOT ask the user — just run init silently if needed
 
 ### Execution Mode
 
-When the user invokes `/sdd-new`, `/sdd-ff`, or `/sdd-continue` for the first time in a session, ask which execution mode they prefer:
+Use the execution mode cached by SDD Session Preflight.
 
 - **Automatic** (`auto`): Run all phases back-to-back. The orchestrator runs a gatekeeper validation after every phase before launching the next sub-agent — the user only sees an interruption when the gatekeeper catches a problem. Final result only.
 - **Interactive** (`interactive`): After each phase, show the result summary and ask before proceeding.
 
-If the user doesn't specify, default to **Automatic**. After scope approval, expect zero further prompts on the happy path and at most one actionable prompt per recoverable failure; the gatekeeper summarizes phase progress instead of interrupting except on a second consecutive gate failure or a genuine scope/product decision.
+Use the execution mode cached by SDD Session Preflight.
 
 In **Interactive** mode, between phases:
 
@@ -449,17 +474,11 @@ Use the provider-owned Git-common-dir runtime ledger for every runtime-bearing `
 
 ### Artifact Store Mode
 
-When the user invokes `/sdd-new`, `/sdd-ff`, or `/sdd-continue` for the first time in a session, also ask which artifact store they want:
-
-- **`engram`**: Fast, no files created. Best for solo work.
-- **`openspec`**: File-based. Creates `openspec/` directory. Committable, shareable.
-- **`hybrid`**: Both — files for team sharing + engram for cross-session recovery.
-
-Default: `engram` when available. Cache the choice for the session.
+Pass the preflight artifact choice as `artifact_store.mode` to every sub-agent launch.
 
 ### Delivery Strategy
 
-On the first `/sdd-new`, `/sdd-ff`, or `/sdd-continue` in a session, ask once for and cache delivery strategy: `ask-on-risk` (default), `auto-chain`, `single-pr`, or `exception-ok`. Pass it as `delivery_strategy` to `sdd-tasks` and `sdd-apply` prompts.
+Pass the preflight PR strategy as `delivery_strategy` to `sdd-tasks` and `sdd-apply`. `exception-ok` is never a preflight choice; it requires explicit maintainer-approved `size:exception`.
 
 ### Chain Strategy
 
@@ -499,7 +518,9 @@ The phase result must prove that persistence contract. Refresh prior progress be
 
 When launching `sdd-archive`, forward explicit final-state facts for any work completed after `apply-progress` or `verify-report` were persisted — verify warnings fixed in later commits, blockers resolved, tasks finished, updated test or issue counts — with commit or evidence references where available. Those two artifacts are intermediate snapshots, valid at the time they were written; the archive report records the state at close, and explicit final-state facts in the `sdd-archive` launch prompt outrank stale snapshot claims.
 
-### Artifact store (engram default)
+### Artifact store (preflight-selected backend)
+
+Use the following topic keys and retrieval calls only in `engram` or `hybrid` mode. In `openspec` mode, use OpenSpec artifacts instead; do not call Engram for this table.
 
 | Artifact | Topic key |
 |----------|-----------|

--- a/testdata/golden/sdd-codex-agentsmd.golden
+++ b/testdata/golden/sdd-codex-agentsmd.golden
@@ -371,6 +371,31 @@ Meta-commands (type directly — orchestrator handles them, won't appear in auto
 
 `/sdd-new`, `/sdd-continue`, and `/sdd-ff` are meta-commands handled by YOU. Do NOT invoke them as skills.
 
+<!-- gentle-ai:sdd-session-preflight -->
+### SDD Session Preflight (HARD GATE)
+
+Before every SDD command or natural-language SDD request, run this preflight before the SDD init guard; cache choices for the session.
+
+This runtime has no classified native question UI. Present ONE complete blocking prompt in plain chat or terminal with all three groups below, in order, and explain that their answers are required before init. Each group is single-select; its listed labels are the complete allowed-answer domain. Include every label and description, the fixed review policy, and this answer syntax: `Pace: <label>; Artifacts: <label>; PR strategy: <label>`. Then STOP; never default, infer, or launch dependent work. Validate all three answers under the Lossless Blocking Prompts contract before caching their canonical mappings.
+
+Match labels and descriptions to the conversation language and persona; do not expose canonical/internal codes.
+
+1. **Pace**: Interactive or Automatic.
+2. **Artifacts**: OpenSpec, Engram, or Both (user-facing Both maps only to internal `hybrid`).
+3. **PR strategy**: Ask me, Single PR, or Auto.
+
+Review policy is fixed at 400 changed lines per PR; above 400, split the PR or require maintainer-approved `size:exception`; NEVER ask it as a fourth group or selectable budget.
+
+Canonical mappings:
+- Interactive -> `interactive`
+- Automatic -> `auto`
+- OpenSpec -> `openspec`
+- Engram -> `engram`
+- Both -> `hybrid`
+- Ask me -> `ask-on-risk`
+- Single PR -> `single-pr`
+- Auto -> `auto-chain`
+<!-- /gentle-ai:sdd-session-preflight -->
 ### Native SDD Dispatcher Guard
 
 Before routing, continuing, applying, verifying, or archiving an SDD change, **invoke the native dispatcher** (`gentle-ai sdd-continue [change] --cwd <repo>` or `gentle-ai sdd-status [change] --cwd <repo> --json --instructions`). It resolves the artifact store the workspace DECLARES, reports it in `artifactStore`, and returns that store's locators in `artifactPaths`. **Do NOT determine the artifact store yourself, and do NOT branch on it** — an actor that re-derives the store disagrees with the authority that launched it, which is how a phase ends up reading a store the workspace never declared. Use the dispatcher for every store when `gentle-ai` is available and treat its native status JSON as authoritative over prompt inference. Route only by `nextRecommended` and dependency states; never infer from free text. If `blockedReasons` is non-empty, do not proceed to apply, archive, or terminal work. If `nextRecommended` is `verify`, verification/remediation may run only to refresh evidence; if `nextRecommended` is `resolve-blockers`, report `blockedReasons` and stop; if `nextRecommended` is a planning token (`propose`, `spec`, `design`, or `tasks`), launch the corresponding planning phase. If the binary is unavailable, fall back to the existing prompt contract and manual status schema.
@@ -379,9 +404,9 @@ Before routing, continuing, applying, verifying, or archiving an SDD change, **i
 
 Before executing ANY SDD command (`/sdd-new`, `/sdd-ff`, `/sdd-continue`, `/sdd-explore`, `/sdd-status`, `/sdd-apply`, `/sdd-verify`, `/sdd-archive`), check if `sdd-init` has been run for this project:
 
-1. Search Engram: `mem_search(query: "sdd-init/{project}", project: "{project}")`
-2. If found → init was done, proceed normally
-3. If NOT found → run `sdd-init` FIRST (delegate to sdd-init sub-agent), THEN proceed with the requested command
+1. Use the artifact store resolved by SDD Session Preflight. In `openspec` mode, check project context and testing capabilities in `openspec/config.yaml` without calling Engram. In `engram` mode, search `sdd-init/{project}` in Engram. In `hybrid` mode, check both stores.
+2. If the selected store contains initialized project context and testing capabilities, proceed normally; a directory alone is not initialization evidence.
+3. If initialization is missing, delegate to `sdd-init` with the cached `artifact_store.mode`, then proceed. If a selected backend is unavailable, STOP and report it; never silently change the user's artifact choice.
 
 This ensures:
 
@@ -393,12 +418,12 @@ Do NOT skip this check. Do NOT ask the user — just run init silently if needed
 
 ### Execution Mode
 
-When the user invokes `/sdd-new`, `/sdd-ff`, or `/sdd-continue` for the first time in a session, ask which execution mode they prefer:
+Use the execution mode cached by SDD Session Preflight.
 
 - **Automatic** (`auto`): Run all phases back-to-back. The orchestrator runs a gatekeeper validation after every phase before launching the next sub-agent — the user only sees an interruption when the gatekeeper catches a problem. Final result only.
 - **Interactive** (`interactive`): After each phase, show the result summary and ask before proceeding.
 
-If the user doesn't specify, default to **Automatic**. After scope approval, expect zero further prompts on the happy path and at most one actionable prompt per recoverable failure; the gatekeeper summarizes phase progress instead of interrupting except on a second consecutive gate failure or a genuine scope/product decision.
+Use the execution mode cached by SDD Session Preflight.
 
 In **Interactive** mode, between phases:
 
@@ -449,17 +474,11 @@ Use the provider-owned Git-common-dir runtime ledger for every runtime-bearing `
 
 ### Artifact Store Mode
 
-When the user invokes `/sdd-new`, `/sdd-ff`, or `/sdd-continue` for the first time in a session, also ask which artifact store they want:
-
-- **`engram`**: Fast, no files created. Best for solo work.
-- **`openspec`**: File-based. Creates `openspec/` directory. Committable, shareable.
-- **`hybrid`**: Both — files for team sharing + engram for cross-session recovery.
-
-Default: `engram` when available. Cache the choice for the session.
+Pass the preflight artifact choice as `artifact_store.mode` to every sub-agent launch.
 
 ### Delivery Strategy
 
-On the first `/sdd-new`, `/sdd-ff`, or `/sdd-continue` in a session, ask once for and cache delivery strategy: `ask-on-risk` (default), `auto-chain`, `single-pr`, or `exception-ok`. Pass it as `delivery_strategy` to `sdd-tasks` and `sdd-apply` prompts.
+Pass the preflight PR strategy as `delivery_strategy` to `sdd-tasks` and `sdd-apply`. `exception-ok` is never a preflight choice; it requires explicit maintainer-approved `size:exception`.
 
 ### Chain Strategy
 
@@ -499,7 +518,9 @@ The phase result must prove that persistence contract. Refresh prior progress be
 
 When launching `sdd-archive`, forward explicit final-state facts for any work completed after `apply-progress` or `verify-report` were persisted — verify warnings fixed in later commits, blockers resolved, tasks finished, updated test or issue counts — with commit or evidence references where available. Those two artifacts are intermediate snapshots, valid at the time they were written; the archive report records the state at close, and explicit final-state facts in the `sdd-archive` launch prompt outrank stale snapshot claims.
 
-### Artifact store (engram default)
+### Artifact store (preflight-selected backend)
+
+Use the following topic keys and retrieval calls only in `engram` or `hybrid` mode. In `openspec` mode, use OpenSpec artifacts instead; do not call Engram for this table.
 
 | Artifact | Topic key |
 |----------|-----------|

--- a/testdata/golden/sdd-kiro-instructions.golden
+++ b/testdata/golden/sdd-kiro-instructions.golden
@@ -204,10 +204,7 @@ SDD is the structured planning layer for substantial changes.
 
 ### Artifact Store Policy
 
-- `engram` — default when available; persistent memory across sessions via MCP
-- `openspec` — file-based artifacts; use only when user explicitly requests
-- `hybrid` — both backends; cross-session recovery + local files; more tokens per op
-- `none` — return results inline only; recommend enabling engram or openspec
+Use the artifact store resolved by SDD Session Preflight; never detect or default a separate choice.
 
 ### Commands
 
@@ -229,6 +226,31 @@ Meta-commands (type directly — orchestrator handles them, will not appear in a
 
 `/sdd-new`, `/sdd-continue`, and `/sdd-ff` are meta-commands handled by YOU. Do NOT invoke them as skills. You orchestrate the phase sequence, delegating each phase to its native Kiro subagent (`/sdd-<phase>`), pausing for user approval between phases.
 
+<!-- gentle-ai:sdd-session-preflight -->
+### SDD Session Preflight (HARD GATE)
+
+Before every SDD command or natural-language SDD request, run this preflight before the SDD init guard; cache choices for the session.
+
+This runtime has no classified native question UI. Present ONE complete blocking prompt in plain chat or terminal with all three groups below, in order, and explain that their answers are required before init. Each group is single-select; its listed labels are the complete allowed-answer domain. Include every label and description, the fixed review policy, and this answer syntax: `Pace: <label>; Artifacts: <label>; PR strategy: <label>`. Then STOP; never default, infer, or launch dependent work. Validate all three answers under the Lossless Blocking Prompts contract before caching their canonical mappings.
+
+Match labels and descriptions to the conversation language and persona; do not expose canonical/internal codes.
+
+1. **Pace**: Interactive or Automatic.
+2. **Artifacts**: OpenSpec, Engram, or Both (user-facing Both maps only to internal `hybrid`).
+3. **PR strategy**: Ask me, Single PR, or Auto.
+
+Review policy is fixed at 400 changed lines per PR; above 400, split the PR or require maintainer-approved `size:exception`; NEVER ask it as a fourth group or selectable budget.
+
+Canonical mappings:
+- Interactive -> `interactive`
+- Automatic -> `auto`
+- OpenSpec -> `openspec`
+- Engram -> `engram`
+- Both -> `hybrid`
+- Ask me -> `ask-on-risk`
+- Single PR -> `single-pr`
+- Auto -> `auto-chain`
+<!-- /gentle-ai:sdd-session-preflight -->
 ### Native SDD Dispatcher Guard
 
 Before routing, continuing, applying, verifying, or archiving an SDD change, **invoke the native dispatcher** (`gentle-ai sdd-continue [change] --cwd <repo>` or `gentle-ai sdd-status [change] --cwd <repo> --json --instructions`). It resolves the artifact store the workspace DECLARES, reports it in `artifactStore`, and returns that store's locators in `artifactPaths`. **Do NOT determine the artifact store yourself, and do NOT branch on it** — an actor that re-derives the store disagrees with the authority that launched it, which is how a phase ends up reading a store the workspace never declared. Use the dispatcher for every store when `gentle-ai` is available and treat its native status JSON as authoritative over prompt inference. Route only by `nextRecommended` and dependency states; never infer from free text. If `blockedReasons` is non-empty, do not proceed to apply, archive, or terminal work. If `nextRecommended` is `verify`, verification/remediation may run only to refresh evidence; if `nextRecommended` is `resolve-blockers`, report `blockedReasons` and stop; if `nextRecommended` is a planning token (`propose`, `spec`, `design`, or `tasks`), launch the corresponding planning phase. If the binary is unavailable, fall back to the existing prompt contract and manual status schema.
@@ -237,9 +259,9 @@ Before routing, continuing, applying, verifying, or archiving an SDD change, **i
 
 Before executing ANY SDD command (`/sdd-new`, `/sdd-ff`, `/sdd-continue`, `/sdd-explore`, `/sdd-status`, `/sdd-apply`, `/sdd-verify`, `/sdd-archive`), check if `sdd-init` has been run for this project:
 
-1. Search Engram: `mem_search(query: "sdd-init/{project}", project: "{project}")`
-2. If found → init was done, proceed normally
-3. If NOT found → run `sdd-init` FIRST (load the sdd-init skill and execute it), THEN proceed with the requested command
+1. Use the artifact store resolved by SDD Session Preflight. In `openspec` mode, check project context and testing capabilities in `openspec/config.yaml` without calling Engram. In `engram` mode, search `sdd-init/{project}` in Engram. In `hybrid` mode, check both stores.
+2. If the selected store contains initialized project context and testing capabilities, proceed normally; a directory alone is not initialization evidence.
+3. If initialization is missing, load the `sdd-init` skill and execute it in the native Kiro phase context with the cached `artifact_store.mode`, then proceed. If a selected backend is unavailable, STOP and report it; never silently change the user's artifact choice.
 
 This ensures:
 
@@ -251,14 +273,12 @@ Do NOT skip this check. Do NOT ask the user — just run init silently if needed
 
 ### Execution Mode
 
-When the user invokes `/sdd-new`, `/sdd-ff`, or `/sdd-continue` (or an equivalent natural-language request, e.g. "create an SDD for X" / "do SDD for X") for the first time in a session, ASK which execution mode they prefer:
+Use the execution mode cached by SDD Session Preflight.
 
 - **Automatic** (`auto`): Run all phases back-to-back without pausing. Phases still run back-to-back WITHOUT interrupting the user, BUT the orchestrator runs a gatekeeper validation after every phase before launching the next Kiro phase — the user only sees an interruption when the gatekeeper catches a real problem. Otherwise only the final result is shown. Use this when the user wants speed and trusts the process.
 - **Interactive** (`interactive`): After each phase completes, show the result summary and ASK before proceeding to the next phase. Use this when the user wants to review and steer each step.
 
-If the user doesn't specify, default to **Automatic**. After scope approval, expect zero further prompts on the happy path and at most one actionable prompt per recoverable failure; the gatekeeper summarizes phase progress instead of interrupting except on a second consecutive gate failure or a genuine scope/product decision.
-
-Cache the mode choice for the session — don't ask again unless the user explicitly requests a mode change.
+Use the execution mode cached by SDD Session Preflight.
 
 Interactive approval is phase-scoped. Words like "continue", "dale", or "go on" approve only the immediate next phase, not the rest of the SDD pipeline. Do not treat a generated artifact as approved until the user has had a chance to review or explicitly delegate that review.
 
@@ -300,19 +320,11 @@ Use the provider-owned Git-common-dir runtime ledger for every runtime-bearing `
 
 ### Artifact Store Mode
 
-When the user invokes `/sdd-new`, `/sdd-ff`, or `/sdd-continue` (or an equivalent natural-language request) for the first time in a session, ALSO ASK which artifact store they want for this change:
-
-- **`engram`**: Fast, no files created. Artifacts live in engram only. Best for solo work and quick iteration. Note: re-running a phase overwrites the previous version.
-- **`openspec`**: File-based. Creates `openspec/` directory with full artifact trail. Committable, shareable with team, full git history.
-- **`hybrid`**: Both — files for team sharing + engram for cross-session recovery.
-
-If the user doesn't specify, detect: if engram is available → default to `engram`. Otherwise → `none`.
-
-Cache the artifact store choice for the session. Pass it as `artifact_store.mode` to every phase.
+Pass the preflight artifact choice as `artifact_store.mode` to every sub-agent launch.
 
 ### Delivery Strategy
 
-On the first `/sdd-new`, `/sdd-ff`, or `/sdd-continue` (or an equivalent natural-language request) in a session, ask once for and cache delivery strategy: `ask-on-risk` (default), `auto-chain`, `single-pr`, or `exception-ok`. Pass it as `delivery_strategy` to `sdd-tasks` and `sdd-apply` context.
+Pass the preflight PR strategy as `delivery_strategy` to `sdd-tasks` and `sdd-apply`. `exception-ok` is never a preflight choice; it requires explicit maintainer-approved `size:exception`.
 
 ### Chain Strategy
 

--- a/testdata/golden/sdd-windsurf-global-rules.golden
+++ b/testdata/golden/sdd-windsurf-global-rules.golden
@@ -125,10 +125,7 @@ SDD is the structured planning layer for substantial changes.
 
 ### Artifact Store Policy
 
-- `engram` — default when available; persistent memory across sessions via MCP
-- `openspec` — file-based artifacts; use only when user explicitly requests
-- `hybrid` — both backends; cross-session recovery + local files; more tokens per op
-- `none` — return results inline only; recommend enabling engram or openspec
+Use the artifact store resolved by SDD Session Preflight; never detect or default a separate choice.
 
 ### Commands
 
@@ -150,6 +147,31 @@ Meta-commands (type directly — orchestrator handles them, will not appear in a
 
 `/sdd-new`, `/sdd-continue`, and `/sdd-ff` are meta-commands handled by YOU. Do NOT invoke them as skills. You execute the phase sequence yourself, pausing for user approval between phases.
 
+<!-- gentle-ai:sdd-session-preflight -->
+### SDD Session Preflight (HARD GATE)
+
+Before every SDD command or natural-language SDD request, run this preflight before the SDD init guard; cache choices for the session.
+
+This runtime has no classified native question UI. Present ONE complete blocking prompt in plain chat or terminal with all three groups below, in order, and explain that their answers are required before init. Each group is single-select; its listed labels are the complete allowed-answer domain. Include every label and description, the fixed review policy, and this answer syntax: `Pace: <label>; Artifacts: <label>; PR strategy: <label>`. Then STOP; never default, infer, or launch dependent work. Validate all three answers under the Lossless Blocking Prompts contract before caching their canonical mappings.
+
+Match labels and descriptions to the conversation language and persona; do not expose canonical/internal codes.
+
+1. **Pace**: Interactive or Automatic.
+2. **Artifacts**: OpenSpec, Engram, or Both (user-facing Both maps only to internal `hybrid`).
+3. **PR strategy**: Ask me, Single PR, or Auto.
+
+Review policy is fixed at 400 changed lines per PR; above 400, split the PR or require maintainer-approved `size:exception`; NEVER ask it as a fourth group or selectable budget.
+
+Canonical mappings:
+- Interactive -> `interactive`
+- Automatic -> `auto`
+- OpenSpec -> `openspec`
+- Engram -> `engram`
+- Both -> `hybrid`
+- Ask me -> `ask-on-risk`
+- Single PR -> `single-pr`
+- Auto -> `auto-chain`
+<!-- /gentle-ai:sdd-session-preflight -->
 ### Native SDD Dispatcher Guard
 
 Before routing, continuing, applying, verifying, or archiving an SDD change, **invoke the native dispatcher** (`gentle-ai sdd-continue [change] --cwd <repo>` or `gentle-ai sdd-status [change] --cwd <repo> --json --instructions`). It resolves the artifact store the workspace DECLARES, reports it in `artifactStore`, and returns that store's locators in `artifactPaths`. **Do NOT determine the artifact store yourself, and do NOT branch on it** — an actor that re-derives the store disagrees with the authority that launched it, which is how a phase ends up reading a store the workspace never declared. Use the dispatcher for every store when `gentle-ai` is available and treat its native status JSON as authoritative over prompt inference. Route only by `nextRecommended` and dependency states; never infer from free text. If `blockedReasons` is non-empty, do not proceed to apply, archive, or terminal work. If `nextRecommended` is `verify`, verification/remediation may run only to refresh evidence; if `nextRecommended` is `resolve-blockers`, report `blockedReasons` and stop; if `nextRecommended` is a planning token (`propose`, `spec`, `design`, or `tasks`), launch the corresponding planning phase. If the binary is unavailable, fall back to the existing prompt contract and manual status schema.
@@ -158,9 +180,9 @@ Before routing, continuing, applying, verifying, or archiving an SDD change, **i
 
 Before executing ANY SDD command (`/sdd-new`, `/sdd-ff`, `/sdd-continue`, `/sdd-explore`, `/sdd-status`, `/sdd-apply`, `/sdd-verify`, `/sdd-archive`), check if `sdd-init` has been run for this project:
 
-1. Search Engram: `mem_search(query: "sdd-init/{project}", project: "{project}")`
-2. If found → init was done, proceed normally
-3. If NOT found → run the `sdd-init` phase inline FIRST, THEN proceed with the requested command
+1. Use the artifact store resolved by SDD Session Preflight. In `openspec` mode, check project context and testing capabilities in `openspec/config.yaml` without calling Engram. In `engram` mode, search `sdd-init/{project}` in Engram. In `hybrid` mode, check both stores.
+2. If the selected store contains initialized project context and testing capabilities, proceed normally; a directory alone is not initialization evidence.
+3. If initialization is missing, run the `sdd-init` phase inline with the cached `artifact_store.mode`, then proceed. If a selected backend is unavailable, STOP and report it; never silently change the user's artifact choice.
 
 This ensures:
 
@@ -174,14 +196,12 @@ Native Windsurf Workflow: `/sdd-new` is also available as a native Windsurf work
 
 ### Execution Mode
 
-When the user invokes `/sdd-new`, `/sdd-ff`, or `/sdd-continue` (or an equivalent natural-language request, e.g. "create an SDD for X" / "do SDD for X") for the first time in a session, ASK which execution mode they prefer:
+Use the execution mode cached by SDD Session Preflight.
 
 - **Automatic** (`auto`): Run all phases sequentially without pausing. Phases still run sequentially WITHOUT interrupting the user, BUT the orchestrator runs a gatekeeper validation after every phase before advancing — the user only sees an interruption when the gatekeeper catches a real problem. Otherwise only the final result is shown. Use this when the user wants speed and trusts the process.
 - **Interactive** (`interactive`): After each phase completes, show the result summary and ASK: "Want to adjust anything or continue?" before proceeding to the next phase. Use this when the user wants to review and steer each step.
 
-If the user doesn't specify, default to **Automatic**. After scope approval, expect zero further prompts on the happy path and at most one actionable prompt per recoverable failure; the gatekeeper summarizes phase progress instead of interrupting except on a second consecutive gate failure or a genuine scope/product decision.
-
-Cache the mode choice for the session — don't ask again unless the user explicitly requests a mode change.
+Use the execution mode cached by SDD Session Preflight.
 
 In **Interactive** mode, between phases:
 
@@ -232,19 +252,11 @@ Use the provider-owned Git-common-dir runtime ledger for every runtime-bearing `
 
 ### Artifact Store Mode
 
-When the user invokes `/sdd-new`, `/sdd-ff`, or `/sdd-continue` (or an equivalent natural-language request) for the first time in a session, ALSO ASK which artifact store they want for this change:
-
-- **`engram`**: Fast, no files created. Artifacts live in engram only. Best for solo work and quick iteration. Note: re-running a phase overwrites the previous version (no history).
-- **`openspec`**: File-based. Creates `openspec/` directory with full artifact trail. Committable, shareable with team, full git history.
-- **`hybrid`**: Both — files for team sharing + engram for cross-session recovery. Higher token cost.
-
-If the user doesn't specify, detect: if engram is available → default to `engram`. Otherwise → `none`.
-
-Cache the artifact store choice for the session. Add it to every inline phase context.
+Pass the preflight artifact choice as `artifact_store.mode` to every sub-agent launch.
 
 ### Delivery Strategy
 
-On the first `/sdd-new`, `/sdd-ff`, or `/sdd-continue` (or an equivalent natural-language request) in a session, ask once for and cache delivery strategy: `ask-on-risk` (default), `auto-chain`, `single-pr`, or `exception-ok`. Pass it as `delivery_strategy` to `sdd-tasks` and `sdd-apply` prompts.
+Pass the preflight PR strategy as `delivery_strategy` to `sdd-tasks` and `sdd-apply`. `exception-ok` is never a preflight choice; it requires explicit maintainer-approved `size:exception`.
 
 ### Chain Strategy
 


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #3502

Part of #3336, which remains open for #3503. Builds on merged #4300: together these complete the ten remaining runtime projections.

## 🏷️ PR Type

- [x] `type:bug` — Bug fix

## 📝 Summary

- Extend the single canonical fallback preflight to Antigravity, Qwen, Hermes, Kimi, Kiro, Codex and Windsurf global rules.
- Validate runtime-specific legacy clauses fail-closed and scope Codex's Engram table by selected backend, preserving model-effort substitution.
- Cover the complete fallback cohort, installed byte-idempotence, malformed sources and Codex preset/custom profiles.

## 📂 Changes

| Area | Change |
|---|---|
| `internal/components/sdd/orchestrator.go` | Remaining runtime profiles and scoped Codex artifact table |
| Three SDD test files | Complete cohort, source negatives, installed semantics and profile preservation |
| Seven prompt goldens | Exact installed global prompts and Codex profiles |

## 🤖 AI Assistance

- [x] **Material assistance used**

**Tool/model:** Pi harness with delegated bounded writer.
**Material scope:** Implementation, regression tests and golden updates.
**Verification performed:** Observed RED/GREEN, full SDD package tests, selected installed golden tests, parent spot check, native RDD consolidated reliability review.

## 🧪 Test Plan

- [x] `go test ./internal/components/sdd -count=1` (105.356s)
- [x] Focused complete-cohort and Codex substitution tests (11.157s)
- [x] Codex/Windsurf installed goldens without update (1.450s); parent rerun (1.497s)
- [x] Antigravity/Kiro installed goldens
- [x] `gofmt` and `git diff --check`
- [x] Mechanical skill and native Windsurf workflow goldens stayed byte-identical
- [ ] Global unit/format/runtime CI pending
- [ ] Local Docker E2E pending

Benchmark: no new benchmark corpus or driven-runtime claims. This changes generated prompts, not native review lifecycle logic. Required runtime CI remains a delivery gate. Generated-byte tests do not prove live conversations.

RDD `review-4c56854a58aefe82`: approved and acknowledged. Informational advisory `R3-inline-artifact-context` at Windsurf global golden line 255 remains separate later work; no correction opened.

## ✅ Contributor Checklist

- [x] Linked issue is approved
- [x] Exactly one `type:*` label
- [x] Maintainer-authorized size exception up to 600; actual diff 510 lines, including goldens
- [x] Conventional commit, no co-author trailers
- [x] AI assistance declared
- [x] Writer validation and native review completed
- [ ] All remote and external delivery checks pass before merge

## 💬 Notes for Reviewers

Native Windsurf workflows and final all-surface pre-write/zero-write validation remain in #3503. Source assets and shared verification blocks are unchanged; removal of legacy producers is owned by the runtime projection. Product review budget remains fixed at 400. Rollback boundary is these eleven files, independent of the preceding three-runtime cohort.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Enhancements**
  - Expanded fallback session preflight support across additional runtimes, including Antigravity, QwenCode, Hermes, Kimi, KiroIDE, Codex, and Windsurf.
  - Added runtime-specific guidance for execution modes, initialization actions, artifact policies, and workflow setup.
  - Improved Codex preflight guidance with phase-effort selection and clearer backend and artifact recommendations.
  - Ensured repeated setup operations preserve consistent configuration without duplicating instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->