### PR TITLE
fix(telemetry): run the collector as a static system user

### DIFF
--- a/deploy/telemetry/gentle-telemetry-backup.service
+++ b/deploy/telemetry/gentle-telemetry-backup.service
@@ -20,9 +20,8 @@ EnvironmentFile=/etc/gentle-telemetry/backup.env
 # systemd to misinterpret.
 ExecStart=/usr/local/bin/gentle-telemetry-backup
 
-# Runs as root: it needs read access to the collector's DynamicUser-owned
-# StateDirectory, which a second, differently-allocated DynamicUser would
-# not have.
+# Runs as root: simplest way to guarantee read access to the collector's
+# StateDirectory regardless of which static user owns it.
 User=root
 Group=root
 PrivateTmp=yes

--- a/deploy/telemetry/gentle-telemetry.service
+++ b/deploy/telemetry/gentle-telemetry.service
@@ -15,14 +15,21 @@ Restart=on-failure
 RestartSec=5s
 TimeoutStopSec=15s
 
-# DynamicUser allocates a private, non-persistent uid/gid for this unit and
-# owns StateDirectory (/var/lib/gentle-telemetry) accordingly; nothing here
-# needs a real system user.
-DynamicUser=yes
+# A static system user/group (created by install.sh) rather than
+# DynamicUser: Grafana needs a stable, grantable path to read the SQLite
+# file via ACL, and DynamicUser materializes StateDirectory under
+# /var/lib/private/<name> with a symlink at /var/lib/gentle-telemetry —
+# granting Grafana search access anywhere under /var/lib/private widens
+# that directory's mode, and systemd refuses to (re)start this unit once
+# /var/lib/private is no longer exactly 0700. A real directory owned by a
+# static user avoids touching /var/lib/private at all.
+DynamicUser=no
+User=gentle-telemetry
+Group=gentle-telemetry
 StateDirectory=gentle-telemetry
-StateDirectoryMode=0700
+StateDirectoryMode=0750
 
-# Hands the root-owned 0600 token to the DynamicUser sandbox read-only at
+# Hands the root-owned 0600 token to this unit's sandbox read-only at
 # $CREDENTIALS_DIRECTORY/summary-token, without granting broader access.
 LoadCredential=summary-token:/etc/gentle-telemetry/summary.token
 

--- a/deploy/telemetry/install.sh
+++ b/deploy/telemetry/install.sh
@@ -42,6 +42,8 @@ BIN_DEST="/usr/local/bin/gentle-telemetry"
 UNIT_DIR="/etc/systemd/system"
 CONFIG_DIR="/etc/gentle-telemetry"
 STATE_DIR="/var/lib/gentle-telemetry"
+# Where systemd keeps DynamicUser state; only the migration reads it.
+PRIVATE_STATE_ROOT="/var/lib/private"
 APACHE_INCLUDE_FILE="/etc/apache2/conf.d/includes/post_virtualhost_global.conf"
 RENDERED_VHOST="/root/telemetry-vhost.conf.rendered"
 GRAFANA_INI="/etc/grafana/grafana.ini"
@@ -189,8 +191,79 @@ if ! command -v rclone >/dev/null 2>&1; then
 	dnf install -y rclone 2>/dev/null || curl -fsS https://rclone.org/install.sh | bash
 fi
 
