### PR TITLE
fix(engram): configure Codex shared files without CLI

### DIFF
--- a/internal/agents/codex/runtime_version.go
+++ b/internal/agents/codex/runtime_version.go
@@ -1,6 +1,7 @@
 package codex
 
 import (
+	"errors"
 	"fmt"
 	"os/exec"
 	"regexp"
@@ -29,6 +30,25 @@ var (
 	}
 )
 
+// gpt56RuntimeUnavailableError marks a missing Codex executable. It preserves
+// the normal requirement message while allowing shared-file configuration to
+// proceed without creating CLI-only GPT-5.6 profiles.
+type gpt56RuntimeUnavailableError struct {
+	requirement error
+	cause       error
+}
+
+func (e *gpt56RuntimeUnavailableError) Error() string { return e.requirement.Error() }
+func (e *gpt56RuntimeUnavailableError) Unwrap() error { return e.cause }
+
+// IsGPT56RuntimeUnavailable reports whether validation failed because the Codex
+// executable was not found. Other execution and version-validation errors remain
+// runtime requirement failures.
+func IsGPT56RuntimeUnavailable(err error) bool {
+	var unavailable *gpt56RuntimeUnavailableError
+	return errors.As(err, &unavailable)
+}
+
 type semanticVersion struct {
 	core       [3]string
 	prerelease []string
@@ -43,7 +63,11 @@ func ValidateGPT56Runtime() error {
 		if detail := strings.TrimSpace(string(output)); detail != "" {
 			reason += ": " + detail
 		}
-		return runtimeRequirementError(reason)
+		requirementErr := runtimeRequirementError(reason)
+		if errors.Is(err, exec.ErrNotFound) {
+			return &gpt56RuntimeUnavailableError{requirement: requirementErr, cause: err}
+		}
+		return requirementErr
 	}
 	installed, err := parseCodexVersion(string(output))
 	if err != nil {

--- a/internal/agents/codex/runtime_version_test.go
+++ b/internal/agents/codex/runtime_version_test.go
@@ -1,6 +1,7 @@
 package codex
 
 import (
+	"os"
 	"os/exec"
 	"strings"
 	"testing"
@@ -34,12 +35,14 @@ func TestCompareSemanticVersionPrerelease(t *testing.T) {
 
 func TestValidateGPT56Runtime(t *testing.T) {
 	tests := []struct {
-		name    string
-		output  string
-		cmdErr  error
-		wantErr bool
+		name        string
+		output      string
+		cmdErr      error
+		wantErr     bool
+		unavailable bool
 	}{
-		{name: "missing command", cmdErr: exec.ErrNotFound, wantErr: true},
+		{name: "missing command", cmdErr: exec.ErrNotFound, wantErr: true, unavailable: true},
+		{name: "permission denied executable", cmdErr: &exec.Error{Name: "codex", Err: os.ErrPermission}, wantErr: true},
 		{name: "malformed version", output: "codex-cli development", wantErr: true},
 		{name: "false match on trailing line", output: "codex-cli development\nhelper 9.9.9", wantErr: true},
 		{name: "trailing token", output: "codex-cli 0.145.0 helper", wantErr: true},
@@ -82,6 +85,9 @@ func TestValidateGPT56Runtime(t *testing.T) {
 			err := ValidateGPT56Runtime()
 			if (err != nil) != tt.wantErr {
 				t.Fatalf("ValidateGPT56Runtime() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if IsGPT56RuntimeUnavailable(err) != tt.unavailable {
+				t.Fatalf("IsGPT56RuntimeUnavailable(%v) = %t, want %t", err, IsGPT56RuntimeUnavailable(err), tt.unavailable)
 			}
 			if tt.wantErr {
 				for _, want := range []string{"Codex >=0.144.0", "npm install -g --ignore-scripts @openai/codex@latest"} {

--- a/internal/assets/codex/sdd-orchestrator.md
+++ b/internal/assets/codex/sdd-orchestrator.md
@@ -415,7 +415,7 @@ Each phase returns: `status`, `executive_summary`, `artifacts`, `next_recommende
 
 ## Model Profiles
 
-gentle-ai writes three SDD model-selection profile files into `~/.codex/` during installation. Each profile pins both a `model` and a `model_reasoning_effort` so Codex picks the right tier for each carril.
+When the Codex CLI is installed and supports GPT-5.6 profiles, gentle-ai writes three SDD model-selection profile files into `~/.codex/` during installation. Without the CLI, gentle-ai still configures shared files but leaves existing profile files unchanged. Each profile pins both a `model` and a `model_reasoning_effort` so Codex picks the right tier for each carril.
 
 These profile files apply to whole CLI sessions: `codex --profile <name> "<prompt>"`. They do NOT apply to spawned sub-agents. When delegating a phase via `spawn_agent`, pass the tier's effort directly as `reasoning_effort` (with `fork_turns: "none"`), using the same tier values below.
 

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -2308,9 +2308,13 @@ func componentPathsWithWorkspaceScoped(homeDir, workspaceDir string, scope Insta
 			case model.StrategyTOMLFile:
 				if p := adapter.MCPConfigPath(targetDir, "engram"); p != "" {
 					paths = append(paths, p)
-					// Track the gentle-ai SDD profile files written alongside
-					// the Codex config.toml so they are removed on uninstall.
+					// Track the gentle-ai files written alongside the Codex config.toml
+					// so they are restored on rollback and removed on uninstall.
 					codexHomeDir := filepath.Dir(p)
+					paths = append(paths,
+						filepath.Join(codexHomeDir, "engram-instructions.md"),
+						filepath.Join(codexHomeDir, "engram-compact-prompt.md"),
+					)
 					paths = append(paths, codexagent.SddProfilePaths(codexHomeDir)...)
 				}
 			}

--- a/internal/cli/run_integration_test.go
+++ b/internal/cli/run_integration_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/gentleman-programming/gentle-ai/v2/internal/agents/codex"
 	"github.com/gentleman-programming/gentle-ai/v2/internal/agents/kimi"
 	"github.com/gentleman-programming/gentle-ai/v2/internal/backup"
 	"github.com/gentleman-programming/gentle-ai/v2/internal/installcmd"
@@ -132,6 +133,45 @@ func TestRunInstallReturnsStatePersistenceFailure(t *testing.T) {
 	}
 	if string(finalState) != string(originalState) {
 		t.Fatalf("state after failed install changed:\n got %s\nwant %s", finalState, originalState)
+	}
+}
+
+func TestRunInstallCodexKeepsOldRuntimeFailure(t *testing.T) {
+	home := t.TempDir()
+	restoreHome := osUserHomeDir
+	restoreCommand := runCommand
+	restoreLookPath := cmdLookPath
+	t.Cleanup(func() {
+		osUserHomeDir = restoreHome
+		runCommand = restoreCommand
+		cmdLookPath = restoreLookPath
+	})
+	osUserHomeDir = func() (string, error) { return home, nil }
+	cmdLookPath = func(string) (string, error) { return "/usr/local/bin/engram", nil }
+	runCommand = func(string, ...string) error { return nil }
+	restoreRuntime := codex.SetRuntimeVersionCommandForTest("codex-cli 0.143.9", nil)
+	t.Cleanup(restoreRuntime)
+
+	profiles := []string{"sdd-strong.config.toml", "sdd-mid.config.toml", "sdd-cheap.config.toml"}
+	for _, name := range profiles {
+		path := filepath.Join(home, ".codex", name)
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(path, []byte("user-content\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	_, err := RunInstall([]string{"--agent", "codex", "--component", "engram"}, macOSDetectionResult())
+	if err == nil || !strings.Contains(err.Error(), "Codex >=0.144.0") {
+		t.Fatalf("RunInstall() error = %v, want old Codex runtime failure", err)
+	}
+	for _, name := range profiles {
+		content, readErr := os.ReadFile(filepath.Join(home, ".codex", name))
+		if readErr != nil || string(content) != "user-content\n" {
+			t.Fatalf("old runtime modified %s: got=%q error=%v", name, content, readErr)
+		}
 	}
 }
 

--- a/internal/cli/sync_test.go
+++ b/internal/cli/sync_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"reflect"
 	"runtime"
@@ -664,18 +665,21 @@ func TestComponentSyncStepPreservesSlimEngramProtocol(t *testing.T) {
 
 func TestComponentSyncStepCodexRuntimeGate(t *testing.T) {
 	tests := []struct {
-		name    string
-		version string
-		wantErr bool
+		name             string
+		version          string
+		commandErr       error
+		wantErr          bool
+		preserveProfiles bool
 	}{
-		{name: "old runtime leaves profiles untouched", version: "codex-cli 0.143.9", wantErr: true},
+		{name: "missing CLI writes shared config and leaves profiles untouched", commandErr: exec.ErrNotFound, preserveProfiles: true},
+		{name: "old runtime leaves profiles untouched", version: "codex-cli 0.143.9", wantErr: true, preserveProfiles: true},
 		{name: "exact runtime writes profiles", version: "codex-cli 0.144.0"},
 		{name: "new runtime writes profiles", version: "codex-cli 0.145.1"},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			restore := codex.SetRuntimeVersionCommandForTest(tt.version, nil)
+			restore := codex.SetRuntimeVersionCommandForTest(tt.version, tt.commandErr)
 			t.Cleanup(restore)
 			home := t.TempDir()
 			codexDir := filepath.Join(home, ".codex")
@@ -699,11 +703,17 @@ func TestComponentSyncStepCodexRuntimeGate(t *testing.T) {
 				if readErr != nil {
 					t.Fatal(readErr)
 				}
-				if tt.wantErr && string(content) != "user-content\n" {
-					t.Errorf("old runtime modified %s: %q", name, content)
+				if tt.preserveProfiles && string(content) != "user-content\n" {
+					t.Errorf("runtime should preserve %s: %q", name, content)
 				}
-				if !tt.wantErr && !strings.Contains(string(content), "gpt-5.6-") {
+				if !tt.wantErr && !tt.preserveProfiles && !strings.Contains(string(content), "gpt-5.6-") {
 					t.Errorf("valid runtime did not write GPT-5.6 profile %s: %q", name, content)
+				}
+			}
+			if !tt.wantErr {
+				config, readErr := os.ReadFile(filepath.Join(codexDir, "config.toml"))
+				if readErr != nil || !strings.Contains(string(config), "[mcp_servers.engram]") {
+					t.Fatalf("shared Codex config was not written: got=%q error=%v", config, readErr)
 				}
 			}
 		})

--- a/internal/cli/sync_test.go
+++ b/internal/cli/sync_test.go
@@ -1685,6 +1685,21 @@ func TestSyncBackupTargetsIncludeClaudeEngramLegacyMigrationSource(t *testing.T)
 	}
 }
 
+func TestSyncBackupTargetsIncludeCodexEngramInstructionFiles(t *testing.T) {
+	home := t.TempDir()
+	selection := model.Selection{Agents: []model.AgentID{model.AgentCodex}, Components: []model.ComponentID{model.ComponentEngram}}
+	targets, err := syncBackupTargets(home, "", selection, resolveAdapters(selection.Agents))
+	if err != nil {
+		t.Fatalf("syncBackupTargets() error = %v", err)
+	}
+	for _, name := range []string{"engram-instructions.md", "engram-compact-prompt.md"} {
+		want := filepath.Join(home, ".codex", name)
+		if !containsPath(targets, want) {
+			t.Fatalf("sync backup targets missing Codex Engram instruction %q: %v", want, targets)
+		}
+	}
+}
+
 func TestSyncBackupTargetsIncludeClaudeContext7CleanupPath(t *testing.T) {
 	home := t.TempDir()
 	selection := model.Selection{
@@ -1779,6 +1794,85 @@ func TestRunSyncRollbackRestoresClaudeEngramMigrationSource(t *testing.T) {
 	}
 	if len(backups) != 1 {
 		t.Fatalf("persistent backup count = %d, want 1 after duplicate transaction", len(backups))
+	}
+}
+
+func TestRunSyncRollbackRestoresCodexEngramInstructionFiles(t *testing.T) {
+	t.Cleanup(codex.SetRuntimeVersionCommandForTest("", exec.ErrNotFound))
+
+	for _, tc := range []struct {
+		name   string
+		exists bool
+	}{
+		{name: "restores existing instruction contents", exists: true},
+		{name: "removes newly created instruction files", exists: false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			home := t.TempDir()
+			codexDir := filepath.Join(home, ".codex")
+			if err := os.MkdirAll(codexDir, 0o755); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.WriteFile(filepath.Join(codexDir, "config.toml"), []byte("custom = true\n"), 0o644); err != nil {
+				t.Fatal(err)
+			}
+
+			setSyncTestHome(t, home)
+
+			instructionFiles := map[string][]byte{
+				"engram-instructions.md":   []byte("original instructions\n"),
+				"engram-compact-prompt.md": []byte("original compact prompt\n"),
+			}
+			if tc.exists {
+				for name, before := range instructionFiles {
+					if err := os.WriteFile(filepath.Join(codexDir, name), before, 0o644); err != nil {
+						t.Fatal(err)
+					}
+				}
+			}
+
+			selection := model.Selection{
+				Agents:     []model.AgentID{model.AgentCodex},
+				Components: []model.ComponentID{model.ComponentEngram},
+			}
+			rt, err := newSyncRuntime(home, selection)
+			if err != nil {
+				t.Fatal(err)
+			}
+			plan := rt.stagePlan()
+			backupStep, ok := plan.Prepare[0].(prepareBackupStep)
+			if !ok {
+				t.Fatalf("prepare step = %T, want prepareBackupStep", plan.Prepare[0])
+			}
+			backupTargets := backupStep.targets[:0]
+			for _, target := range backupStep.targets {
+				rel, err := filepath.Rel(home, target)
+				if err == nil && rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+					backupTargets = append(backupTargets, target)
+				}
+			}
+			backupStep.targets = backupTargets
+			plan.Prepare[0] = backupStep
+			plan.Apply = append(plan.Apply[:2], failingSyncStep{})
+			result := pipeline.NewOrchestrator(pipeline.DefaultRollbackPolicy()).Execute(plan)
+			if result.Err == nil || !result.Rollback.Success {
+				t.Fatalf("sync rollback success=%t error=%v rollback error=%v", result.Rollback.Success, result.Err, result.Rollback.Err)
+			}
+
+			for name, before := range instructionFiles {
+				path := filepath.Join(codexDir, name)
+				if tc.exists {
+					got, err := os.ReadFile(path)
+					if err != nil || !bytes.Equal(got, before) {
+						t.Fatalf("rollback did not restore %q: got=%q error=%v", path, got, err)
+					}
+					continue
+				}
+				if _, err := os.Stat(path); !os.IsNotExist(err) {
+					t.Fatalf("rollback did not remove newly created %q: stat error=%v", path, err)
+				}
+			}
+		})
 	}
 }
 

--- a/internal/components/engram/inject.go
+++ b/internal/components/engram/inject.go
@@ -423,8 +423,9 @@ func injectWithOptions(configHomeDir, promptDir string, adapter agents.Adapter, 
 		if configPath == "" {
 			break
 		}
-		if err := codex.ValidateGPT56Runtime(); err != nil {
-			return InjectionResult{}, err
+		runtimeErr := codex.ValidateGPT56Runtime()
+		if runtimeErr != nil && !codex.IsGPT56RuntimeUnavailable(runtimeErr) {
+			return InjectionResult{}, runtimeErr
 		}
 
 		// Determine instruction file paths before mutating the config.
@@ -488,18 +489,19 @@ func injectWithOptions(configHomeDir, promptDir string, adapter agents.Adapter, 
 		changed = changed || tomlWrite.Changed
 		files = append(files, configPath)
 
-		// Write gentle-ai SDD model-selection profile files into ~/.codex/.
-		// These use the separate-file mechanism from Codex >= 0.134.0 and are
-		// selected at runtime via `codex --profile <name>`.
-		// codexHomeDir is the ~/.codex directory (the parent of config.toml).
-		codexHomeDir := filepath.Dir(configPath)
-		profileAssignments := resolveProfileAssignments(opts.CodexCarrilModelAssignments, opts.CodexModelAssignments)
-		profilesChanged, profileFiles, profileErr := codex.WriteCodexProfiles(codexHomeDir, profileAssignments)
-		if profileErr != nil {
-			return InjectionResult{}, profileErr
+		// Write gentle-ai SDD model-selection profile files only when Codex is
+		// installed and supports GPT-5.6. Without the executable, shared config
+		// still works, but existing CLI-only profiles must remain untouched.
+		if runtimeErr == nil {
+			codexHomeDir := filepath.Dir(configPath)
+			profileAssignments := resolveProfileAssignments(opts.CodexCarrilModelAssignments, opts.CodexModelAssignments)
+			profilesChanged, profileFiles, profileErr := codex.WriteCodexProfiles(codexHomeDir, profileAssignments)
+			if profileErr != nil {
+				return InjectionResult{}, profileErr
+			}
+			changed = changed || profilesChanged
+			files = append(files, profileFiles...)
 		}
-		changed = changed || profilesChanged
-		files = append(files, profileFiles...)
 	}
 
 	// 2. Inject Engram memory protocol into system prompt (if supported).

--- a/internal/components/engram/inject.go
+++ b/internal/components/engram/inject.go
@@ -429,10 +429,12 @@ func injectWithOptions(configHomeDir, promptDir string, adapter agents.Adapter, 
 		}
 
 		// Determine instruction file paths before mutating the config.
-		instructionsPath, compactPath, instrErr := writeCodexInstructionFiles(configHomeDir)
+		instructionsPath, compactPath, instructionsChanged, instructionFiles, instrErr := writeCodexInstructionFiles(configHomeDir)
 		if instrErr != nil {
 			return InjectionResult{}, instrErr
 		}
+		changed = changed || instructionsChanged
+		files = append(files, instructionFiles...)
 
 		// Read existing config and apply all mutations in a single pass.
 		//
@@ -666,8 +668,8 @@ func ensureAntigravitySettings(homeDir string, adapter agents.Adapter) (settings
 }
 
 // writeCodexInstructionFiles writes the Engram memory protocol and compact prompt
-// files to ~/.codex/ and returns their paths.
-func writeCodexInstructionFiles(homeDir string) (instructionsPath, compactPath string, err error) {
+// files to ~/.codex/ and returns their paths and write results.
+func writeCodexInstructionFiles(homeDir string) (instructionsPath, compactPath string, changed bool, files []string, err error) {
 	codexDir := filepath.Join(homeDir, ".codex")
 	instructionsPath = filepath.Join(codexDir, "engram-instructions.md")
 	compactPath = filepath.Join(codexDir, "engram-compact-prompt.md")
@@ -675,18 +677,20 @@ func writeCodexInstructionFiles(homeDir string) (instructionsPath, compactPath s
 	instrContent := codexInstructions()
 	instrWrite, err := filemerge.WriteFileAtomic(instructionsPath, []byte(instrContent), 0o644)
 	if err != nil {
-		return "", "", fmt.Errorf("write codex engram-instructions.md: %w", err)
+		return "", "", false, nil, fmt.Errorf("write codex engram-instructions.md: %w", err)
 	}
-	_ = instrWrite
+	changed = instrWrite.Changed
+	files = append(files, instructionsPath)
 
 	compactContent := codexCompact()
 	compactWrite, err := filemerge.WriteFileAtomic(compactPath, []byte(compactContent), 0o644)
 	if err != nil {
-		return "", "", fmt.Errorf("write codex engram-compact-prompt.md: %w", err)
+		return "", "", false, nil, fmt.Errorf("write codex engram-compact-prompt.md: %w", err)
 	}
-	_ = compactWrite
+	changed = changed || compactWrite.Changed
+	files = append(files, compactPath)
 
-	return instructionsPath, compactPath, nil
+	return instructionsPath, compactPath, changed, files, nil
 }
 
 func mergeJSONFile(path string, overlay []byte) (filemerge.WriteResult, error) {

--- a/internal/components/engram/inject_test.go
+++ b/internal/components/engram/inject_test.go
@@ -1291,6 +1291,51 @@ func TestInjectCodexWithoutCLIUpdatesSharedConfigAndPreservesProfiles(t *testing
 	}
 }
 
+func TestInjectCodexReportsInstructionOnlyRepairsWithoutCLI(t *testing.T) {
+	restore := codex.SetRuntimeVersionCommandForTest("", exec.ErrNotFound)
+	t.Cleanup(restore)
+
+	for _, name := range []string{"engram-instructions.md", "engram-compact-prompt.md"} {
+		t.Run(name, func(t *testing.T) {
+			home := t.TempDir()
+			if _, err := Inject(home, codexAdapter()); err != nil {
+				t.Fatalf("initial Inject(codex) error = %v", err)
+			}
+
+			path := filepath.Join(home, ".codex", name)
+			if err := os.WriteFile(path, []byte("stale instruction\n"), 0o644); err != nil {
+				t.Fatal(err)
+			}
+
+			result, err := Inject(home, codexAdapter())
+			if err != nil {
+				t.Fatalf("instruction-only repair error = %v", err)
+			}
+			if !result.Changed {
+				t.Fatal("instruction-only repair changed = false")
+			}
+			found := false
+			for _, file := range result.Files {
+				if file == path {
+					found = true
+					break
+				}
+			}
+			if !found {
+				t.Fatalf("instruction-only repair files = %v, want %q", result.Files, path)
+			}
+
+			second, err := Inject(home, codexAdapter())
+			if err != nil {
+				t.Fatalf("idempotent Inject(codex) error = %v", err)
+			}
+			if second.Changed {
+				t.Fatal("idempotent instruction-only repair changed = true")
+			}
+		})
+	}
+}
+
 func TestInjectCodexWithoutCLIWritesSharedConfigWithoutCreatingProfiles(t *testing.T) {
 	restore := codex.SetRuntimeVersionCommandForTest("", exec.ErrNotFound)
 	t.Cleanup(restore)

--- a/internal/components/engram/inject_test.go
+++ b/internal/components/engram/inject_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -1229,6 +1230,164 @@ func TestInjectCodexWritesProfiles(t *testing.T) {
 		if !strings.Contains(string(content), want) {
 			t.Fatalf("profile %q: want model_reasoning_effort = %s; got:\n%s", p.name, want, string(content))
 		}
+	}
+}
+
+func TestInjectCodexWithoutCLIUpdatesSharedConfigAndPreservesProfiles(t *testing.T) {
+	restore := codex.SetRuntimeVersionCommandForTest("", exec.ErrNotFound)
+	t.Cleanup(restore)
+
+	home := t.TempDir()
+	configPath := filepath.Join(home, ".codex", "config.toml")
+	if err := os.MkdirAll(filepath.Dir(configPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	const configBefore = "custom = \"preserve\"\n[unrelated]\nkeep = true\n"
+	if err := os.WriteFile(configPath, []byte(configBefore), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	profiles := map[string][]byte{
+		"sdd-strong.config.toml": []byte("user strong profile\n"),
+		"sdd-mid.config.toml":    []byte("user mid profile\n"),
+		"sdd-cheap.config.toml":  []byte("user cheap profile\n"),
+	}
+	for name, before := range profiles {
+		if err := os.WriteFile(filepath.Join(home, ".codex", name), before, 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	first, err := Inject(home, codexAdapter())
+	if err != nil {
+		t.Fatalf("Inject(codex) with absent CLI error = %v", err)
+	}
+	if !first.Changed {
+		t.Fatal("Inject(codex) with absent CLI changed = false")
+	}
+	configAfterFirst, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(configAfterFirst), "custom = \"preserve\"") || !strings.Contains(string(configAfterFirst), "[mcp_servers.engram]") {
+		t.Fatalf("shared config was not preserved and updated:\n%s", configAfterFirst)
+	}
+	for name, before := range profiles {
+		got, readErr := os.ReadFile(filepath.Join(home, ".codex", name))
+		if readErr != nil || !bytes.Equal(got, before) {
+			t.Fatalf("profile %q changed with absent CLI: got=%q error=%v", name, got, readErr)
+		}
+	}
+
+	second, err := Inject(home, codexAdapter())
+	if err != nil {
+		t.Fatalf("second Inject(codex) with absent CLI error = %v", err)
+	}
+	if second.Changed {
+		t.Fatal("second Inject(codex) with absent CLI changed = true")
+	}
+	configAfterSecond, err := os.ReadFile(configPath)
+	if err != nil || !bytes.Equal(configAfterSecond, configAfterFirst) {
+		t.Fatalf("shared config was not idempotent: got=%q error=%v", configAfterSecond, err)
+	}
+}
+
+func TestInjectCodexWithoutCLIWritesSharedConfigWithoutCreatingProfiles(t *testing.T) {
+	restore := codex.SetRuntimeVersionCommandForTest("", exec.ErrNotFound)
+	t.Cleanup(restore)
+
+	home := t.TempDir()
+	configPath := filepath.Join(home, ".codex", "config.toml")
+	profiles := []string{
+		filepath.Join(home, ".codex", "sdd-strong.config.toml"),
+		filepath.Join(home, ".codex", "sdd-mid.config.toml"),
+		filepath.Join(home, ".codex", "sdd-cheap.config.toml"),
+	}
+	assertProfilesAbsent := func(stage string) {
+		t.Helper()
+		for _, path := range profiles {
+			if _, err := os.Stat(path); !os.IsNotExist(err) {
+				t.Fatalf("profile %q %s: stat error = %v; want absent", path, stage, err)
+			}
+		}
+	}
+	assertProfilesAbsent("before injection")
+
+	first, err := Inject(home, codexAdapter())
+	if err != nil {
+		t.Fatalf("Inject(codex) with absent CLI error = %v", err)
+	}
+	if !first.Changed {
+		t.Fatal("Inject(codex) with absent CLI changed = false")
+	}
+	config, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("ReadFile(config.toml) error = %v", err)
+	}
+	if !strings.Contains(string(config), "[mcp_servers.engram]") ||
+		!strings.Contains(string(config), "model_instructions_file") ||
+		!strings.Contains(string(config), "experimental_compact_prompt_file") {
+		t.Fatalf("shared MCP/instruction config was not written:\n%s", config)
+	}
+	for _, path := range []string{
+		filepath.Join(home, ".codex", "engram-instructions.md"),
+		filepath.Join(home, ".codex", "engram-compact-prompt.md"),
+	} {
+		if _, err := os.Stat(path); err != nil {
+			t.Fatalf("shared instruction file %q was not written: %v", path, err)
+		}
+	}
+	assertProfilesAbsent("after first injection")
+
+	second, err := Inject(home, codexAdapter())
+	if err != nil {
+		t.Fatalf("second Inject(codex) with absent CLI error = %v", err)
+	}
+	if second.Changed {
+		t.Fatal("second Inject(codex) with absent CLI changed = true")
+	}
+	assertProfilesAbsent("after repeated injection")
+}
+
+func TestInjectCodexInvalidRuntimeDoesNotMutateFiles(t *testing.T) {
+	tests := []struct {
+		name   string
+		output string
+		err    error
+	}{
+		{name: "broken executable", err: &exec.Error{Name: "codex", Err: os.ErrPermission}},
+		{name: "malformed version", output: "codex-cli development"},
+		{name: "old version", output: "codex-cli 0.143.9"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			restore := codex.SetRuntimeVersionCommandForTest(tt.output, tt.err)
+			t.Cleanup(restore)
+
+			home := t.TempDir()
+			configPath := filepath.Join(home, ".codex", "config.toml")
+			profilePath := filepath.Join(home, ".codex", "sdd-strong.config.toml")
+			const configBefore = "user_setting = \"keep\"\n"
+			const profileBefore = "user profile bytes\n"
+			if err := os.MkdirAll(filepath.Dir(configPath), 0o755); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.WriteFile(configPath, []byte(configBefore), 0o644); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.WriteFile(profilePath, []byte(profileBefore), 0o644); err != nil {
+				t.Fatal(err)
+			}
+
+			if _, err := Inject(home, codexAdapter()); err == nil {
+				t.Fatal("Inject(codex) error = nil")
+			}
+			if got, err := os.ReadFile(configPath); err != nil || string(got) != configBefore {
+				t.Fatalf("config changed after validation failure: got=%q error=%v", got, err)
+			}
+			if got, err := os.ReadFile(profilePath); err != nil || string(got) != profileBefore {
+				t.Fatalf("profile changed after validation failure: got=%q error=%v", got, err)
+			}
+		})
 	}
 }
 

--- a/testdata/golden/sdd-codex-agentsmd-lowcost.golden
+++ b/testdata/golden/sdd-codex-agentsmd-lowcost.golden
@@ -549,7 +549,7 @@ Each phase returns: `status`, `executive_summary`, `artifacts`, `next_recommende
 
 ## Model Profiles
 
-gentle-ai writes three SDD model-selection profile files into `~/.codex/` during installation. Each profile pins both a `model` and a `model_reasoning_effort` so Codex picks the right tier for each carril.
+When the Codex CLI is installed and supports GPT-5.6 profiles, gentle-ai writes three SDD model-selection profile files into `~/.codex/` during installation. Without the CLI, gentle-ai still configures shared files but leaves existing profile files unchanged. Each profile pins both a `model` and a `model_reasoning_effort` so Codex picks the right tier for each carril.
 
 These profile files apply to whole CLI sessions: `codex --profile <name> "<prompt>"`. They do NOT apply to spawned sub-agents. When delegating a phase via `spawn_agent`, pass the tier's effort directly as `reasoning_effort` (with `fork_turns: "none"`), using the same tier values below.
 

--- a/testdata/golden/sdd-codex-agentsmd-powerful.golden
+++ b/testdata/golden/sdd-codex-agentsmd-powerful.golden
@@ -549,7 +549,7 @@ Each phase returns: `status`, `executive_summary`, `artifacts`, `next_recommende
 
 ## Model Profiles
 
-gentle-ai writes three SDD model-selection profile files into `~/.codex/` during installation. Each profile pins both a `model` and a `model_reasoning_effort` so Codex picks the right tier for each carril.
+When the Codex CLI is installed and supports GPT-5.6 profiles, gentle-ai writes three SDD model-selection profile files into `~/.codex/` during installation. Without the CLI, gentle-ai still configures shared files but leaves existing profile files unchanged. Each profile pins both a `model` and a `model_reasoning_effort` so Codex picks the right tier for each carril.
 
 These profile files apply to whole CLI sessions: `codex --profile <name> "<prompt>"`. They do NOT apply to spawned sub-agents. When delegating a phase via `spawn_agent`, pass the tier's effort directly as `reasoning_effort` (with `fork_turns: "none"`), using the same tier values below.
 

--- a/testdata/golden/sdd-codex-agentsmd.golden
+++ b/testdata/golden/sdd-codex-agentsmd.golden
@@ -549,7 +549,7 @@ Each phase returns: `status`, `executive_summary`, `artifacts`, `next_recommende
 
 ## Model Profiles
 
-gentle-ai writes three SDD model-selection profile files into `~/.codex/` during installation. Each profile pins both a `model` and a `model_reasoning_effort` so Codex picks the right tier for each carril.
+When the Codex CLI is installed and supports GPT-5.6 profiles, gentle-ai writes three SDD model-selection profile files into `~/.codex/` during installation. Without the CLI, gentle-ai still configures shared files but leaves existing profile files unchanged. Each profile pins both a `model` and a `model_reasoning_effort` so Codex picks the right tier for each carril.
 
 These profile files apply to whole CLI sessions: `codex --profile <name> "<prompt>"`. They do NOT apply to spawned sub-agents. When delegating a phase via `spawn_agent`, pass the tier's effort directly as `reasoning_effort` (with `fork_turns: "none"`), using the same tier values below.
 


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #4394

## 🏷️ PR Type

- [x] `type:bug` — Bug fix
- [ ] `type:feature` — New feature
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring
- [ ] `type:chore` — Build, CI, or tooling changes
- [ ] `type:breaking-change` — Breaking change

## 📝 Summary

- Configure shared Codex Engram/MCP files when the CLI is genuinely absent, preserving the existing single Codex installer option and detection.
- Leave CLI-only GPT-5.6 profiles absent or byte-preserved without the CLI; retain pre-write rejection for old, malformed, and broken runtimes.
- Cover missing/existing profiles, repeated injection, sync and installer regressions; document conditional profile generation.

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/agents/codex/runtime_version.go` and tests | Typed executable-not-found classification; other probe failures remain blocking. |
| `internal/components/engram/inject.go` and tests | Separate shared configuration from CLI-only profile writes; preservation and idempotence coverage. |
| `internal/cli/sync_test.go`, `run_integration_test.go` | Shared caller regressions for absent and old CLI. |
| `internal/assets/codex/sdd-orchestrator.md` | Explain conditional CLI profile installation. |

## 🤖 AI Assistance

- [ ] **None** — No material AI assistance was used.
- [x] **Material assistance used** — Complete all applicable declaration fields below.

**Tool/model (if known):** el Gentleman on Pi; delegated GPT-5.6 Terra writer/verifier and native four-lens review.

**Material scope:** Investigation, implementation, tests, documentation and substantive review.

**Verification performed:** Automated focused regressions, independent read-only inspection, Go formatting and native review. No claim of human-executed Windows Desktop testing.

## 🧪 Test Plan

Passed locally (Linux/WSL2):

```sh
go test -count=1 ./internal/agents/codex ./internal/components/engram
go test -count=1 ./internal/cli -run 'Test.*Codex|TestRunInstallEngram'
go run ./internal/gofmtcheck
git diff --check
```

- [x] Missing-CLI regression failed before the implementation, then passed.
- [x] Initially absent profiles remain absent after first and repeated injection.
- [x] Existing profile bytes and unrelated shared configuration are preserved.
- [x] Old/malformed/broken CLI errors remain blocking before writes.
- [ ] Full unit suite: awaiting CI (`go test ./...`).
- [x] Go format passes (`go run ./internal/gofmtcheck`).
- [ ] Docker E2E: awaiting CI.
- [ ] Manual Codex Desktop run on Windows 11: not performed.

Benchmark validation: N/A; no review-lifecycle, gate, recovery, delivery, benchmark implementation, or measured benchmark claims changed.

## 🤖 Automated Checks

Awaiting GitHub CI and CodeRabbit. Merge is conditional on green checks and review of actionable feedback; no protection bypass requested.

## ✅ Contributor Checklist

- [x] Linked approved issue.
- [x] Within 400 changed lines: 297 total across seven files.
- [x] Exactly one `type:*` label: `type:bug`.
- [ ] Full unit suite passes: awaiting CI.
- [x] Go format passes.
- [ ] Docker E2E passes: awaiting CI.
- [x] Benchmark applicability documented above.
- [x] Conditional profile guidance updated.
- [x] Conventional commit format.
- [x] AI assistance disclosed with scope and verification.
- [x] No `Co-Authored-By` trailers.

## 💬 Notes for Reviewers

Only `exec.ErrNotFound` permits shared-file setup without profiles. A present but broken executable is not treated as absent. This change does not claim full Desktop runtime or CLI-profile compatibility. No production `internal/cli`, reviewtransaction, or sddstatus guard changed.

Native four-lens review of the final formatted candidate completed approved and was acknowledged. It is supplementary review, not a substitute for CI or contributor responsibility.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Shared Codex configuration and instruction files can now be installed even when the Codex CLI is unavailable.
  * Existing Codex profile files remain unchanged when the CLI is unavailable.
  * Codex instruction files are now included in backup, rollback, and uninstall handling.

* **Bug Fixes**
  * Installation now correctly stops for invalid or outdated Codex runtimes.
  * Repeated configuration injection remains safe and avoids creating unintended profile files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->