### PR TITLE
fix(sdd): unblock pending apply with historical verification

### DIFF
--- a/bench/journeys.go
+++ b/bench/journeys.go
@@ -812,6 +812,7 @@ func Journeys() []Journey {
 	journeys = append(journeys, sddJourneys()...)
 	journeys = append(journeys, issue2891Journeys()...)
 	journeys = append(journeys, issue2696Journeys()...)
+	journeys = append(journeys, issue4210Journeys()...)
 	journeys = append(journeys, sddChainJourneys()...)
 	journeys = append(journeys, issue3094Journeys()...)
 	journeys = append(journeys, issue3065Journeys()...)

--- a/bench/journeys_id_collision_test.go
+++ b/bench/journeys_id_collision_test.go
@@ -27,6 +27,7 @@ func journeySources() []journeySource {
 		{"journeys_sdd.go", sddJourneys()},
 		{"journeys_issue_2891.go", issue2891Journeys()},
 		{"journeys_issue2696.go", issue2696Journeys()},
+		{"journeys_issue4210.go", issue4210Journeys()},
 		{"journeys_sdd_chain.go", sddChainJourneys()},
 		{"journeys_issue3094.go", issue3094Journeys()},
 		{"journeys_issue_3065.go", issue3065Journeys()},

--- a/bench/journeys_issue4210.go
+++ b/bench/journeys_issue4210.go
@@ -1,0 +1,71 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"path/filepath"
+)
+
+// issue4210Journeys recreates the historical report contradiction from #4210:
+// a legacy failed report exists before unfinished tasks, so apply must remain
+// actionable while final verification remains unavailable.
+func issue4210Journeys() []Journey {
+	return []Journey{{
+		ID:     "j128-historical-verification-does-not-block-apply",
+		Review: reviewUntouched,
+		Title:  "Historical verification evidence does not block unfinished apply work",
+		Source: "https://github.com/Gentleman-Programming/gentle-ai/issues/4210",
+		Steps: []Step{
+			{Name: "fixture: pending task with a historical failed verification report", Fixture: issue4210Fixture},
+			{Name: "sdd-status keeps apply actionable", Requires: sddStatusCapability,
+				Args: productArgs("sdd-status", sddChange, "--json"), After: issue4210ApplyAssertion("sdd-status")},
+			{Name: "sdd-continue keeps the same apply contract", Requires: sddContinueCapability,
+				Args: productArgs("sdd-continue", sddChange, "--json"), After: issue4210ApplyAssertion("sdd-continue")},
+		},
+	}}
+}
+
+func issue4210Fixture(sandbox *Sandbox) error {
+	if err := baseRepo(sandbox); err != nil {
+		return err
+	}
+	root := sddChangeRoot(sandbox)
+	for name, content := range map[string]string{
+		"proposal.md":           "# Proposal\n",
+		"design.md":             "# Design\n",
+		"tasks.md":              "- [ ] 1.1 Finish implementation\n",
+		"specs/routing/spec.md": "### Requirement: apply remains actionable\n#### Scenario: historical verification predates unfinished work\n",
+		"verify-report.md":      "## Historical verification\n\nVerdict: FAIL\n\n- coverage was incomplete\n",
+	} {
+		if err := sandbox.write(filepath.Join(root, name), content); err != nil {
+			return err
+		}
+	}
+	if err := sandbox.git(sandbox.Repo, "add", "openspec"); err != nil {
+		return err
+	}
+	return sandbox.git(sandbox.Repo, "commit", "-qm", "issue 4210 historical verification fixture")
+}
+
+func issue4210ApplyAssertion(command string) func(*Sandbox, Observation) error {
+	return func(sandbox *Sandbox, observation Observation) error {
+		var status sddStatusV2
+		if err := json.Unmarshal([]byte(observation.Stdout), &status); err != nil {
+			return fmt.Errorf("parse %s JSON: %w", command, err)
+		}
+		if status.Dependencies.Apply != "ready" || status.Dependencies.Verify != "blocked" ||
+			status.Dependencies.Archive != "blocked" || status.NextRecommended != "apply" ||
+			status.TaskProgress.AllComplete || len(status.BlockedReasons) != 0 {
+			return fmt.Errorf("%s status = apply %q verify %q archive %q next %q complete %t blockers %v, want ready/blocked/blocked/apply/false/[]",
+				command, status.Dependencies.Apply, status.Dependencies.Verify, status.Dependencies.Archive,
+				status.NextRecommended, status.TaskProgress.AllComplete, status.BlockedReasons)
+		}
+		fingerprint := fmt.Sprintf("%s|%s|%s|%s|%t|%v", status.Dependencies.Apply, status.Dependencies.Verify,
+			status.Dependencies.Archive, status.NextRecommended, status.TaskProgress.AllComplete, status.BlockedReasons)
+		if previous := sandbox.Scratch["issue-4210-status"]; previous != "" && previous != fingerprint {
+			return fmt.Errorf("%s status differs from the earlier public command: %q != %q", command, fingerprint, previous)
+		}
+		sandbox.Scratch["issue-4210-status"] = fingerprint
+		return nil
+	}
+}

--- a/bench/review_declarations.go
+++ b/bench/review_declarations.go
@@ -122,6 +122,7 @@ var coreJourneyReviewModes = map[string]ReviewPrecondition{
 	"j120-welcome-tui-runs-under-a-real-tty":                                    reviewUntouched,
 	"j121-rdd-tui-controls-global-mode":                                         reviewUntouched,
 	"j127-customizable-install-rdd-choice":                                      reviewUntouched,
+	"j128-historical-verification-does-not-block-apply":                         reviewUntouched,
 	"j122-global-review-mode-from-non-git-cwd":                                  reviewUntouched,
 	"j123-rejected-provider-validator-starts-fresh-high-risk-review":            reviewOptedIn,
 	"j124-sdd-attempt-reset-after-selected-untracked-lands":                     reviewOptedIn,

--- a/bench/testdata/journeys.manifest
+++ b/bench/testdata/journeys.manifest
@@ -25,6 +25,7 @@ j124-sdd-attempt-reset-after-selected-untracked-lands
 j125-claude-code-stop-hook-reminds-once-per-candidate
 j126-selected-untracked-terminal-status-resumes-without-flags
 j127-customizable-install-rdd-choice
+j128-historical-verification-does-not-block-apply
 j13-next-transition-runs-verbatim
 j14-abandon-needs-a-hand-built-token
 j17-bare-repository

--- a/internal/cli/sdd_status_test.go
+++ b/internal/cli/sdd_status_test.go
@@ -42,6 +42,32 @@ func TestRunSDDStatusAndContinueOmitExpectedPlanningBlockers(t *testing.T) {
 	}
 }
 
+func TestRunSDDStatusAndContinueKeepHistoricalVerificationNonblockingDuringApply(t *testing.T) {
+	root := t.TempDir()
+	changeRoot := seedSDDStatusReadyChange(t, root, "historical", "- [ ] 1.1 Finish implementation\n")
+	writeSDDStatusFile(t, filepath.Join(changeRoot, "verify-report.md"), "## Verification\n\nVerdict: FAIL\n")
+
+	for name, run := range map[string]func([]string, io.Writer) error{
+		"sdd-status":   RunSDDStatus,
+		"sdd-continue": RunSDDContinue,
+	} {
+		t.Run(name, func(t *testing.T) {
+			var stdout bytes.Buffer
+			if err := run([]string{"historical", "--cwd", root, "--json"}, &stdout); err != nil {
+				t.Fatalf("command error = %v", err)
+			}
+
+			var status sddstatus.Status
+			if err := json.Unmarshal(stdout.Bytes(), &status); err != nil {
+				t.Fatalf("JSON decode error = %v\n%s", err, stdout.String())
+			}
+			if status.Dependencies.Apply != sddstatus.DependencyReady || status.NextRecommended != "apply" || len(status.BlockedReasons) != 0 {
+				t.Fatalf("continuation contract = apply %q next %q blocked %v, want ready/apply/no blockers", status.Dependencies.Apply, status.NextRecommended, status.BlockedReasons)
+			}
+		})
+	}
+}
+
 func TestRunSDDStatusPrintsJSONWithInstructions(t *testing.T) {
 	root := t.TempDir()
 	seedSDDStatusReadyChange(t, root, "add-auth", "- [ ] 1.1 Wire routes\n")

--- a/internal/sddstatus/issue4210_routing_test.go
+++ b/internal/sddstatus/issue4210_routing_test.go
@@ -1,0 +1,138 @@
+package sddstatus
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// #4210: verification evidence cannot block implementation that has not yet
+// reached its final verification gate. It remains required once tasks complete.
+func TestHistoricalVerificationEvidenceDoesNotBlockPendingApply(t *testing.T) {
+	partialFailure := testVerifyEnvelope("fail", 1, 0, "0/1", "0/1", 1, 0)
+	if admission := ValidateVerifyReportAdmission(partialFailure, SpecCounts{Requirements: 1, Scenarios: 1}); !admission.Valid {
+		t.Fatalf("partial failed report admission = %#v, want valid", admission)
+	}
+
+	for _, tt := range []struct {
+		name   string
+		report string
+	}{
+		{name: "admitted partial fail", report: partialFailure},
+		{name: "legacy report without envelope", report: "## Verification\n\nVerdict: FAIL\n\n- pending coverage\n"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			root := t.TempDir()
+			changeRoot := seedReadyChange(t, root, "historical", "- [ ] 1.1 Finish implementation\n")
+			write(t, filepath.Join(changeRoot, "verify-report.md"), tt.report)
+
+			status, err := Resolve(ResolveOptions{CWD: root, ChangeName: "historical"})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if status.Dependencies.Apply != DependencyReady || status.NextRecommended != string(PhaseApply) {
+				t.Fatalf("routing = apply %q next %q, want ready/apply", status.Dependencies.Apply, status.NextRecommended)
+			}
+			if len(status.BlockedReasons) != 0 {
+				t.Fatalf("pending implementation inherited final-verification blocker: %v", status.BlockedReasons)
+			}
+			if status.Dependencies.Verify != DependencyBlocked || status.Dependencies.Archive != DependencyBlocked {
+				t.Fatalf("dependencies = %#v, want verification and archive blocked until tasks complete", status.Dependencies)
+			}
+		})
+	}
+}
+
+func TestHistoricalVerificationEvidenceStillBlocksFinalization(t *testing.T) {
+	partialFailure := testVerifyEnvelope("fail", 1, 0, "0/1", "0/1", 1, 0)
+	for _, tt := range []struct {
+		name   string
+		report string
+	}{
+		{name: "admitted partial fail", report: partialFailure},
+		{name: "legacy report without envelope", report: "## Verification\n\nVerdict: FAIL\n"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			root := t.TempDir()
+			changeRoot := seedReadyChange(t, root, "historical", "- [x] 1.1 Implementation complete\n")
+			write(t, filepath.Join(changeRoot, "verify-report.md"), tt.report)
+
+			status, err := Resolve(ResolveOptions{CWD: root, ChangeName: "historical"})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if status.Dependencies.Apply != DependencyAllDone || status.Dependencies.Verify != DependencyReady || status.NextRecommended != string(PhaseVerify) {
+				t.Fatalf("routing = %#v next %q, want apply all_done, verify ready, next verify", status.Dependencies, status.NextRecommended)
+			}
+			if status.Dependencies.Archive != DependencyBlocked || len(status.BlockedReasons) == 0 {
+				t.Fatalf("finalization bypassed incomplete verification: archive %q reasons %v", status.Dependencies.Archive, status.BlockedReasons)
+			}
+		})
+	}
+}
+
+func TestCompleteVerificationFailureStillRequiresRemediation(t *testing.T) {
+	root := t.TempDir()
+	changeRoot := seedReadyChange(t, root, "failed", "- [x] 1.1 Implementation complete\n")
+	write(t, filepath.Join(changeRoot, "verify-report.md"), testVerifyEnvelope("fail", 1, 0, "1/1", "1/1", 1, 0))
+
+	status, err := Resolve(ResolveOptions{CWD: root, ChangeName: "failed"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !status.RemediationState.Required || status.NextRecommended != string(PhaseRemediate) {
+		t.Fatalf("complete failure = remediation %#v next %q, want required/remediate", status.RemediationState, status.NextRecommended)
+	}
+	if status.Dependencies.Archive != DependencyBlocked || !strings.Contains(strings.Join(status.BlockedReasons, "\n"), "remediation") {
+		t.Fatalf("complete failure bypassed remediation: archive %q reasons %v", status.Dependencies.Archive, status.BlockedReasons)
+	}
+}
+
+func TestHistoricalVerificationEvidenceEngramParity(t *testing.T) {
+	partialFailure := testVerifyEnvelope("fail", 1, 0, "0/1", "0/1", 1, 0)
+	for _, report := range []struct {
+		name    string
+		content string
+	}{
+		{name: "admitted partial fail", content: partialFailure},
+		{name: "legacy report without envelope", content: "## Verification\n\nVerdict: FAIL\n"},
+	} {
+		for _, tasks := range []struct {
+			name            string
+			content         string
+			wantApply       DependencyState
+			wantVerify      DependencyState
+			wantNext        string
+			wantBlockReason bool
+		}{
+			{name: "pending tasks", content: "- [ ] 1.1 Finish implementation\n", wantApply: DependencyReady, wantVerify: DependencyBlocked, wantNext: string(PhaseApply)},
+			{name: "completed tasks", content: "- [x] 1.1 Implementation complete\n", wantApply: DependencyAllDone, wantVerify: DependencyReady, wantNext: string(PhaseVerify), wantBlockReason: true},
+		} {
+			t.Run(report.name+"/"+tasks.name, func(t *testing.T) {
+				root := t.TempDir()
+				mkdir(t, filepath.Join(root, ".engram"))
+				project := strings.ToLower(filepath.Base(root))
+				restore := stubEngramExport(t, []engramObservation{
+					{Title: "sdd/historical/proposal", Content: "# Proposal\n", Project: project, Scope: "project"},
+					{Title: "sdd/historical/spec", Content: "### Requirement: routing\n#### Scenario: historical verification\n", Project: project, Scope: "project"},
+					{Title: "sdd/historical/design", Content: "# Design\n", Project: project, Scope: "project"},
+					{Title: "sdd/historical/tasks", Content: tasks.content, Project: project, Scope: "project"},
+					{Title: "sdd/historical/verify-report", Content: report.content, Project: project, Scope: "project"},
+				})
+				defer restore()
+
+				status, err := Resolve(ResolveOptions{CWD: root, ChangeName: "historical"})
+				if err != nil {
+					t.Fatal(err)
+				}
+				if status.ArtifactStore != ArtifactStoreEngram || status.Dependencies.Apply != tasks.wantApply ||
+					status.Dependencies.Verify != tasks.wantVerify || status.NextRecommended != tasks.wantNext {
+					t.Fatalf("Engram status = store %q dependencies %#v next %q", status.ArtifactStore, status.Dependencies, status.NextRecommended)
+				}
+				if (len(status.BlockedReasons) != 0) != tasks.wantBlockReason {
+					t.Fatalf("Engram blockers = %v, want blocker present %t", status.BlockedReasons, tasks.wantBlockReason)
+				}
+			})
+		}
+	}
+}

--- a/internal/sddstatus/status.go
+++ b/internal/sddstatus/status.go
@@ -645,8 +645,9 @@ func resolveByPreferenceOrder(options ResolveOptions) (Status, error) {
 	if artifacts["specs"] == ArtifactPartial {
 		blockedReasons.genuine = append(blockedReasons.genuine, openSpecSpecsLayoutReason(changeName))
 	}
-	if artifacts["verifyReport"] == ArtifactDone {
-		if reason := verifyReportRefreshReason(verifyResult); reason != "" {
+	verifyRefreshReason := verifyReportRefreshReason(verifyResult)
+	if artifacts["verifyReport"] == ArtifactDone && taskProgress.AllComplete {
+		if reason := verifyRefreshReason; reason != "" {
 			blockedReasons.genuine = append(blockedReasons.genuine, reason)
 		}
 	}
@@ -705,6 +706,9 @@ func resolveByPreferenceOrder(options ResolveOptions) (Status, error) {
 	status.RemediationState = remediationState
 	status.RuntimeStatus = runtimeStatus
 	status.runtimeAttemptTokens = runtimeAttemptTokens
+	// Historical verification remains visible in verify instructions, but cannot
+	// block unfinished implementation before final verification is applicable.
+	status.verifyRefreshReason = verifyRefreshReason
 	if runtimeStatusErr != nil {
 		applyNativeRuntimeErrorRouting(&status, runtimeStatusErr)
 	} else {
@@ -945,8 +949,9 @@ func resolveEngramStatus(workspaceRoot string, requestedChange string, includeIn
 	coreReady := artifacts["proposal"] == ArtifactDone && artifacts["specs"] == ArtifactDone && artifacts["design"] == ArtifactDone && artifacts["tasks"] == ArtifactDone && taskProgress.Total > 0
 	applyState := resolveApplyState(coreReady, taskProgress)
 	blockedReasons := artifactBlockedReasons(artifacts, taskProgress, changeName)
-	if artifacts["verifyReport"] == ArtifactDone {
-		if reason := verifyReportRefreshReason(verifyResult); reason != "" {
+	verifyRefreshReason := verifyReportRefreshReason(verifyResult)
+	if artifacts["verifyReport"] == ArtifactDone && taskProgress.AllComplete {
+		if reason := verifyRefreshReason; reason != "" {
 			blockedReasons.genuine = append(blockedReasons.genuine, reason)
 		}
 	}
@@ -987,6 +992,7 @@ func resolveEngramStatus(workspaceRoot string, requestedChange string, includeIn
 	status.RemediationState = remediationState
 	status.RuntimeStatus = runtimeStatus
 	status.runtimeAttemptTokens = runtimeAttemptTokens
+	status.verifyRefreshReason = verifyRefreshReason
 	if runtimeStatusErr != nil {
 		applyNativeRuntimeErrorRouting(&status, runtimeStatusErr)
 	} else {


### PR DESCRIPTION
## Linked Issue

Fixes #4210

---

## PR Type

- [x] `type:bug` - Bug fix (non-breaking change that fixes an issue)
- [ ] `type:feature` - New feature (non-breaking change that adds functionality)
- [ ] `type:docs` - Documentation only
- [ ] `type:refactor` - Code refactoring (no functional changes)
- [ ] `type:chore` - Build, CI, or tooling changes
- [ ] `type:breaking-change` - Breaking change (fix or feature that changes existing behavior)

---

## Summary

- Keeps unfinished SDD apply work actionable when historical verification evidence is failed or incomplete.
- Retains final verification and remediation requirements after tasks complete.
- Adds unit, CLI, and public benchmark regression coverage for #4210.

Scope exclusion: the separate complete-FAIL verification/remediation loop remains unchanged.

---

## Changes

| File / Area | What Changed |
|-------------|--------------|
| `internal/sddstatus/status.go` | Route historical verification blockers only after all tasks complete while retaining refresh guidance. |
| `internal/sddstatus/issue4210_routing_test.go` | Cover OpenSpec and Engram routing for pending and completed work. |
| `internal/cli/sdd_status_test.go` | Cover both public status and continue commands. |
| `bench/` | Add and register the #4210 public-runtime journey. |

---

## AI Assistance

- [ ] **None** - No material AI assistance was used.
- [x] **Material assistance used** - Complete all applicable declaration fields below.

**Tool/model (if known):** OpenCode, openai/gpt-5.6-terra

**Material scope:** Implementation review and publication of the already-tested eight-file fix.

**Verification performed:** Reviewed the full eight-file diff; confirmed candidate bytes before and after commit hooks; ran the recorded focused tests and public benchmark evidence below.

---

## Test Plan

- [ ] Unit tests pass (`go test ./...`) - not run for this publication.
- [x] Go format passes (`go run ./internal/gofmtcheck`)
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`) - not run; this change does not touch E2E coverage.
- [x] Manually tested locally

Completed against the identical committed candidate:

```text
go test ./internal/sddstatus -count=1                         PASS (30.84s)
go test ./internal/cli -count=1 -timeout 8m                  PASS (262.18s)
(cd bench && go test ./... -count=1)                         PASS (5.28s)
go run ./internal/gofmtcheck                                 PASS
git diff --check                                             PASS
bench --binary /tmp/opencode/gentle-ai-4210 --only j128-historical-verification-does-not-block-apply --out /tmp/opencode/j128-4210-results.json
                                                               PASS (2 public commands: sdd-status and sdd-continue; 0 blocks)
```

Benchmark validation is applicable and complete: journey `j128-historical-verification-does-not-block-apply` reproduces the issue through the public runtime boundary.

---

## Contributor Checklist

- [x] PR is linked to an issue with `status:approved`
- [x] PR stays within 400 changed lines; this is 253 changed lines.
- [x] I have added the appropriate `type:*` label to this PR
- [ ] Unit tests pass (`go test ./...`)
- [x] Go format passes (`go run ./internal/gofmtcheck`)
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`)
- [x] Benchmark validation completed.
- [x] Documentation changes are not necessary for this routing correction.
- [x] My commits follow Conventional Commits format
- [x] I understand, reviewed, and take responsibility for the complete submission
- [x] I selected exactly one AI-assistance option and completed the material-assistance declaration
- [x] My commits do not include `Co-Authored-By` trailers

---

## Notes for Reviewers

The routing change intentionally does not alter the separate complete-FAIL verify/remediation loop. Review disabled/unmanaged behavior was not activated or modified.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Historical verification failures no longer block applying unfinished work.
  - Status and continue guidance now consistently recommend **apply** when implementation remains incomplete, without reporting false blockers.
  - Once all tasks are complete, unresolved verification issues continue to route work toward verification or remediation before archival.
  - Improved handling of verification history across supported storage modes, including older report formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->