+# create_telemetry_user idempotently creates the static system user/group
+# gentle-telemetry.service runs as. A static user (rather than systemd's
+# DynamicUser) gives Grafana a stable, grantable path: DynamicUser would
+# materialize StateDirectory under /var/lib/private/<name> with a symlink
+# at STATE_DIR, and granting Grafana search access on /var/lib/private
+# widens that directory beyond the 0700 systemd requires, which makes the
+# unit refuse to (re)start on the next restart.
+create_telemetry_user() {
+	if getent passwd gentle-telemetry >/dev/null 2>&1; then
+		return
+	fi
+	printf 'creating system user/group gentle-telemetry\n'
+	useradd --system --home-dir "${STATE_DIR}" --shell /sbin/nologin --user-group gentle-telemetry
+}
+
+# migrate_dynamic_user_layout moves an existing DynamicUser install (STATE_DIR
+# is a symlink to the private state directory) onto the static-user layout.
+# The data is staged next to STATE_DIR first, so an interrupted run can be
+# resumed by running the installer again, and the private root only ever
+# loses the one ACL entry this kit used to add. Prints one line per step
+# actually taken; a fresh or already migrated install prints nothing.
+migrate_dynamic_user_layout() {
+	local old="${PRIVATE_STATE_ROOT}/gentle-telemetry" staging="${STATE_DIR}.migrating" link
+	if [[ -d "${staging}" && ! -L "${staging}" ]]; then
+		printf 'resuming an interrupted migration from %s\n' "${staging}"
+	elif [[ -L "${STATE_DIR}" ]]; then
+		# Only the exact link systemd wrote is followed, never a prefix match,
+		# and only when it points at a real root-owned directory: a unit that
+		# was installed but never started leaves a dangling link behind.
+		link="$(readlink "${STATE_DIR}")"
+		[[ "${link}" == "${old}" || "${link}" == "private/gentle-telemetry" ]] || return 0
+		if [[ ! -d "${old}" || -L "${old}" || "$(stat -c '%u' "${old}")" != "0" ]]; then
+			printf 'leaving %s alone: %s is not a root-owned directory\n' "${STATE_DIR}" "${old}"
+			return 0
+		fi
+		printf 'migrating %s off the DynamicUser layout\n' "${STATE_DIR}"
+		if systemctl is-active --quiet gentle-telemetry.service 2>/dev/null; then
+			systemctl stop gentle-telemetry.service
+			printf '  stopped gentle-telemetry.service\n'
+		fi
+		mv "${old}" "${staging}"
+		printf '  staged %s as %s\n' "${old}" "${staging}"
+	else
+		return 0
+	fi
+	if [[ -L "${STATE_DIR}" ]]; then
+		rm "${STATE_DIR}"
+		printf '  removed symlink %s\n' "${STATE_DIR}"
+	elif [[ -d "${STATE_DIR}" ]]; then
+		rmdir "${STATE_DIR}" 2>/dev/null || { printf 'refusing to overwrite the non-empty %s; move it aside and rerun\n' "${STATE_DIR}" >&2; exit 1; }
+	fi
+	mv "${staging}" "${STATE_DIR}"
+	printf '  moved the state to %s\n' "${STATE_DIR}"
+	chown -R gentle-telemetry:gentle-telemetry "${STATE_DIR}"
+	printf '  chowned %s to gentle-telemetry:gentle-telemetry\n' "${STATE_DIR}"
+	if [[ -d "${PRIVATE_STATE_ROOT}" ]]; then
+		if command -v setfacl >/dev/null 2>&1 && getfacl -p "${PRIVATE_STATE_ROOT}" 2>/dev/null | grep -q '^user:grafana:'; then
+			setfacl -x u:grafana "${PRIVATE_STATE_ROOT}"
+			printf '  removed the grafana ACL entry from %s\n' "${PRIVATE_STATE_ROOT}"
+		fi
+		if [[ "$(stat -c '%a' "${PRIVATE_STATE_ROOT}")" != "700" ]]; then
+			chmod 0700 "${PRIVATE_STATE_ROOT}"
+			printf '  restored %s to mode 0700\n' "${PRIVATE_STATE_ROOT}"
+		fi
+	fi
+}
+
+create_telemetry_user
+migrate_dynamic_user_layout
+
 mkdir -p "${CONFIG_DIR}" "${STATE_DIR}"
 chmod 0755 "${CONFIG_DIR}"
+chown gentle-telemetry:gentle-telemetry "${STATE_DIR}"
 
 if [[ ! -f "${CONFIG_DIR}/summary.token" ]]; then
 	printf 'generating a new /v1/summary bearer token at %s/summary.token\n' "${CONFIG_DIR}"
@@ -350,25 +423,16 @@ EOF
 	# avoids ever creating -wal/-shm sidecar files. That leaves only one
 	# file for a second, read-only process to deal with: grant Grafana's
 	# system user read access to it via a POSIX ACL rather than group
-	# membership, because gentle-telemetry.service runs under systemd's
-	# DynamicUser, whose group is allocated per-unit with no stable name
-	# to add "grafana" to.
+	# membership, since gentle-telemetry:gentle-telemetry is not a group
+	# grafana belongs to.
 	dnf install -y acl >/dev/null 2>&1 || true
