### PR TITLE
test(telemetry): use the test binary as the sender recorder on every platform

### DIFF
--- a/internal/telemetry/main_test.go
+++ b/internal/telemetry/main_test.go
@@ -1,0 +1,37 @@
+package telemetry
+
+import (
+	"io"
+	"os"
+	"strings"
+	"testing"
+)
+
+// The test binary doubles as the fake sender executable: when these
+// variables are set, it records its argv and stdin to the named files and
+// exits instead of running tests. A real Go executable works the same on
+// every platform, unlike a .cmd fixture, which cmd.exe cannot run as a
+// detached process and which rewrites its output with CRLF.
+const (
+	recorderArgvEnv  = "GENTLE_AI_TELEMETRY_TEST_RECORDER_ARGV"
+	recorderStdinEnv = "GENTLE_AI_TELEMETRY_TEST_RECORDER_STDIN"
+)
+
+func TestMain(m *testing.M) {
+	argvFile := os.Getenv(recorderArgvEnv)
+	stdinFile := os.Getenv(recorderStdinEnv)
+	if argvFile == "" || stdinFile == "" {
+		os.Exit(m.Run())
+	}
+	if err := os.WriteFile(argvFile, []byte(strings.Join(os.Args[1:], " ")), 0o600); err != nil {
+		os.Exit(2)
+	}
+	stdin, err := io.ReadAll(os.Stdin)
+	if err != nil {
+		os.Exit(3)
+	}
+	if err := os.WriteFile(stdinFile, stdin, 0o600); err != nil {
+		os.Exit(4)
+	}
+	os.Exit(0)
+}

--- a/internal/telemetry/spawn_test.go
+++ b/internal/telemetry/spawn_test.go
@@ -5,39 +5,26 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
-	"strings"
 	"testing"
 	"time"
 )
 
-// fakeRecorderExecutable writes a tiny shell script (or, on Windows, a
-// batch file) that records the argv it was invoked with and the bytes on
-// its stdin, then exits 0. It is a real executable and buildSendCommand
-// really runs it as a real subprocess, but it never touches the network —
-// this is the "fake executable" seam the spawner review asked for.
+// fakeRecorderExecutable points the spawner at this test binary in recorder
+// mode (see TestMain): a real executable that records the argv it was
+// invoked with and the bytes on its stdin, then exits 0. buildSendCommand
+// really runs it as a real subprocess, but it never touches the network.
 func fakeRecorderExecutable(t *testing.T) (path, argvFile, stdinFile string) {
 	t.Helper()
 	dir := t.TempDir()
 	argvFile = filepath.Join(dir, "argv.txt")
 	stdinFile = filepath.Join(dir, "stdin.bin")
-	if runtime.GOOS == "windows" {
-		path = filepath.Join(dir, "recorder.cmd")
-		script := "@echo off\r\n" +
-			"echo %* > \"" + argvFile + "\"\r\n" +
-			"more > \"" + stdinFile + "\"\r\n"
-		if err := os.WriteFile(path, []byte(script), 0o755); err != nil {
-			t.Fatal(err)
-		}
-		return path, argvFile, stdinFile
-	}
-	path = filepath.Join(dir, "recorder.sh")
-	script := "#!/bin/sh\n" +
-		"printf '%s\\n' \"$*\" > '" + argvFile + "'\n" +
-		"cat > '" + stdinFile + "'\n"
-	if err := os.WriteFile(path, []byte(script), 0o755); err != nil {
+	self, err := os.Executable()
+	if err != nil {
 		t.Fatal(err)
 	}
-	return path, argvFile, stdinFile
+	t.Setenv(recorderArgvEnv, argvFile)
+	t.Setenv(recorderStdinEnv, stdinFile)
+	return self, argvFile, stdinFile
 }
 
 func TestBuildSendCommandInvokesSelfWithTelemetrySendAndPipesPayloadOnStdin(t *testing.T) {
@@ -63,10 +50,7 @@ func TestBuildSendCommandInvokesSelfWithTelemetrySendAndPipesPayloadOnStdin(t *t
 	if err != nil {
 		t.Fatal(err)
 	}
-	// Normalize line endings and surrounding whitespace: cmd.exe's batch
-	// recorder can pad the captured argv with a trailing space before its
-	// CRLF, which is a recording-helper artifact, not a real argv difference.
-	if got := strings.TrimRight(string(argv), " \t\r\n"); got != "telemetry send" {
+	if got := string(argv); got != "telemetry send" {
 		t.Fatalf("recorded argv = %q, want \"telemetry send\"", got)
 	}
 


### PR DESCRIPTION
## Summary
- The two remaining Windows Full Suite failures were both in `internal/telemetry/spawn_test.go`: the `.cmd` fixture copied stdin through `more`, which appends CRLF, and `cmd.exe` cannot act as a `DETACHED_PROCESS` the way a real executable does, so the detached child never wrote its file.
- The test binary now doubles as the recorder: a `TestMain` mode selected by two environment variables writes argv and stdin to the named files and exits. Same real-subprocess seam, byte-for-byte comparisons, no platform-specific script.

Closes #4357

## Verification
- `go test ./internal/telemetry/ -count=1 -race`: ok on darwin.
- `GOOS=windows GOARCH=amd64 go test -c ./internal/telemetry/`: compiles.
- `scripts/deadcode-ratchet.sh`: no new unreachable functions.
- Native RDD review `review-7f99394a59b78792`: four lenses, approved, acknowledged.
- Real Windows execution: the Windows Full Suite run this merge triggers.

https://claude.ai/code/session_01HHji5T9rP2hJzmhSViQLaW

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Improved telemetry process tests to use a portable self-contained test executable.
  - Added verification that telemetry commands receive the expected arguments and payload through standard input.
  - Improved compatibility across operating systems by avoiding platform-specific test scripts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->