### PR TITLE
docs(pr-template): use absolute URLs so template links resolve from PR bodies

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -52,7 +52,7 @@ Select exactly one option. Do not check both options.
 
 **Verification performed:**
 
-Trivial formatting, spelling, minor autocomplete, search/navigation, and trivial, non-substantive mechanical transformations do not need to be itemized. See [AI_POLICY.md](../AI_POLICY.md) for the canonical policy.
+Trivial formatting, spelling, minor autocomplete, search/navigation, and trivial, non-substantive mechanical transformations do not need to be itemized. See [AI_POLICY.md](https://github.com/Gentleman-Programming/gentle-ai/blob/main/AI_POLICY.md) for the canonical policy.
 
 ---
 
@@ -75,7 +75,7 @@ cd e2e && ./docker-test.sh
 
 **Benchmark Validation**
 
-See the [benchmark guide](../bench/README.md). Benchmark validation applies to review-lifecycle, gates, recovery, delivery, benchmark implementation/corpus/classifier, and benchmark-claim changes. For unrelated changes, explain `N/A` in the Test Plan.
+See the [benchmark guide](https://github.com/Gentleman-Programming/gentle-ai/blob/main/bench/README.md). Benchmark validation applies to review-lifecycle, gates, recovery, delivery, benchmark implementation/corpus/classifier, and benchmark-claim changes. For unrelated changes, explain `N/A` in the Test Plan.
 
 - [ ] Unit tests pass (`go test ./...`)
 - [ ] Go format passes (`go run ./internal/gofmtcheck`)


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #3297

---

## 🏷️ PR Type

- [x] `type:docs` — Documentation only

---

## 📝 Summary

The pull request template links to `AI_POLICY.md` and `bench/README.md` using relative targets (`../AI_POLICY.md`, `../bench/README.md`). GitHub copies the template body verbatim into the pull request description without rewriting relative link targets, so both links resolve against the repository web root (`https://github.com/Gentleman-Programming/gentle-ai/AI_POLICY.md`) and return 404.

This PR replaces both relative targets with absolute `blob/main` URLs, which resolve correctly from both the file view on the blob page and a rendered pull request body.

---

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| `.github/PULL_REQUEST_TEMPLATE.md` | Replaced the two relative links (`../AI_POLICY.md` at line 55, `../bench/README.md` at line 78) with absolute `blob/main` URLs |

---

## 🤖 AI Assistance

Select exactly one option. Do not check both options.

- [ ] **None** — No material AI assistance was used.
- [x] **Material assistance used** — Complete all applicable declaration fields below.

**Tool/model (if known):** GLM-5.3 via the Pi coding agent (el Gentleman harness), directed by the account owner (FranklinF25).

**Material scope:** Locating the two affected template lines, choosing the absolute `blob/main` URL form, applying both edits, and drafting this PR description. The fix direction (relative → absolute URLs) was proposed in issue #3297.

**Verification performed:** Both absolute target URLs verified to return HTTP 200 (`curl -L`); grepped the codebase to confirm no Go test or source file references `PULL_REQUEST_TEMPLATE`; full diff reviewed and approved by the account owner before submission.

---

## 🧪 Test Plan

**Unit Tests**
```bash
go test ./...
```

**Go Format**
```bash
go run ./internal/gofmtcheck
```

**E2E Tests** (Docker required)
```bash
cd e2e && ./docker-test.sh
```

**Benchmark Validation**

N/A — this change touches only two markdown link targets in a `.github` template. It does not affect review-lifecycle, gates, recovery, delivery, benchmark implementation/corpus/classifier, or benchmark claims.

**Local results:** Go format check passed locally (exit 0). No Go files were modified by this change. A local full `go test ./...` run timed out on the `internal/cli` package at the default 600s timeout on this machine (a test-environment limitation, unrelated to this markdown-only change — no Go source or test file was touched); the CI suite is the authoritative run. Local E2E was not run (Docker suite; no runtime behavior was changed).

- [ ] Unit tests pass (`go test ./...`)
- [x] Go format passes (`go run ./internal/gofmtcheck`)
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`)
- [x] Manually tested locally

Manual verification: both replacement URLs return HTTP 200, and the rendered template no longer contains relative targets.

---

## 🤖 Automated Checks

The following checks run automatically on this PR:

| Check | Status | Description |
|-------|--------|-------------|
| Check PR Cognitive Load | ⏳ | PR should stay within 400 changed lines (`additions + deletions`) or use `size:exception` |
| Check Issue Reference | ⏳ | PR body must contain `Closes/Fixes/Resolves #N` |
| Check Issue Has `status:approved` | ⏳ | Linked issue must have been approved before work began |
| Check PR Has `type:*` Label | ⏳ | Exactly one `type:*` label must be applied |
| Unit Tests | ⏳ | `go test ./...` must pass |
| Go Format | ⏳ | `go run ./internal/gofmtcheck` must pass |
| E2E Tests | ⏳ | `cd e2e && ./docker-test.sh` must pass |

---

## ✅ Contributor Checklist

- [x] PR is linked to an issue with `status:approved`
- [x] PR stays within 400 changed lines, or I have requested/obtained maintainer-applied `size:exception` with rationale documented
- [ ] I have added the appropriate `type:*` label to this PR — outside-contributor accounts cannot apply labels; requesting maintainer-applied `type:docs`
- [ ] Unit tests pass (`go test ./...`)
- [x] Go format passes (`go run ./internal/gofmtcheck`)
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`)
- [x] Benchmark validation completed, or this change is not applicable to the benchmark (explain why in the Test Plan).
- [x] I have updated documentation if necessary
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] I understand, reviewed, and take responsibility for the complete submission
- [x] I selected exactly one AI-assistance option and, if material assistance was used, completed all applicable declaration fields
- [x] My commits do not include `Co-Authored-By` trailers

---

## 💬 Notes for Reviewers

This branch changes exactly two link targets in one markdown file. **Request:** maintainer-applied `type:docs` label — the CLI attempt from an outside-contributor account was rejected with `does not have the correct permissions to execute AddLabelsToLabelable`. Every other automated gate (issue reference, approved issue, cognitive load) should resolve from this body.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated pull request template links to use direct URLs for the AI policy and benchmark guide.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->