-	# With DynamicUser, systemd materialises StateDirectory under
-	# /var/lib/private (mode 0700) and leaves a symlink at STATE_DIR, so
-	# grafana also needs search permission on every ancestor that is not
-	# world-searchable; without it the datasource fails with
-	# "permission denied" even though the file ACL below is in place.
-	local ancestor
-	ancestor="$(dirname "$(readlink -f "${STATE_DIR}" 2>/dev/null || printf '/')")"
-	# Walk only absolute paths below "/": an unresolvable STATE_DIR (unit
-	# never started, dangling symlink) yields "." and must not loop forever.
-	while [[ "${ancestor}" == /?* ]]; do
-		if [[ ! -x "${ancestor}" ]] || [[ "$(stat -c '%A' "${ancestor}")" != *x ]]; then
-			setfacl -m u:grafana:--x "${ancestor}"
-		fi
-		ancestor="$(dirname "${ancestor}")"
-	done
+	# STATE_DIR is a real directory owned by the static gentle-telemetry
+	# user (not a DynamicUser symlink into /var/lib/private), so the ACL
+	# only needs to land on it and on the database file — never on an
+	# ancestor. Granting Grafana access anywhere under /var/lib/private
+	# would widen that directory past the exactly-0700 mode systemd
+	# requires for its own DynamicUser bookkeeping and would make other
+	# DynamicUser units refuse to (re)start.
 	setfacl -m u:grafana:rx "${STATE_DIR}"
 	if [[ -f "${STATE_DIR}/events.sqlite" ]]; then
 		setfacl -m u:grafana:r "${STATE_DIR}/events.sqlite"

--- a/docs/telemetry-collector.md
+++ b/docs/telemetry-collector.md
@@ -268,10 +268,10 @@ domain configured this way, so this kit does not use one.
 | File | Purpose |
 |---|---|
 | `apache/telemetry-vhost.conf.tmpl` | Template for the two `<VirtualHost>` blocks (`:80` and `:443`), mirroring the existing pattern: proxies `/v1/`, `/healthz`, and (with `--with-grafana`) `/grafana/` to loopback, asserts `X-Forwarded-For` from Apache itself, force-HTTPS except for the ACME challenge path, and a supplementary access log that omits the client address for `/v1/`. `__DOMAIN__` is substituted by `install.sh --domain`. Not applied automatically — see below. |
