### PR TITLE
fix(ci): make the Windows Full Suite green again

### DIFF
--- a/internal/cli/engram_brew_path_test.go
+++ b/internal/cli/engram_brew_path_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 )
@@ -48,7 +49,10 @@ func TestIsExecutableFile(t *testing.T) {
 		want bool
 	}{
 		{name: "executable regular file", path: executable, want: true},
-		{name: "non-executable regular file", path: plainFile, want: false},
+		// Windows has no POSIX executable permission bit, so isExecutableFile
+		// treats any regular file there as usable; the mode distinction this
+		// case exercises only applies on POSIX platforms.
+		{name: "non-executable regular file", path: plainFile, want: runtime.GOOS == "windows"},
 		{name: "directory", path: directory, want: false},
 		{name: "missing file", path: filepath.Join(t.TempDir(), "missing"), want: false},
 	}
@@ -62,6 +66,9 @@ func TestIsExecutableFile(t *testing.T) {
 }
 
 func TestResolveEngramInstalledPathUsesExecutableHomebrewFallback(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Homebrew's standard install prefixes are macOS/Linux-only; this fallback never runs on Windows")
+	}
 	restoreLookPath := cmdLookPath
 	cmdLookPath = missingBinaryLookPath
 	t.Cleanup(func() { cmdLookPath = restoreLookPath })
@@ -89,6 +96,9 @@ func TestResolveEngramInstalledPathRejectsNonExecutableFile(t *testing.T) {
 }
 
 func TestRepro4020RunInstallUsesOffPathEngramWithoutInvokingBrew(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Homebrew's standard install prefixes are macOS/Linux-only; this fallback never runs on Windows")
+	}
 	home := t.TempDir()
 	restoreHome := osUserHomeDir
 	restoreCommand := runCommand
