### PR TITLE
fix(review): explain consent with concise risk-based copy

### DIFF
--- a/contracts/review-integration/v1/fixtures/consent.fixture.json
+++ b/contracts/review-integration/v1/fixtures/consent.fixture.json
@@ -10,7 +10,7 @@
   "changed_files": 1,
   "changed_lines": 1,
   "headline": "Gentle AI can review this change before you call it done.",
-  "reason": "These changes may affect execution; review can help detect problems.",
+  "reason": "Review can help detect execution issues in these changes.",
   "value": "Reviewing takes a little longer and makes the result safer.",
   "risk_evidence": [
     "shell scripting in scripts/deploy.sh"

--- a/contracts/review-integration/v1/fixtures/consent.fixture.json
+++ b/contracts/review-integration/v1/fixtures/consent.fixture.json
@@ -9,7 +9,7 @@
   "risk_level": "high",
   "changed_files": 1,
   "changed_lines": 1,
-  "headline": "Review this change now?",
+  "headline": "Gentle AI can review this change before you call it done.",
   "reason": "These changes may affect execution; review can help detect problems.",
   "value": "Reviewing takes a little longer and makes the result safer.",
   "risk_evidence": [

--- a/contracts/review-integration/v1/fixtures/consent.fixture.json
+++ b/contracts/review-integration/v1/fixtures/consent.fixture.json
@@ -9,23 +9,23 @@
   "risk_level": "high",
   "changed_files": 1,
   "changed_lines": 1,
-  "headline": "Gentle AI can review this change before you call it done.",
-  "reason": "this change gets a deeper review because it touches shell scripting in scripts/deploy.sh.",
-  "value": "Reviewing takes a bit longer, and it makes the result substantially safer.",
+  "headline": "Review this change now?",
+  "reason": "These changes may affect execution; review can help detect problems.",
+  "value": "Reviewing takes a little longer and makes the result safer.",
   "risk_evidence": [
     "shell scripting in scripts/deploy.sh"
   ],
   "choices": [
     {
       "answer": "granted",
-      "label": "Run the review now",
-      "effect": "Reviews this exact frozen candidate now; nothing is granted for later candidates, so each later medium- or high-risk candidate asks again.",
+      "label": "Review this change",
+      "effect": "Reviews only this change; later medium- or high-risk changes ask again, and delivery needs separate approval.",
       "invocation": "gentle-ai review start --contract gentle-ai.review-integration/v1 --cwd /repo --target sha256:04c970c2b0f7c128751ed2b0f7e672a2fe26dc267f018bf10e612096d19cfa04 --projection workspace --lineage review-consent-fixture --consent granted"
     },
     {
       "answer": "declined",
-      "label": "Not now, just this once",
-      "effect": "Skips the review for this candidate only; nothing is persisted and the next candidate is asked again. This is not the kill switch.",
+      "label": "Skip this time",
+      "effect": "Skips only this change; no review record is created, and future reviews stay enabled.",
       "invocation": "gentle-ai review start --contract gentle-ai.review-integration/v1 --cwd /repo --target sha256:04c970c2b0f7c128751ed2b0f7e672a2fe26dc267f018bf10e612096d19cfa04 --projection workspace --lineage review-consent-fixture --consent declined"
     }
   ],

--- a/contracts/review-integration/v2/fixtures/consent-v3.fixture.json
+++ b/contracts/review-integration/v2/fixtures/consent-v3.fixture.json
@@ -10,7 +10,7 @@
   "risk_level": "high",
   "changed_files": 1,
   "changed_lines": 1,
-  "headline": "Review this change now?",
+  "headline": "Gentle AI can review this change before you call it done.",
   "reason": "These changes may affect execution; review can help detect problems.",
   "value": "Reviewing takes a little longer and makes the result safer.",
   "risk_evidence": [

--- a/contracts/review-integration/v2/fixtures/consent-v3.fixture.json
+++ b/contracts/review-integration/v2/fixtures/consent-v3.fixture.json
@@ -10,23 +10,23 @@
   "risk_level": "high",
   "changed_files": 1,
   "changed_lines": 1,
-  "headline": "Gentle AI can review this change before you call it done.",
-  "reason": "this change gets a deeper review because it touches shell scripting in scripts/deploy.sh.",
-  "value": "Reviewing takes a bit longer, and it makes the result substantially safer.",
+  "headline": "Review this change now?",
+  "reason": "These changes may affect execution; review can help detect problems.",
+  "value": "Reviewing takes a little longer and makes the result safer.",
   "risk_evidence": [
     "shell scripting in scripts/deploy.sh"
   ],
   "choices": [
     {
       "answer": "granted",
-      "label": "Run the review now",
-      "effect": "Reviews this exact frozen candidate now; nothing is granted for later candidates, so each later medium- or high-risk candidate asks again.",
+      "label": "Review this change",
+      "effect": "Reviews only this change; later medium- or high-risk changes ask again, and delivery needs separate approval.",
       "invocation": "gentle-ai review start --contract gentle-ai.review-integration/v2 --cwd /repo --target sha256:04c970c2b0f7c128751ed2b0f7e672a2fe26dc267f018bf10e612096d19cfa04 --projection workspace --lineage review-consent-fixture --consent granted"
     },
     {
       "answer": "declined",
-      "label": "Not now, just this once",
-      "effect": "Skips the review for this exact candidate only; no review lineage or receipt is created, and ordinary delivery is unmanaged by candidate choice. The next candidate is asked again. This is not the kill switch.",
+      "label": "Skip this time",
+      "effect": "Skips only this change; no review record is created, and future reviews stay enabled.",
       "invocation": "gentle-ai review start --contract gentle-ai.review-integration/v2 --cwd /repo --target sha256:04c970c2b0f7c128751ed2b0f7e672a2fe26dc267f018bf10e612096d19cfa04 --projection workspace --lineage review-consent-fixture --consent declined"
     }
   ],

--- a/contracts/review-integration/v2/fixtures/consent-v3.fixture.json
+++ b/contracts/review-integration/v2/fixtures/consent-v3.fixture.json
@@ -11,7 +11,7 @@
   "changed_files": 1,
   "changed_lines": 1,
   "headline": "Gentle AI can review this change before you call it done.",
-  "reason": "These changes may affect execution; review can help detect problems.",
+  "reason": "Review can help detect execution issues in these changes.",
   "value": "Reviewing takes a little longer and makes the result safer.",
   "risk_evidence": [
     "shell scripting in scripts/deploy.sh"

--- a/contracts/review-integration/v2/fixtures/consent.fixture.json
+++ b/contracts/review-integration/v2/fixtures/consent.fixture.json
@@ -10,7 +10,7 @@
   "changed_files": 1,
   "changed_lines": 1,
   "headline": "Gentle AI can review this change before you call it done.",
-  "reason": "These changes may affect execution; review can help detect problems.",
+  "reason": "Review can help detect execution issues in these changes.",
   "value": "Reviewing takes a little longer and makes the result safer.",
   "risk_evidence": [
     "shell scripting in scripts/deploy.sh"

--- a/contracts/review-integration/v2/fixtures/consent.fixture.json
+++ b/contracts/review-integration/v2/fixtures/consent.fixture.json
@@ -9,23 +9,23 @@
   "risk_level": "high",
   "changed_files": 1,
   "changed_lines": 1,
-  "headline": "Gentle AI can review this change before you call it done.",
-  "reason": "this change gets a deeper review because it touches shell scripting in scripts/deploy.sh.",
-  "value": "Reviewing takes a bit longer, and it makes the result substantially safer.",
+  "headline": "Review this change now?",
+  "reason": "These changes may affect execution; review can help detect problems.",
+  "value": "Reviewing takes a little longer and makes the result safer.",
   "risk_evidence": [
     "shell scripting in scripts/deploy.sh"
   ],
   "choices": [
     {
       "answer": "granted",
-      "label": "Run the review now",
-      "effect": "Reviews this exact frozen candidate now; nothing is granted for later candidates, so each later medium- or high-risk candidate asks again.",
+      "label": "Review this change",
+      "effect": "Reviews only this change; later medium- or high-risk changes ask again, and delivery needs separate approval.",
       "invocation": "gentle-ai review start --contract gentle-ai.review-integration/v2 --cwd /repo --target sha256:136dc6556e3bac8c2e7f7af7cc5ec361f449e383a997638128729059fefa06a5 --projection workspace --lineage review-consent-fixture --consent granted"
     },
     {
       "answer": "declined",
-      "label": "Not now, just this once",
-      "effect": "Skips the review for this exact candidate only; no review lineage or receipt is created, and ordinary delivery is unmanaged by candidate choice. The next candidate is asked again. This is not the kill switch.",
+      "label": "Skip this time",
+      "effect": "Skips only this change; no review record is created, and future reviews stay enabled.",
       "invocation": "gentle-ai review start --contract gentle-ai.review-integration/v2 --cwd /repo --target sha256:136dc6556e3bac8c2e7f7af7cc5ec361f449e383a997638128729059fefa06a5 --projection workspace --lineage review-consent-fixture --consent declined"
     }
   ],

--- a/contracts/review-integration/v2/fixtures/consent.fixture.json
+++ b/contracts/review-integration/v2/fixtures/consent.fixture.json
@@ -9,7 +9,7 @@
   "risk_level": "high",
   "changed_files": 1,
   "changed_lines": 1,
-  "headline": "Review this change now?",
+  "headline": "Gentle AI can review this change before you call it done.",
   "reason": "These changes may affect execution; review can help detect problems.",
   "value": "Reviewing takes a little longer and makes the result safer.",
   "risk_evidence": [

--- a/internal/cli/review_consent_contract.go
+++ b/internal/cli/review_consent_contract.go
@@ -126,20 +126,6 @@ func reviewConsentSpanishRiskEvidence(assessment reviewtransaction.RiskAssessmen
 	}
 }
 
-func reviewConsentSpanishEvidence(reasons []reviewtransaction.RiskReason) string {
-	phrases := reviewConsentSpanishEvidencePhrases(reasons)
-	switch len(phrases) {
-	case 0:
-		return ""
-	case 1:
-		return phrases[0]
-	case 2:
-		return phrases[0] + " y " + phrases[1]
-	default:
-		return fmt.Sprintf("%s, %s y %d más", phrases[0], phrases[1], len(phrases)-2)
-	}
-}
-
 func reviewConsentSpanishEvidencePhrases(reasons []reviewtransaction.RiskReason) []string {
 	var phrases []string
 	for _, reason := range reasons {

--- a/internal/cli/review_consent_contract.go
+++ b/internal/cli/review_consent_contract.go
@@ -69,13 +69,8 @@ type ReviewIntegrationConsentOffPath = consentenvelope.OffPath
 const reviewConsentActionRequired = "consent_required"
 
 const (
-	reviewConsentGrantedEffect = "Reviews this exact frozen candidate now; nothing is granted for later candidates, so each later medium- or high-risk candidate asks again."
-	// reviewConsentDeclinedEffect is the published v1 wording. Keep it exact for
-	// legacy consumers; v2 states the new candidate-decline delivery behavior.
-	reviewConsentDeclinedEffect = "Skips the review for this candidate only; nothing is persisted and the next candidate is asked again. " +
-		"This is not the kill switch."
-	reviewConsentDeclinedEffectV2 = "Skips the review for this exact candidate only; no review lineage or receipt is created, and ordinary delivery is unmanaged by candidate choice. " +
-		"The next candidate is asked again. This is not the kill switch."
+	reviewConsentGrantedEffect  = "Reviews only this change; later medium- or high-risk changes ask again, and delivery needs separate approval."
+	reviewConsentDeclinedEffect = "Skips only this change; no review record is created, and future reviews stay enabled."
 )
 
 type reviewConsentEnvelopeText struct {
@@ -85,44 +80,39 @@ type reviewConsentEnvelopeText struct {
 	declinedLabel, declinedEffect, offPathNote string
 }
 
-func reviewConsentEnvelopeTextFor(locale reviewConsentLocale, assessment reviewtransaction.RiskAssessment, contract string) reviewConsentEnvelopeText {
+func reviewConsentEnvelopeTextFor(locale reviewConsentLocale, assessment reviewtransaction.RiskAssessment, _ string) reviewConsentEnvelopeText {
 	if locale != reviewConsentLocaleSpanish {
-		declinedEffect := reviewConsentDeclinedEffect
-		if contract == ReviewIntegrationContractV2 {
-			declinedEffect = reviewConsentDeclinedEffectV2
-		}
 		return reviewConsentEnvelopeText{
 			headline: reviewConsentHeadline, reason: reviewConsentReason(assessment), value: reviewConsentValue,
 			evidence: reviewConsentRiskEvidence(assessment), grantedLabel: reviewConsentAnswerRunLabel,
 			grantedEffect: reviewConsentGrantedEffect, declinedLabel: reviewConsentAnswerNotNowLabel,
-			declinedEffect: declinedEffect, offPathNote: reviewConsentOffPathNote,
+			declinedEffect: reviewConsentDeclinedEffect, offPathNote: reviewConsentOffPathNote,
 		}
 	}
 	return reviewConsentEnvelopeText{
-		headline:       "Gentle AI puede revisar este cambio antes de que lo des por terminado.",
+		headline:       "¿Revisar este cambio ahora?",
 		reason:         reviewConsentSpanishReason(assessment),
 		value:          "La revisión lleva un poco más de tiempo y hace que el resultado sea considerablemente más seguro.",
 		evidence:       reviewConsentSpanishRiskEvidence(assessment),
-		grantedLabel:   "Ejecutar la revisión ahora",
-		grantedEffect:  "Revisa ahora este candidato congelado exacto; no se otorga nada para candidatos posteriores, por lo que cada candidato posterior de riesgo medio o alto vuelve a pedir confirmación.",
-		declinedLabel:  "Ahora no, solo esta vez",
-		declinedEffect: "Omite la revisión solo para este candidato exacto; no se crea ninguna línea de revisión ni recibo, y la entrega ordinaria queda sin administrar por elección del candidato. El siguiente candidato vuelve a pedir confirmación. No es el interruptor de apagado.",
+		grantedLabel:   "Revisar este cambio",
+		grantedEffect:  "Revisa solo este cambio; los cambios posteriores de riesgo medio o alto vuelven a pedir confirmación y la entrega requiere otra aprobación.",
+		declinedLabel:  "Omitir esta vez",
+		declinedEffect: "Omite solo este cambio; no crea un registro de revisión y las revisiones futuras siguen activas.",
 		offPathNote:    "Para desactivar las revisiones de forma permanente, ejecuta '" + reviewConsentOffPathCommand + "'.",
 	}
 }
 
 func reviewConsentSpanishReason(assessment reviewtransaction.RiskAssessment) string {
-	evidence := reviewConsentSpanishEvidence(assessment.Reasons)
-	if assessment.Level != reviewtransaction.RiskHigh {
-		if evidence == "" {
-			return "este cambio no es documentación puramente pasiva, por lo que recibe una revisión consolidada."
-		}
-		return "este cambio no es documentación puramente pasiva, por lo que recibe una revisión consolidada. La revisión parte de " + evidence + "."
+	switch reviewConsentReasonCategoryFor(assessment.Reasons) {
+	case reviewConsentReasonSecurity:
+		return "Estos cambios pueden afectar la seguridad; la revisión puede ayudar a detectar problemas."
+	case reviewConsentReasonExecution:
+		return "Estos cambios pueden afectar la ejecución; la revisión puede ayudar a detectar problemas."
+	case reviewConsentReasonUpdates:
+		return "Estos cambios pueden afectar las actualizaciones; la revisión puede ayudar a detectar problemas."
+	default:
+		return "Estos cambios alteran el comportamiento; la revisión puede ayudar a detectar regresiones."
 	}
-	if evidence == "" {
-		return "este cambio toca algo sensible, por lo que recibe una revisión más profunda."
-	}
-	return "este cambio recibe una revisión más profunda porque afecta a " + evidence + "."
 }
 
 func reviewConsentSpanishRiskEvidence(assessment reviewtransaction.RiskAssessment) []string {

--- a/internal/cli/review_consent_contract.go
+++ b/internal/cli/review_consent_contract.go
@@ -90,7 +90,7 @@ func reviewConsentEnvelopeTextFor(locale reviewConsentLocale, assessment reviewt
 		}
 	}
 	return reviewConsentEnvelopeText{
-		headline:       "¿Revisar este cambio ahora?",
+		headline:       "Gentle AI puede revisar este cambio antes de que lo des por terminado.",
 		reason:         reviewConsentSpanishReason(assessment),
 		value:          "La revisión lleva un poco más de tiempo y hace que el resultado sea considerablemente más seguro.",
 		evidence:       reviewConsentSpanishRiskEvidence(assessment),

--- a/internal/cli/review_consent_contract.go
+++ b/internal/cli/review_consent_contract.go
@@ -105,13 +105,13 @@ func reviewConsentEnvelopeTextFor(locale reviewConsentLocale, assessment reviewt
 func reviewConsentSpanishReason(assessment reviewtransaction.RiskAssessment) string {
 	switch reviewConsentReasonCategoryFor(assessment.Reasons) {
 	case reviewConsentReasonSecurity:
-		return "Estos cambios pueden afectar la seguridad; la revisión puede ayudar a detectar problemas."
+		return "La revisión puede ayudar a identificar posibles problemas de seguridad."
 	case reviewConsentReasonExecution:
-		return "Estos cambios pueden afectar la ejecución; la revisión puede ayudar a detectar problemas."
+		return "La revisión puede ayudar a detectar problemas de ejecución en estos cambios."
 	case reviewConsentReasonUpdates:
-		return "Estos cambios pueden afectar las actualizaciones; la revisión puede ayudar a detectar problemas."
+		return "La revisión puede ayudar a detectar problemas relacionados con las actualizaciones."
 	default:
-		return "Estos cambios alteran el comportamiento; la revisión puede ayudar a detectar regresiones."
+		return "La revisión puede ayudar a detectar regresiones en estos cambios."
 	}
 }
 

--- a/internal/cli/review_consent_envelope_bytes_test.go
+++ b/internal/cli/review_consent_envelope_bytes_test.go
@@ -40,7 +40,7 @@ func TestReviewConsentEnvelopeSerializedBytesUnchanged(t *testing.T) {
 			if err := result.Validate(); err != nil {
 				t.Fatalf("consent fixture no longer validates: %v", err)
 			}
-			const executionReason = "These changes may affect execution; review can help detect problems."
+			const executionReason = "Review can help detect execution issues in these changes."
 			if result.Reason != executionReason || bytes.Contains([]byte(result.Reason), []byte("/")) {
 				t.Fatalf("%s reason = %q, want generic path-free %q", fixture.name, result.Reason, executionReason)
 			}

--- a/internal/cli/review_consent_envelope_bytes_test.go
+++ b/internal/cli/review_consent_envelope_bytes_test.go
@@ -40,6 +40,10 @@ func TestReviewConsentEnvelopeSerializedBytesUnchanged(t *testing.T) {
 			if err := result.Validate(); err != nil {
 				t.Fatalf("consent fixture no longer validates: %v", err)
 			}
+			const executionReason = "These changes may affect execution; review can help detect problems."
+			if result.Reason != executionReason || bytes.Contains([]byte(result.Reason), []byte("/")) {
+				t.Fatalf("%s reason = %q, want generic path-free %q", fixture.name, result.Reason, executionReason)
+			}
 			remarshaled, err := json.MarshalIndent(result, "", "  ")
 			if err != nil {
 				t.Fatal(err)

--- a/internal/cli/review_consent_locale_test.go
+++ b/internal/cli/review_consent_locale_test.go
@@ -17,7 +17,7 @@ func TestRelayedConsentSpanishLocalizesHumanFieldsWithoutChangingMachineTokens(t
 	})).Bytes())
 	if question.Headline != "Gentle AI puede revisar este cambio antes de que lo des por terminado." ||
 		question.Value != "La revisión lleva un poco más de tiempo y hace que el resultado sea considerablemente más seguro." ||
-		question.Reason != "Estos cambios pueden afectar la ejecución; la revisión puede ayudar a detectar problemas." ||
+		question.Reason != "La revisión puede ayudar a detectar problemas de ejecución en estos cambios." ||
 		strings.Contains(question.Reason, "scripts/deploy.sh") {
 		t.Fatalf("Spanish consent envelope did not localize its generic reason and brief benefit: %#v", question)
 	}

--- a/internal/cli/review_consent_locale_test.go
+++ b/internal/cli/review_consent_locale_test.go
@@ -15,7 +15,7 @@ func TestRelayedConsentSpanishLocalizesHumanFieldsWithoutChangingMachineTokens(t
 		"start", "--contract", ReviewIntegrationContractV2, "--cwd", repo,
 		"--lineage", "review-consent-spanish", "--locale", "es", "--consent", "relay",
 	})).Bytes())
-	if question.Headline != "¿Revisar este cambio ahora?" ||
+	if question.Headline != "Gentle AI puede revisar este cambio antes de que lo des por terminado." ||
 		question.Value != "La revisión lleva un poco más de tiempo y hace que el resultado sea considerablemente más seguro." ||
 		question.Reason != "Estos cambios pueden afectar la ejecución; la revisión puede ayudar a detectar problemas." ||
 		strings.Contains(question.Reason, "scripts/deploy.sh") {

--- a/internal/cli/review_consent_locale_test.go
+++ b/internal/cli/review_consent_locale_test.go
@@ -15,12 +15,16 @@ func TestRelayedConsentSpanishLocalizesHumanFieldsWithoutChangingMachineTokens(t
 		"start", "--contract", ReviewIntegrationContractV2, "--cwd", repo,
 		"--lineage", "review-consent-spanish", "--locale", "es", "--consent", "relay",
 	})).Bytes())
-	if question.Headline == reviewConsentHeadline || question.Value == reviewConsentValue ||
-		!strings.Contains(question.Headline, "Gentle AI") || !strings.Contains(question.Reason, "revisión") {
-		t.Fatalf("Spanish consent envelope did not localize human fields: %#v", question)
+	if question.Headline != "¿Revisar este cambio ahora?" ||
+		question.Value != "La revisión lleva un poco más de tiempo y hace que el resultado sea considerablemente más seguro." ||
+		question.Reason != "Estos cambios pueden afectar la ejecución; la revisión puede ayudar a detectar problemas." ||
+		strings.Contains(question.Reason, "scripts/deploy.sh") {
+		t.Fatalf("Spanish consent envelope did not localize its generic reason and brief benefit: %#v", question)
 	}
-	if len(question.Choices) != 2 || question.Choices[0].Answer != "granted" || question.Choices[1].Answer != "declined" {
-		t.Fatalf("Spanish consent envelope changed machine answers: %#v", question.Choices)
+	if len(question.Choices) != 2 || question.Choices[0].Answer != "granted" || question.Choices[1].Answer != "declined" ||
+		question.Choices[0].Label != "Revisar este cambio" || question.Choices[0].Effect != "Revisa solo este cambio; los cambios posteriores de riesgo medio o alto vuelven a pedir confirmación y la entrega requiere otra aprobación." ||
+		question.Choices[1].Label != "Omitir esta vez" || question.Choices[1].Effect != "Omite solo este cambio; no crea un registro de revisión y las revisiones futuras siguen activas." {
+		t.Fatalf("Spanish consent envelope changed machine answers or concise informed-consent copy: %#v", question.Choices)
 	}
 	for _, choice := range question.Choices {
 		if !strings.Contains(choice.Invocation, "--target "+question.TargetIdentity) ||

--- a/internal/cli/review_consent_relay_test.go
+++ b/internal/cli/review_consent_relay_test.go
@@ -158,11 +158,15 @@ func TestNegotiatedHighRiskStartWithRelayDeclarationEmitsBlockingConsentQuestion
 	}
 	// The envelope must carry the same semantic phrases the interactive question
 	// uses, so the orchestrator can localize the complete decision faithfully.
-	if question.Headline != reviewConsentHeadline || question.Value != reviewConsentValue {
-		t.Fatalf("consent question dropped the interactive framing: %#v", question)
+	if question.Headline != "Review this change now?" {
+		t.Fatalf("consent headline = %q, want a direct question", question.Headline)
 	}
-	if !strings.Contains(question.Reason, "deeper review") {
-		t.Fatalf("consent question reason does not explain the tier: %q", question.Reason)
+	if question.Value != "Reviewing takes a little longer and makes the result safer." {
+		t.Fatalf("consent value must remain one short benefit = %q", question.Value)
+	}
+	if question.Reason != "These changes may affect execution; review can help detect problems." ||
+		strings.Contains(question.Reason, "scripts/deploy.sh") {
+		t.Fatalf("consent question reason is not generic execution copy: %q", question.Reason)
 	}
 	evidence := strings.Join(question.RiskEvidence, "\n")
 	if !strings.Contains(evidence, "shell scripting in scripts/deploy.sh") {
@@ -175,9 +179,13 @@ func TestNegotiatedHighRiskStartWithRelayDeclarationEmitsBlockingConsentQuestion
 		t.Fatalf("consent question offers %d choices, want exactly 2: %#v", len(question.Choices), question.Choices)
 	}
 	granted, declined := question.Choices[0], question.Choices[1]
-	if granted.Answer != "granted" || granted.Label != reviewConsentAnswerRunLabel ||
-		declined.Answer != "declined" || declined.Label != reviewConsentAnswerNotNowLabel {
+	if granted.Answer != "granted" || granted.Label != "Review this change" ||
+		declined.Answer != "declined" || declined.Label != "Skip this time" {
 		t.Fatalf("consent choices = %#v", question.Choices)
+	}
+	if granted.Effect != "Reviews only this change; later medium- or high-risk changes ask again, and delivery needs separate approval." ||
+		declined.Effect != "Skips only this change; no review record is created, and future reviews stay enabled." {
+		t.Fatalf("consent choice effects = %#v", question.Choices)
 	}
 	for _, choice := range question.Choices {
 		if !strings.Contains(choice.Invocation, "--consent "+choice.Answer) ||
@@ -190,11 +198,12 @@ func TestNegotiatedHighRiskStartWithRelayDeclarationEmitsBlockingConsentQuestion
 			t.Fatalf("consent choice states no effect: %#v", choice)
 		}
 	}
-	if !strings.Contains(declined.Effect, "not the kill switch") {
-		t.Fatalf("decline effect must say it is not the kill switch: %q", declined.Effect)
-	}
-	if !strings.Contains(granted.Effect, "exact frozen candidate") || !strings.Contains(granted.Effect, "asks again") {
-		t.Fatalf("grant effect must remain candidate-scoped: %q", granted.Effect)
+	for _, choice := range question.Choices {
+		for _, jargon := range []string{"frozen candidate", "lineage", "receipt", "grant scope"} {
+			if strings.Contains(strings.ToLower(choice.Label+" "+choice.Effect), jargon) {
+				t.Fatalf("primary choice copy leaked %q: %#v", jargon, choice)
+			}
+		}
 	}
 	if question.OffPath.Command != reviewConsentOffPathCommand || !strings.Contains(question.OffPath.Note, "for good") {
 		t.Fatalf("consent off path = %#v", question.OffPath)
@@ -211,6 +220,32 @@ func TestNegotiatedHighRiskStartWithRelayDeclarationEmitsBlockingConsentQuestion
 	}
 	if console.Len() != 0 {
 		t.Fatalf("relay declaration must replace the console notice, not add to it:\n%s", console.String())
+	}
+}
+
+func TestRelayedConsentMediumRiskKeepsBriefDecisionAndRiskContext(t *testing.T) {
+	reviewEnabledHome(t)
+	repo := initReviewCLIRepo(t)
+	stubReviewConsole(t, false, "")
+	writeReviewStartCandidate(t, repo, "internal/app.go", "package internal\n", 0o644)
+
+	question := decodeConsentQuestion(t, runConsentRelayStart(t, boundNegotiatedStartArgs(t, []string{
+		"start", "--contract", ReviewIntegrationContractV2, "--cwd", repo,
+		"--lineage", "review-consent-medium-copy", "--consent", "relay",
+	})).Bytes())
+	if question.RiskLevel != reviewtransaction.RiskMedium || question.Headline != "Review this change now?" {
+		t.Fatalf("medium consent identity/copy = %#v", question)
+	}
+	if question.Value != "Reviewing takes a little longer and makes the result safer." ||
+		len(question.Choices) != 2 ||
+		question.Choices[0].Effect != "Reviews only this change; later medium- or high-risk changes ask again, and delivery needs separate approval." ||
+		question.Choices[1].Effect != "Skips only this change; no review record is created, and future reviews stay enabled." {
+		t.Fatalf("medium consent primary context/choices = %#v", question)
+	}
+	if question.Reason != "These changes alter behavior; review can help check for regressions." ||
+		strings.Contains(question.Reason, "internal/app.go") || len(question.RiskEvidence) == 0 ||
+		!strings.Contains(question.RiskEvidence[0], "consolidated review") {
+		t.Fatalf("medium consent did not separate generic reason from detailed risk context: %#v", question)
 	}
 }
 

--- a/internal/cli/review_consent_relay_test.go
+++ b/internal/cli/review_consent_relay_test.go
@@ -164,7 +164,7 @@ func TestNegotiatedHighRiskStartWithRelayDeclarationEmitsBlockingConsentQuestion
 	if question.Value != "Reviewing takes a little longer and makes the result safer." {
 		t.Fatalf("consent value must remain one short benefit = %q", question.Value)
 	}
-	if question.Reason != "These changes may affect execution; review can help detect problems." ||
+	if question.Reason != "Review can help detect execution issues in these changes." ||
 		strings.Contains(question.Reason, "scripts/deploy.sh") {
 		t.Fatalf("consent question reason is not generic execution copy: %q", question.Reason)
 	}
@@ -242,7 +242,7 @@ func TestRelayedConsentMediumRiskKeepsBriefDecisionAndRiskContext(t *testing.T) 
 		question.Choices[1].Effect != "Skips only this change; no review record is created, and future reviews stay enabled." {
 		t.Fatalf("medium consent primary context/choices = %#v", question)
 	}
-	if question.Reason != "These changes alter behavior; review can help check for regressions." ||
+	if question.Reason != "Review can help detect regressions in these changes." ||
 		strings.Contains(question.Reason, "internal/app.go") || len(question.RiskEvidence) == 0 ||
 		!strings.Contains(question.RiskEvidence[0], "consolidated review") {
 		t.Fatalf("medium consent did not separate generic reason from detailed risk context: %#v", question)

--- a/internal/cli/review_consent_relay_test.go
+++ b/internal/cli/review_consent_relay_test.go
@@ -158,8 +158,8 @@ func TestNegotiatedHighRiskStartWithRelayDeclarationEmitsBlockingConsentQuestion
 	}
 	// The envelope must carry the same semantic phrases the interactive question
 	// uses, so the orchestrator can localize the complete decision faithfully.
-	if question.Headline != "Review this change now?" {
-		t.Fatalf("consent headline = %q, want a direct question", question.Headline)
+	if question.Headline != "Gentle AI can review this change before you call it done." {
+		t.Fatalf("consent headline = %q, want the established offer", question.Headline)
 	}
 	if question.Value != "Reviewing takes a little longer and makes the result safer." {
 		t.Fatalf("consent value must remain one short benefit = %q", question.Value)
@@ -233,7 +233,7 @@ func TestRelayedConsentMediumRiskKeepsBriefDecisionAndRiskContext(t *testing.T) 
 		"start", "--contract", ReviewIntegrationContractV2, "--cwd", repo,
 		"--lineage", "review-consent-medium-copy", "--consent", "relay",
 	})).Bytes())
-	if question.RiskLevel != reviewtransaction.RiskMedium || question.Headline != "Review this change now?" {
+	if question.RiskLevel != reviewtransaction.RiskMedium || question.Headline != "Gentle AI can review this change before you call it done." {
 		t.Fatalf("medium consent identity/copy = %#v", question)
 	}
 	if question.Value != "Reviewing takes a little longer and makes the result safer." ||

--- a/internal/cli/review_mode.go
+++ b/internal/cli/review_mode.go
@@ -570,7 +570,7 @@ func normalizeReviewConsentLocale(value string) (reviewConsentLocale, error) {
 }
 
 const (
-	reviewConsentHeadline = "Review this change now?"
+	reviewConsentHeadline = "Gentle AI can review this change before you call it done."
 	reviewConsentValue    = "Reviewing takes a little longer and makes the result safer."
 
 	// reviewConsentAnswerRunLabel and reviewConsentAnswerNotNowLabel are the

--- a/internal/cli/review_mode.go
+++ b/internal/cli/review_mode.go
@@ -891,21 +891,6 @@ func reviewConsentReason(assessment reviewtransaction.RiskAssessment) string {
 	}
 }
 
-func reviewConsentEvidence(reasons []reviewtransaction.RiskReason) string {
-	phrases := reviewConsentEvidencePhrases(reasons)
-	switch len(phrases) {
-	case 0:
-		return ""
-	case 1:
-		return phrases[0]
-	case 2:
-		return phrases[0] + " and " + phrases[1]
-	default:
-		// Naming every path would bury the decision the user has to make.
-		return fmt.Sprintf("%s, %s, and %d more", phrases[0], phrases[1], len(phrases)-2)
-	}
-}
-
 // reviewConsentRiskEvidence projects an already-classified assessment into
 // the detailed risk_evidence phrases a non-interactive START result carries.
 // It remains separate from the brief generic consent reason: tier 2 names the

--- a/internal/cli/review_mode.go
+++ b/internal/cli/review_mode.go
@@ -881,13 +881,13 @@ func reviewConsentReasonCategoryFor(reasons []reviewtransaction.RiskReason) revi
 func reviewConsentReason(assessment reviewtransaction.RiskAssessment) string {
 	switch reviewConsentReasonCategoryFor(assessment.Reasons) {
 	case reviewConsentReasonSecurity:
-		return "These changes may affect security; review can help detect problems."
+		return "Review can help identify potential security issues."
 	case reviewConsentReasonExecution:
-		return "These changes may affect execution; review can help detect problems."
+		return "Review can help detect execution issues in these changes."
 	case reviewConsentReasonUpdates:
-		return "These changes may affect updates; review can help detect problems."
+		return "Review can help detect update-related issues."
 	default:
-		return "These changes alter behavior; review can help check for regressions."
+		return "Review can help detect regressions in these changes."
 	}
 }
 

--- a/internal/cli/review_mode.go
+++ b/internal/cli/review_mode.go
@@ -570,15 +570,15 @@ func normalizeReviewConsentLocale(value string) (reviewConsentLocale, error) {
 }
 
 const (
-	reviewConsentHeadline = "Gentle AI can review this change before you call it done."
-	reviewConsentValue    = "Reviewing takes a bit longer, and it makes the result substantially safer."
+	reviewConsentHeadline = "Review this change now?"
+	reviewConsentValue    = "Reviewing takes a little longer and makes the result safer."
 
 	// reviewConsentAnswerRunLabel and reviewConsentAnswerNotNowLabel are the
 	// single wording source for the two offered answers: the interactive
 	// prompt and the relayed consent envelope both speak them, so the two
 	// surfaces cannot drift.
-	reviewConsentAnswerRunLabel    = "Run the review now"
-	reviewConsentAnswerNotNowLabel = "Not now, just this once"
+	reviewConsentAnswerRunLabel    = "Review this change"
+	reviewConsentAnswerNotNowLabel = "Skip this time"
 	reviewConsentAnswers           = "  1) " + reviewConsentAnswerRunLabel + "\n  2) " + reviewConsentAnswerNotNowLabel + "\n"
 
 	// reviewConsentOffPath keeps the permanent disable reachable but deliberate.
@@ -832,28 +832,63 @@ func reviewConsentPrompt(assessment reviewtransaction.RiskAssessment) string {
 		reviewConsentAnswers, reviewConsentOffPath, reviewConsentQuestion)
 }
 
-// reviewConsentMediumReason is the single wording source for the tier-1
-// reason: the interactive consent prompt speaks it and the machine-readable
-// START result relays it verbatim, so the two surfaces cannot drift.
+// reviewConsentMediumReason remains the first medium-tier risk_evidence item.
+// The brief consent reason below deliberately does not repeat this detailed
+// evidence, which stays available in its own field for relays that need it.
 const reviewConsentMediumReason = "this change is not purely passive documentation, so it gets one consolidated review."
 
-// reviewConsentReason states why this candidate is reviewed, in the user's own
-// terms. Both tiers name the evidence that triggered them through the same
-// phrasing helper, so neither review's cost is ever unexplained: tier 1 keeps
-// the consolidated-review sentence and appends what made the candidate
-// non-passive (issue #1827); tier 2 names what triggered the deeper review.
-func reviewConsentReason(assessment reviewtransaction.RiskAssessment) string {
-	evidence := reviewConsentEvidence(assessment.Reasons)
-	if assessment.Level != reviewtransaction.RiskHigh {
-		if evidence == "" {
-			return reviewConsentMediumReason
+type reviewConsentReasonCategory string
+
+const (
+	reviewConsentReasonBehavior  reviewConsentReasonCategory = "behavior"
+	reviewConsentReasonSecurity  reviewConsentReasonCategory = "security"
+	reviewConsentReasonExecution reviewConsentReasonCategory = "execution"
+	reviewConsentReasonUpdates   reviewConsentReasonCategory = "updates"
+)
+
+// reviewConsentReasonCategoryFor uses only the classifier's structured signals,
+// never the human-readable evidence phrases. Security signals take precedence,
+// followed by execution and update signals; absent or unknown signals fall back
+// to behavior, so a high tier alone never claims a security concern.
+func reviewConsentReasonCategoryFor(reasons []reviewtransaction.RiskReason) reviewConsentReasonCategory {
+	security, execution, updates := false, false, false
+	for _, reason := range reasons {
+		switch reason.Signal {
+		case reviewtransaction.SignalAuth, reviewtransaction.SignalSecurity,
+			reviewtransaction.SignalPayments, reviewtransaction.SignalDataExposure,
+			reviewtransaction.SignalDataLoss, reviewtransaction.SignalPermissions:
+			security = true
+		case reviewtransaction.SignalShellProcess:
+			execution = true
+		case reviewtransaction.SignalUpdate:
+			updates = true
 		}
-		return reviewConsentMediumReason + " The review starts from " + evidence + "."
 	}
-	if evidence == "" {
-		return "this change touches something sensitive, so it gets a deeper review."
+	switch {
+	case security:
+		return reviewConsentReasonSecurity
+	case execution:
+		return reviewConsentReasonExecution
+	case updates:
+		return reviewConsentReasonUpdates
+	default:
+		return reviewConsentReasonBehavior
 	}
-	return "this change gets a deeper review because it touches " + evidence + "."
+}
+
+// reviewConsentReason explains the broad concern and review benefit without
+// exposing paths or duplicating detailed risk evidence.
+func reviewConsentReason(assessment reviewtransaction.RiskAssessment) string {
+	switch reviewConsentReasonCategoryFor(assessment.Reasons) {
+	case reviewConsentReasonSecurity:
+		return "These changes may affect security; review can help detect problems."
+	case reviewConsentReasonExecution:
+		return "These changes may affect execution; review can help detect problems."
+	case reviewConsentReasonUpdates:
+		return "These changes may affect updates; review can help detect problems."
+	default:
+		return "These changes alter behavior; review can help check for regressions."
+	}
 }
 
 func reviewConsentEvidence(reasons []reviewtransaction.RiskReason) string {
@@ -872,13 +907,11 @@ func reviewConsentEvidence(reasons []reviewtransaction.RiskReason) string {
 }
 
 // reviewConsentRiskEvidence projects an already-classified assessment into
-// the risk_evidence phrases a non-interactive START result carries. It is an
-// output-only projection of facts the start already computed: tier 2 names
-// the triggering evidence, tier 1 leads with the exact consolidated-review
-// reason the consent prompt speaks and appends the same evidence phrases so
-// the path that made the candidate non-passive is named (issue #1827), and
-// tier 0 stays nil so the omitempty field is absent rather than empty-string
-// noise.
+// the detailed risk_evidence phrases a non-interactive START result carries.
+// It remains separate from the brief generic consent reason: tier 2 names the
+// triggering evidence, tier 1 retains its consolidated-review sentence and
+// appends the path that made the candidate non-passive (issue #1827), and tier
+// 0 stays nil so the omitempty field is absent rather than empty-string noise.
 func reviewConsentRiskEvidence(assessment reviewtransaction.RiskAssessment) []string {
 	switch assessment.Level {
 	case reviewtransaction.RiskHigh:

--- a/internal/cli/review_mode_test.go
+++ b/internal/cli/review_mode_test.go
@@ -644,7 +644,7 @@ func TestTierOneReviewStartAsksOnceForOneConsolidatedReview(t *testing.T) {
 	if started.RiskLevel != reviewtransaction.RiskMedium || len(started.SelectedLenses) != 1 {
 		t.Fatalf("tier 1 START = %#v", started)
 	}
-	assertReviewConsentPrompt(t, console.String(), "one consolidated review")
+	assertReviewConsentPrompt(t, console.String(), "These changes alter behavior; review can help check for regressions.")
 	// Accepting the review is the safe direction, so it is the only answer that
 	// is persisted: later candidates are reviewed silently.
 	if asked, err := reviewtransaction.RDDConsentAsked(context.Background(), repo); err != nil || !asked {
@@ -662,7 +662,7 @@ func TestTierOneReviewStartAsksOnceForOneConsolidatedReview(t *testing.T) {
 	}
 }
 
-func TestTierTwoReviewStartAsksOnceNamingTheTriggeringEvidence(t *testing.T) {
+func TestTierTwoReviewStartAsksOnceWithGenericExecutionReason(t *testing.T) {
 	reviewEnabledHome(t)
 	repo := initReviewCLIRepo(t)
 	console := stubReviewConsole(t, true, "1\n")
@@ -677,9 +677,9 @@ func TestTierTwoReviewStartAsksOnceNamingTheTriggeringEvidence(t *testing.T) {
 	if started.RiskLevel != reviewtransaction.RiskHigh || len(started.SelectedLenses) != 4 {
 		t.Fatalf("tier 2 START = %#v", started)
 	}
-	prompt := assertReviewConsentPrompt(t, console.String(), "scripts/deploy.sh")
-	if !strings.Contains(prompt, "shell") {
-		t.Fatalf("tier 2 prompt does not name the triggering evidence:\n%s", prompt)
+	prompt := assertReviewConsentPrompt(t, console.String(), "These changes may affect execution; review can help detect problems.")
+	if strings.Contains(prompt, "scripts/deploy.sh") || strings.Contains(prompt, "shell scripting") {
+		t.Fatalf("tier 2 prompt leaked detailed evidence:\n%s", prompt)
 	}
 
 	console.Reset()
@@ -754,7 +754,7 @@ func TestReviewConsentUnrecognizedAnswerReviewsAndAsksAgain(t *testing.T) {
 	if err := RunReviewFacadeStart([]string{"--cwd", repo, "--lineage", "review-unknown-second"}, &output); err != nil {
 		t.Fatalf("second start after an unrecognized answer: %v\n%s", err, output.String())
 	}
-	assertReviewConsentPrompt(t, console.String(), "one consolidated review")
+	assertReviewConsentPrompt(t, console.String(), "These changes alter behavior; review can help check for regressions.")
 }
 
 // TestReviewConsentNotNowIsNotPersisted pins the asymmetric latch and the
@@ -805,7 +805,7 @@ func TestReviewConsentNotNowIsNotPersisted(t *testing.T) {
 	if err := RunReviewFacadeStart([]string{"--cwd", repo, "--lineage", "review-not-now-second"}, &output); err != nil {
 		t.Fatalf("the next candidate after not-now must ask again without an error: %v\n%s", err, output.String())
 	}
-	assertReviewConsentPrompt(t, console.String(), "one consolidated review")
+	assertReviewConsentPrompt(t, console.String(), "These changes alter behavior; review can help check for regressions.")
 	var second ReviewFacadeStartResult
 	decodeStrictReviewJSON(t, output.Bytes(), &second)
 	if second.Consent != ReviewStartConsentDeclinedThisCandidate {
@@ -889,10 +889,10 @@ func assertReviewConsentPrompt(t *testing.T, prompt, reason string) string {
 	t.Helper()
 	for _, want := range []string{
 		reason,
-		"takes a bit longer",
-		"substantially safer",
-		"1) Run the review now",
-		"2) Not now, just this once",
+		"takes a little longer",
+		"result safer",
+		"1) Review this change",
+		"2) Skip this time",
 		"gentle-ai review mode disable",
 	} {
 		if !strings.Contains(prompt, want) {

--- a/internal/cli/review_mode_test.go
+++ b/internal/cli/review_mode_test.go
@@ -644,7 +644,7 @@ func TestTierOneReviewStartAsksOnceForOneConsolidatedReview(t *testing.T) {
 	if started.RiskLevel != reviewtransaction.RiskMedium || len(started.SelectedLenses) != 1 {
 		t.Fatalf("tier 1 START = %#v", started)
 	}
-	assertReviewConsentPrompt(t, console.String(), "These changes alter behavior; review can help check for regressions.")
+	assertReviewConsentPrompt(t, console.String(), "Review can help detect regressions in these changes.")
 	// Accepting the review is the safe direction, so it is the only answer that
 	// is persisted: later candidates are reviewed silently.
 	if asked, err := reviewtransaction.RDDConsentAsked(context.Background(), repo); err != nil || !asked {
@@ -677,7 +677,7 @@ func TestTierTwoReviewStartAsksOnceWithGenericExecutionReason(t *testing.T) {
 	if started.RiskLevel != reviewtransaction.RiskHigh || len(started.SelectedLenses) != 4 {
 		t.Fatalf("tier 2 START = %#v", started)
 	}
-	prompt := assertReviewConsentPrompt(t, console.String(), "These changes may affect execution; review can help detect problems.")
+	prompt := assertReviewConsentPrompt(t, console.String(), "Review can help detect execution issues in these changes.")
 	if strings.Contains(prompt, "scripts/deploy.sh") || strings.Contains(prompt, "shell scripting") {
 		t.Fatalf("tier 2 prompt leaked detailed evidence:\n%s", prompt)
 	}
@@ -754,7 +754,7 @@ func TestReviewConsentUnrecognizedAnswerReviewsAndAsksAgain(t *testing.T) {
 	if err := RunReviewFacadeStart([]string{"--cwd", repo, "--lineage", "review-unknown-second"}, &output); err != nil {
 		t.Fatalf("second start after an unrecognized answer: %v\n%s", err, output.String())
 	}
-	assertReviewConsentPrompt(t, console.String(), "These changes alter behavior; review can help check for regressions.")
+	assertReviewConsentPrompt(t, console.String(), "Review can help detect regressions in these changes.")
 }
 
 // TestReviewConsentNotNowIsNotPersisted pins the asymmetric latch and the
@@ -805,7 +805,7 @@ func TestReviewConsentNotNowIsNotPersisted(t *testing.T) {
 	if err := RunReviewFacadeStart([]string{"--cwd", repo, "--lineage", "review-not-now-second"}, &output); err != nil {
 		t.Fatalf("the next candidate after not-now must ask again without an error: %v\n%s", err, output.String())
 	}
-	assertReviewConsentPrompt(t, console.String(), "These changes alter behavior; review can help check for regressions.")
+	assertReviewConsentPrompt(t, console.String(), "Review can help detect regressions in these changes.")
 	var second ReviewFacadeStartResult
 	decodeStrictReviewJSON(t, output.Bytes(), &second)
 	if second.Consent != ReviewStartConsentDeclinedThisCandidate {

--- a/internal/cli/review_negotiated_stderr_silence_test.go
+++ b/internal/cli/review_negotiated_stderr_silence_test.go
@@ -243,7 +243,7 @@ func TestNegotiatedStartUndeclaredInteractiveKeepsConsentCeremony(t *testing.T) 
 		t.Fatalf("interactive negotiated refusal = %v, want errReviewDeclinedForCandidate\n%s", err, output.String())
 	}
 	prompt := assertReviewConsentPrompt(t, console.String(), "These changes may affect execution; review can help detect problems.")
-	if !bytes.Contains([]byte(prompt), []byte("Review this change now?")) {
+	if !bytes.Contains([]byte(prompt), []byte("Gentle AI can review this change before you call it done.")) {
 		t.Fatalf("interactive consent prompt lost its question: %q", prompt)
 	}
 }

--- a/internal/cli/review_negotiated_stderr_silence_test.go
+++ b/internal/cli/review_negotiated_stderr_silence_test.go
@@ -242,7 +242,7 @@ func TestNegotiatedStartUndeclaredInteractiveKeepsConsentCeremony(t *testing.T) 
 	if !errors.Is(err, errReviewDeclinedForCandidate) {
 		t.Fatalf("interactive negotiated refusal = %v, want errReviewDeclinedForCandidate\n%s", err, output.String())
 	}
-	prompt := assertReviewConsentPrompt(t, console.String(), "These changes may affect execution; review can help detect problems.")
+	prompt := assertReviewConsentPrompt(t, console.String(), "Review can help detect execution issues in these changes.")
 	if !bytes.Contains([]byte(prompt), []byte("Gentle AI can review this change before you call it done.")) {
 		t.Fatalf("interactive consent prompt lost its question: %q", prompt)
 	}

--- a/internal/cli/review_negotiated_stderr_silence_test.go
+++ b/internal/cli/review_negotiated_stderr_silence_test.go
@@ -242,7 +242,10 @@ func TestNegotiatedStartUndeclaredInteractiveKeepsConsentCeremony(t *testing.T) 
 	if !errors.Is(err, errReviewDeclinedForCandidate) {
 		t.Fatalf("interactive negotiated refusal = %v, want errReviewDeclinedForCandidate\n%s", err, output.String())
 	}
-	assertReviewConsentPrompt(t, console.String(), "scripts/deploy.sh")
+	prompt := assertReviewConsentPrompt(t, console.String(), "These changes may affect execution; review can help detect problems.")
+	if !bytes.Contains([]byte(prompt), []byte("Review this change now?")) {
+		t.Fatalf("interactive consent prompt lost its question: %q", prompt)
+	}
 }
 
 // TestNegotiatedStartUndeclaredAskedLatchProceedsSilently proves the machine

--- a/internal/cli/review_provider_artifact_contract_test.go
+++ b/internal/cli/review_provider_artifact_contract_test.go
@@ -56,7 +56,7 @@ func TestReviewProviderArtifactV20ContractsArePinned(t *testing.T) {
 	root := filepath.Join("..", "..", "contracts", "review-integration", "v2")
 	want := map[string]string{
 		"fixtures/capabilities.fixture.json": "8d5e1a8491db1a5a2f6329e8c1d5cd210dd175e0525ff4d51fa914351d2fcf08",
-		"fixtures/consent.fixture.json":      "a5d0ac8add6947aae29c375894d38cb15906403d5ee015c2272f96308311b9c5",
+		"fixtures/consent.fixture.json":      "adcab6a3e2d2926be721df127ca7ad0539d3e2a1ed5b1c0add36000df23eae64",
 		// issue #3922 / #4199 / gentle-pi#543: the native-git reviewer_result
 		// collect input no longer inlines changed_path_manifest -- it is
 		// already committed to by artifact_subject.changed_path_manifest_sha256
@@ -86,7 +86,7 @@ func TestReviewProviderArtifactV21ContractsArePinned(t *testing.T) {
 		// issue #2659: consent-v3 embeds a freshly minted target_identity;
 		// the purified identity domain legitimately changed that hash.
 		// Deliberate, not drift.
-		"fixtures/consent-v3.fixture.json":      "3af3cc530ba87d289778e09dba6c01c373e793031c23a09c3de29b1aa2d0ec62",
+		"fixtures/consent-v3.fixture.json":      "86c7af15a49a04c5d63755d1a9eb0eccc681ea4c0cd2d62145185fa165786cee",
 		"schemas/capabilities-v2.1.schema.json": "95d2b8b46e9be6e6fbc874fc763029cb7994951336c8974dc1694834d64bf06e",
 		// Cross-lane battery conformance fix: the schema pinned the choice
 		// invocations to `--agent claude-code`, but the live emitter omits the

--- a/internal/cli/review_provider_artifact_contract_test.go
+++ b/internal/cli/review_provider_artifact_contract_test.go
@@ -17,6 +17,7 @@ func TestReviewProviderArtifactV1ContractsArePinned(t *testing.T) {
 	root := filepath.Join("..", "..", "contracts", "review-integration", "v1")
 	want := map[string]string{
 		"fixtures/capabilities-v1.4.fixture.json": "84e0db457b76b97b35c2be772dfc647f9eab66810ea98f64fed85645c3c266ba",
+		"fixtures/consent.fixture.json":           "110eb39e2326e9472368b77a2c2545d4856bdafe50bd0b3f714f6a137141482a",
 		"fixtures/start.fixture.json":             "3b963b221cd1560eb8872cbabbb5407096f593ced2f13eb9cb06eb61e4cca4d1",
 		// issue #2659: start-v2/status-v2 embed a freshly minted target_identity,
 		// and the purified identity domain legitimately changed that hash for
@@ -56,7 +57,7 @@ func TestReviewProviderArtifactV20ContractsArePinned(t *testing.T) {
 	root := filepath.Join("..", "..", "contracts", "review-integration", "v2")
 	want := map[string]string{
 		"fixtures/capabilities.fixture.json": "8d5e1a8491db1a5a2f6329e8c1d5cd210dd175e0525ff4d51fa914351d2fcf08",
-		"fixtures/consent.fixture.json":      "adcab6a3e2d2926be721df127ca7ad0539d3e2a1ed5b1c0add36000df23eae64",
+		"fixtures/consent.fixture.json":      "66a3a9d7d3fe1b8956739616f333f8e38c2515bf8e0030e65f5213b415d48ad2",
 		// issue #3922 / #4199 / gentle-pi#543: the native-git reviewer_result
 		// collect input no longer inlines changed_path_manifest -- it is
 		// already committed to by artifact_subject.changed_path_manifest_sha256
@@ -86,7 +87,7 @@ func TestReviewProviderArtifactV21ContractsArePinned(t *testing.T) {
 		// issue #2659: consent-v3 embeds a freshly minted target_identity;
 		// the purified identity domain legitimately changed that hash.
 		// Deliberate, not drift.
-		"fixtures/consent-v3.fixture.json":      "86c7af15a49a04c5d63755d1a9eb0eccc681ea4c0cd2d62145185fa165786cee",
+		"fixtures/consent-v3.fixture.json":      "8479e6248535bc315e43a3cb9e1862d1bf37ff988ca36f959f5ed2733cbbbdfd",
 		"schemas/capabilities-v2.1.schema.json": "95d2b8b46e9be6e6fbc874fc763029cb7994951336c8974dc1694834d64bf06e",
 		// Cross-lane battery conformance fix: the schema pinned the choice
 		// invocations to `--agent claude-code`, but the live emitter omits the

--- a/internal/cli/review_provider_artifact_contract_test.go
+++ b/internal/cli/review_provider_artifact_contract_test.go
@@ -56,7 +56,7 @@ func TestReviewProviderArtifactV20ContractsArePinned(t *testing.T) {
 	root := filepath.Join("..", "..", "contracts", "review-integration", "v2")
 	want := map[string]string{
 		"fixtures/capabilities.fixture.json": "8d5e1a8491db1a5a2f6329e8c1d5cd210dd175e0525ff4d51fa914351d2fcf08",
-		"fixtures/consent.fixture.json":      "203cc96d5c29ba0f27b5c4db04c2e88566e0a923d3a0cdb317f78d9065349075",
+		"fixtures/consent.fixture.json":      "a5d0ac8add6947aae29c375894d38cb15906403d5ee015c2272f96308311b9c5",
 		// issue #3922 / #4199 / gentle-pi#543: the native-git reviewer_result
 		// collect input no longer inlines changed_path_manifest -- it is
 		// already committed to by artifact_subject.changed_path_manifest_sha256
@@ -86,7 +86,7 @@ func TestReviewProviderArtifactV21ContractsArePinned(t *testing.T) {
 		// issue #2659: consent-v3 embeds a freshly minted target_identity;
 		// the purified identity domain legitimately changed that hash.
 		// Deliberate, not drift.
-		"fixtures/consent-v3.fixture.json":      "feb1dc7705f7da6490698ef48021bb7730de154ae23ec73d033d8d96fa996a21",
+		"fixtures/consent-v3.fixture.json":      "3af3cc530ba87d289778e09dba6c01c373e793031c23a09c3de29b1aa2d0ec62",
 		"schemas/capabilities-v2.1.schema.json": "95d2b8b46e9be6e6fbc874fc763029cb7994951336c8974dc1694834d64bf06e",
 		// Cross-lane battery conformance fix: the schema pinned the choice
 		// invocations to `--agent claude-code`, but the live emitter omits the

--- a/internal/cli/review_start_evidence_test.go
+++ b/internal/cli/review_start_evidence_test.go
@@ -36,8 +36,8 @@ func TestReviewFacadeStartHighRiskCarriesConsentEvidencePhrases(t *testing.T) {
 	if !reflect.DeepEqual(started.RiskEvidence, want) {
 		t.Fatalf("start risk_evidence = %#v, want %#v", started.RiskEvidence, want)
 	}
-	// Prompt parity: the phrases must be exactly what the interactive consent
-	// prompt would say for the same assessed candidate, from the same helper.
+	// Detailed evidence remains in risk_evidence; the prompt uses the same brief
+	// generic reason as the relay without exposing the evidence path.
 	builder := reviewtransaction.SnapshotBuilder{Repo: repo}
 	intended, err := builder.DiscoverUnignoredUntracked(context.Background())
 	if err != nil {
@@ -58,10 +58,8 @@ func TestReviewFacadeStartHighRiskCarriesConsentEvidencePhrases(t *testing.T) {
 			started.RiskEvidence, reviewConsentEvidencePhrases(assessment.Reasons))
 	}
 	prompt := reviewConsentPrompt(assessment)
-	for _, phrase := range started.RiskEvidence {
-		if !strings.Contains(prompt, phrase) {
-			t.Fatalf("interactive consent prompt %q does not speak phrase %q", prompt, phrase)
-		}
+	if !strings.Contains(prompt, reviewConsentReason(assessment)) || strings.Contains(prompt, "service-token.ts") {
+		t.Fatalf("interactive consent prompt did not keep generic reason separate from evidence: %q", prompt)
 	}
 }
 
@@ -92,8 +90,8 @@ func TestReviewFacadeStartMediumRiskCarriesConsentReason(t *testing.T) {
 	if !reflect.DeepEqual(started.RiskEvidence[1:], []string{want}) {
 		t.Fatalf("medium start risk_evidence = %#v, want the evidence phrase %q after the reason", started.RiskEvidence, want)
 	}
-	// Prompt parity: every phrase the START result carries must be spoken by
-	// the interactive consent prompt for the same assessed candidate.
+	// The prompt keeps the generic reason separate while the START result keeps
+	// the detailed evidence available to a relay.
 	builder := reviewtransaction.SnapshotBuilder{Repo: repo}
 	intended, err := builder.DiscoverUnignoredUntracked(context.Background())
 	if err != nil {
@@ -110,10 +108,8 @@ func TestReviewFacadeStartMediumRiskCarriesConsentReason(t *testing.T) {
 		t.Fatal(err)
 	}
 	prompt := reviewConsentPrompt(assessment)
-	for _, phrase := range started.RiskEvidence {
-		if !strings.Contains(prompt, phrase) {
-			t.Fatalf("interactive consent prompt %q does not speak phrase %q", prompt, phrase)
-		}
+	if !strings.Contains(prompt, reviewConsentReason(assessment)) || strings.Contains(prompt, "view.go") {
+		t.Fatalf("interactive consent prompt did not keep generic reason separate from evidence: %q", prompt)
 	}
 }
 
@@ -134,12 +130,11 @@ func TestReviewConsentRiskEvidenceMediumNamesEvidencePath(t *testing.T) {
 		t.Fatalf("medium risk_evidence = %#v, want %#v", got, want)
 	}
 
-	// The interactive Why line speaks the same facts from the same helpers.
-	reason := reviewConsentReason(assessment)
-	for _, phrase := range want {
-		if !strings.Contains(reason, phrase) {
-			t.Fatalf("consent reason %q does not speak phrase %q", reason, phrase)
-		}
+	// The interactive Why line is intentionally generic; detailed evidence stays
+	// in risk_evidence for relays that need it.
+	if reason := reviewConsentReason(assessment); reason != "These changes alter behavior; review can help check for regressions." ||
+		strings.Contains(reason, "internal/counter/counter.go") {
+		t.Fatalf("consent reason did not stay generic and path-free: %q", reason)
 	}
 }
 
@@ -153,8 +148,8 @@ func TestReviewConsentRiskEvidenceMediumWithoutSpeakableReasonsStaysSingle(t *te
 	if got := reviewConsentRiskEvidence(assessment); !reflect.DeepEqual(got, want) {
 		t.Fatalf("medium risk_evidence without speakable reasons = %#v, want %#v", got, want)
 	}
-	if reason := reviewConsentReason(assessment); reason != reviewConsentMediumReason {
-		t.Fatalf("consent reason without speakable reasons = %q, want %q", reason, reviewConsentMediumReason)
+	if reason := reviewConsentReason(assessment); reason != "These changes alter behavior; review can help check for regressions." {
+		t.Fatalf("consent reason without specific signals = %q", reason)
 	}
 }
 
@@ -171,6 +166,81 @@ func TestReviewConsentRiskEvidenceHighTierUnchanged(t *testing.T) {
 	want := []string{"service credentials in service-token.ts"}
 	if got := reviewConsentRiskEvidence(assessment); !reflect.DeepEqual(got, want) {
 		t.Fatalf("high risk_evidence = %#v, want %#v", got, want)
+	}
+}
+
+func TestReviewConsentReasonUsesAuthoritativeRiskSignals(t *testing.T) {
+	for _, tt := range []struct {
+		name    string
+		level   reviewtransaction.RiskLevel
+		reasons []reviewtransaction.RiskReason
+		english string
+		spanish string
+	}{
+		{
+			name: "security signal", level: reviewtransaction.RiskHigh,
+			reasons: []reviewtransaction.RiskReason{{Code: reviewtransaction.RiskReasonHotPath, Signal: reviewtransaction.SignalSecurity, Path: "security.go"}},
+			english: "These changes may affect security; review can help detect problems.",
+			spanish: "Estos cambios pueden afectar la seguridad; la revisión puede ayudar a detectar problemas.",
+		},
+		{
+			name: "execution signal", level: reviewtransaction.RiskHigh,
+			reasons: []reviewtransaction.RiskReason{{Code: reviewtransaction.RiskReasonShellSource, Signal: reviewtransaction.SignalShellProcess, Path: "scripts/deploy.sh"}},
+			english: "These changes may affect execution; review can help detect problems.",
+			spanish: "Estos cambios pueden afectar la ejecución; la revisión puede ayudar a detectar problemas.",
+		},
+		{
+			name: "update signal", level: reviewtransaction.RiskHigh,
+			reasons: []reviewtransaction.RiskReason{{Code: reviewtransaction.RiskReasonHotPath, Signal: reviewtransaction.SignalUpdate, Path: "update.go"}},
+			english: "These changes may affect updates; review can help detect problems.",
+			spanish: "Estos cambios pueden afectar las actualizaciones; la revisión puede ayudar a detectar problemas.",
+		},
+		{
+			name: "security takes precedence", level: reviewtransaction.RiskHigh,
+			reasons: []reviewtransaction.RiskReason{
+				{Code: reviewtransaction.RiskReasonHotPath, Signal: reviewtransaction.SignalUpdate, Path: "update.go"},
+				{Code: reviewtransaction.RiskReasonHotPath, Signal: reviewtransaction.SignalSecurity, Path: "security.go"},
+			},
+			english: "These changes may affect security; review can help detect problems.",
+			spanish: "Estos cambios pueden afectar la seguridad; la revisión puede ayudar a detectar problemas.",
+		},
+		{
+			name: "no specific signal", level: reviewtransaction.RiskMedium,
+			reasons: []reviewtransaction.RiskReason{{Code: reviewtransaction.RiskReasonExecutableChange, Path: "internal/app.go"}},
+			english: "These changes alter behavior; review can help check for regressions.",
+			spanish: "Estos cambios alteran el comportamiento; la revisión puede ayudar a detectar regresiones.",
+		},
+		{
+			name: "unsupported signal", level: reviewtransaction.RiskHigh,
+			reasons: []reviewtransaction.RiskReason{{Code: reviewtransaction.RiskReasonHotPath, Signal: reviewtransaction.RiskSignal("unsupported"), Path: "unknown.go"}},
+			english: "These changes alter behavior; review can help check for regressions.",
+			spanish: "Estos cambios alteran el comportamiento; la revisión puede ayudar a detectar regresiones.",
+		},
+		{
+			name:    "high without evidence is not security",
+			level:   reviewtransaction.RiskHigh,
+			english: "These changes alter behavior; review can help check for regressions.",
+			spanish: "Estos cambios alteran el comportamiento; la revisión puede ayudar a detectar regresiones.",
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			assessment := reviewtransaction.RiskAssessment{Level: tt.level, Reasons: tt.reasons}
+			for locale, got := range map[string]string{
+				"English": reviewConsentReason(assessment),
+				"Spanish": reviewConsentSpanishReason(assessment),
+			} {
+				want := tt.english
+				if locale == "Spanish" {
+					want = tt.spanish
+				}
+				if got != want {
+					t.Fatalf("%s reason = %q, want %q", locale, got, want)
+				}
+				if len(strings.Fields(got)) > 25 || strings.Contains(got, ".go") || strings.Contains(got, ".sh") {
+					t.Fatalf("%s reason is not concise generic copy: %q", locale, got)
+				}
+			}
+		})
 	}
 }
 

--- a/internal/cli/review_start_evidence_test.go
+++ b/internal/cli/review_start_evidence_test.go
@@ -132,7 +132,7 @@ func TestReviewConsentRiskEvidenceMediumNamesEvidencePath(t *testing.T) {
 
 	// The interactive Why line is intentionally generic; detailed evidence stays
 	// in risk_evidence for relays that need it.
-	if reason := reviewConsentReason(assessment); reason != "These changes alter behavior; review can help check for regressions." ||
+	if reason := reviewConsentReason(assessment); reason != "Review can help detect regressions in these changes." ||
 		strings.Contains(reason, "internal/counter/counter.go") {
 		t.Fatalf("consent reason did not stay generic and path-free: %q", reason)
 	}
@@ -148,7 +148,7 @@ func TestReviewConsentRiskEvidenceMediumWithoutSpeakableReasonsStaysSingle(t *te
 	if got := reviewConsentRiskEvidence(assessment); !reflect.DeepEqual(got, want) {
 		t.Fatalf("medium risk_evidence without speakable reasons = %#v, want %#v", got, want)
 	}
-	if reason := reviewConsentReason(assessment); reason != "These changes alter behavior; review can help check for regressions." {
+	if reason := reviewConsentReason(assessment); reason != "Review can help detect regressions in these changes." {
 		t.Fatalf("consent reason without specific signals = %q", reason)
 	}
 }
@@ -180,20 +180,20 @@ func TestReviewConsentReasonUsesAuthoritativeRiskSignals(t *testing.T) {
 		{
 			name: "security signal", level: reviewtransaction.RiskHigh,
 			reasons: []reviewtransaction.RiskReason{{Code: reviewtransaction.RiskReasonHotPath, Signal: reviewtransaction.SignalSecurity, Path: "security.go"}},
-			english: "These changes may affect security; review can help detect problems.",
-			spanish: "Estos cambios pueden afectar la seguridad; la revisión puede ayudar a detectar problemas.",
+			english: "Review can help identify potential security issues.",
+			spanish: "La revisión puede ayudar a identificar posibles problemas de seguridad.",
 		},
 		{
 			name: "execution signal", level: reviewtransaction.RiskHigh,
 			reasons: []reviewtransaction.RiskReason{{Code: reviewtransaction.RiskReasonShellSource, Signal: reviewtransaction.SignalShellProcess, Path: "scripts/deploy.sh"}},
-			english: "These changes may affect execution; review can help detect problems.",
-			spanish: "Estos cambios pueden afectar la ejecución; la revisión puede ayudar a detectar problemas.",
+			english: "Review can help detect execution issues in these changes.",
+			spanish: "La revisión puede ayudar a detectar problemas de ejecución en estos cambios.",
 		},
 		{
 			name: "update signal", level: reviewtransaction.RiskHigh,
 			reasons: []reviewtransaction.RiskReason{{Code: reviewtransaction.RiskReasonHotPath, Signal: reviewtransaction.SignalUpdate, Path: "update.go"}},
-			english: "These changes may affect updates; review can help detect problems.",
-			spanish: "Estos cambios pueden afectar las actualizaciones; la revisión puede ayudar a detectar problemas.",
+			english: "Review can help detect update-related issues.",
+			spanish: "La revisión puede ayudar a detectar problemas relacionados con las actualizaciones.",
 		},
 		{
 			name: "security takes precedence", level: reviewtransaction.RiskHigh,
@@ -201,26 +201,26 @@ func TestReviewConsentReasonUsesAuthoritativeRiskSignals(t *testing.T) {
 				{Code: reviewtransaction.RiskReasonHotPath, Signal: reviewtransaction.SignalUpdate, Path: "update.go"},
 				{Code: reviewtransaction.RiskReasonHotPath, Signal: reviewtransaction.SignalSecurity, Path: "security.go"},
 			},
-			english: "These changes may affect security; review can help detect problems.",
-			spanish: "Estos cambios pueden afectar la seguridad; la revisión puede ayudar a detectar problemas.",
+			english: "Review can help identify potential security issues.",
+			spanish: "La revisión puede ayudar a identificar posibles problemas de seguridad.",
 		},
 		{
 			name: "no specific signal", level: reviewtransaction.RiskMedium,
 			reasons: []reviewtransaction.RiskReason{{Code: reviewtransaction.RiskReasonExecutableChange, Path: "internal/app.go"}},
-			english: "These changes alter behavior; review can help check for regressions.",
-			spanish: "Estos cambios alteran el comportamiento; la revisión puede ayudar a detectar regresiones.",
+			english: "Review can help detect regressions in these changes.",
+			spanish: "La revisión puede ayudar a detectar regresiones en estos cambios.",
 		},
 		{
 			name: "unsupported signal", level: reviewtransaction.RiskHigh,
 			reasons: []reviewtransaction.RiskReason{{Code: reviewtransaction.RiskReasonHotPath, Signal: reviewtransaction.RiskSignal("unsupported"), Path: "unknown.go"}},
-			english: "These changes alter behavior; review can help check for regressions.",
-			spanish: "Estos cambios alteran el comportamiento; la revisión puede ayudar a detectar regresiones.",
+			english: "Review can help detect regressions in these changes.",
+			spanish: "La revisión puede ayudar a detectar regresiones en estos cambios.",
 		},
 		{
 			name:    "high without evidence is not security",
 			level:   reviewtransaction.RiskHigh,
-			english: "These changes alter behavior; review can help check for regressions.",
-			spanish: "Estos cambios alteran el comportamiento; la revisión puede ayudar a detectar regresiones.",
+			english: "Review can help detect regressions in these changes.",
+			spanish: "La revisión puede ayudar a detectar regresiones en estos cambios.",
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #4417

Companion Pi presentation: Gentleman-Programming/gentle-pi#796 (issue Gentleman-Programming/gentle-pi#680).

## 🏷️ PR Type

- [x] `type:bug` — Non-breaking consent-copy correction

## 📝 Summary

- Keep the established consent headline, with concise choice consequences and a benefit-oriented `value`.
- Derive a generic reason from structured risk signals: security, execution, updates, or behavior, without exposing paths in the primary explanation.
- Preserve detailed risk evidence, consent scope, schema, answer tokens and invocations; keep English/Spanish and versioned fixtures consistent.

## 📂 Changes

| File / Area | What Changed |
| --- | --- |
| `internal/cli/review_mode.go` | Concise primary copy and deterministic risk-based reason selection. |
| `internal/cli/review_consent_contract.go` | Concise consequences and matching Spanish localization. |
| Consent, evidence, locale and interactive-prompt tests | Assert generic/path-free reasons, evidence separation, scope and existing ceremony. |
| v1/v2/v2.1 consent fixtures and artifact-pin tests | Update human-readable strings and their byte-integrity expectations. |

Total: **405 changed lines (258 additions, 147 deletions), 12 files**. The maintainer explicitly approved `size:exception` for this cohesive fix.

## 🤖 AI Assistance

- [ ] **None**
- [x] **Material assistance used**

**Tool/model (if known):** Pi coding-agent workflow with delegated implementation and independent verification.

**Material scope:** Consent-copy implementation, tests, fixtures, and PR preparation.

**Verification performed:** Independent source inspection; isolated focused Go tests; formatting and whitespace checks; source/configuration before-and-after hash checks. The original validation limits are recorded below; subsequent CI results are authoritative for their tested commits.

## 🧪 Test Plan

- [x] Focused checks passed independently:
  ```bash
  go test ./internal/cli -timeout=60s -run 'Test.*(Consent|Risk|Schema|Pin|ProviderArtifact)' -count=1
  ```
  Exit 0, 7.493s in the final independent run. The selector matches 91 top-level test declarations; nonverbose output does not enumerate executed counts.
- [x] Go format: `go run ./internal/gofmtcheck` passed.
- [x] `git diff acc62463 --check` passed.
- [ ] Clean full-suite result: earlier `go test ./... -timeout=90s -count=1` runs failed assertions and timed out in packages. Some isolation overrides conflicted with per-test HOME fixtures. The final focused run corrected that setup; the complete suite has not been rerun successfully.
- [ ] Docker E2E: not run; Docker is unavailable in the local environment.
- [ ] Benchmark/cross-lane validation: pending; no benchmark or live-provider parity claim is made.
- [ ] Live updated-provider manual test: not performed. The maintainer evaluated a display-only Pi preview using the changed fixture strings, not an installed candidate binary.

Final focused tests ran with private HOME/USERPROFILE/XDG/cache/temp directories, both Pi path overrides unset, and dependency downloads disabled. Real configuration hashes and modes remained unchanged during those final runs.

## 🤖 Automated Checks

CI results are pending. The PR is ready for review. Check the latest commit’s CI status before merging.

## ✅ Contributor Checklist

- [x] Linked an issue with `status:approved`.
- [x] Maintainer-approved `size:exception` for the current 405 changed lines; obsolete helpers were removed rather than hidden from the analyzer.
- [x] Exactly one PR type: `type:bug`.
- [ ] Complete unit suite passed.
- [x] Go formatting passed.
- [ ] Docker E2E passed.
- [ ] Applicable benchmark/cross-lane validation completed.
- [x] Updated the existing contract examples and tests with the copy change.
- [x] Conventional commit with no `Co-Authored-By` trailers.
- [x] AI-assistance disclosure completed.

## Latest CI correction

Commit `af7529ab` removes the two obsolete private evidence-formatting helpers reported by the dead-code check. No baseline suppression or dependency-file change was made.

Independent verification on these exact source bytes passed:
- `./scripts/deadcode-ratchet.sh`: **no new unreachable functions**.
- Focused consent/risk/schema/provider-artifact Go tests: exit 0 (8.200s).
- `go run ./internal/gofmtcheck` and whitespace checks: passed.

Verification used fresh private caches, the pinned analyzer, and isolated configuration directories. Real configuration hashes/modes stayed unchanged. That correction passed CI and CodeRabbit. The latest headline revision requires its own CI run.

## Approved headline restoration

Commit `abcfd702` restores “Gentle AI can review this change before you call it done.” and its established Spanish equivalent, as requested by the maintainer. Generic risk-dependent reasons and concise effects remain unchanged.

Independent focused consent/risk/schema/artifact tests, formatting and whitespace checks passed. All three fixture changes are headline-only; their pins were recomputed. CI is rerunning for this exact commit. No merge is performed by this update.

## Review-focused reason wording

Commit `371ba961` phrases the reason around what review helps detect, rather than saying that changes may affect something. For example: “Review can help detect execution issues in these changes.” Reasons still vary by the existing structured risk category; the original headline and all consent behavior are unchanged.

Independent focused Go tests, formatting and fixture/pin integrity checks passed. CI must validate this new head before merge.

## 💬 Notes for Reviewers

- `value` remains a benefits field; it is not used to store lifecycle disclaimers. Choice effects retain current-change scope, skip semantics and delivery separation.
- Reason categories use structured signals rather than matching prose or assuming every high-risk change concerns security. Detailed `risk_evidence` remains separate.
- No permission state machine, admission rule, review budget, schema or machine invocation is changed.
- Native inspection stopped at `managed_assets_outdated` before review START. No synchronization workaround, review lineage, receipt or native approval was created. This blocker remains unresolved and is not represented as approval.
- No merge or auto-merge is authorized.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Updated review consent prompts with shorter, clearer wording.
  * Clarified that reviews apply only to the current change, while delivery requires separate approval.
  * Clarified that skipping a review creates no review record and keeps future reviews enabled.
  * Replaced detailed or path-specific explanations with concise, risk-based reasons.
  * Updated Spanish translations for headlines, explanations, and response choices.
  * Standardized consent wording across supported review contract versions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->