### PR TITLE
fix(ci): run promotion GoReleaser steps with the promoted source identity

### DIFF
--- a/.github/workflows/promote-stable-rc.yml
+++ b/.github/workflows/promote-stable-rc.yml
@@ -77,14 +77,28 @@ jobs:
           [[ "$semver" =~ ^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$ ]]
           printf 'semver=%s\n' "$semver" >>"$GITHUB_OUTPUT"
           printf 'PROVIDER_CONTRACT_SEMVER=%s\n' "$semver" >>"$GITHUB_ENV"
-      - name: Resolve source distribution plan without publishing
+      - name: Install GoReleaser
         uses: goreleaser/goreleaser-action@f06c13b6b1a9625abc9e6e439d9c05a8f2190e94 # v7.2.3
         with:
           version: v2.15.2
-          workdir: source
-          args: release --snapshot --clean --skip=sign,publish
+          install-only: true
+      # The provenance hook binds its manifest to GITHUB_REF_NAME and GITHUB_SHA.
+      # Under workflow_dispatch those name this run on main, not the promoted
+      # source, so the hook refuses ("release provenance input is invalid") or,
+      # worse, would record the wrong commit. The hook runs from the promoted
+      # source tree, which may predate any code fix, so the stable identity is
+      # exported here in the shell, where the runner's reserved variables can be
+      # shadowed for the child process.
+      - name: Resolve source distribution plan without publishing
+        working-directory: source
         env:
           MINISIGN_PUBLIC_KEYS_CANONICAL: release-policy-validation-only
+          SOURCE_SHA: ${{ steps.provenance.outputs.source_sha }}
+          STABLE_TAG: ${{ inputs.stable_tag }}
+        run: |
+          set -euo pipefail
+          export GITHUB_REF="refs/tags/$STABLE_TAG" GITHUB_REF_NAME="$STABLE_TAG" GITHUB_REF_TYPE=tag GITHUB_SHA="$SOURCE_SHA"
+          goreleaser release --snapshot --clean --skip=sign,publish
       - name: Verify source distribution policy
         working-directory: source
         run: ./scripts/verify-release-distribution-policy.sh
@@ -204,20 +218,30 @@ jobs:
           MINISIGN_PUBLIC_KEYS: ${{ vars.MINISIGN_PUBLIC_KEYS }}
           MINISIGN_PUBLIC_KEYS_CANONICAL: ${{ steps.trust-anchors.outputs.canonical }}
         run: ./scripts/release-signing-preflight.sh
-      - name: Run GoReleaser
+      - name: Install GoReleaser
         if: steps.tag.outputs.publish == 'true'
         uses: goreleaser/goreleaser-action@f06c13b6b1a9625abc9e6e439d9c05a8f2190e94 # v7.2.3
         with:
           version: v2.15.2
-          workdir: source
-          args: release --clean
+          install-only: true
+      # Same identity shadowing as the preflight plan: the provenance manifest
+      # must name the stable tag and the promoted source commit.
+      - name: Run GoReleaser
+        if: steps.tag.outputs.publish == 'true'
+        working-directory: source
         env:
           GITHUB_TOKEN: ${{ github.token }}
           GORELEASER_CURRENT_TAG: ${{ inputs.stable_tag }}
+          SOURCE_SHA: ${{ needs.preflight.outputs.source_sha }}
+          STABLE_TAG: ${{ inputs.stable_tag }}
           PROVIDER_CONTRACT_SEMVER: ${{ needs.preflight.outputs.provider_contract_semver }}
           HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
           MINISIGN_SECRET_KEY_FILE: ${{ env.MINISIGN_SECRET_KEY_FILE }}
           MINISIGN_PUBLIC_KEYS_CANONICAL: ${{ steps.trust-anchors.outputs.canonical }}
+        run: |
+          set -euo pipefail
+          export GITHUB_REF="refs/tags/$STABLE_TAG" GITHUB_REF_NAME="$STABLE_TAG" GITHUB_REF_TYPE=tag GITHUB_SHA="$SOURCE_SHA"
+          goreleaser release --clean
       - name: Remove signing material
         if: always()
         run: |


### PR DESCRIPTION
## Summary
- `promote-stable-rc.yml` failed at "Resolve source distribution plan without publishing" with `release provenance input is invalid` (run 34195693353, promoting `v2.7.0-rc.1`).
- Cause: the provenance hook reads `GITHUB_REF_NAME` and `GITHUB_SHA`; under `workflow_dispatch` they are `main` and the `main` head, not the promoted source. Even a passing manifest would have named the wrong commit.
- Fix, workflow-only so it applies to older promoted source trees: install GoReleaser with `install-only`, then run both invocations from the shell with `GITHUB_REF`, `GITHUB_REF_NAME`, `GITHUB_REF_TYPE`, and `GITHUB_SHA` exported as the stable tag and the source commit. `GORELEASER_CURRENT_TAG` stays pinned on the publication step.

Closes #4350

## Verification
- YAML parses; step shapes checked (preflight plan and publication are `run` steps preceded by an `install-only` action step).
- Native RDD review `review-3ad47dc04e4aea54`: four lenses, approved, acknowledged.
- Real validation: the next promotion dispatch.

https://claude.ai/code/session_01HHji5T9rP2hJzmhSViQLaW

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Release Process**
  - Stable releases now preserve accurate provenance and commit identity in generated release manifests.
  - Release publishing steps run only when a stable release is marked for publication.
  - Preflight validation and release execution now use consistent stable-release metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->