@@ -144,6 +154,9 @@ func TestRepro4020RunInstallUsesOffPathEngramWithoutInvokingBrew(t *testing.T) {
 }
 
 func TestRunInstallFreshBrewInstallUsesInstalledBinaryForVersionProbeAndSetup(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Homebrew's standard install prefixes are macOS/Linux-only; this fallback never runs on Windows")
+	}
 	home := t.TempDir()
 	brewFixture := writeFakeExecutable(t, 0o755)
 	engramFixture := writeFakeExecutable(t, 0o755)

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -1930,7 +1930,16 @@ func ggaAvailable(profile system.PlatformProfile) bool {
 
 func isExecutableFile(path string) bool {
 	info, err := osStat(path)
-	return err == nil && info.Mode().IsRegular() && info.Mode().Perm()&0o111 != 0
+	if err != nil || !info.Mode().IsRegular() {
+		return false
+	}
+	// Windows has no POSIX executable permission bit (os.FileMode.Perm()
+	// never carries 0o111 there), so a regular file at a known binary path
+	// is treated as usable without a permission check.
+	if runtime.GOOS == "windows" {
+		return true
+	}
+	return info.Mode().Perm()&0o111 != 0
 }
 
 func standardHomebrewExecutable(name string) (string, bool) {

--- a/internal/opencode/config_test.go
+++ b/internal/opencode/config_test.go
@@ -327,6 +327,9 @@ func TestResolveEffectiveConfigUsesOpenCodeConfigDir(t *testing.T) {
 func TestRuntimeConfigPreservesWriteAuthorityAndLayeredReads(t *testing.T) {
 	home, project, override := t.TempDir(), t.TempDir(), t.TempDir()
 	t.Setenv("HOME", home)
+	// os.UserHomeDir (used by ResolveEffectiveConfig) reads USERPROFILE on
+	// Windows, not HOME, so both must point at the fixture home directory.
+	t.Setenv("USERPROFILE", home)
 	t.Setenv("XDG_CONFIG_HOME", "")
 	t.Setenv("OPENCODE_CONFIG_DIR", override)
 	global := DefaultSettingsPathForHome(home)

--- a/internal/sddstatus/edit_authority.go
+++ b/internal/sddstatus/edit_authority.go
@@ -203,6 +203,16 @@ func looksLikeGlobPattern(token string) bool {
 	return false
 }
 
+// isRootedToken reports whether token is already an absolute path rather
+// than one that should be resolved against workspaceRoot. filepath.IsAbs
+// alone is not enough: on Windows it requires a volume name, so a bare
+// POSIX-style route literal like `/` or `/api/health` reads as relative and
+// gets joined onto workspaceRoot — which trivially exists — misclassifying
+// the route literal as a real edit path (#4192).
+func isRootedToken(token string) bool {
+	return filepath.IsAbs(token) || strings.HasPrefix(token, "/")
+}
+
 // candidatePathExists reports whether token, resolved against workspaceRoot
 // when relative, already exists on disk — either the path itself or its
 // containing directory (a plausible new file location). The bare filesystem
@@ -210,7 +220,7 @@ func looksLikeGlobPattern(token string) bool {
 // treating it as "existing" would readmit #4192's bare `/` route literal.
 func candidatePathExists(token string, workspaceRoot string) bool {
 	resolved := token
-	if !filepath.IsAbs(resolved) {
+	if !isRootedToken(resolved) {
 		resolved = filepath.Join(workspaceRoot, resolved)
 	}
 	resolved = filepath.Clean(resolved)

--- a/internal/telemetry/spawn.go
+++ b/internal/telemetry/spawn.go
@@ -47,6 +47,12 @@ func SpawnDetachedSend(ctx context.Context, payload []byte) error {
 	if err != nil {
 		return err
 	}
+	// Detach the child from any console/process-group the triggering command
+	// owns. This is a no-op on Unix (spawn_unix.go); on Windows
+	// (spawn_windows.go) it skips console allocation/inheritance, which the
+	// synchronous buildSendCommand callers (tests running cmd.Run()) do not
+	// need or want.
+	configureDetachedProcAttr(cmd)
 	if err := cmd.Start(); err != nil {
 		_ = stdinRead.Close()
 		return err

--- a/internal/telemetry/spawn_test.go
+++ b/internal/telemetry/spawn_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"testing"
 	"time"
 )
@@ -62,7 +63,10 @@ func TestBuildSendCommandInvokesSelfWithTelemetrySendAndPipesPayloadOnStdin(t *t
 	if err != nil {
 		t.Fatal(err)
 	}
-	if got := string(argv); got != "telemetry send\n" && got != "telemetry send\r\n" {
+	// Normalize line endings and surrounding whitespace: cmd.exe's batch
+	// recorder can pad the captured argv with a trailing space before its
+	// CRLF, which is a recording-helper artifact, not a real argv difference.
+	if got := strings.TrimRight(string(argv), " \t\r\n"); got != "telemetry send" {
 		t.Fatalf("recorded argv = %q, want \"telemetry send\"", got)
 	}
 
@@ -87,8 +91,14 @@ func TestSpawnDetachedSendDoesNotBlockAndReaches(t *testing.T) {
 	}
 	// SpawnDetachedSend does not wait for the child; poll briefly (bounded,
 	// no unbounded sleep) for the file it produces rather than assuming it
-	// is already there.
-	deadline := time.Now().Add(5 * time.Second)
+	// is already there. Windows runners are slower to spawn a detached
+	// process (console/job-object setup), so the deadline is more generous
+	// than a bare Unix fork+exec needs.
+	timeout := 5 * time.Second
+	if runtime.GOOS == "windows" {
+		timeout = 10 * time.Second
+	}
+	deadline := time.Now().Add(timeout)
 	for {
 		if data, err := os.ReadFile(stdinFile); err == nil && string(data) == string(payload) {
 			return

--- a/internal/telemetry/spawn_unix.go
+++ b/internal/telemetry/spawn_unix.go
@@ -1,0 +1,10 @@
+//go:build !windows
+
+package telemetry
+
+import "os/exec"
+
+// configureDetachedProcAttr is a no-op on Unix: SpawnDetachedSend's existing
+// behavior (no SysProcAttr, reaped via a background goroutine's cmd.Wait())
+// is unchanged by this seam.
+func configureDetachedProcAttr(cmd *exec.Cmd) {}

--- a/internal/telemetry/spawn_windows.go
+++ b/internal/telemetry/spawn_windows.go
@@ -1,0 +1,23 @@
+//go:build windows
+
+package telemetry
+
+import (
+	"os/exec"
+	"syscall"
+
+	"golang.org/x/sys/windows"
+)
+
+// configureDetachedProcAttr asks Windows not to allocate or inherit a
+// console for the detached telemetry sender. Without this, spawning the
+// child (itself launched through cmd.exe for a .bat/.cmd fixture in tests,
+// and potentially attached to the parent's console in production) can incur
+// console-allocation overhead or leave the child tied to a console the
+// triggering command no longer owns; CREATE_NEW_PROCESS_GROUP additionally
+// keeps Ctrl+C delivered to the parent's console from reaching the child.
+func configureDetachedProcAttr(cmd *exec.Cmd) {
+	cmd.SysProcAttr = &syscall.SysProcAttr{
+		CreationFlags: windows.CREATE_NEW_PROCESS_GROUP | windows.DETACHED_PROCESS,
+	}
+}


### PR DESCRIPTION
## Summary
Eight tests failed on every `main` push since 2026-09-06. Product fixes where the behavior must hold on Windows, explicit `runtime.GOOS` guards only where the behavior is Unix-only by design:

- `internal/cli`: `isExecutableFile` treats any regular file as executable on Windows (no POSIX bit there); the three Homebrew-fallback tests skip on Windows because that code path is darwin-only.
- `internal/opencode`: the layered-config test also sets `USERPROFILE`, which is what `os.UserHomeDir` reads on Windows.
- `internal/sddstatus`: a POSIX-rooted token such as the route literal `/` is never joined onto the workspace root, so it is not misclassified as an edit path on Windows.
- `internal/telemetry`: the recording fixture's CRLF is normalized in the test, and `SpawnDetachedSend` sets `CREATE_NEW_PROCESS_GROUP|DETACHED_PROCESS` on Windows through a build-tagged file; the Unix path is byte-for-byte unchanged.

Closes #4348

## Verification
- `gofmt`, `go build ./...`, `GOOS=windows GOARCH=amd64 go build ./...`, Windows `go vet` and `go test -c` for the four packages: clean.
- `go test ./internal/...`: all packages pass on darwin.
- Native RDD review `review-6b7e63920021ef40`: four lenses, approved, acknowledged.
- The Windows Full Suite runs only on push to `main`, so the real Windows execution is validated by the run this merge triggers.

https://claude.ai/code/session_01HHji5T9rP2hJzmhSViQLaW

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Windows compatibility for executable detection, path resolution, and Homebrew-related workflows.
  * Prevented detached telemetry processes on Windows from opening or inheriting a console.
  * Improved handling of absolute route paths on Windows.

* **Tests**
  * Updated platform-specific tests and timing checks for more reliable Windows validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->