### PR TITLE
feat(sdd): declare exact Pi research evidence grants

### DIFF
--- a/docs/pi.md
+++ b/docs/pi.md
@@ -61,6 +61,30 @@ Files updated by Gentle AI's Engram provisioning:
 
 `gentle-engram` owns the MCP schema itself. The installer runs `pi-engram init`, which initializes Pi's Engram MCP config under the Pi agent config directory instead of having Gentle AI hand-write that file.
 
+## SDD Research Capability
+
+Gentle AI declares Pi's canonical research capability under
+`gentle-ai.sdd-research-capability/v1`. Admission requires **all grants** for the
+requested class, with exact lowercase names:
+
+| Class | Required grants |
+| --- | --- |
+| `documentation` | `fetch_content` |
+| `open-web` | `web_search`, `source_check`, `fetch_content`, `get_search_content` |
+
+The observed grants must match the class exactly. Order does not matter; missing,
+renamed, duplicate, or unexpected grants deny admission. None of the four
+open-web grants is optional. Unknown classes or schemas also deny admission,
+returning no verified grants and no claims. Bash, generic MCP access, package
+installation, and inherited tools are not substitutes for observed grants.
+Admission verifies tool grants only; it does not create source-backed claims.
+
+Downstream [`gentle-pi`](https://github.com/Gentleman-Programming/gentle-pi) owns
+runtime tool observation, child tool projection, and research execution. This
+upstream declaration neither installs new tools nor proves that a live Pi child
+can use them. A separate downstream runtime probe is still required to establish
+live research evidence.
+
 ## Optional CodeGraph
 
 Select CodeGraph during Gentle AI installation to add its read-only MCP server to Pi. This integration is optional and owned entirely by Gentle AI; `gentle-pi` is not modified.

--- a/internal/agents/researchcapability/contract.go
+++ b/internal/agents/researchcapability/contract.go
@@ -22,6 +22,11 @@ const (
 	GrantWebFetch  Grant = "WebFetch"
 	GrantWebSearch Grant = "WebSearch"
 	GrantContext7  Grant = "@context7"
+
+	GrantPiFetchContent     Grant = "fetch_content"
+	GrantPiWebSearch        Grant = "web_search"
+	GrantPiSourceCheck      Grant = "source_check"
+	GrantPiGetSearchContent Grant = "get_search_content"
 )
 
 // Capability is one runtime's maximum declared evidence capability.
@@ -47,6 +52,13 @@ type Result struct {
 }
 
 var capabilities = map[model.AgentID]Capability{
+	model.AgentPi: {
+		Schema: SchemaV1,
+		Grants: map[Class][]Grant{
+			ClassDocumentation: {GrantPiFetchContent},
+			ClassOpenWeb:       {GrantPiWebSearch, GrantPiSourceCheck, GrantPiFetchContent, GrantPiGetSearchContent},
+		},
+	},
 	model.AgentClaudeCode: {
 		Schema: SchemaV1,
 		Grants: map[Class][]Grant{

--- a/internal/agents/researchcapability/contract_test.go
+++ b/internal/agents/researchcapability/contract_test.go
@@ -67,6 +67,99 @@ func TestAdmitFailsClosedAndReturnsOnlyVerifiedGrants(t *testing.T) {
 	}
 }
 
+func TestPiAdmissionRequiresExactGrants(t *testing.T) {
+	t.Parallel()
+
+	openWeb := []Grant{"web_search", "source_check", "fetch_content", "get_search_content"}
+	type admissionCase struct {
+		name   string
+		schema SchemaVersion
+		class  Class
+		grants []Grant
+		want   []Grant
+	}
+	tests := []admissionCase{
+		{"documentation", SchemaV1, ClassDocumentation, []Grant{"fetch_content"}, []Grant{"fetch_content"}},
+		{"open web", SchemaV1, ClassOpenWeb, openWeb, openWeb},
+		{"reordered open web", SchemaV1, ClassOpenWeb, []Grant{"get_search_content", "fetch_content", "source_check", "web_search"}, openWeb},
+		{"missing documentation tool", SchemaV1, ClassDocumentation, nil, nil},
+		{"renamed documentation tool", SchemaV1, ClassDocumentation, []Grant{"Fetch_Content"}, nil},
+		{"duplicate documentation tool", SchemaV1, ClassDocumentation, []Grant{"fetch_content", "fetch_content"}, nil},
+		{"unexpected documentation grant", SchemaV1, ClassDocumentation, []Grant{"fetch_content", "web_search"}, nil},
+		{"missing schema", "", ClassOpenWeb, openWeb, nil},
+		{"invalid schema", "gentle-ai.sdd-research-capability/v2", ClassOpenWeb, openWeb, nil},
+		{"missing class", SchemaV1, "", openWeb, nil},
+		{"invalid class", SchemaV1, "repository", openWeb, nil},
+		{"Bash is not evidence", SchemaV1, ClassDocumentation, []Grant{"Bash"}, nil},
+		{"generic MCP is not evidence", SchemaV1, ClassDocumentation, []Grant{"mcp"}, nil},
+		{"inheritance is not evidence", SchemaV1, ClassDocumentation, []Grant{"inherited"}, nil},
+	}
+	for i, grant := range openWeb {
+		missing := append([]Grant(nil), openWeb[:i]...)
+		missing = append(missing, openWeb[i+1:]...)
+		renamed := append([]Grant(nil), openWeb...)
+		renamed[i] = grant + "_renamed"
+		duplicate := append([]Grant(nil), openWeb...)
+		duplicate[i] = openWeb[(i+1)%len(openWeb)]
+		for _, variant := range []struct {
+			name   string
+			grants []Grant
+		}{
+			{"missing " + string(grant), missing},
+			{"renamed " + string(grant), renamed},
+			{"duplicate replacing " + string(grant), duplicate},
+			{"extra " + string(grant), append(append([]Grant(nil), openWeb...), grant)},
+		} {
+			tests = append(tests, admissionCase{variant.name, SchemaV1, ClassOpenWeb, variant.grants, nil})
+		}
+	}
+	for _, extra := range []Grant{"Bash", "mcp", "unexpected"} {
+		tests = append(tests, admissionCase{"unexpected " + string(extra), SchemaV1, ClassOpenWeb, append(append([]Grant(nil), openWeb...), extra), nil})
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			got := Admit(Request{Schema: test.schema, AgentID: model.AgentPi, Class: test.class, ObservedGrants: test.grants})
+			if got.Allowed != (test.want != nil) || !reflect.DeepEqual(got.VerifiedGrants, test.want) || len(got.Claims) != 0 {
+				t.Fatalf("Admit() = %#v, want grants %v and no claims", got, test.want)
+			}
+		})
+	}
+}
+
+func TestCapabilitiesAndAdmissionReturnDefensiveCopies(t *testing.T) {
+	t.Parallel()
+
+	for _, agent := range []model.AgentID{model.AgentClaudeCode, model.AgentKiroIDE, model.AgentPi} {
+		t.Run(string(agent), func(t *testing.T) {
+			t.Parallel()
+			original, ok := ForAgent(agent)
+			if !ok {
+				t.Fatal("expected declared capability")
+			}
+			for class, grants := range original.Grants {
+				copyOf, _ := ForAgent(agent)
+				copyOf.Grants[class][0] = "mutated"
+				delete(copyOf.Grants, class)
+				observed := append([]Grant(nil), grants...)
+				result := Admit(Request{Schema: SchemaV1, AgentID: agent, Class: class, ObservedGrants: observed})
+				if !result.Allowed {
+					t.Fatal("copy mutation changed admission")
+				}
+				observed[0] = "mutated input"
+				if !reflect.DeepEqual(result.VerifiedGrants, grants) {
+					t.Fatal("verified grants alias request")
+				}
+				result.VerifiedGrants[0] = "mutated result"
+				fresh, _ := ForAgent(agent)
+				if !reflect.DeepEqual(fresh, original) {
+					t.Fatal("caller mutation changed canonical capability")
+				}
+			}
+		})
+	}
+}
+
 func TestDocumentationLikeInputsNeverBecomeGrants(t *testing.T) {
 	t.Parallel()
 
@@ -91,7 +184,7 @@ func TestDocumentationLikeInputsNeverBecomeGrants(t *testing.T) {
 	}
 }
 
-func TestForAgentDeclaresOnlyClaudeAndKiro(t *testing.T) {
+func TestForAgentDeclaresOnlyClaudeKiroAndPi(t *testing.T) {
 	t.Parallel()
 
 	want := map[model.AgentID]map[Class][]Grant{
@@ -100,6 +193,10 @@ func TestForAgentDeclaresOnlyClaudeAndKiro(t *testing.T) {
 			ClassOpenWeb:       {GrantWebSearch, GrantWebFetch},
 		},
 		model.AgentKiroIDE: {ClassDocumentation: {GrantContext7}},
+		model.AgentPi: {
+			ClassDocumentation: {"fetch_content"},
+			ClassOpenWeb:       {"web_search", "source_check", "fetch_content", "get_search_content"},
+		},
 	}
 	for _, agent := range []model.AgentID{
 		model.AgentClaudeCode, model.AgentOpenCode, model.AgentKilocode, model.AgentGeminiCLI,


### PR DESCRIPTION
## 🔗 Linked Issue
Closes #3846
Downstream: Gentleman-Programming/gentle-pi#471.

## 🏷️ PR Type
- [x] `type:feature` — New feature

## 📝 Summary
- Declare Pi documentation grants as `fetch_content` and open-web grants as all four exact pi-web-access tools.
- Preserve exact-set, fail-closed admission; add missing, renamed, duplicate, unexpected, schema/class, and defensive-copy coverage.
- Document the boundary between canonical admission and downstream runtime evidence.

## 📂 Changes
| File / Area | What Changed |
|---|---|
| `internal/agents/researchcapability/contract.go` | Exact Pi grant declaration |
| `internal/agents/researchcapability/contract_test.go` | Positive and negative admission regressions |
| `docs/pi.md` | Required tool sets and downstream ownership |

## 🤖 AI Assistance
- [ ] **None**
- [x] **Material assistance used**
**Tool/model:** Pi coding assistant and delegated implementation/verification agents.
**Material scope:** Investigation, implementation, tests, documentation, and substantive review.
**Verification performed:** Independent source inspection and executed focused/full Go tests, vet, formatting, and Docker E2E. Parent inspected the complete diff and reran focused tests, formatting, and whitespace checks.

## 🧪 Test Plan
- [x] `go test ./internal/agents/researchcapability -count=1`
- [x] `TMPDIR=<owner-only canonical temporary directory> go test -json -timeout 20m ./...`: 12,317 test/subtest passes, 26 skips; 77 packages passed, 4 skipped.
- [x] `go vet ./...`
- [x] `go run ./internal/gofmtcheck`
- [x] `(cd e2e && bash ./docker-test.sh)`: Ubuntu, Arch, Fedora each 79 passed / 0 failed; default Tier 1 only.
- [x] `git diff --check`

The initial macOS full-suite run failed 18 reviewtransaction tests. All 18 failed with identical diagnostics on the clean base. A subprocess-only canonical TMPDIR eliminated the symlink-path failures; the adjusted full suite passed. No global configuration or unrelated source was changed.

Benchmark validation: N/A, this adds a static research capability declaration, not a review-lifecycle, delivery, or benchmark behavior change.

## ✅ Contributor Checklist
- [x] Linked approved issue and exactly one type label.
- [x] 135 authored changed lines, within the 400-line budget.
- [x] Code, tests, and documentation are one reversible work unit.
- [x] Applicable verification completed and limitations disclosed.
- [x] Conventional commit without Co-Authored-By trailers.

## 💬 Notes for Reviewers
Admission verifies grants, not research claims. Live child execution and downstream dependency pinning remain the responsibility of gentle-pi#471. No upstream live-research success is claimed.
Native review consent expired before any lineage was created; no native receipt is claimed. Independent source verification and the executed tests above are the available evidence.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added research capabilities for the Pi runtime, supporting documentation lookup and open-web research.
  - Access is granted only when the required tool permissions match the configured research class exactly.

- **Documentation**
  - Added guidance describing Pi’s research capability, required permissions, admission rules, and runtime handling of tool observations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->