### PR TITLE
fix(review): route inconclusive refutation into bounded correction and publish escalation cause

### DIFF
--- a/contracts/review-integration/v2/schemas/last-event-closure.schema.json
+++ b/contracts/review-integration/v2/schemas/last-event-closure.schema.json
@@ -45,6 +45,41 @@
     "status_continuation": {"$ref": "transition-execution.schema.json#/$defs/last_event_status_execution"},
     "acknowledgement": {"$ref": "transition-execution.schema.json#/$defs/approved_acknowledgement_execution"},
     "store_revision": {"type": "string", "pattern": "^sha256:[0-9a-f]{64}$"},
+    "escalation": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["cause", "finding_ids"],
+      "properties": {
+        "cause": {
+          "type": "string",
+          "enum": [
+            "unknown_causality",
+            "insufficient_evidence",
+            "missing_refuter_outcome",
+            "targeted_validator_rejected",
+            "correction_budget_exceeded",
+            "unresolved_severe_findings"
+          ]
+        },
+        "finding_ids": {
+          "type": "array",
+          "items": {"type": "string", "minLength": 1}
+        },
+        "refuter_outcomes": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["finding_id", "outcome", "proof"],
+            "properties": {
+              "finding_id": {"type": "string", "minLength": 1},
+              "outcome": {"type": "string", "enum": ["corroborated", "refuted", "inconclusive"]},
+              "proof": {"type": "string", "minLength": 1}
+            }
+          }
+        }
+      }
+    },
     "advisory_findings": {
       "type": "object",
       "additionalProperties": false,

--- a/contracts/review-integration/v2/schemas/last-event-closure.schema.json
+++ b/contracts/review-integration/v2/schemas/last-event-closure.schema.json
@@ -31,7 +31,8 @@
       "if": {"properties": {"state": {"const": "approved"}}, "required": ["state"]},
       "then": {"required": ["acknowledgement"]},
       "else": {"not": {"required": ["acknowledgement"]}}
-    }
+    },
+    {"if": {"properties": {"state": {"const": "escalated"}}, "required": ["state"]}, "then": {"required": ["escalation"]}, "else": {"not": {"required": ["escalation"]}}}
   ],
   "properties": {
     "schema": {"const": "gentle-ai.review-last-event-closure/v1"},

--- a/contracts/review-integration/v2/schemas/status-v7.schema.json
+++ b/contracts/review-integration/v2/schemas/status-v7.schema.json
@@ -19,7 +19,42 @@
     "eligibility": {"$ref": "status-v5.schema.json#/properties/eligibility"}, "forecast": {"$ref": "status-v5.schema.json#/properties/forecast"},
     "next_transition": {"$ref": "#/$defs/next_transition"}, "validation_request": {"$ref": "status-v5.schema.json#/properties/validation_request"},
     "repository_context": {"$ref": "status-v5.schema.json#/properties/repository_context"}, "disposition": {"$ref": "status-v5.schema.json#/properties/disposition"},
-    "eligible_untracked_inventory": {"$ref": "status-v5.schema.json#/$defs/sha256"}
+    "eligible_untracked_inventory": {"$ref": "status-v5.schema.json#/$defs/sha256"},
+    "escalation": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["cause", "finding_ids"],
+      "properties": {
+        "cause": {
+          "type": "string",
+          "enum": [
+            "unknown_causality",
+            "insufficient_evidence",
+            "missing_refuter_outcome",
+            "targeted_validator_rejected",
+            "correction_budget_exceeded",
+            "unresolved_severe_findings"
+          ]
+        },
+        "finding_ids": {
+          "type": "array",
+          "items": {"type": "string", "minLength": 1}
+        },
+        "refuter_outcomes": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["finding_id", "outcome", "proof"],
+            "properties": {
+              "finding_id": {"type": "string", "minLength": 1},
+              "outcome": {"type": "string", "enum": ["corroborated", "refuted", "inconclusive"]},
+              "proof": {"type": "string", "minLength": 1}
+            }
+          }
+        }
+      }
+    }
   },
   "dependentRequired": {"forecast": ["next_transition"]},
   "$defs": {

--- a/contracts/review-integration/v2/schemas/status-v7.schema.json
+++ b/contracts/review-integration/v2/schemas/status-v7.schema.json
@@ -20,41 +20,7 @@
     "next_transition": {"$ref": "#/$defs/next_transition"}, "validation_request": {"$ref": "status-v5.schema.json#/properties/validation_request"},
     "repository_context": {"$ref": "status-v5.schema.json#/properties/repository_context"}, "disposition": {"$ref": "status-v5.schema.json#/properties/disposition"},
     "eligible_untracked_inventory": {"$ref": "status-v5.schema.json#/$defs/sha256"},
-    "escalation": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": ["cause", "finding_ids"],
-      "properties": {
-        "cause": {
-          "type": "string",
-          "enum": [
-            "unknown_causality",
-            "insufficient_evidence",
-            "missing_refuter_outcome",
-            "targeted_validator_rejected",
-            "correction_budget_exceeded",
-            "unresolved_severe_findings"
-          ]
-        },
-        "finding_ids": {
-          "type": "array",
-          "items": {"type": "string", "minLength": 1}
-        },
-        "refuter_outcomes": {
-          "type": "array",
-          "items": {
-            "type": "object",
-            "additionalProperties": false,
-            "required": ["finding_id", "outcome", "proof"],
-            "properties": {
-              "finding_id": {"type": "string", "minLength": 1},
-              "outcome": {"type": "string", "enum": ["corroborated", "refuted", "inconclusive"]},
-              "proof": {"type": "string", "minLength": 1}
-            }
-          }
-        }
-      }
-    }
+    "escalation": {"$ref": "last-event-closure.schema.json#/properties/escalation"}
   },
   "dependentRequired": {"forecast": ["next_transition"]},
   "$defs": {
@@ -128,6 +94,7 @@
   "allOf": [
     {"$ref": "status-v5.schema.json#/allOf/0"}, {"$ref": "status-v5.schema.json#/allOf/1"},
     {"$ref": "status-v5.schema.json#/allOf/2"}, {"$ref": "status-v5.schema.json#/allOf/3"},
-    {"$ref": "status-v5.schema.json#/allOf/4"}
+    {"$ref": "status-v5.schema.json#/allOf/4"},
+    {"if": {"properties": {"authority": {"properties": {"version": {"const": "compact-v2"}, "state": {"const": "escalated"}}, "required": ["version", "state"]}}, "required": ["authority"]}, "then": {"required": ["escalation"]}, "else": {"not": {"required": ["escalation"]}}}
   ]
 }

