### PR TITLE
docs(contributors): refresh CONTRIBUTORS.md from merged pull request history

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -10,7 +10,7 @@ Thanks to everyone who has contributed to gentle-ai. This project exists because
 
 ## Contributors
 
-Ordered by number of merged pull requests.
+Ordered by number of merged pull requests descending, then alphabetically by GitHub login.
 
 | | Name | GitHub | Contributions |
 |---|---|---|---|

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -10,23 +10,81 @@ Thanks to everyone who has contributed to gentle-ai. This project exists because
 
 ## Contributors
 
+Ordered by number of merged pull requests.
+
 | | Name | GitHub | Contributions |
 |---|---|---|---|
-| <img src="https://github.com/IrrealV.png" width="40"> | Victor Manuel | [@IrrealV](https://github.com/IrrealV) | Windsurf support, Antigravity compatibility, MCP routing fixes |
+| <img src="https://github.com/dnlrsls.png" width="40"> | Daniel Rosales | [@dnlrsls](https://github.com/dnlrsls) | OpenCode runtime model discovery, SDD nested workspace projects, Windows beta self-update, change-intent guidance, skills publishing |
+| <img src="https://github.com/decode2.png" width="40"> | Matías D. | [@decode2](https://github.com/decode2) | TUI install state persistence, global RDD mode controls, shared RDD mode API, bench PTY execution for TUI journeys |
+| <img src="https://github.com/ardelperal.png" width="40"> | aroman | [@ardelperal](https://github.com/ardelperal) | Review authority classification on Windows, install rollback on state failure, orchestrator single-select contract, Judgment Day role binding |
+| <img src="https://github.com/Matere413.png" width="40"> | David Guevara Cascante | [@Matere413](https://github.com/Matere413) | Review recovery targeting, installer progress reporting, Codex hooks in backup targets, Windows junction support in filemerge |
+| <img src="https://github.com/aparragithub.png" width="40"> | Angel Parra | [@aparragithub](https://github.com/aparragithub) | Immutable review slot identity, Engram project identity from linked worktrees, SDD change identity resolution, pre-PR delivery graph |
+| <img src="https://github.com/Cobies.png" width="40"> | Cobies | [@Cobies](https://github.com/Cobies) | Antigravity CLI support (#590), immutable candidate diff from START (#1517), stale asset detection (#2728), Windows release hardening |
+| <img src="https://github.com/danielgap.png" width="40"> | Danielgap | [@danielgap](https://github.com/danielgap) | Judgment Day agent definitions and model assignment foundation (#475, #476), TUI model picker for JD agents (#477), sync change reporting (#498) |
+| <img src="https://github.com/Basparin.png" width="40"> | Basparin | [@Basparin](https://github.com/Basparin) | Untrusted path validation in backup, restore and upgrade (#219), skill-creator template fix (#371), Windows test fixes (#372) |
+| <img src="https://github.com/ElCaaarnal.png" width="40"> | Panda | [@ElCaaarnal](https://github.com/ElCaaarnal) | README onboarding restructure (#3890), brand motif redesign (#4102), version advisory update (#4184) |
+| <img src="https://github.com/LCubero.png" width="40"> | Luis Diego Cubero Chavarría | [@LCubero](https://github.com/LCubero) | Explicit SDD task permission allowlists (#287), TUI upgrade feedback (#282), Context7 config cleanup (#369) |
+| <img src="https://github.com/aleka.png" width="40"> | Aleka | [@aleka](https://github.com/aleka) | GGA upgrade install.sh fallback (#133), model picker fixes, auto-upgrade skip on TUI entry (#706) |
+| <img src="https://github.com/AndySabina.png" width="40"> | Andy Sabina | [@AndySabina](https://github.com/AndySabina) | Secure repository locator storage (#1594), escalated predecessor recovery (#2811) |
+| <img src="https://github.com/Denver2828.png" width="40"> | Denver | [@Denver2828](https://github.com/Denver2828) | Claude Code Context7 MCP registration (#1909), bench TTY inactivity handling (#3997) |
+| <img src="https://github.com/GerardoFC8.png" width="40"> | Gerardo Franco | [@GerardoFC8](https://github.com/GerardoFC8) | Native SDD sub-agents with per-phase model assignment (#338), orchestrator gate and delegate-only flag (#402) |
+| <img src="https://github.com/IrrealV.png" width="40"> | Victor Manuel | [@IrrealV](https://github.com/IrrealV) | Windsurf support, Antigravity compatibility, MCP routing fixes, granular uninstall flow (#241) |
+| <img src="https://github.com/juansacdev.png" width="40"> | Juan Sebastián Agudelo | [@juansacdev](https://github.com/juansacdev) | OpenSpec YAML template fix (#1008), memory save never replacing the user reply (#1075) |
+| <img src="https://github.com/lu149e.png" width="40"> | lu149e | [@lu149e](https://github.com/lu149e) | Fable model alias (#799), per-phase subagent effort configuration (#818) |
+| <img src="https://github.com/MzaGuille.png" width="40"> | Mza.Guille | [@MzaGuille](https://github.com/MzaGuille) | sdd-onboard Go pipeline registration (#196), Codex multi-agent v2 lifecycle (#2030) |
+| <img src="https://github.com/pablon.png" width="40"> | pablon | [@pablon](https://github.com/pablon) | OpenCode effective model selector config (#3988), managed config authority selection (#4315) |
+| <img src="https://github.com/pablontiv.png" width="40"> | Pablo Ontiveros | [@pablontiv](https://github.com/pablontiv) | Key Learnings for Engram passive capture (#1707), lossless blocking prompts in SDD orchestrators (#1747) |
+| <img src="https://github.com/Thrasno.png" width="40"> | Thrasno | [@Thrasno](https://github.com/Thrasno) | Git merge-tree capability handling (#2927), durable post-commit effect reconciliation (#3201) |
+| <img src="https://github.com/tonyblu331.png" width="40"> | Antonio Bonet | [@tonyblu331](https://github.com/tonyblu331) | Kimi support (#251), Engram data-dir disk-space infrastructure (#638) |
+| <img src="https://github.com/0xMar.png" width="40"> | Victor Martin Ortiz Palacio | [@0xMar](https://github.com/0xMar) | Skip self-update for explicit update/upgrade commands (#250) |
+| <img src="https://github.com/Agustin-Prieto.png" width="40"> | Agustin Prieto | [@Agustin-Prieto](https://github.com/Agustin-Prieto) | Allow global review mode outside git (#3899) |
+| <img src="https://github.com/AgustinCastanol.png" width="40"> | Agustin Castañol | [@AgustinCastanol](https://github.com/AgustinCastanol) | Classify webhook paths as security high risk (#2347) |
+| <img src="https://github.com/alexandervazquez98.png" width="40"> | Edgar Alexander Vazquez | [@alexandervazquez98](https://github.com/alexandervazquez98) | Antigravity IDE agent support |
+| <img src="https://github.com/Andiveli.png" width="40"> | Andrei Véliz | [@Andiveli](https://github.com/Andiveli) | Allow interrupted SDD settlement without evidence (#3162) |
+| <img src="https://github.com/andresnator.png" width="40"> | Jose Andrés González Guevara | [@andresnator](https://github.com/andresnator) | Per-model variant and effort selection in the OpenCode model picker (#440) |
+| <img src="https://github.com/ARG-PROG.png" width="40"> | ARG-PROG | [@ARG-PROG](https://github.com/ARG-PROG) | Early contributions |
 | <img src="https://github.com/atarico.png" width="40"> | Agustin Tarico | [@atarico](https://github.com/atarico) | GGA PowerShell shim on Windows (#101) |
-| <img src="https://github.com/aleka.png" width="40"> | Aleka | [@aleka](https://github.com/aleka) | GGA upgrade install.sh fallback (#133), model picker fixes |
-| <img src="https://github.com/mr0bles.png" width="40"> | mr0bles | [@mr0bles](https://github.com/mr0bles) | GGA already-installed Windows fix (#142) |
-| <img src="https://github.com/MzaGuille.png" width="40"> | Mza.Guille | [@MzaGuille](https://github.com/MzaGuille) | sdd-onboard Go pipeline registration (#196) |
-| <img src="https://github.com/JamsMendez.png" width="40"> | Jose Angel Mendez | [@JamsMendez](https://github.com/JamsMendez) | Install script trap cleanup (#117) |
-| <img src="https://github.com/mgaldamez.png" width="40"> | mgaldamez | [@mgaldamez](https://github.com/mgaldamez) | Fedora/RHEL Linux distro support (#61) |
+| <img src="https://github.com/AutanaSoft.png" width="40"> | Leandro Cárdenas | [@AutanaSoft](https://github.com/AutanaSoft) | Unique tmp path to avoid rename race on plugin double-load (#836) |
+| <img src="https://github.com/barbatdev.png" width="40"> | Juan Barbat | [@barbatdev](https://github.com/barbatdev) | Deterministic provenance binding in release (#3854) |
+| <img src="https://github.com/borja-glez.png" width="40"> | Borja González Enríquez | [@borja-glez](https://github.com/borja-glez) | Custom provider support in the TUI model picker (#252) |
+| <img src="https://github.com/carlosindriago.png" width="40"> | Carlos Indriago | [@carlosindriago](https://github.com/carlosindriago) | Correct provider for OpenRouter models in the TUI catalog (#780) |
+| <img src="https://github.com/christorres-hu.png" width="40"> | Christian Torres A. | [@christorres-hu](https://github.com/christorres-hu) | Persist model assignments across sync runs (#265) |
+| <img src="https://github.com/DelgadoTrueba.png" width="40"> | Jose Manuel Delgado Trueba | [@DelgadoTrueba](https://github.com/DelgadoTrueba) | OpenSpec customization documentation (#344) |
+| <img src="https://github.com/diegonaranjo.png" width="40"> | diegosn79 | [@diegonaranjo](https://github.com/diegonaranjo) | Qwen Code agent integration (#263) |
+| <img src="https://github.com/difagume.png" width="40"> | Diego Fabricio | [@difagume](https://github.com/difagume) | Installer method for Windows self-replace (#257) |
+| <img src="https://github.com/ezequielmm.png" width="40"> | Ezequiel | [@ezequielmm](https://github.com/ezequielmm) | Prune old backups and add --no-backup flag (#398) |
+| <img src="https://github.com/facchin21.png" width="40"> | Fermin Facchin Quiroga | [@facchin21](https://github.com/facchin21) | Follow symlinked parent directories in filemerge (#734) |
+| <img src="https://github.com/franruiz0986-ai.png" width="40"> | franruiz0986-ai | [@franruiz0986-ai](https://github.com/franruiz0986-ai) | Dual-anomaly recovery edge reconciliation (#1465) |
+| <img src="https://github.com/ftorga.png" width="40"> | ftorga | [@ftorga](https://github.com/ftorga) | Discover Codex installer models from the CLI (#2080) |
 | <img src="https://github.com/Geraldow.png" width="40"> | Geraldow | [@Geraldow](https://github.com/Geraldow) | Engram preflight Go validation (#50) |
+| <img src="https://github.com/GuillermoUsh.png" width="40"> | GuillermoUsh | [@GuillermoUsh](https://github.com/GuillermoUsh) | Split long ManualHint across two lines to avoid terminal clipping (#954) |
+| <img src="https://github.com/hansell82.png" width="40"> | hansell82 | [@hansell82](https://github.com/hansell82) | Engram stop script exits 0 on clean Windows install (#935) |
+| <img src="https://github.com/JamsMendez.png" width="40"> | Jose Angel Mendez | [@JamsMendez](https://github.com/JamsMendez) | Install script trap cleanup (#117) |
+| <img src="https://github.com/jojosenthusiast.png" width="40"> | jojosenthusiast | [@jojosenthusiast](https://github.com/jojosenthusiast) | Detect PATH-shadowed binaries on Windows via PATHEXT (#952) |
+| <img src="https://github.com/JOSEVELASFLOW.png" width="40"> | JOSEVELASFLOW | [@JOSEVELASFLOW](https://github.com/JOSEVELASFLOW) | Reject unsupported gates before resolution (#2455) |
+| <img src="https://github.com/juanitourquiza.png" width="40"> | Juan Urquiza | [@juanitourquiza](https://github.com/juanitourquiza) | Qwen Code added to supported agents documentation (#312) |
+| <img src="https://github.com/julianbruno.png" width="40"> | julianbruno | [@julianbruno](https://github.com/julianbruno) | Validate Antigravity CodeGraph wiring in the installer (#1544) |
+| <img src="https://github.com/JulianGarcia04.png" width="40"> | Julián Camilo García Rincón | [@JulianGarcia04](https://github.com/JulianGarcia04) | Publish the eligible untracked inventory for recovery routing (#4066) |
+| <img src="https://github.com/LucianoDPerez.png" width="40"> | Luciano D. Perez | [@LucianoDPerez](https://github.com/LucianoDPerez) | Workspace detection via bash for OpenCode Desktop (#574) |
+| <img src="https://github.com/MataM15.png" width="40"> | MataM15 | [@MataM15](https://github.com/MataM15) | Reject completed tasks with empty reviewer results (#1550) |
+| <img src="https://github.com/maxiozonas.png" width="40"> | Maximo Ozonas | [@maxiozonas](https://github.com/maxiozonas) | sdd-onboard OpenCode registration (#200) |
+| <img src="https://github.com/mgaldamez.png" width="40"> | mgaldamez | [@mgaldamez](https://github.com/mgaldamez) | Fedora/RHEL Linux distro support (#61) |
+| <img src="https://github.com/mitre88.png" width="40"> | Dr Alex Mitre | [@mitre88](https://github.com/mitre88) | Fail closed when checksums are unavailable or mismatched (#269) |
+| <img src="https://github.com/mr0bles.png" width="40"> | mr0bles | [@mr0bles](https://github.com/mr0bles) | GGA already-installed Windows fix (#142) |
+| <img src="https://github.com/MrMonkey09.png" width="40"> | Alfredo Guerra Estay | [@MrMonkey09](https://github.com/MrMonkey09) | Skip directory fsync on Windows to avoid Access Denied (#296) |
+| <img src="https://github.com/Nathanael-Huaman.png" width="40"> | Nathanael Javier Huaman Campos | [@Nathanael-Huaman](https://github.com/Nathanael-Huaman) | Trae IDE added as a first-class agent (#532) |
+| <img src="https://github.com/ninjoan.png" width="40"> | ninjoan | [@ninjoan](https://github.com/ninjoan) | Judgment Day rows in OpenCode profiles (#920) |
 | <img src="https://github.com/RevoltPW.png" width="40"> | RevoltPW | [@RevoltPW](https://github.com/RevoltPW) | Brew detection on Linux, skip already-installed agents (#24) |
+| <img src="https://github.com/SantiagoGaonaC.png" width="40"> | Santiago Gaona | [@SantiagoGaonaC](https://github.com/SantiagoGaonaC) | Native Kiro SDD subagents and dedicated model config flow (#283) |
+| <img src="https://github.com/Sitray.png" width="40"> | Èric Marès | [@Sitray](https://github.com/Sitray) | Refresh existing shared skills (#1359) |
+| <img src="https://github.com/sombraxxl.png" width="40"> | Sombra | [@sombraxxl](https://github.com/sombraxxl) | Handle Pi manifest permissions on Windows (#1181) |
+| <img src="https://github.com/Tech-Codde.png" width="40"> | Tech-Codde | [@Tech-Codde](https://github.com/Tech-Codde) | Early contributions |
 | <img src="https://github.com/Tech-Code1.png" width="40"> | Tech-Code1 | [@Tech-Code1](https://github.com/Tech-Code1) | GGA temp dir cleanup on re-install (#17) |
 | <img src="https://github.com/Unamunoqueva.png" width="40"> | Unamunoqueva | [@Unamunoqueva](https://github.com/Unamunoqueva) | Engram MCP config fix (#59) |
-| <img src="https://github.com/Tech-Codde.png" width="40"> | Tech-Codde | [@Tech-Codde](https://github.com/Tech-Codde) | Early contributions |
-| <img src="https://github.com/alexandervazquez98.png" width="40"> | Edgar Alexander Vazquez | [@alexandervazquez98](https://github.com/alexandervazquez98) | Antigravity IDE agent support |
-| <img src="https://github.com/ARG-PROG.png" width="40"> | ARG-PROG | [@ARG-PROG](https://github.com/ARG-PROG) | Early contributions |
-| <img src="https://github.com/maxiozonas.png" width="40"> | Maximo Ozonas | [@maxiozonas](https://github.com/maxiozonas) | sdd-onboard OpenCode registration (#200) |
+| <img src="https://github.com/utafrali.png" width="40"> | Uğur Tafralı | [@utafrali](https://github.com/utafrali) | Correct Antigravity setup slug and settings initialization (#317) |
+| <img src="https://github.com/viniciosrab.png" width="40"> | Vinicios | [@viniciosrab](https://github.com/viniciosrab) | Scope community tool injectors to the selected agents (#3493) |
+| <img src="https://github.com/x4barin.png" width="40"> | x4barin | [@x4barin](https://github.com/x4barin) | Unify {project-name} to {project} in SDD templates (#454) |
+| <img src="https://github.com/yllada.png" width="40"> | Yadian Llada Lopez | [@yllada](https://github.com/yllada) | Kilo Code agent support (#161) |
 
 ## Contributing
 

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -6,7 +6,7 @@ Thanks to everyone who has contributed to gentle-ai. This project exists because
 
 | | Name | GitHub |
 |---|---|---|
-| <img src="https://github.com/Alan-TheGentleman.png" width="40"> | **Alan Buscaglia** | [@Alan-TheGentleman](https://github.com/Alan-TheGentleman) |
+| <img src="https://github.com/Alan-TheGentleman.png" alt="" width="40"> | **Alan Buscaglia** | [@Alan-TheGentleman](https://github.com/Alan-TheGentleman) |
 
 ## Contributors
 
@@ -14,77 +14,77 @@ Ordered by number of merged pull requests descending, then alphabetically by Git
 
 | | Name | GitHub | Contributions |
 |---|---|---|---|
-| <img src="https://github.com/dnlrsls.png" width="40"> | Daniel Rosales | [@dnlrsls](https://github.com/dnlrsls) | OpenCode runtime model discovery, SDD nested workspace projects, Windows beta self-update, change-intent guidance, skills publishing |
-| <img src="https://github.com/decode2.png" width="40"> | Matías D. | [@decode2](https://github.com/decode2) | TUI install state persistence, global RDD mode controls, shared RDD mode API, bench PTY execution for TUI journeys |
-| <img src="https://github.com/ardelperal.png" width="40"> | aroman | [@ardelperal](https://github.com/ardelperal) | Review authority classification on Windows, install rollback on state failure, orchestrator single-select contract, Judgment Day role binding |
-| <img src="https://github.com/Matere413.png" width="40"> | David Guevara Cascante | [@Matere413](https://github.com/Matere413) | Review recovery targeting, installer progress reporting, Codex hooks in backup targets, Windows junction support in filemerge |
-| <img src="https://github.com/aparragithub.png" width="40"> | Angel Parra | [@aparragithub](https://github.com/aparragithub) | Immutable review slot identity, Engram project identity from linked worktrees, SDD change identity resolution, pre-PR delivery graph |
-| <img src="https://github.com/Cobies.png" width="40"> | Cobies | [@Cobies](https://github.com/Cobies) | Antigravity CLI support (#590), immutable candidate diff from START (#1517), stale asset detection (#2728), Windows release hardening |
-| <img src="https://github.com/danielgap.png" width="40"> | Danielgap | [@danielgap](https://github.com/danielgap) | Judgment Day agent definitions and model assignment foundation (#475, #476), TUI model picker for JD agents (#477), sync change reporting (#498) |
-| <img src="https://github.com/Basparin.png" width="40"> | Basparin | [@Basparin](https://github.com/Basparin) | Untrusted path validation in backup, restore and upgrade (#219), skill-creator template fix (#371), Windows test fixes (#372) |
-| <img src="https://github.com/ElCaaarnal.png" width="40"> | Panda | [@ElCaaarnal](https://github.com/ElCaaarnal) | README onboarding restructure (#3890), brand motif redesign (#4102), version advisory update (#4184) |
-| <img src="https://github.com/LCubero.png" width="40"> | Luis Diego Cubero Chavarría | [@LCubero](https://github.com/LCubero) | Explicit SDD task permission allowlists (#287), TUI upgrade feedback (#282), Context7 config cleanup (#369) |
-| <img src="https://github.com/aleka.png" width="40"> | Aleka | [@aleka](https://github.com/aleka) | GGA upgrade install.sh fallback (#133), model picker fixes, auto-upgrade skip on TUI entry (#706) |
-| <img src="https://github.com/AndySabina.png" width="40"> | Andy Sabina | [@AndySabina](https://github.com/AndySabina) | Secure repository locator storage (#1594), escalated predecessor recovery (#2811) |
-| <img src="https://github.com/Denver2828.png" width="40"> | Denver | [@Denver2828](https://github.com/Denver2828) | Claude Code Context7 MCP registration (#1909), bench TTY inactivity handling (#3997) |
-| <img src="https://github.com/GerardoFC8.png" width="40"> | Gerardo Franco | [@GerardoFC8](https://github.com/GerardoFC8) | Native SDD sub-agents with per-phase model assignment (#338), orchestrator gate and delegate-only flag (#402) |
-| <img src="https://github.com/IrrealV.png" width="40"> | Victor Manuel | [@IrrealV](https://github.com/IrrealV) | Windsurf support, Antigravity compatibility, MCP routing fixes, granular uninstall flow (#241) |
-| <img src="https://github.com/juansacdev.png" width="40"> | Juan Sebastián Agudelo | [@juansacdev](https://github.com/juansacdev) | OpenSpec YAML template fix (#1008), memory save never replacing the user reply (#1075) |
-| <img src="https://github.com/lu149e.png" width="40"> | lu149e | [@lu149e](https://github.com/lu149e) | Fable model alias (#799), per-phase subagent effort configuration (#818) |
-| <img src="https://github.com/MzaGuille.png" width="40"> | Mza.Guille | [@MzaGuille](https://github.com/MzaGuille) | sdd-onboard Go pipeline registration (#196), Codex multi-agent v2 lifecycle (#2030) |
-| <img src="https://github.com/pablon.png" width="40"> | pablon | [@pablon](https://github.com/pablon) | OpenCode effective model selector config (#3988), managed config authority selection (#4315) |
-| <img src="https://github.com/pablontiv.png" width="40"> | Pablo Ontiveros | [@pablontiv](https://github.com/pablontiv) | Key Learnings for Engram passive capture (#1707), lossless blocking prompts in SDD orchestrators (#1747) |
-| <img src="https://github.com/Thrasno.png" width="40"> | Thrasno | [@Thrasno](https://github.com/Thrasno) | Git merge-tree capability handling (#2927), durable post-commit effect reconciliation (#3201) |
-| <img src="https://github.com/tonyblu331.png" width="40"> | Antonio Bonet | [@tonyblu331](https://github.com/tonyblu331) | Kimi support (#251), Engram data-dir disk-space infrastructure (#638) |
-| <img src="https://github.com/0xMar.png" width="40"> | Victor Martin Ortiz Palacio | [@0xMar](https://github.com/0xMar) | Skip self-update for explicit update/upgrade commands (#250) |
-| <img src="https://github.com/Agustin-Prieto.png" width="40"> | Agustin Prieto | [@Agustin-Prieto](https://github.com/Agustin-Prieto) | Allow global review mode outside git (#3899) |
-| <img src="https://github.com/AgustinCastanol.png" width="40"> | Agustin Castañol | [@AgustinCastanol](https://github.com/AgustinCastanol) | Classify webhook paths as security high risk (#2347) |
-| <img src="https://github.com/alexandervazquez98.png" width="40"> | Edgar Alexander Vazquez | [@alexandervazquez98](https://github.com/alexandervazquez98) | Antigravity IDE agent support |
-| <img src="https://github.com/Andiveli.png" width="40"> | Andrei Véliz | [@Andiveli](https://github.com/Andiveli) | Allow interrupted SDD settlement without evidence (#3162) |
-| <img src="https://github.com/andresnator.png" width="40"> | Jose Andrés González Guevara | [@andresnator](https://github.com/andresnator) | Per-model variant and effort selection in the OpenCode model picker (#440) |
-| <img src="https://github.com/ARG-PROG.png" width="40"> | ARG-PROG | [@ARG-PROG](https://github.com/ARG-PROG) | Early contributions |
-| <img src="https://github.com/atarico.png" width="40"> | Agustin Tarico | [@atarico](https://github.com/atarico) | GGA PowerShell shim on Windows (#101) |
-| <img src="https://github.com/AutanaSoft.png" width="40"> | Leandro Cárdenas | [@AutanaSoft](https://github.com/AutanaSoft) | Unique tmp path to avoid rename race on plugin double-load (#836) |
-| <img src="https://github.com/barbatdev.png" width="40"> | Juan Barbat | [@barbatdev](https://github.com/barbatdev) | Deterministic provenance binding in release (#3854) |
-| <img src="https://github.com/borja-glez.png" width="40"> | Borja González Enríquez | [@borja-glez](https://github.com/borja-glez) | Custom provider support in the TUI model picker (#252) |
-| <img src="https://github.com/carlosindriago.png" width="40"> | Carlos Indriago | [@carlosindriago](https://github.com/carlosindriago) | Correct provider for OpenRouter models in the TUI catalog (#780) |
-| <img src="https://github.com/christorres-hu.png" width="40"> | Christian Torres A. | [@christorres-hu](https://github.com/christorres-hu) | Persist model assignments across sync runs (#265) |
-| <img src="https://github.com/DelgadoTrueba.png" width="40"> | Jose Manuel Delgado Trueba | [@DelgadoTrueba](https://github.com/DelgadoTrueba) | OpenSpec customization documentation (#344) |
-| <img src="https://github.com/diegonaranjo.png" width="40"> | diegosn79 | [@diegonaranjo](https://github.com/diegonaranjo) | Qwen Code agent integration (#263) |
-| <img src="https://github.com/difagume.png" width="40"> | Diego Fabricio | [@difagume](https://github.com/difagume) | Installer method for Windows self-replace (#257) |
-| <img src="https://github.com/ezequielmm.png" width="40"> | Ezequiel | [@ezequielmm](https://github.com/ezequielmm) | Prune old backups and add --no-backup flag (#398) |
-| <img src="https://github.com/facchin21.png" width="40"> | Fermin Facchin Quiroga | [@facchin21](https://github.com/facchin21) | Follow symlinked parent directories in filemerge (#734) |
-| <img src="https://github.com/franruiz0986-ai.png" width="40"> | franruiz0986-ai | [@franruiz0986-ai](https://github.com/franruiz0986-ai) | Dual-anomaly recovery edge reconciliation (#1465) |
-| <img src="https://github.com/ftorga.png" width="40"> | ftorga | [@ftorga](https://github.com/ftorga) | Discover Codex installer models from the CLI (#2080) |
-| <img src="https://github.com/Geraldow.png" width="40"> | Geraldow | [@Geraldow](https://github.com/Geraldow) | Engram preflight Go validation (#50) |
-| <img src="https://github.com/GuillermoUsh.png" width="40"> | GuillermoUsh | [@GuillermoUsh](https://github.com/GuillermoUsh) | Split long ManualHint across two lines to avoid terminal clipping (#954) |
-| <img src="https://github.com/hansell82.png" width="40"> | hansell82 | [@hansell82](https://github.com/hansell82) | Engram stop script exits 0 on clean Windows install (#935) |
-| <img src="https://github.com/JamsMendez.png" width="40"> | Jose Angel Mendez | [@JamsMendez](https://github.com/JamsMendez) | Install script trap cleanup (#117) |
-| <img src="https://github.com/jojosenthusiast.png" width="40"> | jojosenthusiast | [@jojosenthusiast](https://github.com/jojosenthusiast) | Detect PATH-shadowed binaries on Windows via PATHEXT (#952) |
-| <img src="https://github.com/JOSEVELASFLOW.png" width="40"> | JOSEVELASFLOW | [@JOSEVELASFLOW](https://github.com/JOSEVELASFLOW) | Reject unsupported gates before resolution (#2455) |
-| <img src="https://github.com/juanitourquiza.png" width="40"> | Juan Urquiza | [@juanitourquiza](https://github.com/juanitourquiza) | Qwen Code added to supported agents documentation (#312) |
-| <img src="https://github.com/julianbruno.png" width="40"> | julianbruno | [@julianbruno](https://github.com/julianbruno) | Validate Antigravity CodeGraph wiring in the installer (#1544) |
-| <img src="https://github.com/JulianGarcia04.png" width="40"> | Julián Camilo García Rincón | [@JulianGarcia04](https://github.com/JulianGarcia04) | Publish the eligible untracked inventory for recovery routing (#4066) |
-| <img src="https://github.com/LucianoDPerez.png" width="40"> | Luciano D. Perez | [@LucianoDPerez](https://github.com/LucianoDPerez) | Workspace detection via bash for OpenCode Desktop (#574) |
-| <img src="https://github.com/MataM15.png" width="40"> | MataM15 | [@MataM15](https://github.com/MataM15) | Reject completed tasks with empty reviewer results (#1550) |
-| <img src="https://github.com/maxiozonas.png" width="40"> | Maximo Ozonas | [@maxiozonas](https://github.com/maxiozonas) | sdd-onboard OpenCode registration (#200) |
-| <img src="https://github.com/mgaldamez.png" width="40"> | mgaldamez | [@mgaldamez](https://github.com/mgaldamez) | Fedora/RHEL Linux distro support (#61) |
-| <img src="https://github.com/mitre88.png" width="40"> | Dr Alex Mitre | [@mitre88](https://github.com/mitre88) | Fail closed when checksums are unavailable or mismatched (#269) |
-| <img src="https://github.com/mr0bles.png" width="40"> | mr0bles | [@mr0bles](https://github.com/mr0bles) | GGA already-installed Windows fix (#142) |
-| <img src="https://github.com/MrMonkey09.png" width="40"> | Alfredo Guerra Estay | [@MrMonkey09](https://github.com/MrMonkey09) | Skip directory fsync on Windows to avoid Access Denied (#296) |
-| <img src="https://github.com/Nathanael-Huaman.png" width="40"> | Nathanael Javier Huaman Campos | [@Nathanael-Huaman](https://github.com/Nathanael-Huaman) | Trae IDE added as a first-class agent (#532) |
-| <img src="https://github.com/ninjoan.png" width="40"> | ninjoan | [@ninjoan](https://github.com/ninjoan) | Judgment Day rows in OpenCode profiles (#920) |
-| <img src="https://github.com/RevoltPW.png" width="40"> | RevoltPW | [@RevoltPW](https://github.com/RevoltPW) | Brew detection on Linux, skip already-installed agents (#24) |
-| <img src="https://github.com/SantiagoGaonaC.png" width="40"> | Santiago Gaona | [@SantiagoGaonaC](https://github.com/SantiagoGaonaC) | Native Kiro SDD subagents and dedicated model config flow (#283) |
-| <img src="https://github.com/Sitray.png" width="40"> | Èric Marès | [@Sitray](https://github.com/Sitray) | Refresh existing shared skills (#1359) |
-| <img src="https://github.com/sombraxxl.png" width="40"> | Sombra | [@sombraxxl](https://github.com/sombraxxl) | Handle Pi manifest permissions on Windows (#1181) |
-| <img src="https://github.com/Tech-Codde.png" width="40"> | Tech-Codde | [@Tech-Codde](https://github.com/Tech-Codde) | Early contributions |
-| <img src="https://github.com/Tech-Code1.png" width="40"> | Tech-Code1 | [@Tech-Code1](https://github.com/Tech-Code1) | GGA temp dir cleanup on re-install (#17) |
-| <img src="https://github.com/Unamunoqueva.png" width="40"> | Unamunoqueva | [@Unamunoqueva](https://github.com/Unamunoqueva) | Engram MCP config fix (#59) |
-| <img src="https://github.com/utafrali.png" width="40"> | Uğur Tafralı | [@utafrali](https://github.com/utafrali) | Correct Antigravity setup slug and settings initialization (#317) |
-| <img src="https://github.com/viniciosrab.png" width="40"> | Vinicios | [@viniciosrab](https://github.com/viniciosrab) | Scope community tool injectors to the selected agents (#3493) |
-| <img src="https://github.com/x4barin.png" width="40"> | x4barin | [@x4barin](https://github.com/x4barin) | Unify {project-name} to {project} in SDD templates (#454) |
-| <img src="https://github.com/yllada.png" width="40"> | Yadian Llada Lopez | [@yllada](https://github.com/yllada) | Kilo Code agent support (#161) |
+| <img src="https://github.com/dnlrsls.png" alt="" width="40"> | Daniel Rosales | [@dnlrsls](https://github.com/dnlrsls) | OpenCode runtime model discovery, SDD nested workspace projects, Windows beta self-update, change-intent guidance, skills publishing |
+| <img src="https://github.com/decode2.png" alt="" width="40"> | Matías D. | [@decode2](https://github.com/decode2) | TUI install state persistence, global RDD mode controls, shared RDD mode API, bench PTY execution for TUI journeys |
+| <img src="https://github.com/ardelperal.png" alt="" width="40"> | aroman | [@ardelperal](https://github.com/ardelperal) | Review authority classification on Windows, install rollback on state failure, orchestrator single-select contract, Judgment Day role binding |
+| <img src="https://github.com/Matere413.png" alt="" width="40"> | David Guevara Cascante | [@Matere413](https://github.com/Matere413) | Review recovery targeting, installer progress reporting, Codex hooks in backup targets, Windows junction support in filemerge |
+| <img src="https://github.com/aparragithub.png" alt="" width="40"> | Angel Parra | [@aparragithub](https://github.com/aparragithub) | Immutable review slot identity, Engram project identity from linked worktrees, SDD change identity resolution, pre-PR delivery graph |
+| <img src="https://github.com/Cobies.png" alt="" width="40"> | Cobies | [@Cobies](https://github.com/Cobies) | Antigravity CLI support (#590), immutable candidate diff from START (#1517), stale asset detection (#2728), Windows release hardening |
+| <img src="https://github.com/danielgap.png" alt="" width="40"> | Danielgap | [@danielgap](https://github.com/danielgap) | Judgment Day agent definitions and model assignment foundation (#475, #476), TUI model picker for JD agents (#477), sync change reporting (#498) |
+| <img src="https://github.com/Basparin.png" alt="" width="40"> | Basparin | [@Basparin](https://github.com/Basparin) | Untrusted path validation in backup, restore and upgrade (#219), skill-creator template fix (#371), Windows test fixes (#372) |
+| <img src="https://github.com/ElCaaarnal.png" alt="" width="40"> | Panda | [@ElCaaarnal](https://github.com/ElCaaarnal) | README onboarding restructure (#3890), brand motif redesign (#4102), version advisory update (#4184) |
+| <img src="https://github.com/LCubero.png" alt="" width="40"> | Luis Diego Cubero Chavarría | [@LCubero](https://github.com/LCubero) | Explicit SDD task permission allowlists (#287), TUI upgrade feedback (#282), Context7 config cleanup (#369) |
+| <img src="https://github.com/aleka.png" alt="" width="40"> | Aleka | [@aleka](https://github.com/aleka) | GGA upgrade install.sh fallback (#133), model picker fixes, auto-upgrade skip on TUI entry (#706) |
+| <img src="https://github.com/AndySabina.png" alt="" width="40"> | Andy Sabina | [@AndySabina](https://github.com/AndySabina) | Secure repository locator storage (#1594), escalated predecessor recovery (#2811) |
+| <img src="https://github.com/Denver2828.png" alt="" width="40"> | Denver | [@Denver2828](https://github.com/Denver2828) | Claude Code Context7 MCP registration (#1909), bench TTY inactivity handling (#3997) |
+| <img src="https://github.com/GerardoFC8.png" alt="" width="40"> | Gerardo Franco | [@GerardoFC8](https://github.com/GerardoFC8) | Native SDD sub-agents with per-phase model assignment (#338), orchestrator gate and delegate-only flag (#402) |
+| <img src="https://github.com/IrrealV.png" alt="" width="40"> | Victor Manuel | [@IrrealV](https://github.com/IrrealV) | Windsurf support, Antigravity compatibility, MCP routing fixes, granular uninstall flow (#241) |
+| <img src="https://github.com/juansacdev.png" alt="" width="40"> | Juan Sebastián Agudelo | [@juansacdev](https://github.com/juansacdev) | OpenSpec YAML template fix (#1008), memory save never replacing the user reply (#1075) |
+| <img src="https://github.com/lu149e.png" alt="" width="40"> | lu149e | [@lu149e](https://github.com/lu149e) | Fable model alias (#799), per-phase subagent effort configuration (#818) |
+| <img src="https://github.com/MzaGuille.png" alt="" width="40"> | Mza.Guille | [@MzaGuille](https://github.com/MzaGuille) | sdd-onboard Go pipeline registration (#196), Codex multi-agent v2 lifecycle (#2030) |
+| <img src="https://github.com/pablon.png" alt="" width="40"> | pablon | [@pablon](https://github.com/pablon) | OpenCode effective model selector config (#3988), managed config authority selection (#4315) |
+| <img src="https://github.com/pablontiv.png" alt="" width="40"> | Pablo Ontiveros | [@pablontiv](https://github.com/pablontiv) | Key Learnings for Engram passive capture (#1707), lossless blocking prompts in SDD orchestrators (#1747) |
+| <img src="https://github.com/Thrasno.png" alt="" width="40"> | Thrasno | [@Thrasno](https://github.com/Thrasno) | Git merge-tree capability handling (#2927), durable post-commit effect reconciliation (#3201) |
+| <img src="https://github.com/tonyblu331.png" alt="" width="40"> | Antonio Bonet | [@tonyblu331](https://github.com/tonyblu331) | Kimi support (#251), Engram data-dir disk-space infrastructure (#638) |
+| <img src="https://github.com/0xMar.png" alt="" width="40"> | Victor Martin Ortiz Palacio | [@0xMar](https://github.com/0xMar) | Skip self-update for explicit update/upgrade commands (#250) |
+| <img src="https://github.com/Agustin-Prieto.png" alt="" width="40"> | Agustin Prieto | [@Agustin-Prieto](https://github.com/Agustin-Prieto) | Allow global review mode outside git (#3899) |
+| <img src="https://github.com/AgustinCastanol.png" alt="" width="40"> | Agustin Castañol | [@AgustinCastanol](https://github.com/AgustinCastanol) | Classify webhook paths as security high risk (#2347) |
+| <img src="https://github.com/alexandervazquez98.png" alt="" width="40"> | Edgar Alexander Vazquez | [@alexandervazquez98](https://github.com/alexandervazquez98) | Antigravity IDE agent support |
+| <img src="https://github.com/Andiveli.png" alt="" width="40"> | Andrei Véliz | [@Andiveli](https://github.com/Andiveli) | Allow interrupted SDD settlement without evidence (#3162) |
+| <img src="https://github.com/andresnator.png" alt="" width="40"> | Jose Andrés González Guevara | [@andresnator](https://github.com/andresnator) | Per-model variant and effort selection in the OpenCode model picker (#440) |
+| <img src="https://github.com/ARG-PROG.png" alt="" width="40"> | ARG-PROG | [@ARG-PROG](https://github.com/ARG-PROG) | Early contributions |
+| <img src="https://github.com/atarico.png" alt="" width="40"> | Agustin Tarico | [@atarico](https://github.com/atarico) | GGA PowerShell shim on Windows (#101) |
+| <img src="https://github.com/AutanaSoft.png" alt="" width="40"> | Leandro Cárdenas | [@AutanaSoft](https://github.com/AutanaSoft) | Unique tmp path to avoid rename race on plugin double-load (#836) |
+| <img src="https://github.com/barbatdev.png" alt="" width="40"> | Juan Barbat | [@barbatdev](https://github.com/barbatdev) | Deterministic provenance binding in release (#3854) |
+| <img src="https://github.com/borja-glez.png" alt="" width="40"> | Borja González Enríquez | [@borja-glez](https://github.com/borja-glez) | Custom provider support in the TUI model picker (#252) |
+| <img src="https://github.com/carlosindriago.png" alt="" width="40"> | Carlos Indriago | [@carlosindriago](https://github.com/carlosindriago) | Correct provider for OpenRouter models in the TUI catalog (#780) |
+| <img src="https://github.com/christorres-hu.png" alt="" width="40"> | Christian Torres A. | [@christorres-hu](https://github.com/christorres-hu) | Persist model assignments across sync runs (#265) |
+| <img src="https://github.com/DelgadoTrueba.png" alt="" width="40"> | Jose Manuel Delgado Trueba | [@DelgadoTrueba](https://github.com/DelgadoTrueba) | OpenSpec customization documentation (#344) |
+| <img src="https://github.com/diegonaranjo.png" alt="" width="40"> | diegosn79 | [@diegonaranjo](https://github.com/diegonaranjo) | Qwen Code agent integration (#263) |
+| <img src="https://github.com/difagume.png" alt="" width="40"> | Diego Fabricio | [@difagume](https://github.com/difagume) | Installer method for Windows self-replace (#257) |
+| <img src="https://github.com/ezequielmm.png" alt="" width="40"> | Ezequiel | [@ezequielmm](https://github.com/ezequielmm) | Prune old backups and add --no-backup flag (#398) |
+| <img src="https://github.com/facchin21.png" alt="" width="40"> | Fermin Facchin Quiroga | [@facchin21](https://github.com/facchin21) | Follow symlinked parent directories in filemerge (#734) |
+| <img src="https://github.com/franruiz0986-ai.png" alt="" width="40"> | franruiz0986-ai | [@franruiz0986-ai](https://github.com/franruiz0986-ai) | Dual-anomaly recovery edge reconciliation (#1465) |
+| <img src="https://github.com/ftorga.png" alt="" width="40"> | ftorga | [@ftorga](https://github.com/ftorga) | Discover Codex installer models from the CLI (#2080) |
+| <img src="https://github.com/Geraldow.png" alt="" width="40"> | Geraldow | [@Geraldow](https://github.com/Geraldow) | Engram preflight Go validation (#50) |
+| <img src="https://github.com/GuillermoUsh.png" alt="" width="40"> | GuillermoUsh | [@GuillermoUsh](https://github.com/GuillermoUsh) | Split long ManualHint across two lines to avoid terminal clipping (#954) |
+| <img src="https://github.com/hansell82.png" alt="" width="40"> | hansell82 | [@hansell82](https://github.com/hansell82) | Engram stop script exits 0 on clean Windows install (#935) |
+| <img src="https://github.com/JamsMendez.png" alt="" width="40"> | Jose Angel Mendez | [@JamsMendez](https://github.com/JamsMendez) | Install script trap cleanup (#117) |
+| <img src="https://github.com/jojosenthusiast.png" alt="" width="40"> | jojosenthusiast | [@jojosenthusiast](https://github.com/jojosenthusiast) | Detect PATH-shadowed binaries on Windows via PATHEXT (#952) |
+| <img src="https://github.com/JOSEVELASFLOW.png" alt="" width="40"> | JOSEVELASFLOW | [@JOSEVELASFLOW](https://github.com/JOSEVELASFLOW) | Reject unsupported gates before resolution (#2455) |
+| <img src="https://github.com/juanitourquiza.png" alt="" width="40"> | Juan Urquiza | [@juanitourquiza](https://github.com/juanitourquiza) | Qwen Code added to supported agents documentation (#312) |
+| <img src="https://github.com/julianbruno.png" alt="" width="40"> | julianbruno | [@julianbruno](https://github.com/julianbruno) | Validate Antigravity CodeGraph wiring in the installer (#1544) |
+| <img src="https://github.com/JulianGarcia04.png" alt="" width="40"> | Julián Camilo García Rincón | [@JulianGarcia04](https://github.com/JulianGarcia04) | Publish the eligible untracked inventory for recovery routing (#4066) |
+| <img src="https://github.com/LucianoDPerez.png" alt="" width="40"> | Luciano D. Perez | [@LucianoDPerez](https://github.com/LucianoDPerez) | Workspace detection via bash for OpenCode Desktop (#574) |
+| <img src="https://github.com/MataM15.png" alt="" width="40"> | MataM15 | [@MataM15](https://github.com/MataM15) | Reject completed tasks with empty reviewer results (#1550) |
+| <img src="https://github.com/maxiozonas.png" alt="" width="40"> | Maximo Ozonas | [@maxiozonas](https://github.com/maxiozonas) | sdd-onboard OpenCode registration (#200) |
+| <img src="https://github.com/mgaldamez.png" alt="" width="40"> | mgaldamez | [@mgaldamez](https://github.com/mgaldamez) | Fedora/RHEL Linux distro support (#61) |
+| <img src="https://github.com/mitre88.png" alt="" width="40"> | Dr Alex Mitre | [@mitre88](https://github.com/mitre88) | Fail closed when checksums are unavailable or mismatched (#269) |
+| <img src="https://github.com/mr0bles.png" alt="" width="40"> | mr0bles | [@mr0bles](https://github.com/mr0bles) | GGA already-installed Windows fix (#142) |
+| <img src="https://github.com/MrMonkey09.png" alt="" width="40"> | Alfredo Guerra Estay | [@MrMonkey09](https://github.com/MrMonkey09) | Skip directory fsync on Windows to avoid Access Denied (#296) |
+| <img src="https://github.com/Nathanael-Huaman.png" alt="" width="40"> | Nathanael Javier Huaman Campos | [@Nathanael-Huaman](https://github.com/Nathanael-Huaman) | Trae IDE added as a first-class agent (#532) |
+| <img src="https://github.com/ninjoan.png" alt="" width="40"> | ninjoan | [@ninjoan](https://github.com/ninjoan) | Judgment Day rows in OpenCode profiles (#920) |
+| <img src="https://github.com/RevoltPW.png" alt="" width="40"> | RevoltPW | [@RevoltPW](https://github.com/RevoltPW) | Brew detection on Linux, skip already-installed agents (#24) |
+| <img src="https://github.com/SantiagoGaonaC.png" alt="" width="40"> | Santiago Gaona | [@SantiagoGaonaC](https://github.com/SantiagoGaonaC) | Native Kiro SDD subagents and dedicated model config flow (#283) |
+| <img src="https://github.com/Sitray.png" alt="" width="40"> | Èric Marès | [@Sitray](https://github.com/Sitray) | Refresh existing shared skills (#1359) |
+| <img src="https://github.com/sombraxxl.png" alt="" width="40"> | Sombra | [@sombraxxl](https://github.com/sombraxxl) | Handle Pi manifest permissions on Windows (#1181) |
+| <img src="https://github.com/Tech-Codde.png" alt="" width="40"> | Tech-Codde | [@Tech-Codde](https://github.com/Tech-Codde) | Early contributions |
+| <img src="https://github.com/Tech-Code1.png" alt="" width="40"> | Tech-Code1 | [@Tech-Code1](https://github.com/Tech-Code1) | GGA temp dir cleanup on re-install (#17) |
+| <img src="https://github.com/Unamunoqueva.png" alt="" width="40"> | Unamunoqueva | [@Unamunoqueva](https://github.com/Unamunoqueva) | Engram MCP config fix (#59) |
+| <img src="https://github.com/utafrali.png" alt="" width="40"> | Uğur Tafralı | [@utafrali](https://github.com/utafrali) | Correct Antigravity setup slug and settings initialization (#317) |
+| <img src="https://github.com/viniciosrab.png" alt="" width="40"> | Vinicios | [@viniciosrab](https://github.com/viniciosrab) | Scope community tool injectors to the selected agents (#3493) |
+| <img src="https://github.com/x4barin.png" alt="" width="40"> | x4barin | [@x4barin](https://github.com/x4barin) | Unify {project-name} to {project} in SDD templates (#454) |
+| <img src="https://github.com/yllada.png" alt="" width="40"> | Yadian Llada Lopez | [@yllada](https://github.com/yllada) | Kilo Code agent support (#161) |
 
 ## Contributing
 


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #4325

---

## 🏷️ PR Type

- [ ] `type:bug` — Bug fix (non-breaking change that fixes an issue)
- [ ] `type:feature` — New feature (non-breaking change that adds functionality)
- [x] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring (no functional changes)
- [ ] `type:chore` — Build, CI, or tooling changes
- [ ] `type:breaking-change` — Breaking change (fix or feature that changes existing behavior)

---

## 📝 Summary

- Rebuilds the Contributors table in `CONTRIBUTORS.md` from merged pull request history: 15 rows to 71, adding 56 people and removing nobody.
- Documents the ordering rule the table follows — merged pull request count descending, then alphabetically by GitHub login — so the order can be reproduced from what the file says.
- Marks every avatar as a decorative image with an empty `alt`, since the adjacent name and profile link already identify each contributor.
- Preserves every pre-existing contribution description verbatim. The intro, the maintainer entry, and the closing prose are otherwise untouched.

---

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| `CONTRIBUTORS.md` | Contributors table rebuilt from merged pull request history; ordering rule documented; `alt=""` added to all 72 avatar images |

---

## 🤖 AI Assistance

- [ ] **None** — No material AI assistance was used.
- [x] **Material assistance used** — Complete all applicable declaration fields below.

**Tool/model (if known):** Claude Code (Claude Opus 5)

**Material scope:** Reconstructing the contributor set from merged pull request history, resolving display names through the GitHub API, and generating the rebuilt Markdown table. The document's structure and the pre-existing contribution descriptions were not authored by the model — they are carried over unchanged.

**Verification performed:** Confirmed against the diff that 56 rows were added and none removed, that no GitHub login appears twice, that every pre-existing contribution description survives byte-identical, and that each login resolves to a real account. Display names come from the GitHub API, falling back to the login where no name is set. Verified the documented ordering rule reproduces the table's actual order, including the case-insensitive login tie-break. Confirmed all 72 avatar images carry `alt`. Ran `go run ./internal/gofmtcheck` (passes) and `go test ./...` locally — one pre-existing environment failure, detailed in the Test Plan.

---

## 🧪 Test Plan

Documentation-only change. No Go source, shell script, or review-lifecycle surface is touched, so the meaningful verification here is reading the diff — which contributor rows changed, and that no existing description was rewritten.

- [ ] Unit tests pass (`go test ./...`) — **one pre-existing environment failure, unrelated to this change.** `internal/update` fails on the authoring machine because macOS ships bash 3.2, which supports neither `[[ -v VAR ]]` nor `declare -A`. `TestReleaseSecurityScriptsAreSyntacticallyValidAndFailClosed` and `TestCanonicalReleasePublicKeysControlRealLinkerBuild` fail on that bash syntax, not on anything in this diff. Every other package passes locally, and the job passes here on CI's Linux runner.
- [x] Go format passes (`go run ./internal/gofmtcheck`)
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`) — **not run locally.** The Docker suite exercises install and runtime behavior that a Markdown-only change cannot reach. It passes on CI for this PR.
- [x] Manually tested locally — verified by full diff review against the merged pull request data

**Benchmark validation:** N/A. This change touches no review-lifecycle, gate, recovery, delivery, benchmark implementation, corpus, classifier, or benchmark-claim surface.

---

## ✅ Contributor Checklist

- [x] PR is linked to an issue with `status:approved`
- [x] PR stays within 400 changed lines (90 changed lines)
- [x] I have added the appropriate `type:*` label to this PR
- [ ] Unit tests pass (`go test ./...`) — one pre-existing environment failure locally; rationale in the Test Plan
- [x] Go format passes (`go run ./internal/gofmtcheck`)
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`) — not run locally; rationale in the Test Plan
- [x] Benchmark validation completed, or this change is not applicable to the benchmark (explained in the Test Plan)
- [x] I have updated documentation if necessary
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] I understand, reviewed, and take responsibility for the complete submission
- [x] I selected exactly one AI-assistance option and completed all applicable declaration fields
- [x] My commits do not include `Co-Authored-By` trailers

---

## 💬 Notes for Reviewers

Two things worth a reviewer's attention:

**The prose column is curated, not generated.** Existing rows keep their descriptions exactly as they were. New rows describe the merged work by title and number, so they read differently from the older hand-written entries. Rewording any of them is welcome — that text is editorial, not data.

**This file has no owner in automation.** Nothing under `.github/`, `scripts/`, or any build target references `CONTRIBUTORS.md`, which is why it went five months without an update. This PR only pays down the backlog; it does not prevent the next one. Automating the refresh is a separate decision that touches `.github/`, so it will be filed as its own issue rather than folded into this one.

Both CodeRabbit findings were applied, each as its own commit: the ordering note now states the full rule including the tie-break, and the decorative-avatar `alt` was added across the whole table rather than only the new rows, so the markup stays consistent.

The guard-population checklist above applies to production Go changes in `internal/cli`, `internal/reviewtransaction`, and `internal/sddstatus`. Not applicable here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Expanded the contributors list with additional entries.
  - Added or updated descriptions of contributors’ work.
  - Added a note explaining that contributors are ordered by the number of merged pull requests, followed by alphabetical login order.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->