### PR TITLE
fix(telemetry): never count CI runs or dev builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -606,7 +606,7 @@ What is never sent: repository names, file paths, code, diffs, prompts, reviewer
 
 See the exact payload before anything leaves your machine with `gentle-ai telemetry preview --json`. The first run only prints a notice and sends nothing; the first real event goes out starting from the next run.
 
-Turn it off with `gentle-ai telemetry disable`, or `DO_NOT_TRACK` set to anything but `0` / `GENTLE_AI_TELEMETRY=0`. `CI=true` disables it automatically. `gentle-ai telemetry status` shows the deciding source.
+Turn it off with `gentle-ai telemetry disable`, or `DO_NOT_TRACK` set to anything but `0` / `GENTLE_AI_TELEMETRY=0`. `CI` or `GITHUB_ACTIONS` set to anything but `0`/`false` disables it automatically, and builds without a release identity (`dev`, `0.0.0-dev`) never send. `gentle-ai telemetry status` shows the deciding source.
 
 It goes to a collector we run ourselves, whose source is in this repository (`cmd/gentle-telemetry`). Raw events are kept for 90 days, then only aggregated counts remain. Full contract and schema: **[Telemetry](docs/telemetry.md)**.
 

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -78,7 +78,9 @@ Telemetry respects, in this order:
 
 1. `DO_NOT_TRACK` set to anything but empty, `0`, or `false`
 2. `GENTLE_AI_TELEMETRY=0`
-3. `CI=true` (most CI providers set this already)
+3. `CI` or `GITHUB_ACTIONS` set to anything but empty, `0`, or `false` (most CI providers export one of them)
+
+Builds without a release identity (`gentle-ai --version` reporting `dev` or `0.0.0-dev`, which is what a plain `go build` or a test harness produces) never send anything and never write telemetry state; the collector refuses such versions too. Pseudo-versions from `go install ...@main` carry a commit stamp and count as real installs.
 4. `gentle-ai telemetry disable`
 
 Any one of these disables sending; nothing else needs to change. Re-enable a

