### PR TITLE
fix(telemetry): make the Grafana dashboard live and render every panel

### DIFF
--- a/deploy/telemetry/grafana/dashboards/gentle-ai-usage.json
+++ b/deploy/telemetry/grafana/dashboards/gentle-ai-usage.json
@@ -7,21 +7,91 @@
   "schemaVersion": 39,
   "version": 1,
   "time": { "from": "now-90d", "to": "now" },
-  "refresh": "1h",
+  "refresh": "5m",
   "panels": [
     {
-      "id": 1,
-      "title": "Unique installs per month (12 months)",
-      "description": "Distinct install ids active in each of the last 12 calendar months, from rollups_daily.active_install. Matches GET /v1/summary's installs_per_month.",
-      "type": "barchart",
-      "gridPos": { "x": 0, "y": 0, "w": 12, "h": 8 },
+      "id": 10,
+      "title": "Installs today (UTC)",
+      "description": "Distinct install ids that sent an install event since 00:00 UTC today, read live from the events table (the rollup panels below lag one day).",
+      "type": "stat",
+      "gridPos": { "x": 0, "y": 0, "w": 4, "h": 8 },
       "datasource": { "type": "frser-sqlite-datasource", "uid": "gentle-telemetry-sqlite" },
       "targets": [
         {
           "refId": "A",
           "queryType": "table",
-          "queryText": "SELECT substr(day,1,7) AS month, COUNT(DISTINCT key) AS unique_installs FROM rollups_daily WHERE metric = 'active_install' GROUP BY month ORDER BY month DESC LIMIT 12",
-          "rawQueryText": "SELECT substr(day,1,7) AS month, COUNT(DISTINCT key) AS unique_installs FROM rollups_daily WHERE metric = 'active_install' GROUP BY month ORDER BY month DESC LIMIT 12"
+          "queryText": "SELECT COUNT(DISTINCT install_id) AS installs_today FROM events WHERE event = 'install' AND received_at >= CAST(strftime('%s', date('now')) AS INTEGER) * 1000000000",
+          "rawQueryText": "SELECT COUNT(DISTINCT install_id) AS installs_today FROM events WHERE event = 'install' AND received_at >= CAST(strftime('%s', date('now')) AS INTEGER) * 1000000000"
+        }
+      ],
+      "fieldConfig": { "defaults": { "unit": "none" }, "overrides": [] }
+    },
+    {
+      "id": 11,
+      "title": "Heartbeats today (UTC)",
+      "description": "Heartbeat events received since 00:00 UTC today: installs that were used again after their first report.",
+      "type": "stat",
+      "gridPos": { "x": 4, "y": 0, "w": 4, "h": 8 },
+      "datasource": { "type": "frser-sqlite-datasource", "uid": "gentle-telemetry-sqlite" },
+      "targets": [
+        {
+          "refId": "A",
+          "queryType": "table",
+          "queryText": "SELECT COUNT(*) AS heartbeats_today FROM events WHERE event = 'heartbeat' AND received_at >= CAST(strftime('%s', date('now')) AS INTEGER) * 1000000000",
+          "rawQueryText": "SELECT COUNT(*) AS heartbeats_today FROM events WHERE event = 'heartbeat' AND received_at >= CAST(strftime('%s', date('now')) AS INTEGER) * 1000000000"
+        }
+      ],
+      "fieldConfig": { "defaults": { "unit": "none" }, "overrides": [] }
+    },
+    {
+      "id": 12,
+      "title": "Platforms today",
+      "description": "Distinct installs seen today by operating system, live from the events table.",
+      "type": "bargauge",
+      "gridPos": { "x": 8, "y": 0, "w": 5, "h": 8 },
+      "datasource": { "type": "frser-sqlite-datasource", "uid": "gentle-telemetry-sqlite" },
+      "targets": [
+        {
+          "refId": "A",
+          "queryType": "table",
+          "queryText": "SELECT os, COUNT(DISTINCT install_id) AS installs FROM events WHERE received_at >= CAST(strftime('%s', date('now')) AS INTEGER) * 1000000000 GROUP BY os ORDER BY installs DESC",
+          "rawQueryText": "SELECT os, COUNT(DISTINCT install_id) AS installs FROM events WHERE received_at >= CAST(strftime('%s', date('now')) AS INTEGER) * 1000000000 GROUP BY os ORDER BY installs DESC"
+        }
+      ],
+      "options": { "orientation": "horizontal", "displayMode": "basic", "showUnfilled": true, "reduceOptions": { "values": true, "calcs": ["lastNotNull"], "fields": "" } },
+      "fieldConfig": { "defaults": { "min": 0 }, "overrides": [] }
+    },
+    {
+      "id": 13,
+      "title": "Installs per hour (last 48 h)",
+      "description": "New install events per UTC hour over the last 48 hours, live from the events table.",
+      "type": "timeseries",
+      "gridPos": { "x": 13, "y": 0, "w": 11, "h": 8 },
+      "datasource": { "type": "frser-sqlite-datasource", "uid": "gentle-telemetry-sqlite" },
+      "targets": [
+        {
+          "refId": "A",
+          "queryType": "table",
+          "queryText": "SELECT CAST(strftime('%s', strftime('%Y-%m-%d %H:00:00', received_at / 1000000000, 'unixepoch')) AS INTEGER) AS hour, COUNT(DISTINCT install_id) AS installs FROM events WHERE event = 'install' AND received_at >= (CAST(strftime('%s', 'now') AS INTEGER) - 172800) * 1000000000 GROUP BY hour ORDER BY hour ASC",
+          "rawQueryText": "SELECT CAST(strftime('%s', strftime('%Y-%m-%d %H:00:00', received_at / 1000000000, 'unixepoch')) AS INTEGER) AS hour, COUNT(DISTINCT install_id) AS installs FROM events WHERE event = 'install' AND received_at >= (CAST(strftime('%s', 'now') AS INTEGER) - 172800) * 1000000000 GROUP BY hour ORDER BY hour ASC",
+          "timeColumns": ["hour"]
+        }
+      ],
+      "fieldConfig": { "defaults": { "min": 0, "custom": { "drawStyle": "bars", "fillOpacity": 70, "lineWidth": 1, "showPoints": "never" } }, "overrides": [] }
+    },
+    {
+      "id": 1,
+      "title": "Unique installs per month (12 months)",
+      "description": "Distinct install ids active in each of the last 12 calendar months: live from the events table for the retention window, from rollups_daily.active_install beyond it. Matches GET /v1/summary's installs_per_month.",
+      "type": "barchart",
+      "gridPos": { "x": 0, "y": 8, "w": 12, "h": 8 },
+      "datasource": { "type": "frser-sqlite-datasource", "uid": "gentle-telemetry-sqlite" },
+      "targets": [
+        {
+          "refId": "A",
+          "queryType": "table",
+          "queryText": "SELECT month, COUNT(DISTINCT id) AS unique_installs FROM (SELECT substr(day,1,7) AS month, key AS id FROM rollups_daily WHERE metric = 'active_install' AND day < date('now', '-89 day') UNION SELECT strftime('%Y-%m', received_at / 1000000000, 'unixepoch') AS month, install_id AS id FROM events WHERE received_at >= CAST(strftime('%s', date('now', '-89 day')) AS INTEGER) * 1000000000) GROUP BY month ORDER BY month DESC LIMIT 12",
+          "rawQueryText": "SELECT month, COUNT(DISTINCT id) AS unique_installs FROM (SELECT substr(day,1,7) AS month, key AS id FROM rollups_daily WHERE metric = 'active_install' AND day < date('now', '-89 day') UNION SELECT strftime('%Y-%m', received_at / 1000000000, 'unixepoch') AS month, install_id AS id FROM events WHERE received_at >= CAST(strftime('%s', date('now', '-89 day')) AS INTEGER) * 1000000000) GROUP BY month ORDER BY month DESC LIMIT 12"
         }
       ],
       "fieldConfig": { "defaults": {}, "overrides": [] }
@@ -31,14 +101,14 @@
       "title": "Weekly active installs (12 weeks)",
       "description": "Distinct install ids active per week, from rollups_daily.active_install. Uses SQLite's strftime('%W') (Monday-based week-of-year); this can disagree with the API's ISO week numbering right at a year boundary, so treat this as a trend view rather than a byte-for-byte match to /v1/summary.",
       "type": "barchart",
-      "gridPos": { "x": 12, "y": 0, "w": 12, "h": 8 },
+      "gridPos": { "x": 12, "y": 8, "w": 12, "h": 8 },
       "datasource": { "type": "frser-sqlite-datasource", "uid": "gentle-telemetry-sqlite" },
       "targets": [
         {
           "refId": "A",
           "queryType": "table",
-          "queryText": "SELECT strftime('%Y-W%W', day) AS week, COUNT(DISTINCT key) AS active_installs FROM rollups_daily WHERE metric = 'active_install' GROUP BY week ORDER BY week DESC LIMIT 12",
-          "rawQueryText": "SELECT strftime('%Y-W%W', day) AS week, COUNT(DISTINCT key) AS active_installs FROM rollups_daily WHERE metric = 'active_install' GROUP BY week ORDER BY week DESC LIMIT 12"
+          "queryText": "SELECT strftime('%Y-W%W', received_at / 1000000000, 'unixepoch') AS week, COUNT(DISTINCT install_id) AS active_installs FROM events WHERE received_at >= (CAST(strftime('%s','now') AS INTEGER) - 7776000) * 1000000000 GROUP BY week ORDER BY week DESC LIMIT 12",
+          "rawQueryText": "SELECT strftime('%Y-W%W', received_at / 1000000000, 'unixepoch') AS week, COUNT(DISTINCT install_id) AS active_installs FROM events WHERE received_at >= (CAST(strftime('%s','now') AS INTEGER) - 7776000) * 1000000000 GROUP BY week ORDER BY week DESC LIMIT 12"
         }
       ],
       "fieldConfig": { "defaults": {}, "overrides": [] }
@@ -47,50 +117,52 @@
       "id": 3,
       "title": "Agent distribution (trailing 30 days)",
       "description": "Install-days per agent over the trailing 30 rolled-up days: an install active on 10 different days contributes 10, once per day it reported that agent. Not distinct installs. Matches GET /v1/summary's agent_distribution.",
-      "type": "piechart",
-      "gridPos": { "x": 0, "y": 8, "w": 8, "h": 8 },
+      "type": "bargauge",
+      "gridPos": { "x": 0, "y": 16, "w": 8, "h": 8 },
       "datasource": { "type": "frser-sqlite-datasource", "uid": "gentle-telemetry-sqlite" },
       "targets": [
         {
           "refId": "A",
           "queryType": "table",
-          "queryText": "SELECT key AS agent, SUM(value) AS install_days FROM rollups_daily WHERE metric = 'agent' AND day >= date('now', '-30 day') GROUP BY key ORDER BY install_days DESC",
-          "rawQueryText": "SELECT key AS agent, SUM(value) AS install_days FROM rollups_daily WHERE metric = 'agent' AND day >= date('now', '-30 day') GROUP BY key ORDER BY install_days DESC"
+          "queryText": "SELECT je.value AS agent, COUNT(DISTINCT e.install_id) AS installs FROM events e, json_each(e.agents_json) je WHERE e.received_at >= (CAST(strftime('%s','now') AS INTEGER) - 2592000) * 1000000000 GROUP BY agent ORDER BY installs DESC",
+          "rawQueryText": "SELECT je.value AS agent, COUNT(DISTINCT e.install_id) AS installs FROM events e, json_each(e.agents_json) je WHERE e.received_at >= (CAST(strftime('%s','now') AS INTEGER) - 2592000) * 1000000000 GROUP BY agent ORDER BY installs DESC"
         }
       ],
-      "fieldConfig": { "defaults": {}, "overrides": [] }
+      "options": { "orientation": "horizontal", "displayMode": "basic", "showUnfilled": true, "reduceOptions": { "values": true, "calcs": ["lastNotNull"], "fields": "" } },
+      "fieldConfig": { "defaults": { "min": 0 }, "overrides": [] }
     },
     {
       "id": 4,
       "title": "Component distribution (trailing 30 days)",
       "description": "Install-days per component over the trailing 30 rolled-up days, same install-days semantics as agent distribution. Matches GET /v1/summary's component_distribution.",
-      "type": "piechart",
-      "gridPos": { "x": 8, "y": 8, "w": 8, "h": 8 },
+      "type": "bargauge",
+      "gridPos": { "x": 8, "y": 16, "w": 8, "h": 8 },
       "datasource": { "type": "frser-sqlite-datasource", "uid": "gentle-telemetry-sqlite" },
       "targets": [
         {
           "refId": "A",
           "queryType": "table",
-          "queryText": "SELECT key AS component, SUM(value) AS install_days FROM rollups_daily WHERE metric = 'component' AND day >= date('now', '-30 day') GROUP BY key ORDER BY install_days DESC",
-          "rawQueryText": "SELECT key AS component, SUM(value) AS install_days FROM rollups_daily WHERE metric = 'component' AND day >= date('now', '-30 day') GROUP BY key ORDER BY install_days DESC"
+          "queryText": "SELECT je.value AS component, COUNT(DISTINCT e.install_id) AS installs FROM events e, json_each(e.components_json) je WHERE e.received_at >= (CAST(strftime('%s','now') AS INTEGER) - 2592000) * 1000000000 GROUP BY component ORDER BY installs DESC",
+          "rawQueryText": "SELECT je.value AS component, COUNT(DISTINCT e.install_id) AS installs FROM events e, json_each(e.components_json) je WHERE e.received_at >= (CAST(strftime('%s','now') AS INTEGER) - 2592000) * 1000000000 GROUP BY component ORDER BY installs DESC"
         }
       ],
-      "fieldConfig": { "defaults": {}, "overrides": [] }
+      "options": { "orientation": "horizontal", "displayMode": "basic", "showUnfilled": true, "reduceOptions": { "values": true, "calcs": ["lastNotNull"], "fields": "" } },
+      "fieldConfig": { "defaults": { "min": 0 }, "overrides": [] }
     },
     {
       "id": 5,
       "title": "RDD enabled ratio (trailing 30 days)",
       "description": "Share of install-days over the trailing 30 rolled-up days reporting rdd_enabled=true. Matches GET /v1/summary's rdd_enabled_ratio.",
       "type": "stat",
-      "gridPos": { "x": 16, "y": 8, "w": 8, "h": 8 },
+      "gridPos": { "x": 16, "y": 16, "w": 8, "h": 8 },
       "datasource": { "type": "frser-sqlite-datasource", "uid": "gentle-telemetry-sqlite" },
       "fieldConfig": { "defaults": { "unit": "percentunit", "min": 0, "max": 1 }, "overrides": [] },
       "targets": [
         {
           "refId": "A",
           "queryType": "table",
-          "queryText": "SELECT SUM(CASE WHEN key = 'true' THEN value ELSE 0 END) * 1.0 / NULLIF(SUM(value), 0) AS rdd_enabled_ratio FROM rollups_daily WHERE metric = 'rdd_enabled' AND day >= date('now', '-30 day')",
-          "rawQueryText": "SELECT SUM(CASE WHEN key = 'true' THEN value ELSE 0 END) * 1.0 / NULLIF(SUM(value), 0) AS rdd_enabled_ratio FROM rollups_daily WHERE metric = 'rdd_enabled' AND day >= date('now', '-30 day')"
+          "queryText": "SELECT SUM(rdd) * 1.0 / NULLIF(COUNT(*), 0) AS rdd_enabled_ratio FROM (SELECT install_id, MAX(rdd_enabled) AS rdd FROM events WHERE received_at >= (CAST(strftime('%s','now') AS INTEGER) - 2592000) * 1000000000 GROUP BY install_id)",
+          "rawQueryText": "SELECT SUM(rdd) * 1.0 / NULLIF(COUNT(*), 0) AS rdd_enabled_ratio FROM (SELECT install_id, MAX(rdd_enabled) AS rdd FROM events WHERE received_at >= (CAST(strftime('%s','now') AS INTEGER) - 2592000) * 1000000000 GROUP BY install_id)"
         }
       ]
     },
@@ -99,31 +171,32 @@
       "title": "Version distribution (trailing 30 days)",
       "description": "Install-days per reported version over the trailing 30 rolled-up days. A useful proxy for upgrade lag. Matches GET /v1/summary's version_distribution.",
       "type": "bargauge",
-      "gridPos": { "x": 0, "y": 16, "w": 12, "h": 8 },
+      "gridPos": { "x": 0, "y": 24, "w": 12, "h": 8 },
       "datasource": { "type": "frser-sqlite-datasource", "uid": "gentle-telemetry-sqlite" },
       "targets": [
         {
           "refId": "A",
           "queryType": "table",
-          "queryText": "SELECT key AS version, SUM(value) AS install_days FROM rollups_daily WHERE metric = 'version' AND day >= date('now', '-30 day') GROUP BY key ORDER BY install_days DESC",
-          "rawQueryText": "SELECT key AS version, SUM(value) AS install_days FROM rollups_daily WHERE metric = 'version' AND day >= date('now', '-30 day') GROUP BY key ORDER BY install_days DESC"
+          "queryText": "SELECT version, COUNT(DISTINCT install_id) AS installs FROM events WHERE received_at >= (CAST(strftime('%s','now') AS INTEGER) - 2592000) * 1000000000 GROUP BY version ORDER BY installs DESC LIMIT 10",
+          "rawQueryText": "SELECT version, COUNT(DISTINCT install_id) AS installs FROM events WHERE received_at >= (CAST(strftime('%s','now') AS INTEGER) - 2592000) * 1000000000 GROUP BY version ORDER BY installs DESC LIMIT 10"
         }
       ],
-      "fieldConfig": { "defaults": {}, "overrides": [] }
+      "options": { "orientation": "horizontal", "displayMode": "basic", "showUnfilled": true, "reduceOptions": { "values": true, "calcs": ["lastNotNull"], "fields": "" } },
+      "fieldConfig": { "defaults": { "min": 0 }, "overrides": [] }
     },
     {
       "id": 7,
       "title": "Events per day",
       "description": "Raw event volume (install + heartbeat), bounded by --retention-days: older raw rows are purged, so this panel only ever shows the retention window, unlike the rollup-backed panels above which cover full history.",
       "type": "timeseries",
-      "gridPos": { "x": 12, "y": 16, "w": 12, "h": 8 },
+      "gridPos": { "x": 12, "y": 24, "w": 12, "h": 8 },
       "datasource": { "type": "frser-sqlite-datasource", "uid": "gentle-telemetry-sqlite" },
       "targets": [
         {
           "refId": "A",
           "timeColumns": ["day"],
-          "queryText": "SELECT date(received_at / 1000000000, 'unixepoch') AS day, COUNT(*) AS events FROM events GROUP BY day ORDER BY day ASC",
-          "rawQueryText": "SELECT date(received_at / 1000000000, 'unixepoch') AS day, COUNT(*) AS events FROM events GROUP BY day ORDER BY day ASC"
+          "queryText": "SELECT CAST(strftime('%s', date(received_at / 1000000000, 'unixepoch')) AS INTEGER) AS day, COUNT(*) AS events FROM events GROUP BY day ORDER BY day ASC",
+          "rawQueryText": "SELECT CAST(strftime('%s', date(received_at / 1000000000, 'unixepoch')) AS INTEGER) AS day, COUNT(*) AS events FROM events GROUP BY day ORDER BY day ASC"
         }
       ],
       "fieldConfig": { "defaults": { "min": 0, "custom": { "drawStyle": "bars", "fillOpacity": 70, "lineWidth": 1, "showPoints": "never" } }, "overrides": [] }
@@ -133,14 +206,14 @@
       "title": "npm downloads per day (gentle-pi, gentle-engram)",
       "description": "Daily download counts from the npm registry's public API (api.npmjs.org) — a public count, not telemetry from any gentle-ai install. Matches GET /v1/summary's downloads.npm. The gentle_pi and gentle_engram columns mirror the collector's default --npm-package list; any other package it is configured to fetch lands in other_packages so nothing is silently dropped.",
       "type": "timeseries",
-      "gridPos": { "x": 0, "y": 24, "w": 12, "h": 8 },
+      "gridPos": { "x": 0, "y": 32, "w": 12, "h": 8 },
       "datasource": { "type": "frser-sqlite-datasource", "uid": "gentle-telemetry-sqlite" },
       "targets": [
         {
           "refId": "A",
           "timeColumns": ["day"],
-          "queryText": "SELECT day, SUM(CASE WHEN key = 'gentle-pi' THEN value ELSE 0 END) AS gentle_pi, SUM(CASE WHEN key = 'gentle-engram' THEN value ELSE 0 END) AS gentle_engram, SUM(CASE WHEN key NOT IN ('gentle-pi', 'gentle-engram') THEN value ELSE 0 END) AS other_packages FROM rollups_daily WHERE metric = 'npm_downloads_day' GROUP BY day ORDER BY day ASC",
-          "rawQueryText": "SELECT day, SUM(CASE WHEN key = 'gentle-pi' THEN value ELSE 0 END) AS gentle_pi, SUM(CASE WHEN key = 'gentle-engram' THEN value ELSE 0 END) AS gentle_engram, SUM(CASE WHEN key NOT IN ('gentle-pi', 'gentle-engram') THEN value ELSE 0 END) AS other_packages FROM rollups_daily WHERE metric = 'npm_downloads_day' GROUP BY day ORDER BY day ASC"
+          "queryText": "SELECT CAST(strftime('%s', day) AS INTEGER) AS day, SUM(CASE WHEN key = 'gentle-pi' THEN value ELSE 0 END) AS gentle_pi, SUM(CASE WHEN key = 'gentle-engram' THEN value ELSE 0 END) AS gentle_engram, SUM(CASE WHEN key NOT IN ('gentle-pi', 'gentle-engram') THEN value ELSE 0 END) AS other_packages FROM rollups_daily WHERE metric = 'npm_downloads_day' GROUP BY day ORDER BY day ASC",
+          "rawQueryText": "SELECT CAST(strftime('%s', day) AS INTEGER) AS day, SUM(CASE WHEN key = 'gentle-pi' THEN value ELSE 0 END) AS gentle_pi, SUM(CASE WHEN key = 'gentle-engram' THEN value ELSE 0 END) AS gentle_engram, SUM(CASE WHEN key NOT IN ('gentle-pi', 'gentle-engram') THEN value ELSE 0 END) AS other_packages FROM rollups_daily WHERE metric = 'npm_downloads_day' GROUP BY day ORDER BY day ASC"
         }
       ],
       "fieldConfig": { "defaults": { "min": 0, "custom": { "drawStyle": "bars", "fillOpacity": 70, "lineWidth": 1, "showPoints": "never" } }, "overrides": [] }
@@ -150,7 +223,7 @@
       "title": "gentle-ai release downloads (cumulative per tag)",
       "description": "Cumulative GitHub release asset download counts per tag, from the public GitHub API (api.github.com) — a public count, not telemetry from any gentle-ai install. Each bar is the latest known total for that tag, not a per-day delta. Matches GET /v1/summary's downloads.github.",
       "type": "bargauge",
-      "gridPos": { "x": 12, "y": 24, "w": 12, "h": 8 },
+      "gridPos": { "x": 12, "y": 32, "w": 12, "h": 8 },
       "datasource": { "type": "frser-sqlite-datasource", "uid": "gentle-telemetry-sqlite" },
       "targets": [
         {
@@ -160,7 +233,26 @@
           "rawQueryText": "SELECT r.key AS tag, r.value AS total_downloads FROM rollups_daily r INNER JOIN (SELECT key, MAX(day) AS max_day FROM rollups_daily WHERE metric = 'github_release_downloads_total' GROUP BY key) latest ON latest.key = r.key AND latest.max_day = r.day WHERE r.metric = 'github_release_downloads_total' ORDER BY total_downloads DESC"
         }
       ],
-      "fieldConfig": { "defaults": {}, "overrides": [] }
+      "options": { "orientation": "horizontal", "displayMode": "basic", "showUnfilled": true, "reduceOptions": { "values": true, "calcs": ["lastNotNull"], "fields": "" } },
+      "fieldConfig": { "defaults": { "min": 0 }, "overrides": [] }
+    },
+    {
+      "id": 14,
+      "title": "Agents declared today",
+      "description": "Distinct installs seen today that declare each agent, live from the events table (json_each over agents_json). One install can declare several agents.",
+      "type": "bargauge",
+      "gridPos": { "x": 0, "y": 40, "w": 24, "h": 8 },
+      "datasource": { "type": "frser-sqlite-datasource", "uid": "gentle-telemetry-sqlite" },
+      "targets": [
+        {
+          "refId": "A",
+          "queryType": "table",
+          "queryText": "SELECT je.value AS agent, COUNT(DISTINCT e.install_id) AS installs FROM events e, json_each(e.agents_json) je WHERE e.event = 'install' AND e.received_at >= CAST(strftime('%s', date('now')) AS INTEGER) * 1000000000 GROUP BY agent ORDER BY installs DESC",
+          "rawQueryText": "SELECT je.value AS agent, COUNT(DISTINCT e.install_id) AS installs FROM events e, json_each(e.agents_json) je WHERE e.event = 'install' AND e.received_at >= CAST(strftime('%s', date('now')) AS INTEGER) * 1000000000 GROUP BY agent ORDER BY installs DESC"
+        }
+      ],
+      "options": { "orientation": "horizontal", "displayMode": "basic", "showUnfilled": true, "reduceOptions": { "values": true, "calcs": ["lastNotNull"], "fields": "" } },
+      "fieldConfig": { "defaults": { "min": 0 }, "overrides": [] }
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Time columns are emitted as unix seconds: the SQLite datasource plugin leaves date strings null, so "Events per day" and the npm series showed "Data outside time range".
- The trailing-30-day, weekly, and monthly panels read the raw `events` table (90-day retention), falling back to `rollups_daily` only for months beyond retention, so numbers are exact whenever the dashboard is opened instead of lagging one day.
- Pies become per-row bar gauges (the categories overlap: one install declares several agents or components) and every bar gauge reduces per row, which fixes the single-slice and single-value renders.
- A live "today" row leads the dashboard (installs, heartbeats, platforms, installs per hour over 48 h) plus an "agents declared today" panel; refresh interval 1 h → 5 min.

Configuration-only change to a provisioned Grafana dashboard. Verified on the reference Grafana against the live collector database: every panel query returns rows through the HTTP API and renders in the browser. No native review was run for this candidate by the maintainer's decision.

Closes #4380

https://claude.ai/code/session_01HHji5T9rP2hJzmhSViQLaW

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added live dashboard panels for today’s installs, heartbeats, platforms, hourly installs, and declared agents.
  - Added recent retention views for unique installs, weekly activity, agent and component distributions, RDD ratio, and version distribution.

- **Improvements**
  - Dashboard data now uses Unix timestamps for more accurate time-based visualizations.
  - Dashboard refreshes automatically every five minutes.
  - Reorganized panel layout for improved readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->