-| `gentle-telemetry.service` | systemd unit: `DynamicUser=yes`, `StateDirectory=gentle-telemetry`, and a hardened sandbox (no new privileges, restricted syscalls/namespaces/capabilities, private `/tmp` and devices). |
-| `gentle-telemetry-backup` + `.service` + `.timer` | Nightly `sqlite3 .backup` snapshot uploaded via `rclone copy` to a configurable remote, then deleted locally. The logic lives in the standalone `gentle-telemetry-backup` script (installed to `/usr/local/bin`), not inline in the unit's `ExecStart` — systemd expands `$VAR`/`${VAR}` there using its own environment before the shell runs, which would mangle a script's local variables. The unit runs as root (not `DynamicUser`) because it needs to read the collector's `DynamicUser`-owned state directory, which a second, independently allocated dynamic user could not. |
+| `gentle-telemetry.service` | systemd unit: runs as the static `gentle-telemetry` system user (created by `install.sh`), `StateDirectory=gentle-telemetry`, and a hardened sandbox (no new privileges, restricted syscalls/namespaces/capabilities, private `/tmp` and devices). See [Why a static user, not `DynamicUser`](#why-a-static-user-not-dynamicuser). |
+| `gentle-telemetry-backup` + `.service` + `.timer` | Nightly `sqlite3 .backup` snapshot uploaded via `rclone copy` to a configurable remote, then deleted locally. The logic lives in the standalone `gentle-telemetry-backup` script (installed to `/usr/local/bin`), not inline in the unit's `ExecStart` — systemd expands `$VAR`/`${VAR}` there using its own environment before the shell runs, which would mangle a script's local variables. The unit runs as root for simplicity: it just needs read access to the collector's state directory. |
 | `grafana/` | Datasource and dashboard provisioning for an optional on-box Grafana; see [Grafana dashboards](#grafana-dashboards). |
-| `install.sh` | Installs the binary, `sqlite3` and `rclone` (via `dnf`), the systemd units, and a generated summary token; with `--domain`, renders the vhost template to `/root/telemetry-vhost.conf.rendered`; with `--with-grafana`, installs Grafana OSS from its official rpm repo. It never edits `post_virtualhost_global.conf`, runs `apachectl configtest`, or reloads `httpd` — those, plus DNS and the certificate, are printed at the end as operator steps, in the order they must run. |
+| `install.sh` | Creates the static `gentle-telemetry` system user (migrating an older `DynamicUser`-layout install in place if found), installs the binary, `sqlite3` and `rclone` (via `dnf`), the systemd units, and a generated summary token; with `--domain`, renders the vhost template to `/root/telemetry-vhost.conf.rendered`; with `--with-grafana`, installs Grafana OSS from its official rpm repo. It never edits `post_virtualhost_global.conf`, runs `apachectl configtest`, or reloads `httpd` — those, plus DNS and the certificate, are printed at the end as operator steps, in the order they must run. |
 
 ```
 sudo ./deploy/telemetry/install.sh --local-source /path/to/gentle-ai/checkout \
@@ -281,6 +281,47 @@ sudo ./deploy/telemetry/install.sh --local-source /path/to/gentle-ai/checkout \
 (Omit `--domain` to install just the service and have the script print
 where to render `apache/telemetry-vhost.conf.tmpl` yourself; omit
 `--with-grafana` to skip Grafana entirely.)
+
+### Why a static user, not DynamicUser
+
+`gentle-telemetry.service` used to run with `DynamicUser=yes`. With
+`DynamicUser`, systemd materializes `StateDirectory=gentle-telemetry` under
+`/var/lib/private/gentle-telemetry` (a directory it keeps at exactly mode
+`0700`) and leaves a symlink at `/var/lib/gentle-telemetry`. To let Grafana
+read the SQLite file, `install.sh --with-grafana` had to grant the
+`grafana` user search access on every ancestor of that private directory
+that was not already world-searchable, including `/var/lib/private`
+itself. That ACL raised `/var/lib/private`'s effective mode above `0700`,
+and on the next restart systemd refused to start the unit at all:
+
+```
+Directory "/var/lib/private" already exists, but has mode 0710 that is
+too permissive (0700 was requested), refusing.
+```
+
+That is a hard requirement of `DynamicUser`, not a bug to work around with
+a looser ACL: `/var/lib/private` is shared by every `DynamicUser` unit on
+the box, so anything that widens it risks every one of them. The fix is to
+not need a path under `/var/lib/private` at all. `install.sh` now creates
+a static system user/group (`useradd --system --home-dir
+/var/lib/gentle-telemetry --shell /sbin/nologin --user-group
+gentle-telemetry`), and the unit runs with `DynamicUser=no`,
+`User=gentle-telemetry`, `Group=gentle-telemetry`. `StateDirectory` then
+resolves to the real directory `/var/lib/gentle-telemetry` — no symlink,
+nothing under `/var/lib/private` — owned by that user, with
+`StateDirectoryMode=0750`. Grafana gets access via a POSIX ACL scoped to
+exactly two paths: the state directory itself (`u:grafana:rx`) and
+`events.sqlite` (`u:grafana:r`) — never an ancestor.
+
+**Migrating an existing install**: run `install.sh` again. It detects the
+old layout (`/var/lib/gentle-telemetry` is a symlink into
+`/var/lib/private`) and migrates it in place before installing the unit:
+stops `gentle-telemetry.service`, removes the symlink, moves the private
+directory to `/var/lib/gentle-telemetry`, `chown -R`s it to the new
+`gentle-telemetry` user, and strips any ACL this script previously granted
+on `/var/lib/private` (`setfacl -b /var/lib/private; chmod 0700
+/var/lib/private`). It prints one line per step actually taken; nothing
+prints on a fresh install or one already migrated.
 
 ### Going live: DNS, the vhost blocks, and the certificate
 
@@ -360,8 +401,9 @@ skip it if `/v1/summary` (see below) is enough.
 ### Token rotation
 
 `install.sh` generates `/etc/gentle-telemetry/summary.token` (root-owned
-0600) if missing; `LoadCredential` in the unit hands it to the DynamicUser
-service without loosening ownership. To rotate, edit the file and restart:
+0600) if missing; `LoadCredential` in the unit hands it to the service
+(running as the static `gentle-telemetry` user) without loosening
+ownership. To rotate, edit the file and restart:
 
 ```
 sudo install -m 0600 <(openssl rand -hex 32) /etc/gentle-telemetry/summary.token
@@ -417,13 +459,14 @@ optional; `/v1/summary` above already answers the headline questions.
 uses the [`frser-sqlite-datasource`](https://grafana.com/grafana/plugins/frser-sqlite-datasource/)
 plugin pointed read-only at `/var/lib/gentle-telemetry/events.sqlite`.
 Grafana's own process needs read access to that one file; since
-`gentle-telemetry.service` runs under systemd's `DynamicUser` (a group
-allocated per-unit, with no stable name to add `grafana` to),
-`install.sh --with-grafana` grants access via a POSIX ACL
-(`setfacl -m u:grafana:r ...`) instead of group membership. This stays a
-single file to grant because the collector opens SQLite with
-`journal_mode=DELETE`, not WAL (see [Storage](#storage)) — no `-wal`/`-shm`
-sidecar files are ever created for a second ACL entry to chase.
+`gentle-telemetry.service` runs as the static `gentle-telemetry` system
+user (see [Why a static user, not DynamicUser](#why-a-static-user-not-dynamicuser)),
+which `grafana` does not belong to, `install.sh --with-grafana` grants
+access via a POSIX ACL (`setfacl -m u:grafana:r ...`) instead of group
+membership. This stays a single file to grant because the collector opens
+SQLite with `journal_mode=DELETE`, not WAL (see [Storage](#storage)) — no
+`-wal`/`-shm` sidecar files are ever created for a second ACL entry to
+chase.
 
 **Dashboard**: `deploy/telemetry/grafana/dashboards/gentle-ai-usage.json`,
 provisioned via `deploy/telemetry/grafana/provisioning/dashboards/telemetry.yaml`


### PR DESCRIPTION
## Summary
- The `DynamicUser` layout forced an ACL on `/var/lib/private` for Grafana; that raises the directory to 0710 and systemd refuses `STATE_DIRECTORY` on the next start (status 238). The reference host crash-looped after a rebuild.
- `gentle-telemetry.service`: `DynamicUser=no`, `User`/`Group=gentle-telemetry`, `StateDirectory=gentle-telemetry`, `StateDirectoryMode=0750`; hardening and `LoadCredential` unchanged. Backup unit aligned.
- `install.sh`: creates the system user idempotently; migrates an existing DynamicUser install through a `.migrating` staging directory (resumable), follows only the exact link systemd wrote and only when it targets a root-owned real directory, removes only the `u:grafana` ACL entry from `/var/lib/private`, restores 0700; the ancestor ACL loop from #4359 is gone. Grafana access is granted only on the state directory and the database file.
- `docs/telemetry-collector.md` describes the static-user layout and the migration.

Closes #4367

## Verification
- `bash -n` on both scripts; backup test script passes; documented-invocation corpus passes.
- Migration exercised in a sandbox: normal migration, dangling link left alone, foreign link target untouched, interrupted run resumed from staging, fresh install silent.
- The same layout was applied by hand on the reference host and survives restarts (healthz 200, Grafana datasource OK).
- Native RDD review `review-4d5fad41bf2302cf`: four lenses, six findings on the migration, corrected in 73 lines, validated, acknowledged approved.

https://claude.ai/code/session_01HHji5T9rP2hJzmhSViQLaW

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Telemetry services now use a stable system account and group, providing consistent access to collector state.
  * Existing installations using dynamic service storage are migrated in place, with safeguards to preserve data and prevent unsafe overwrites.
  * Grafana access permissions are applied directly to the collector’s state directory.
* **Documentation**
  * Updated deployment, migration, token rotation, and Grafana configuration guidance to reflect the stable service account setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->