--- a/internal/cli/telemetry_test.go
+++ b/internal/cli/telemetry_test.go
@@ -132,6 +132,12 @@ func enableTelemetryForTest(t *testing.T) {
 	t.Setenv("DO_NOT_TRACK", "")
 	t.Setenv("GENTLE_AI_TELEMETRY", "")
 	t.Setenv("CI", "")
+	t.Setenv("GITHUB_ACTIONS", "")
+	// The test binary reports "dev", which the client refuses to count;
+	// pretend to be a released build so the send path is exercised.
+	previous := AppVersion
+	AppVersion = "2.7.0"
+	t.Cleanup(func() { AppVersion = previous })
 }
 
 func telemetryTestHome(t *testing.T) string {

--- a/internal/telemetry/counters_test.go
+++ b/internal/telemetry/counters_test.go
@@ -25,6 +25,7 @@ func TestIncrementSyncsWhenEnabledPersistsTheCounter(t *testing.T) {
 	t.Setenv("DO_NOT_TRACK", "")
 	t.Setenv("GENTLE_AI_TELEMETRY", "")
 	t.Setenv("CI", "")
+	t.Setenv("GITHUB_ACTIONS", "")
 
 	if err := IncrementSyncs(home); err != nil {
 		t.Fatal(err)
@@ -46,6 +47,7 @@ func TestIncrementSyncsConcurrentDoesNotLoseUpdates(t *testing.T) {
 	t.Setenv("DO_NOT_TRACK", "")
 	t.Setenv("GENTLE_AI_TELEMETRY", "")
 	t.Setenv("CI", "")
+	t.Setenv("GITHUB_ACTIONS", "")
 
 	const n = 20
 	var wg sync.WaitGroup

--- a/internal/telemetry/killswitch.go
+++ b/internal/telemetry/killswitch.go
@@ -26,7 +26,8 @@ type Getenv func(key string) string
 
 // Decide evaluates the kill switches in their documented precedence:
 // DO_NOT_TRACK set to anything but empty, "0", or "false", then
-// GENTLE_AI_TELEMETRY=0, then CI=true, then the persisted state's enabled
+// GENTLE_AI_TELEMETRY=0, then CI or GITHUB_ACTIONS set to anything but
+// empty, "0", or "false", then the persisted state's enabled
 // flag. The first one that opts out wins; with none present, telemetry is
 // enabled by default.
 func Decide(getenv Getenv, persisted State) Decision {
@@ -36,7 +37,7 @@ func Decide(getenv Getenv, persisted State) Decision {
 	if getenv("GENTLE_AI_TELEMETRY") == "0" {
 		return Decision{Enabled: false, Source: SourceEnvOptOut}
 	}
-	if strings.EqualFold(strings.TrimSpace(getenv("CI")), "true") {
+	if truthy(getenv("CI")) || truthy(getenv("GITHUB_ACTIONS")) {
 		return Decision{Enabled: false, Source: SourceCI}
 	}
 	if !persisted.Enabled {
@@ -47,7 +48,12 @@ func Decide(getenv Getenv, persisted State) Decision {
 
 // doNotTrack follows the console DO_NOT_TRACK convention: opted out for any
 // value other than empty, "0", or "false" (case-insensitive, trimmed).
-func doNotTrack(v string) bool {
+func doNotTrack(v string) bool { return truthy(v) }
+
+// truthy reads a CI-style flag: set to anything but empty, "0", or "false".
+// CI systems disagree on the value (GitHub Actions and most others export
+// CI=true, some export CI=1), so equality with "true" is not enough.
+func truthy(v string) bool {
 	v = strings.ToLower(strings.TrimSpace(v))
 	return v != "" && v != "0" && v != "false"
 }

--- a/internal/telemetry/killswitch_test.go
+++ b/internal/telemetry/killswitch_test.go
@@ -55,3 +55,22 @@ func TestEndpointDefaultAndOverride(t *testing.T) {
 		t.Fatalf("Endpoint() with blank override = %q, want default", got)
 	}
 }
+
+func TestDecideTreatsCIStyleFlagsAsSet(t *testing.T) {
+	cases := map[string]map[string]string{
+		"CI=1":                {"CI": "1"},
+		"CI=yes":              {"CI": "yes"},
+		"GITHUB_ACTIONS=true": {"GITHUB_ACTIONS": "true"},
+		"CI=true upper":       {"CI": "TRUE"},
+	}
+	for name, env := range cases {
+		if d := Decide(envMap(env), State{Enabled: true}); d.Enabled || d.Source != SourceCI {
+			t.Fatalf("%s: decision = %+v, want disabled by CI", name, d)
+		}
+	}
+	for _, v := range []string{"", "0", "false"} {
+		if d := Decide(envMap(map[string]string{"CI": v, "GITHUB_ACTIONS": v}), State{Enabled: true}); !d.Enabled {
+			t.Fatalf("CI=%q: decision = %+v, want enabled", v, d)
+		}
+	}
+}

--- a/internal/telemetry/opportunistic.go
+++ b/internal/telemetry/opportunistic.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"strings"
 	"time"
 )
 
@@ -89,6 +90,13 @@ func Opportunistic(d Deps) Outcome {
 	decision := Decide(d.Getenv, preState)
 	if !decision.Enabled {
 		return Outcome{Decision: DecisionDisabled, Source: decision.Source, Reason: "disabled by " + string(decision.Source)}
+	}
+	// A build with no release identity (plain `go build`, test harnesses,
+	// CI end-to-end journeys) is not an installation anyone uses; counting
+	// it would inflate the numbers with every test run. Nothing is written
+	// to disk either, so a fresh temp HOME stays empty.
+	if IsDevBuild(d.Version) {
+		return Outcome{Decision: DecisionDisabled, Source: decision.Source, Reason: "dev build: nothing to report"}
 	}
 
 	persisted, err := EnsureState(d.HomeDir)
@@ -179,4 +187,13 @@ func Opportunistic(d Deps) Outcome {
 		sentDecision = DecisionSentHeartbeat
 	}
 	return Outcome{Attempted: true, Kind: kind, Decision: sentDecision, Source: decision.Source}
+}
+
+// IsDevBuild reports whether a version string names a build without release
+// identity: empty, "dev", or the "0.0.0-dev" form ResolveVersion produces
+// when no VCS stamp is available. Pseudo-versions from `go install ...@main`
+// carry a commit stamp and are real installs.
+func IsDevBuild(version string) bool {
+	v := strings.TrimSpace(version)
+	return v == "" || v == "dev" || strings.HasPrefix(v, "0.0.0-dev")
 }

--- a/internal/telemetry/opportunistic_test.go
+++ b/internal/telemetry/opportunistic_test.go
@@ -31,7 +31,7 @@ func enrollHome(t *testing.T, home string, now time.Time) (installID string, not
 	t.Helper()
 	var calls []recordedSpawn
 	var stderr bytes.Buffer
-	outcome := Opportunistic(Deps{
+	outcome := Opportunistic(Deps{Version: "2.7.0",
 		HomeDir: home, Getenv: envMap(nil), Now: func() time.Time { return now }, Spawn: fakeSpawner(&calls), Stderr: &stderr,
 	})
 	if outcome.Attempted {
@@ -78,7 +78,7 @@ func TestOpportunisticSecondTriggerSendsInstall(t *testing.T) {
 	installID, _ := enrollHome(t, home, now)
 
 	var calls []recordedSpawn
-	outcome := Opportunistic(Deps{
+	outcome := Opportunistic(Deps{Version: "2.7.0",
 		HomeDir: home, Getenv: envMap(nil), Now: func() time.Time { return now.Add(time.Minute) }, Spawn: fakeSpawner(&calls),
 	})
 	if !outcome.Attempted || outcome.Kind != EventInstall {
@@ -106,7 +106,7 @@ func TestOpportunisticNoticeIsNeverPrintedTwice(t *testing.T) {
 
 	var calls []recordedSpawn
 	var stderr bytes.Buffer
-	Opportunistic(Deps{HomeDir: home, Getenv: envMap(nil), Now: func() time.Time { return now.Add(time.Hour) }, Spawn: fakeSpawner(&calls), Stderr: &stderr})
+	Opportunistic(Deps{Version: "2.7.0", HomeDir: home, Getenv: envMap(nil), Now: func() time.Time { return now.Add(time.Hour) }, Spawn: fakeSpawner(&calls), Stderr: &stderr})
 	if stderr.Len() != 0 {
 		t.Fatalf("stderr on the second trigger = %q, want no further notice", stderr.String())
 	}
@@ -126,7 +126,7 @@ func TestOpportunisticHeartbeatRateLimit(t *testing.T) {
 
 	var calls []recordedSpawn
 	within24h := lastHeartbeat.Add(23 * time.Hour)
-	outcome := Opportunistic(Deps{
+	outcome := Opportunistic(Deps{Version: "2.7.0",
 		HomeDir: home, Getenv: envMap(nil), Now: func() time.Time { return within24h }, Spawn: fakeSpawner(&calls),
 	})
 	if outcome.Attempted {
@@ -134,7 +134,7 @@ func TestOpportunisticHeartbeatRateLimit(t *testing.T) {
 	}
 
 	after24h := lastHeartbeat.Add(25 * time.Hour)
-	outcome = Opportunistic(Deps{
+	outcome = Opportunistic(Deps{Version: "2.7.0",
 		HomeDir: home, Getenv: envMap(nil), Now: func() time.Time { return after24h }, Spawn: fakeSpawner(&calls),
 	})
 	if !outcome.Attempted || outcome.Kind != EventHeartbeat {
@@ -150,7 +150,7 @@ func TestOpportunisticFirstHeartbeatFiresImmediatelyAfterInstall(t *testing.T) {
 		t.Fatal(err)
 	}
 	var calls []recordedSpawn
-	outcome := Opportunistic(Deps{
+	outcome := Opportunistic(Deps{Version: "2.7.0",
 		HomeDir: home, Getenv: envMap(nil), Now: func() time.Time { return sentInstall.Add(time.Minute) }, Spawn: fakeSpawner(&calls),
 	})
 	if !outcome.Attempted || outcome.Kind != EventHeartbeat {
@@ -169,7 +169,7 @@ func TestOpportunisticBacksOffAfterAFailureAndResumesAfterTheWindow(t *testing.T
 
 	var calls []recordedSpawn
 	withinBackoff := failedAt.Add(FailureBackoff - time.Minute)
-	outcome := Opportunistic(Deps{
+	outcome := Opportunistic(Deps{Version: "2.7.0",
 		HomeDir: home, Getenv: envMap(nil), Now: func() time.Time { return withinBackoff }, Spawn: fakeSpawner(&calls),
 	})
 	if outcome.Attempted || outcome.Decision != DecisionBackoff {
@@ -180,7 +180,7 @@ func TestOpportunisticBacksOffAfterAFailureAndResumesAfterTheWindow(t *testing.T
 	}
 
 	afterBackoff := failedAt.Add(FailureBackoff + time.Minute)
-	outcome = Opportunistic(Deps{
+	outcome = Opportunistic(Deps{Version: "2.7.0",
 		HomeDir: home, Getenv: envMap(nil), Now: func() time.Time { return afterBackoff }, Spawn: fakeSpawner(&calls),
 	})
 	if !outcome.Attempted || outcome.Decision != DecisionSentHeartbeat {
@@ -208,7 +208,7 @@ func TestOpportunisticDisabledByEachKillSwitch(t *testing.T) {
 				t.Fatal(err)
 			}
 			var calls []recordedSpawn
-			outcome := Opportunistic(Deps{HomeDir: home, Getenv: envMap(c.env), Spawn: fakeSpawner(&calls)})
+			outcome := Opportunistic(Deps{Version: "2.7.0", HomeDir: home, Getenv: envMap(c.env), Spawn: fakeSpawner(&calls)})
 			if outcome.Attempted {
 				t.Fatalf("outcome = %+v, want disabled", outcome)
 			}
@@ -227,7 +227,7 @@ func TestOpportunisticDisabledDuringEnrollmentStillPersistsNothingBeyondTheKillS
 	home := t.TempDir()
 	var calls []recordedSpawn
 	var stderr bytes.Buffer
-	outcome := Opportunistic(Deps{
+	outcome := Opportunistic(Deps{Version: "2.7.0",
 		HomeDir: home, Getenv: envMap(map[string]string{"DO_NOT_TRACK": "1"}), Spawn: fakeSpawner(&calls), Stderr: &stderr,
 	})
 	if outcome.Attempted {
@@ -248,7 +248,7 @@ func TestOpportunisticAttemptWindowThrottlesRespawnUntilSuccessOrWindowElapses(t
 
 	var calls []recordedSpawn
 	first := now.Add(time.Minute)
-	outcome := Opportunistic(Deps{HomeDir: home, Getenv: envMap(nil), Now: func() time.Time { return first }, Spawn: fakeSpawner(&calls)})
+	outcome := Opportunistic(Deps{Version: "2.7.0", HomeDir: home, Getenv: envMap(nil), Now: func() time.Time { return first }, Spawn: fakeSpawner(&calls)})
 	if !outcome.Attempted || len(calls) != 1 {
 		t.Fatalf("first attempt outcome = %+v, calls = %d, want one attempted spawn", outcome, len(calls))
 	}
@@ -257,7 +257,7 @@ func TestOpportunisticAttemptWindowThrottlesRespawnUntilSuccessOrWindowElapses(t
 	// failure was ever recorded (the detached child never finished): must
 	// not fork another sender.
 	second := first.Add(time.Minute)
-	outcome = Opportunistic(Deps{HomeDir: home, Getenv: envMap(nil), Now: func() time.Time { return second }, Spawn: fakeSpawner(&calls)})
+	outcome = Opportunistic(Deps{Version: "2.7.0", HomeDir: home, Getenv: envMap(nil), Now: func() time.Time { return second }, Spawn: fakeSpawner(&calls)})
 	if outcome.Attempted || outcome.Decision != DecisionBackoff || len(calls) != 1 {
 		t.Fatalf("in-flight retry outcome = %+v, calls = %d, want backoff with still 1 spawn", outcome, len(calls))
 	}
@@ -274,7 +274,7 @@ func TestOpportunisticAttemptWindowThrottlesRespawnUntilSuccessOrWindowElapses(t
 		t.Fatal(err)
 	}
 	third := second.Add(time.Minute)
-	outcome = Opportunistic(Deps{HomeDir: home, Getenv: envMap(nil), Now: func() time.Time { return third }, Spawn: fakeSpawner(&calls)})
+	outcome = Opportunistic(Deps{Version: "2.7.0", HomeDir: home, Getenv: envMap(nil), Now: func() time.Time { return third }, Spawn: fakeSpawner(&calls)})
 	if !outcome.Attempted || len(calls) != 2 {
 		t.Fatalf("post-success outcome = %+v, calls = %d, want a second spawn once success was recorded", outcome, len(calls))
 	}
@@ -291,7 +291,7 @@ func TestOpportunisticNeverErrorsWhenStateUnwritable(t *testing.T) {
 		t.Fatal(err)
 	}
 	var calls []recordedSpawn
-	outcome := Opportunistic(Deps{HomeDir: blocker + "/child", Getenv: envMap(nil), Spawn: fakeSpawner(&calls)})
+	outcome := Opportunistic(Deps{Version: "2.7.0", HomeDir: blocker + "/child", Getenv: envMap(nil), Spawn: fakeSpawner(&calls)})
 	if outcome.Attempted {
 		t.Fatalf("outcome = %+v, want not attempted", outcome)
 	}
@@ -305,7 +305,7 @@ func TestOpportunisticQuietTriggerNeverEnrollsSilently(t *testing.T) {
 	now := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
 	var calls []recordedSpawn
 	// A closure hook has no stderr to show the notice on.
-	outcome := Opportunistic(Deps{HomeDir: home, Getenv: envMap(nil), Now: func() time.Time { return now }, Spawn: fakeSpawner(&calls)})
+	outcome := Opportunistic(Deps{Version: "2.7.0", HomeDir: home, Getenv: envMap(nil), Now: func() time.Time { return now }, Spawn: fakeSpawner(&calls)})
 	if outcome.Decision != DecisionEnrolled || outcome.Attempted || len(calls) != 0 {
 		t.Fatalf("quiet first trigger = %+v (spawns %d), want enrolled with nothing attempted", outcome, len(calls))
 	}
@@ -319,5 +319,25 @@ func TestOpportunisticQuietTriggerNeverEnrollsSilently(t *testing.T) {
 	// The next interactive trigger shows the notice; only then does enrollment complete.
 	if _, notice := enrollHome(t, home, now); !strings.Contains(notice, NoticeLine) {
 		t.Fatalf("stderr = %q, want the notice line", notice)
+	}
+}
+
+func TestOpportunisticSkipsDevBuildsWithoutTouchingDisk(t *testing.T) {
+	for _, version := range []string{"", "dev", "0.0.0-dev", "0.0.0-dev+abc"} {
+		home := t.TempDir()
+		var calls []recordedSpawn
+		var stderr bytes.Buffer
+		outcome := Opportunistic(Deps{HomeDir: home, Getenv: envMap(nil), Version: version, Spawn: fakeSpawner(&calls), Stderr: &stderr})
+		if outcome.Decision != DecisionDisabled || outcome.Attempted || len(calls) != 0 || stderr.Len() != 0 {
+			t.Fatalf("version %q: outcome = %+v spawns=%d stderr=%q, want disabled, silent", version, outcome, len(calls), stderr.String())
+		}
+		if _, err := os.Stat(Path(home)); !os.IsNotExist(err) {
+			t.Fatalf("version %q: a dev build must leave no state file (stat err = %v)", version, err)
+		}
+	}
+	for _, version := range []string{"2.7.0", "2.7.1-0.20260908070514-a12e1321eea8"} {
+		if IsDevBuild(version) {
+			t.Fatalf("%q must count as a real build", version)
+		}
 	}
 }

--- a/internal/telemetrycollector/event.go
+++ b/internal/telemetrycollector/event.go
@@ -155,8 +155,22 @@ func ParseEvent(raw []byte) (Event, error) {
 	if event.Kind == EventInstall && event.Counters != nil {
 		return Event{}, invalid("install event must not carry counters")
 	}
+	if isDevBuildVersion(event.Version) {
+		// A build with no release identity (plain `go build`, test harnesses,
+		// CI journeys) is not an installation anyone uses. Refusing it here
+		// keeps the counts honest even when an older client sends it.
+		return Event{}, invalid("dev build versions are not counted")
+	}
 
 	return event, nil
+}
+
+// isDevBuildVersion mirrors the client's IsDevBuild: empty, "dev", or the
+// "0.0.0-dev" form a build without a VCS stamp reports. Pseudo-versions from
+// `go install ...@main` carry a commit stamp and are real installs.
+func isDevBuildVersion(version string) bool {
+	v := strings.TrimSpace(version)
+	return v == "" || v == "dev" || strings.HasPrefix(v, "0.0.0-dev")
 }
 
 // NormalizedInstallID lower-cases the install id for storage and grouping,

--- a/internal/telemetrycollector/event_test.go
+++ b/internal/telemetrycollector/event_test.go
@@ -167,3 +167,16 @@ func TestParseEvent_RejectsOversizeBody(t *testing.T) {
 		t.Errorf("Code = %v, want ErrOversize", verr.Code)
 	}
 }
+
+func TestParseEventRejectsDevBuildVersions(t *testing.T) {
+	for _, version := range []string{"dev", "0.0.0-dev", "0.0.0-dev+local"} {
+		raw := []byte(`{"schema":"gentle-ai.telemetry-event/v1","event":"install","install_id":"0f6a9c4e-7b2d-4e8a-9c31-2d7f5b8a1c3e","sent_at":"2026-09-08T08:00:00Z","version":"` + version + `","os":"linux","arch":"amd64","agents":[],"components":[],"rdd_enabled":false}`)
+		if _, err := ParseEvent(raw); err == nil {
+			t.Fatalf("version %q: want rejection", version)
+		}
+	}
+	raw := []byte(`{"schema":"gentle-ai.telemetry-event/v1","event":"install","install_id":"0f6a9c4e-7b2d-4e8a-9c31-2d7f5b8a1c3e","sent_at":"2026-09-08T08:00:00Z","version":"2.7.1-0.20260908070514-a12e1321eea8","os":"linux","arch":"amd64","agents":[],"components":[],"rdd_enabled":false}`)
+	if _, err := ParseEvent(raw); err != nil {
+		t.Fatalf("pseudo-version must be accepted: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
- `CI` and `GITHUB_ACTIONS` disable telemetry when set to anything but empty, `0`, or `false` (one e2e harness exports `CI=1`, which the `CI=true` check missed).
- A build without release identity (`dev`, `0.0.0-dev`) never sends and never writes telemetry state; pseudo-versions from `go install ...@main` still count. `IsDevBuild` is the single definition.
- The collector's `ParseEvent` refuses dev-build versions, so an older client cannot pollute the counts.
- Docs and README describe both rules. Tests: CI-style flags, dev builds leave no state, collector rejection, CLI tests act as a released build.

Closes #4361

## Verification
- `go test ./internal/telemetry/ ./internal/telemetrycollector/ -count=1`: ok.
- `go test ./internal/cli/ -run 'Telemetry|Sync|SDDAttempt'`, `./internal/app/ -run 'Telemetry|Update|Documented'`: ok.
- `scripts/deadcode-ratchet.sh`: no new unreachable functions.
- Native RDD review `review-80e5a23261d36cbf`: approved, acknowledged.
- Evidence: 218 CI-originated rows purged from the collector on 2026-09-08 (bursts of 4 per e2e run at 08:23, 08:29, 08:33 UTC).

https://claude.ai/code/session_01HHji5T9rP2hJzmhSViQLaW

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Telemetry is now automatically disabled when `CI` or `GITHUB_ACTIONS` contains a truthy value, including case-insensitive variants.
  - Development builds do not send telemetry, create telemetry state, or count as valid telemetry events.
  - Valid versioned installs, including Go pseudo-versions, continue to support telemetry.

- **Documentation**
  - Updated telemetry guidance to explain CI-based opt-out behavior and development-build restrictions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->