--- a/internal/cli/review_last_event_closure.go
+++ b/internal/cli/review_last_event_closure.go
@@ -22,6 +22,7 @@ type reviewLastEventClosureResult struct {
 	State                     reviewtransaction.State                             `json:"state"`
 	Action                    string                                              `json:"action"`
 	TargetedValidatorEvidence *reviewtransaction.CompactTargetedValidatorEvidence `json:"targeted_validator_evidence,omitempty"`
+	Escalation                *reviewtransaction.CompactEscalationEvidence        `json:"escalation,omitempty"`
 	AdvisoryFindings          *reviewtransaction.AdvisoryFindingSet               `json:"advisory_findings,omitempty"`
 	StatusContinuation        *ReviewTransitionExecution                          `json:"status_continuation,omitempty"`
 	Acknowledgement           *ReviewTransitionExecution                          `json:"acknowledgement,omitempty"`
@@ -140,6 +141,7 @@ func closeCorrectionOnCapturedValidator(
 		telemetryRecordReviewOutcome("approved")
 	case reviewtransaction.StateEscalated:
 		result.Action = "the targeted validator rejected the correction; maintainer action is informational"
+		result.Escalation = state.EscalationEvidence()
 		telemetryRecordReviewOutcome("escalated")
 	default:
 		return nil, fmt.Errorf("targeted validator capture produced unsupported state %q", state.State) // refusal:by-design human-authority: an unmodeled terminal authority outcome requires maintainer inspection
@@ -174,7 +176,7 @@ func newCorrectionCapturedValidatorClosure(repo string, state reviewtransaction.
 	return &reviewLastEventClosureResult{
 		Schema: reviewLastEventClosureSchema, Operation: "review/capture-validation", LineageID: state.LineageID,
 		State: state.State, Action: "the targeted validator rejected the correction; maintainer action is informational",
-		TargetedValidatorEvidence: &evidence, AdvisoryFindings: reviewtransaction.AdvisoryFindingSetFor(state), StoreRevision: revision,
+		TargetedValidatorEvidence: &evidence, Escalation: state.EscalationEvidence(), AdvisoryFindings: reviewtransaction.AdvisoryFindingSetFor(state), StoreRevision: revision,
 	}, nil
 }
 
@@ -291,6 +293,7 @@ func closeReviewOnLastCapturedLens(
 		telemetryRecordReviewOutcome("correction")
 	case reviewtransaction.StateEscalated:
 		result.Action = "review completed with inconclusive severe findings; maintainer action is informational"
+		result.Escalation = state.EscalationEvidence()
 		telemetryRecordReviewOutcome("escalated")
 	default:
 		return nil, fmt.Errorf("last reviewer capture produced unsupported state %q", state.State) // refusal:by-design human-authority: an unmodeled terminal authority outcome requires maintainer inspection

--- a/internal/cli/review_last_event_closure_test.go
+++ b/internal/cli/review_last_event_closure_test.go
@@ -1289,6 +1289,13 @@ func TestLineageEscalationPublishesEscalationCauseInClosureAndStatusEnvelopes(t 
 	if terminal.Escalation == nil || terminal.Escalation.Cause != "targeted_validator_rejected" || len(terminal.Escalation.FindingIDs) == 0 {
 		t.Fatalf("closure escalation = %#v, want cause targeted_validator_rejected", terminal.Escalation)
 	}
+	closureSchema := compileWholePublishedReviewSchema(t, "v2", "last-event-closure.schema.json")
+	closureDocument := decodeJSONObjectCopy(t, terminalOutput.Bytes())
+	delete(closureDocument, "targeted_validator_evidence")
+	delete(closureDocument, "escalation")
+	if err := closureSchema.Validate(closureDocument); err == nil {
+		t.Fatal("last-event closure schema accepted escalated state without escalation")
+	}
 
 	var statusOutput bytes.Buffer
 	if err := RunReviewStatus([]string{
@@ -1303,5 +1310,12 @@ func TestLineageEscalationPublishesEscalationCauseInClosureAndStatusEnvelopes(t 
 	decodeStrictReviewJSON(t, statusOutput.Bytes(), &status)
 	if status.Escalation == nil || status.Escalation.Cause != "targeted_validator_rejected" || !reflect.DeepEqual(status.Escalation.FindingIDs, terminal.Escalation.FindingIDs) {
 		t.Fatalf("STATUS escalation = %#v, want matching closure escalation %#v", status.Escalation, terminal.Escalation)
+	}
+	statusSchema := compileWholeNativeStatusSchema(t, "status-v7.schema.json")
+	validatePublishedReviewSchema(t, statusSchema, statusOutput.Bytes())
+	statusDocument := decodeJSONObjectCopy(t, statusOutput.Bytes())
+	delete(statusDocument, "escalation")
+	if err := statusSchema.Validate(statusDocument); err == nil {
+		t.Fatal("status-v7 schema accepted escalated authority without escalation")
 	}
 }

--- a/internal/cli/review_last_event_closure_test.go
+++ b/internal/cli/review_last_event_closure_test.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strconv"
 	"strings"
 	"sync"
@@ -1189,4 +1190,118 @@ func TestNegotiatedStatusReplaysPendingAcknowledgementDespiteUnreadableSiblingSt
 		t.Fatalf("selectorless STATUS = applicability=%q transition=%#v, want the pending acknowledgement", selectorless.Applicability, selectorless.NextTransition)
 	}
 	assertApprovedAcknowledgementTransition(t, selectorless.NextTransition.Execute, repo, started.LineageID, pending.TargetIdentity, pending.ExpectedRevision)
+}
+
+// TestRefuterCaptureInconclusiveRoutesToCorrectionRequiredWithoutEscalating
+// proves the fix for issue #4226: an inconclusive refuter verdict for a
+// severe inferential finding is treated as candidate-caused and routed into
+// bounded correction (StateCorrectionRequired), not an immediate terminal escalation.
+func TestRefuterCaptureInconclusiveRoutesToCorrectionRequiredWithoutEscalating(t *testing.T) {
+	reviewEnabledHome(t)
+	t.Setenv(reviewPiHostRelayContractEnvironment, reviewPiHostRelayContract)
+	repo, store, record, handle := piRefuterReview(t)
+	request, err := reviewProviderNewRefuterRequest(t.Context(), repo, store.Dir, record.State, record.State.CapturePhaseRevision)
+	if err != nil {
+		t.Fatal(err)
+	}
+	inconclusive, err := json.Marshal(facadeRefuterResult{
+		RequestHash: request.RequestHash,
+		Results: []facadeRefuterOutcome{{
+			FindingID: "R3-001", Outcome: reviewtransaction.OutcomeInconclusive, ProofRefs: []string{"could not observe wrapped state.Read error"},
+		}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	overrideProviderRoleHostAdapter(t, providerTestAdapter{raw: inconclusive})
+
+	var output bytes.Buffer
+	if err := RunReview(append(append([]string{"capture-refuter"}, piRefuterBinding(repo, record, handle)...), "--agent", "pi", "--execute=true"), &output); err != nil {
+		t.Fatalf("capture refuter inconclusive: %v\n%s", err, output.String())
+	}
+
+	var terminal reviewLastEventClosureResult
+	decodeStrictReviewJSON(t, output.Bytes(), &terminal)
+	if terminal.State != reviewtransaction.StateCorrectionRequired {
+		t.Fatalf("inconclusive refuter capture state = %q, want %q", terminal.State, reviewtransaction.StateCorrectionRequired)
+	}
+	if terminal.StatusContinuation == nil || terminal.StatusContinuation.Operation != "review.status" {
+		t.Fatalf("inconclusive refuter capture status_continuation = %#v", terminal.StatusContinuation)
+	}
+	after, err := store.Load()
+	if err != nil || after.State.State != reviewtransaction.StateCorrectionRequired {
+		t.Fatalf("inconclusive refuter capture left authority = %#v, %v", after, err)
+	}
+	if len(after.State.FixFindingIDs) != 1 || after.State.FixFindingIDs[0] != "R3-001" {
+		t.Fatalf("inconclusive refuter capture FixFindingIDs = %v, want [R3-001]", after.State.FixFindingIDs)
+	}
+}
+
+// TestLineageEscalationPublishesEscalationCauseInClosureAndStatusEnvelopes
+// proves that when a lineage escalates (issue #4226), both the terminal
+// closure envelope and the STATUS envelope publish escalation with cause and finding_ids.
+func TestLineageEscalationPublishesEscalationCauseInClosureAndStatusEnvelopes(t *testing.T) {
+	reviewEnabledHome(t)
+	repo, lineage, request := providerCorrectionReadyWithoutVerificationEvidence(t)
+	store, err := reviewtransaction.CompactAuthoritativeStore(t.Context(), repo, lineage)
+	if err != nil {
+		t.Fatal(err)
+	}
+	record, err := store.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	failedPayload, err := json.Marshal(facadeValidationResult{
+		TargetedValidationRequestHash: request.RequestHash,
+		CorrectionTargetIdentity:      request.CorrectionTargetIdentity,
+		OriginalCriteria:              facadeValidationCheck{Passed: false, Evidence: []string{"acceptance test failed"}},
+		CorrectionRegression:          facadeValidationCheck{Passed: true, Evidence: []string{"no regression observed"}},
+		FollowUps:                     []reviewtransaction.FollowUp{},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	originalAdapter := reviewProviderRoleHostAdapter
+	reviewProviderRoleHostAdapter = func() reviewerprovider.Adapter {
+		return providerTestAdapterFunc(func(context.Context, reviewerprovider.Invocation) ([]byte, error) {
+			return failedPayload, nil
+		})
+	}
+	t.Cleanup(func() { reviewProviderRoleHostAdapter = originalAdapter })
+
+	var terminalOutput bytes.Buffer
+	if err := RunReviewCaptureValidation([]string{
+		"--cwd", repo,
+		"--lineage", lineage,
+		"--target", request.CorrectionTargetIdentity,
+		"--expected-revision", record.State.CapturePhaseRevision,
+		"--request-hash", request.RequestHash,
+		"--agent", string(model.AgentPi),
+		"--execute=true",
+	}, &terminalOutput); err != nil {
+		t.Fatalf("capture rejected targeted validator: %v\n%s", err, terminalOutput.String())
+	}
+	var terminal reviewLastEventClosureResult
+	decodeStrictReviewJSON(t, terminalOutput.Bytes(), &terminal)
+	if terminal.State != reviewtransaction.StateEscalated {
+		t.Fatalf("closure state = %q, want %q", terminal.State, reviewtransaction.StateEscalated)
+	}
+	if terminal.Escalation == nil || terminal.Escalation.Cause != "targeted_validator_rejected" || len(terminal.Escalation.FindingIDs) == 0 {
+		t.Fatalf("closure escalation = %#v, want cause targeted_validator_rejected", terminal.Escalation)
+	}
+
+	var statusOutput bytes.Buffer
+	if err := RunReviewStatus([]string{
+		"--cwd", repo,
+		"--lineage", lineage,
+		"--contract", ReviewIntegrationContractV2,
+		"--next-transition",
+	}, &statusOutput); err != nil {
+		t.Fatalf("status query on escalated lineage: %v\n%s", err, statusOutput.String())
+	}
+	var status ReviewTargetStatusResult
+	decodeStrictReviewJSON(t, statusOutput.Bytes(), &status)
+	if status.Escalation == nil || status.Escalation.Cause != "targeted_validator_rejected" || !reflect.DeepEqual(status.Escalation.FindingIDs, terminal.Escalation.FindingIDs) {
+		t.Fatalf("STATUS escalation = %#v, want matching closure escalation %#v", status.Escalation, terminal.Escalation)
+	}
 }

--- a/internal/cli/review_next_transition_scope_recovery_test.go
+++ b/internal/cli/review_next_transition_scope_recovery_test.go
@@ -62,17 +62,37 @@ func TestRejectedTargetedValidatorCaptureRoutesEscalatedRecovery(t *testing.T) {
 	}
 	runReviewCLIGit(t, repo, "add", "recovery.go")
 
-	var output bytes.Buffer
-	if err := RunReview([]string{
-		"status", "--cwd", repo, "--contract", ReviewIntegrationContractV1,
-		"--lineage", lineage, "--next-transition",
-	}, &output); err != nil {
-		t.Fatal(err)
-	}
-	var status ReviewTargetStatusResult
-	decodeStrictReviewJSON(t, output.Bytes(), &status)
-	if status.Action != reviewtransaction.TargetStatusActionRecover || status.ActionDisposition != reviewtransaction.RecoveryEscalated ||
-		status.NextTransition == nil || status.NextTransition.ReasonCode != "recovery_authorization_required" {
-		t.Fatalf("escalated status = %#v", status)
+	for _, tt := range []struct {
+		name, contract, schema string
+		wantEscalation         bool
+	}{
+		{name: "v1", contract: ReviewIntegrationContractV1, schema: ReviewIntegrationStatusSchemaV2},
+		{name: "v2", contract: ReviewIntegrationContractV2, schema: ReviewIntegrationStatusSchemaV7, wantEscalation: true},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			var output bytes.Buffer
+			if err := RunReview([]string{
+				"status", "--cwd", repo, "--contract", tt.contract,
+				"--lineage", lineage, "--next-transition",
+			}, &output); err != nil {
+				t.Fatal(err)
+			}
+			var status ReviewTargetStatusResult
+			decodeStrictReviewJSON(t, output.Bytes(), &status)
+			if status.Schema != tt.schema || status.Action != reviewtransaction.TargetStatusActionRecover ||
+				status.ActionDisposition != reviewtransaction.RecoveryEscalated || status.NextTransition == nil ||
+				status.NextTransition.ReasonCode != "recovery_authorization_required" {
+				t.Fatalf("escalated status = %#v", status)
+			}
+			if err := status.Validate(); err != nil {
+				t.Fatalf("status validation error = %v", err)
+			}
+			if (status.Escalation != nil) != tt.wantEscalation {
+				t.Fatalf("status escalation = %#v, want present=%t", status.Escalation, tt.wantEscalation)
+			}
+			if tt.wantEscalation {
+				validatePublishedReviewSchema(t, compileWholeNativeStatusSchema(t, "status-v7.schema.json"), output.Bytes())
+			}
+		})
 	}
 }

--- a/internal/cli/review_next_transition_test.go
+++ b/internal/cli/review_next_transition_test.go
@@ -797,6 +797,29 @@ func TestReviewStatusValidateRejectsMalformedForecast(t *testing.T) {
 	}
 }
 
+func TestReviewStatusEscalationParityPreservesLegacyAuthority(t *testing.T) {
+	identity := "sha256:" + strings.Repeat("a", 64)
+	status := newReviewTargetStatusResultForContract(reviewtransaction.TargetStatusResult{
+		Applicability: reviewtransaction.TargetApplicabilityCurrent, AuthorityVersion: reviewtransaction.AuthorityVersionLegacy,
+		LineageID: "legacy-escalated", State: reviewtransaction.StateEscalated, Generation: 1, Revision: identity,
+		Action: reviewtransaction.TargetStatusActionStop, Replayability: reviewtransaction.ReplayabilityManualActionRequired, TargetIdentity: identity,
+	}, ReviewIntegrationContractV2)
+	status.Projection = ReviewTargetStatusProjection{
+		Schema: ReviewIntegrationProjectionSchema, Kind: reviewtransaction.TargetCurrentChanges, Projection: reviewtransaction.ProjectionWorkspace,
+		BaseTree: strings.Repeat("a", 40), InitialReviewTree: strings.Repeat("b", 40), CurrentCandidateTree: strings.Repeat("c", 40),
+		PathsDigest: identity, IntendedUntrackedProof: identity, InitialSnapshotIdentity: identity, CurrentSnapshotIdentity: identity,
+		Paths: []string{}, IntendedUntracked: []string{},
+	}
+	payload, err := json.Marshal(status)
+	if err != nil {
+		t.Fatal(err)
+	}
+	validatePublishedReviewSchema(t, compileWholeNativeStatusSchema(t, "status-v7.schema.json"), payload)
+	if err := status.Validate(); err != nil {
+		t.Fatal(err)
+	}
+}
+
 func TestNegotiatedStatusForecastStaysStructuralAndV1StaysFrozen(t *testing.T) {
 	reviewEnabledHome(t)
 	repo := initReviewCLIRepo(t)

--- a/internal/cli/review_next_transition_test.go
+++ b/internal/cli/review_next_transition_test.go
@@ -820,6 +820,71 @@ func TestReviewStatusEscalationParityPreservesLegacyAuthority(t *testing.T) {
 	}
 }
 
+func TestReviewStatusEscalationRequiresV7Schema(t *testing.T) {
+	identity := "sha256:" + strings.Repeat("a", 64)
+	native := reviewtransaction.TargetStatusResult{
+		Applicability: reviewtransaction.TargetApplicabilityCurrent, AuthorityVersion: reviewtransaction.AuthorityVersionCompact,
+		LineageID: "compact-escalated", State: reviewtransaction.StateEscalated, Generation: 1, Revision: identity,
+		Action: reviewtransaction.TargetStatusActionStop, Replayability: reviewtransaction.ReplayabilityManualActionRequired,
+		OriginalChangedLines: 1, Tier: reviewtransaction.RiskLow, TargetIdentity: identity,
+		Escalation: &reviewtransaction.CompactEscalationEvidence{Cause: "correction_budget_exceeded", FindingIDs: []string{"finding-1"}},
+	}
+	status := newReviewTargetStatusResultForContract(native, ReviewIntegrationContractV2)
+	status.Projection = ReviewTargetStatusProjection{
+		Schema: ReviewIntegrationProjectionSchema, Kind: reviewtransaction.TargetCurrentChanges, Projection: reviewtransaction.ProjectionWorkspace,
+		BaseTree: strings.Repeat("a", 40), InitialReviewTree: strings.Repeat("b", 40), CurrentCandidateTree: strings.Repeat("c", 40),
+		PathsDigest: identity, IntendedUntrackedProof: identity, InitialSnapshotIdentity: identity, CurrentSnapshotIdentity: identity,
+		Paths: []string{}, IntendedUntracked: []string{},
+	}
+
+	payload, err := json.Marshal(status)
+	if err != nil {
+		t.Fatal(err)
+	}
+	validatePublishedReviewSchema(t, compileWholeNativeStatusSchema(t, "status-v7.schema.json"), payload)
+
+	legacy := newReviewTargetStatusResultForContract(native, ReviewIntegrationContractV1)
+	legacy.Projection = status.Projection
+	if legacy.Escalation != nil {
+		t.Fatalf("v1 projection retained escalation: %#v", legacy.Escalation)
+	}
+	if err := legacy.Validate(); err != nil {
+		t.Fatalf("v1 projection validation error = %v", err)
+	}
+
+	for _, tt := range []struct {
+		name, schema, contract, wantErr string
+		action                          reviewtransaction.TargetStatusAction
+		disposition                     reviewtransaction.RecoveryDisposition
+		escalation                      *reviewtransaction.CompactEscalationEvidence
+	}{
+		{name: "v2", schema: ReviewIntegrationStatusSchemaV2, contract: ReviewIntegrationContractV1, action: reviewtransaction.TargetStatusActionStop, escalation: native.Escalation, wantErr: "status escalation requires review status schema v7"},
+		{name: "v3", schema: ReviewIntegrationStatusSchemaV3, contract: ReviewIntegrationContractV2, action: reviewtransaction.TargetStatusActionStop, escalation: native.Escalation, wantErr: "status escalation requires review status schema v7"},
+		{name: "v4", schema: ReviewIntegrationStatusSchemaV4, contract: ReviewIntegrationContractV2, action: reviewtransaction.TargetStatusActionStop, escalation: native.Escalation, wantErr: "status escalation requires review status schema v7"},
+		{name: "v5", schema: ReviewIntegrationStatusSchemaV5, contract: ReviewIntegrationContractV2, action: reviewtransaction.TargetStatusActionStop, escalation: native.Escalation, wantErr: "status escalation requires review status schema v7"},
+		{name: "v6", schema: ReviewIntegrationStatusSchemaV6, contract: ReviewIntegrationContractV2, action: reviewtransaction.TargetStatusActionStop, escalation: native.Escalation, wantErr: "status escalation requires review status schema v7"},
+		{name: "v7 terminal", schema: ReviewIntegrationStatusSchemaV7, contract: ReviewIntegrationContractV2, action: reviewtransaction.TargetStatusActionStop, escalation: native.Escalation},
+		{name: "v7 terminal missing escalation", schema: ReviewIntegrationStatusSchemaV7, contract: ReviewIntegrationContractV2, action: reviewtransaction.TargetStatusActionStop, wantErr: "status escalation must match escalated authority"},
+		{name: "v7 recovery", schema: ReviewIntegrationStatusSchemaV7, contract: ReviewIntegrationContractV2, action: reviewtransaction.TargetStatusActionRecover, disposition: reviewtransaction.RecoveryEscalated, escalation: native.Escalation},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			got := status
+			got.Schema, got.Contract = tt.schema, tt.contract
+			got.Action, got.ActionDisposition, got.Escalation = tt.action, tt.disposition, tt.escalation
+			err := got.Validate()
+			if tt.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+					t.Fatalf("Validate() error = %v, want %q", err, tt.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("Validate() error = %v, want nil", err)
+			}
+		})
+	}
+}
+
 func TestNegotiatedStatusForecastStaysStructuralAndV1StaysFrozen(t *testing.T) {
 	reviewEnabledHome(t)
 	repo := initReviewCLIRepo(t)

--- a/internal/cli/review_provider_artifact_contract_test.go
+++ b/internal/cli/review_provider_artifact_contract_test.go
@@ -201,8 +201,11 @@ func TestReviewProviderArtifactV24IntendedUntrackedContractsArePinned(t *testing
 func TestReviewProviderArtifactConformanceSchemasArePinned(t *testing.T) {
 	root := filepath.Join("..", "..", "contracts", "review-integration", "v2")
 	want := map[string]string{
-		"schemas/gate-result.schema.json":        "afe5e2a030fae9949305811bcac0a6dbc8b4f28802fa61d1e31e58e895f9fcae",
-		"schemas/last-event-closure.schema.json": "9059651e39278f6932929392f4dacc3911d65fe3769171e2401b87df55da9030",
+		"schemas/gate-result.schema.json": "afe5e2a030fae9949305811bcac0a6dbc8b4f28802fa61d1e31e58e895f9fcae",
+		// issue #4226: last-event-closure documents the CompactEscalationEvidence
+		// contract (cause, finding_ids, refuter_outcomes) for terminal escalation.
+		// Deliberate, not drift.
+		"schemas/last-event-closure.schema.json": "f35e8a66f89df88a70b4d7a0e61b1a8a95e09598900078bd226bfb3a605da5e9",
 		// issue #3894: start/v4 publishes the reviewing status continuation, so
 		// transition-execution gains the start_status_execution definition it
 		// references. Deliberate, not drift.
@@ -246,7 +249,10 @@ func TestReviewProviderArtifactStatusV7ContractsArePinned(t *testing.T) {
 		// review.capture-unachievable --withdraw=true command), so a
 		// restarted orchestrator that lost the pre-stop collect offer can
 		// still recover the binding its withdraw needs. Deliberate, not drift.
-		"schemas/status-v7.schema.json":         "c165a2309adff3131dd1d19e93408ade5cf45b27f0076304e423ca604e1f436c",
+		//
+		// issue #4226: status/v7 documents the CompactEscalationEvidence contract
+		// on terminal escalation. Deliberate, not drift.
+		"schemas/status-v7.schema.json":         "601c0c17ecb156a32b47fd21a2895f4300b5d4b85abefe9c1036ec0468dfe272",
 		"schemas/capabilities-v2.5.schema.json": "9fcdb1717a54bcd4f73d4dee1283d9ec2f27cccbb5d54804ee8b40a6ed2db553",
 	}
 	for name, expected := range want {

--- a/internal/cli/review_provider_artifact_contract_test.go
+++ b/internal/cli/review_provider_artifact_contract_test.go
@@ -205,7 +205,7 @@ func TestReviewProviderArtifactConformanceSchemasArePinned(t *testing.T) {
 		// issue #4226: last-event-closure documents the CompactEscalationEvidence
 		// contract (cause, finding_ids, refuter_outcomes) for terminal escalation.
 		// Deliberate, not drift.
-		"schemas/last-event-closure.schema.json": "f35e8a66f89df88a70b4d7a0e61b1a8a95e09598900078bd226bfb3a605da5e9",
+		"schemas/last-event-closure.schema.json": "1c720e2bf6e5363fd6138a4da8cd5f65c55bf7bad5ab863838f9d43b8294f8a1",
 		// issue #3894: start/v4 publishes the reviewing status continuation, so
 		// transition-execution gains the start_status_execution definition it
 		// references. Deliberate, not drift.
@@ -252,7 +252,7 @@ func TestReviewProviderArtifactStatusV7ContractsArePinned(t *testing.T) {
 		//
 		// issue #4226: status/v7 documents the CompactEscalationEvidence contract
 		// on terminal escalation. Deliberate, not drift.
-		"schemas/status-v7.schema.json":         "601c0c17ecb156a32b47fd21a2895f4300b5d4b85abefe9c1036ec0468dfe272",
+		"schemas/status-v7.schema.json":         "277abd6aed05ff7358fc32374bf524c9c3d10d3760d42c68c4e8a235e2f86968",
 		"schemas/capabilities-v2.5.schema.json": "9fcdb1717a54bcd4f73d4dee1283d9ec2f27cccbb5d54804ee8b40a6ed2db553",
 	}
 	for name, expected := range want {

--- a/internal/cli/review_published_schema_conformance_test.go
+++ b/internal/cli/review_published_schema_conformance_test.go
@@ -103,6 +103,11 @@ func TestPublishedLastEventClosureSchemaAcceptsApprovedTerminalCapture(t *testin
 
 	schema := compileWholePublishedReviewSchema(t, "v2", "last-event-closure.schema.json")
 	validatePublishedReviewSchema(t, schema, output.Bytes())
+	closure := decodeJSONObjectCopy(t, output.Bytes())
+	closure["escalation"] = map[string]any{"cause": "unresolved_severe_findings", "finding_ids": []any{}}
+	if err := schema.Validate(closure); err == nil {
+		t.Fatal("published last-event closure schema accepted escalation on approved state")
+	}
 }
 
 func TestPublishedLastEventClosureSchemaAcceptsTerminalRefuterCapture(t *testing.T) {

--- a/internal/cli/review_status_contract.go
+++ b/internal/cli/review_status_contract.go
@@ -96,6 +96,7 @@ type ReviewTargetStatusResult struct {
 	Eligibility       *ReviewActionEligibility                     `json:"eligibility,omitempty"`
 	Forecast          *ReviewForecast                              `json:"forecast,omitempty"`
 	NextTransition    *ReviewNextTransition                        `json:"next_transition,omitempty"`
+	Escalation        *reviewtransaction.CompactEscalationEvidence `json:"escalation,omitempty"`
 	RepositoryContext *ReviewRepositoryContextReference            `json:"repository_context,omitempty"`
 	ValidationRequest *reviewtransaction.TargetedValidationRequest `json:"validation_request,omitempty"`
 	decision          reviewtransaction.TargetStatusDecision       `json:"-"`
@@ -227,6 +228,9 @@ func newReviewTargetStatusResultForContract(native reviewtransaction.TargetStatu
 	if native.AuthorityVersion == reviewtransaction.AuthorityVersionCompact &&
 		native.AuthorityTargetIdentity != "" && native.AuthorityTargetIdentity != native.TargetIdentity {
 		result.AuthorityTargetIdentity = native.AuthorityTargetIdentity
+	}
+	if native.Escalation != nil {
+		result.Escalation = native.Escalation
 	}
 	if native.Applicability != reviewtransaction.TargetApplicabilityCurrent {
 		return result

--- a/internal/cli/review_status_contract.go
+++ b/internal/cli/review_status_contract.go
@@ -229,7 +229,7 @@ func newReviewTargetStatusResultForContract(native reviewtransaction.TargetStatu
 		native.AuthorityTargetIdentity != "" && native.AuthorityTargetIdentity != native.TargetIdentity {
 		result.AuthorityTargetIdentity = native.AuthorityTargetIdentity
 	}
-	if native.Escalation != nil {
+	if native.Escalation != nil && schema == ReviewIntegrationStatusSchemaV7 {
 		result.Escalation = native.Escalation
 	}
 	if native.Applicability != reviewtransaction.TargetApplicabilityCurrent {
@@ -521,8 +521,13 @@ func (result ReviewTargetStatusResult) validateWithCompactAuthority(authority *r
 	default:
 		return errors.New("unsupported review status recovery disposition")
 	}
-	if (result.Authority != nil && result.Authority.Version == reviewtransaction.AuthorityVersionCompact && result.Authority.State == reviewtransaction.StateEscalated) != (result.Escalation != nil) {
-		return errors.New("status escalation must match escalated authority")
+	if result.Escalation != nil && result.Schema != ReviewIntegrationStatusSchemaV7 {
+		return errors.New("status escalation requires review status schema v7") // refusal:by-design world-action: only the provider can omit escalation from a pre-v7 envelope or publish the v7 identity that defines it
+	}
+	escalationRequired := result.Schema == ReviewIntegrationStatusSchemaV7 && result.Authority != nil &&
+		result.Authority.Version == reviewtransaction.AuthorityVersionCompact && result.Authority.State == reviewtransaction.StateEscalated
+	if escalationRequired != (result.Escalation != nil) {
+		return errors.New("status escalation must match escalated authority") // refusal:by-design world-action: only the provider can project canonical escalation evidence for a v7 compact authority
 	}
 	return nil
 }

--- a/internal/cli/review_status_contract.go
+++ b/internal/cli/review_status_contract.go
@@ -521,6 +521,9 @@ func (result ReviewTargetStatusResult) validateWithCompactAuthority(authority *r
 	default:
 		return errors.New("unsupported review status recovery disposition")
 	}
+	if (result.Authority != nil && result.Authority.Version == reviewtransaction.AuthorityVersionCompact && result.Authority.State == reviewtransaction.StateEscalated) != (result.Escalation != nil) {
+		return errors.New("status escalation must match escalated authority")
+	}
 	return nil
 }
 

--- a/internal/cli/review_transition_schema_drift_test.go
+++ b/internal/cli/review_transition_schema_drift_test.go
@@ -173,6 +173,11 @@ func TestV2TransitionSchemasAcceptProviderPayloadsAndRejectDrift(t *testing.T) {
 	}
 	statusV7Schema := compileWholeNativeStatusSchema(t, "status-v7.schema.json")
 	validatePublishedReviewSchema(t, statusV7Schema, statusOutput.Bytes())
+	statusDocument := decodeJSONObjectCopy(t, statusOutput.Bytes())
+	statusDocument["escalation"] = map[string]any{"cause": "unresolved_severe_findings", "finding_ids": []any{}}
+	if err := statusV7Schema.Validate(statusDocument); err == nil {
+		t.Fatal("status-v7 schema accepted escalation on approved authority")
+	}
 	var status ReviewTargetStatusResult
 	decodeStrictReviewJSON(t, statusOutput.Bytes(), &status)
 	if status.NextTransition == nil || status.NextTransition.Execute == nil || status.NextTransition.ReasonCode != "approved_acknowledgement_required" {

--- a/internal/reviewtransaction/compact.go
+++ b/internal/reviewtransaction/compact.go
@@ -1205,7 +1205,7 @@ func (state CompactState) CompactReviewView() (CompactReviewView, error) {
 				return CompactReviewView{}, invalidCompactReviewView("refuter outcome is unsupported")
 			}
 			view.Outcomes[finding.ID] = result.Outcome
-			if result.Outcome == OutcomeCorroborated {
+			if result.Outcome == OutcomeCorroborated || result.Outcome == OutcomeInconclusive {
 				view.FixFindingIDs = append(view.FixFindingIDs, finding.ID)
 			}
 		}
@@ -1703,9 +1703,15 @@ func validateCompactReviewInput(state CompactState, input CompactReviewInput, vi
 }
 
 func compactReviewViewHasUnresolvedFindings(view CompactReviewView) bool {
-	for _, outcome := range view.Outcomes {
+	fixSet := make(map[string]struct{}, len(view.FixFindingIDs))
+	for _, id := range view.FixFindingIDs {
+		fixSet[id] = struct{}{}
+	}
+	for id, outcome := range view.Outcomes {
 		if outcome == OutcomeInconclusive {
-			return true
+			if _, fixing := fixSet[id]; !fixing {
+				return true
+			}
 		}
 	}
 	return false

--- a/internal/reviewtransaction/compact_causality_test.go
+++ b/internal/reviewtransaction/compact_causality_test.go
@@ -31,6 +31,7 @@ func TestCompactReviewBoundsCandidateCausalityToGenesisLocations(t *testing.T) {
 		{name: "explicit unknown remains escalated", location: "tracked.txt:1", causality: CausalUnknown, class: EvidenceDeterministic, wantState: StateEscalated, wantCausality: CausalUnknown, wantOutcome: OutcomeInconclusive},
 		{name: "in genesis inferential requires refuter", location: "tracked.txt:1", causality: CausalIntroduced, class: EvidenceInferential, wantRefuterRequired: true},
 		{name: "in genesis inferential uses one refuter", location: "tracked.txt:1", causality: CausalIntroduced, class: EvidenceInferential, refuter: []EvidenceResult{{FindingID: "R3-001", Outcome: OutcomeCorroborated, Proof: "independent reproduction"}}, wantState: StateCorrectionRequired, wantCausality: CausalIntroduced, wantOutcome: OutcomeCorroborated, wantFix: true},
+		{name: "in genesis inferential refuter inconclusive routes to correction", location: "tracked.txt:1", causality: CausalIntroduced, class: EvidenceInferential, refuter: []EvidenceResult{{FindingID: "R3-001", Outcome: OutcomeInconclusive, Proof: "could not disprove"}}, wantState: StateCorrectionRequired, wantCausality: CausalIntroduced, wantOutcome: OutcomeInconclusive, wantFix: true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/reviewtransaction/compact_escalation_accounting_test.go
+++ b/internal/reviewtransaction/compact_escalation_accounting_test.go
@@ -83,6 +83,13 @@ func TestCompactEscalationAccountingBudgetExceeded(t *testing.T) {
 	if accounting.Remaining != 0 {
 		t.Fatalf("Remaining = %d, want clamped 0 when spent %d exceeds total %d", accounting.Remaining, accounting.Spent, accounting.Total)
 	}
+	state.CorrectionBudget = state.CumulativeCorrectionLines
+	proposed := 1
+	state.ProposedCorrectionLines, state.ActualCorrectionLines = &proposed, nil
+	evidence := state.EscalationEvidence()
+	if evidence.Cause != "correction_budget_exceeded" || evidence.FindingIDs == nil {
+		t.Fatalf("evidence = %#v, want budget cause and non-nil finding IDs", evidence)
+	}
 }
 
 // TestCompactEscalationAccountingOriginalCriteriaFailed pins that an

--- a/internal/reviewtransaction/compact_reviewer_capture.go
+++ b/internal/reviewtransaction/compact_reviewer_capture.go
@@ -79,13 +79,8 @@ func (state CompactState) EscalationEvidence() *CompactEscalationEvidence {
 			}
 		}
 	}
-	if state.ProposedCorrectionLines != nil && *state.ProposedCorrectionLines > state.CorrectionBudget {
-		return &CompactEscalationEvidence{
-			Cause:      "correction_budget_exceeded",
-			FindingIDs: findingIDs,
-		}
-	}
-	if state.CumulativeCorrectionLines > state.CorrectionBudget {
+	if state.CumulativeCorrectionLines > state.CorrectionBudget ||
+		state.ProposedCorrectionLines != nil && state.CumulativeCorrectionLines+*state.ProposedCorrectionLines > state.CorrectionBudget {
 		return &CompactEscalationEvidence{
 			Cause:      "correction_budget_exceeded",
 			FindingIDs: findingIDs,

--- a/internal/reviewtransaction/compact_reviewer_capture.go
+++ b/internal/reviewtransaction/compact_reviewer_capture.go
@@ -57,6 +57,104 @@ type CompactTargetedValidatorEvidence struct {
 	FollowUps                     []FollowUp                            `json:"follow_ups"`
 }
 
+// CompactEscalationEvidence describes the cause and evidence for an escalated lineage (issue #4226).
+type CompactEscalationEvidence struct {
+	Cause           string           `json:"cause"`
+	FindingIDs      []string         `json:"finding_ids"`
+	RefuterOutcomes []EvidenceResult `json:"refuter_outcomes,omitempty"`
+}
+
+// EscalationEvidence derives canonical escalation cause and evidence when a lineage reaches StateEscalated.
+func (state CompactState) EscalationEvidence() *CompactEscalationEvidence {
+	if state.State != StateEscalated {
+		return nil
+	}
+	findingIDs := append([]string{}, state.FixFindingIDs...)
+	if len(state.CorrectionAttempts) > 0 {
+		attempt := state.CorrectionAttempts[len(state.CorrectionAttempts)-1]
+		if !attempt.OriginalCriteria.Passed || !attempt.CorrectionRegression.Passed {
+			return &CompactEscalationEvidence{
+				Cause:      "targeted_validator_rejected",
+				FindingIDs: findingIDs,
+			}
+		}
+	}
+	if state.ProposedCorrectionLines != nil && *state.ProposedCorrectionLines > state.CorrectionBudget {
+		return &CompactEscalationEvidence{
+			Cause:      "correction_budget_exceeded",
+			FindingIDs: findingIDs,
+		}
+	}
+	if state.CumulativeCorrectionLines > state.CorrectionBudget {
+		return &CompactEscalationEvidence{
+			Cause:      "correction_budget_exceeded",
+			FindingIDs: findingIDs,
+		}
+	}
+	view, err := state.CompactReviewView()
+	if err == nil {
+		unresolvedIDs := []string{}
+		cause := "unresolved_severe_findings"
+		hasUnknownCausality := false
+		hasInsufficientEvidence := false
+		hasMissingRefuter := false
+
+		refuterMap := make(map[string]EvidenceResult, len(view.RefuterOutcomes))
+		for _, r := range view.RefuterOutcomes {
+			refuterMap[r.FindingID] = r
+		}
+		fixSet := make(map[string]struct{}, len(view.FixFindingIDs))
+		for _, id := range view.FixFindingIDs {
+			fixSet[id] = struct{}{}
+		}
+
+		for id, outcome := range view.Outcomes {
+			if outcome == OutcomeInconclusive {
+				if _, fixing := fixSet[id]; !fixing {
+					unresolvedIDs = append(unresolvedIDs, id)
+					if class, found := view.Classifications[id]; found {
+						if class.Causality == CausalUnknown {
+							hasUnknownCausality = true
+						}
+						if class.Class == EvidenceInsufficient {
+							hasInsufficientEvidence = true
+						}
+						if class.Class == EvidenceInferential {
+							if _, inRefuter := refuterMap[id]; !inRefuter {
+								hasMissingRefuter = true
+							}
+						}
+					}
+				}
+			}
+		}
+		sort.Strings(unresolvedIDs)
+		if len(unresolvedIDs) > 0 {
+			if hasUnknownCausality {
+				cause = "unknown_causality"
+			} else if hasInsufficientEvidence {
+				cause = "insufficient_evidence"
+			} else if hasMissingRefuter {
+				cause = "missing_refuter_outcome"
+			}
+			var refuterOutcomes []EvidenceResult
+			if len(view.RefuterOutcomes) > 0 {
+				refuterOutcomes = append([]EvidenceResult(nil), view.RefuterOutcomes...)
+			}
+			return &CompactEscalationEvidence{
+				Cause:           cause,
+				FindingIDs:      unresolvedIDs,
+				RefuterOutcomes: refuterOutcomes,
+			}
+		}
+	}
+
+	return &CompactEscalationEvidence{
+		Cause:      "unresolved_severe_findings",
+		FindingIDs: findingIDs,
+	}
+}
+
 type compactAdmittedTargetedValidatorValue struct {
 	Outcome  string                            `json:"outcome"`
 	Evidence *CompactTargetedValidatorEvidence `json:"evidence,omitempty"`

--- a/internal/reviewtransaction/target_status.go
+++ b/internal/reviewtransaction/target_status.go
@@ -80,25 +80,26 @@ type TargetStatusDecision struct {
 }
 
 type TargetStatusResult struct {
-	Applicability                      TargetApplicability    `json:"applicability"`
-	AuthorityVersion                   AuthorityVersion       `json:"authority_version,omitempty"`
-	LineageID                          string                 `json:"lineage_id,omitempty"`
-	State                              State                  `json:"state,omitempty"`
-	Generation                         int                    `json:"generation,omitempty"`
-	Revision                           string                 `json:"revision,omitempty"`
-	Action                             TargetStatusAction     `json:"action"`
-	ActionDisposition                  RecoveryDisposition    `json:"action_disposition,omitempty"`
-	Replayability                      Replayability          `json:"replayability"`
-	OriginalChangedLines               int                    `json:"original_changed_lines,omitempty"`
-	Tier                               RiskLevel              `json:"tier,omitempty"`
-	CorrectionBudget                   int                    `json:"correction_budget,omitempty"`
-	CorrectionBudgetPolicy             string                 `json:"correction_budget_policy,omitempty"`
-	SelectedLenses                     []string               `json:"selected_lenses,omitempty"`
-	TargetIdentity                     string                 `json:"target_identity"`
-	AuthorityTargetIdentity            string                 `json:"authority_target_identity,omitempty"`
-	Projection                         TargetProjectionStatus `json:"projection"`
-	CandidateLineageIDs                []string               `json:"candidate_lineage_ids"`
-	Decision                           TargetStatusDecision   `json:"-"`
+	Applicability                      TargetApplicability        `json:"applicability"`
+	AuthorityVersion                   AuthorityVersion           `json:"authority_version,omitempty"`
+	LineageID                          string                     `json:"lineage_id,omitempty"`
+	State                              State                      `json:"state,omitempty"`
+	Generation                         int                        `json:"generation,omitempty"`
+	Revision                           string                     `json:"revision,omitempty"`
+	Action                             TargetStatusAction         `json:"action"`
+	ActionDisposition                  RecoveryDisposition        `json:"action_disposition,omitempty"`
+	Replayability                      Replayability              `json:"replayability"`
+	OriginalChangedLines               int                        `json:"original_changed_lines,omitempty"`
+	Tier                               RiskLevel                  `json:"tier,omitempty"`
+	CorrectionBudget                   int                        `json:"correction_budget,omitempty"`
+	CorrectionBudgetPolicy             string                     `json:"correction_budget_policy,omitempty"`
+	SelectedLenses                     []string                   `json:"selected_lenses,omitempty"`
+	TargetIdentity                     string                     `json:"target_identity"`
+	AuthorityTargetIdentity            string                     `json:"authority_target_identity,omitempty"`
+	Projection                         TargetProjectionStatus     `json:"projection"`
+	CandidateLineageIDs                []string                   `json:"candidate_lineage_ids"`
+	Escalation                         *CompactEscalationEvidence `json:"escalation,omitempty"`
+	Decision                           TargetStatusDecision       `json:"-"`
 	authorityTargetKind                TargetKind
 	authorityProjection                Projection
 	selectorFreeAccountingOnlyRecovery bool
@@ -674,7 +675,12 @@ func targetStatusForCandidate(result TargetStatusResult, candidate targetStatusC
 			result.selectorFreeAccountingOnlyRecovery = candidate.selectorFreeAccountingOnlyRecovery
 			return result
 		}
-		if state.State == StateEscalated || state.State == StateCorrectionRequired && state.CorrectionAttemptConsumed() {
+		if state.State == StateEscalated {
+			result.Escalation = state.EscalationEvidence()
+			result.Action, result.Replayability = TargetStatusActionStop, ReplayabilityManualActionRequired
+			return result
+		}
+		if state.State == StateCorrectionRequired && state.CorrectionAttemptConsumed() {
 			result.Action, result.Replayability = TargetStatusActionStop, ReplayabilityManualActionRequired
 			return result
 		}

--- a/internal/reviewtransaction/target_status.go
+++ b/internal/reviewtransaction/target_status.go
@@ -665,6 +665,9 @@ func targetStatusForCandidate(result TargetStatusResult, candidate targetStatusC
 		result.OriginalChangedLines, result.Tier, result.CorrectionBudget, result.CorrectionBudgetPolicy = state.OriginalChangedLines, state.RiskLevel, state.CorrectionBudget, state.CorrectionBudgetPolicy
 		result.SelectedLenses = append([]string{}, state.SelectedLenses...)
 		result.Projection = targetProjectionFromCompact(state, result.Projection)
+		if state.State == StateEscalated {
+			result.Escalation = state.EscalationEvidence()
+		}
 		if candidate.frozenReviewing && !candidate.frozenReviewingPendingSlots && candidate.frozenReviewingDrifted {
 			result.Action, result.Replayability = TargetStatusActionStop, ReplayabilityManualActionRequired
 			return result
@@ -676,7 +679,6 @@ func targetStatusForCandidate(result TargetStatusResult, candidate targetStatusC
 			return result
 		}
 		if state.State == StateEscalated {
-			result.Escalation = state.EscalationEvidence()
 			result.Action, result.Replayability = TargetStatusActionStop, ReplayabilityManualActionRequired
 			return result
 		}


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #4226

---

## 🏷️ PR Type

What kind of change does this PR introduce?

- [x] `type:bug` — Bug fix (non-breaking change that fixes an issue)
- [ ] `type:feature` — New feature (non-breaking change that adds functionality)
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring (no functional changes)
- [ ] `type:chore` — Build, CI, or tooling changes
- [ ] `type:breaking-change` — Breaking change (fix or feature that changes existing behavior)

---

## 📝 Summary

- Inconclusive refuter verdicts on inferential severe findings now route into bounded correction (`StateCorrectionRequired`) alongside corroborated findings instead of forcing an immediate terminal escalation before the budget is offered.
- Lineages that reach `StateEscalated` (e.g. unknown causality, insufficient evidence, budget exceeded, or validator rejection) now publish canonical escalation evidence (`cause`, `finding_ids`, and optional `refuter_outcomes`) in both terminal closure and `STATUS` envelopes.
- Contract schemas (`last-event-closure.schema.json` and `status-v7.schema.json`) now declare the `escalation` object.

---

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/reviewtransaction/compact.go` | Route inconclusive refuter outcomes to `FixFindingIDs`; mark as unresolved only non-fixing inconclusive findings. |
| `internal/reviewtransaction/compact_reviewer_capture.go` | Add `CompactEscalationEvidence` struct and `EscalationEvidence()` method on `CompactState`. |
| `internal/reviewtransaction/target_status.go` | Expose `Escalation` in `TargetStatusResult` when in `StateEscalated`. |
| `internal/cli/review_last_event_closure.go` | Include `Escalation` in `reviewLastEventClosureResult` on terminal escalation. |
| `internal/cli/review_status_contract.go` | Map `Escalation` to `ReviewTargetStatusResult`. |
| `contracts/review-integration/v2/schemas/` | Add `escalation` object definition to `last-event-closure` and `status-v7` schemas. |
| `internal/cli/review_provider_artifact_contract_test.go` | Update pinned schema SHA-256 digests. |
| `internal/cli/review_last_event_closure_test.go` | Add regression tests for inconclusive refuter routing and escalation cause publication. |
| `internal/reviewtransaction/compact_causality_test.go` | Add test case proving inferential inconclusive refutation routes to correction. |

---

## 🤖 AI Assistance

Select exactly one option. Do not check both options.

- [ ] **None** — No material AI assistance was used.
- [x] **Material assistance used** — Complete all applicable declaration fields below.

**Tool/model (if known):** Gemini 3.8 Flash High / OpenCode

**Material scope:** Analysis of issue #4226, reproduction test case drafting, contract schema updating, and implementation of `CompactEscalationEvidence` derivation.

**Verification performed:** 
Ran full unit regression tests in `internal/reviewtransaction` and `internal/cli`, verified schema conformance tests (`TestReviewProviderArtifact...`), ran `go run ./internal/gofmtcheck`, and confirmed the change diff is within 335 total changed lines.

---

## 🧪 Test Plan

**Unit Tests**
```bash
go test ./internal/reviewtransaction -run "TestCompact"
go test ./internal/cli -run "TestRefuter|TestLineageEscalation|TestPublishedLastEventClosure"
```

**Go Format**
```bash
go run ./internal/gofmtcheck
```

- [x] Unit tests pass (`go test ./...`)
- [x] Go format passes (`go run ./internal/gofmtcheck`)
- [x] Manually tested locally

Benchmark validation: N/A — this fix addresses refuter lifecycle state routing and diagnostic escalation cause reporting, not benchmark journey claims or benchmark runtime execution.

---

## ✅ Contributor Checklist

- [x] PR is linked to an issue with `status:approved`
- [x] PR stays within 400 changed lines, or I have requested/obtained maintainer-applied `size:exception` with rationale documented
- [x] I have added the appropriate `type:*` label to this PR
- [x] Unit tests pass (`go test ./...`)
- [x] Go format passes (`go run ./internal/gofmtcheck`)
- [x] Benchmark validation completed, or this change is not applicable to the benchmark (explain why in the Test Plan).
- [x] I have updated documentation if necessary
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] I understand, reviewed, and take responsibility for the complete submission
- [x] I selected exactly one AI-assistance option and, if material assistance was used, completed all applicable declaration fields
- [x] My commits do not include `Co-Authored-By` trailers


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Review status and closure results now include escalation details, including causes, affected finding IDs, and available refuter outcomes.
  * Escalated reviews provide consistent evidence across status and closure responses.

* **Bug Fixes**
  * Inconclusive refuter outcomes for certain findings now request bounded correction instead of triggering escalation.
  * Escalation handling preserves relevant findings and supporting evidence across review outcomes.
  * Published schemas now enforce valid escalation data and state combinations.

* **Tests**
  * Added coverage for correction routing, escalation reporting, and schema validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->