### PR TITLE
fix(review): route Pi host relay through bounded one-correction retry

### DIFF
--- a/internal/cli/review_artifact.go
+++ b/internal/cli/review_artifact.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 
 	"github.com/gentleman-programming/gentle-ai/v2/internal/model"
+	"github.com/gentleman-programming/gentle-ai/v2/internal/reviewerprovider"
 	"github.com/gentleman-programming/gentle-ai/v2/internal/reviewtransaction"
 )
 
@@ -154,6 +155,17 @@ func RunReviewCaptureResult(args []string, stdout io.Writer) error {
 	input := flags.String("input", "", "raw reviewer result JSON file or - for stdin; `gentle-ai review schema reviewer` emits the schema and a working example")
 	preflight := flags.Bool("preflight", false, "validate the capture binding and, when --input is supplied, the result admission without persisting anything")
 	materialize := flags.Bool("materialize", false, "print the exact Go-materialized opaque provider task for a host-relay --agent runtime without capturing anything; mutually exclusive with --input and --preflight")
+	execute := flags.Bool("execute", false, "run the Go-owned host-relay provider process and admit its raw result; mutually exclusive with --input and --materialize")
+	// Provider-runtime metadata arguments (provider-cost-version,
+	// provider-model-runs-min, provider-model-runs-max, provider-retry-reasons)
+	// are emitted by the negotiated collect transition alongside the host-relay
+	// binding; they are accepted for the parser's own argv shape only and never
+	// consulted here, since admission and retry stay Go-owned in
+	// reviewProviderCaptureWithOneCorrection.
+	_ = flags.String("provider-cost-version", "", "provider-owned runtime metadata, emitted by the negotiated collect transition; ignored at capture")
+	_ = flags.String("provider-model-runs-min", "", "provider-owned runtime metadata, emitted by the negotiated collect transition; ignored at capture")
+	_ = flags.String("provider-model-runs-max", "", "provider-owned runtime metadata, emitted by the negotiated collect transition; ignored at capture")
+	_ = flags.String("provider-retry-reasons", "", "provider-owned runtime metadata, emitted by the negotiated collect transition; ignored at capture")
 	if err := parseReviewFlags(flags, args); err != nil {
 		return err
 	}
@@ -165,12 +177,12 @@ func RunReviewCaptureResult(args []string, stdout io.Writer) error {
 	rawInputSupplied := strings.TrimSpace(*input) != ""
 	providerExecution := providerRuntimeSupplied && !rawInputSupplied
 	hostRelaySubmission := providerRuntimeSupplied && rawInputSupplied
-	if *materialize {
-		if *preflight || strings.TrimSpace(*input) != "" {
-			return reviewPreflightError(errors.New("review capture-result --materialize only prints the Go-materialized provider task and cannot be combined with --input or --preflight")) // refusal:by-design world-action: materialization is read-only and never authors or admits reviewer output
+	if *materialize || *execute {
+		if *preflight || strings.TrimSpace(*input) != "" || (*materialize && *execute) {
+			return reviewPreflightError(errors.New("review capture-result --materialize and --execute are mutually exclusive and cannot be combined with --input or --preflight")) // refusal:by-design world-action: provider execution and materialization are distinct Go-owned routes
 		}
 		if !providerExecution {
-			return reviewPreflightError(errors.New("review capture-result --materialize requires --agent naming the host-relay runtime")) // refusal:by-design operator-knowledge: only a compiled host-relay runtime identity selects the materialize form
+			return reviewPreflightError(errors.New("review capture-result --materialize or --execute requires --agent naming the provider runtime")) // refusal:by-design operator-knowledge: provider execution is a Go-owned route
 		}
 	}
 	if flags.NArg() != 0 || strings.TrimSpace(*lineage) == "" || strings.TrimSpace(*target) == "" ||
@@ -217,9 +229,9 @@ func RunReviewCaptureResult(args []string, stdout io.Writer) error {
 			if !isHostRelayMaterializeTransport {
 				return reviewPreflightError(fmt.Errorf("review capture-result --agent %q with --input is unavailable: only a compiled host-relay runtime may submit its raw reviewer result with the provider-owned runtime binding; this runtime's compiled transport is %q", providerRuntime, providerTransport)) // refusal:by-design world-action: caller input cannot impersonate an in-process provider runtime
 			}
-		} else if !reviewProviderCaptureRuntime(providerRuntime) {
+		} else if !reviewProviderCaptureRuntime(providerRuntime) && !(isHostRelayMaterializeTransport && *execute) {
 			if isHostRelayMaterializeTransport {
-				return reviewPreflightError(fmt.Errorf("review capture-result --agent %q without --materialize has no in-process reviewer to run: its compiled transport is %q, whose host owns the reviewer subprocess; print the provider task with --materialize=true, run it in the host, then submit the raw result with --input and the same binding", providerRuntime, providerTransport)) // refusal:by-design world-action: the host relay owns the reviewer subprocess this process cannot launch
+				return reviewPreflightError(fmt.Errorf("review capture-result --agent %q without --materialize or --execute has no in-process reviewer to run: its compiled transport is %q, whose host owns the reviewer subprocess; use --execute=true for the Go-owned corrective retry route", providerRuntime, providerTransport)) // refusal:by-design world-action: the host relay must use the provider-owned execution route for bounded corrective admission retries
 			}
 			return reviewPreflightError(fmt.Errorf("review capture-result --agent %q has no compiled in-process reviewer adapter: its compiled transport is %q; collect its reviewer result through that live host transport instead", providerRuntime, providerTransport)) // refusal:by-design world-action: only compiled subprocess adapters use this capture path
 		}
@@ -325,16 +337,22 @@ func RunReviewCaptureResult(args []string, stdout io.Writer) error {
 			}
 			return nil
 		}
-		adapter, adapterErr := reviewProviderAdapter(reviewProviderRoleLens, providerRuntime)
-		if adapterErr != nil {
-			return reviewPreflightError(adapterErr)
+		var adapter reviewerprovider.Adapter = reviewProviderRoleHostAdapter()
+		if reviewProviderCaptureRuntime(providerRuntime) {
+			adapter, err = reviewProviderAdapter(reviewProviderRoleLens, providerRuntime)
 		}
-		// --agent is refused together with --preflight above, so this branch
-		// never runs under preflight and its preservation needs no guard.
+		if err != nil {
+			return reviewPreflightError(err)
+		}
 		admitted, rawPayload, err = reviewProviderCaptureWithOneCorrection(ctx, reviewProviderCapture{
 			root: root, runtime: providerRuntime, adapter: adapter, state: state, frozen: frozen, subject: subject,
+			preserveRawPayload: reviewProviderHostRelayMaterializeRuntime(providerRuntime) && *execute,
 		}, request.Invocation)
 		if err != nil {
+			var refused *reviewProviderCaptureRefusedError
+			if reviewProviderHostRelayMaterializeRuntime(providerRuntime) && *execute && errors.As(err, &refused) {
+				return reviewPreflightRefusal(reviewPreflightProviderCaptureRefusedReason, err)
+			}
 			return reviewPreflightError(err)
 		}
 	} else {

--- a/internal/cli/review_capture_result_refusal_distinct_test.go
+++ b/internal/cli/review_capture_result_refusal_distinct_test.go
@@ -53,10 +53,9 @@ func TestCaptureResultHostMediatedRefusalsAreDistinguishable(t *testing.T) {
 			// gentle-pi report into a checkable question.
 			name: "materialize omitted for the pi host relay",
 			argv: append(slices.Clone(binding), "--agent", string(model.AgentPi)),
-			want: `review capture-result --agent "pi" without --materialize has no in-process reviewer to run: ` +
+			want: `review capture-result --agent "pi" without --materialize or --execute has no in-process reviewer to run: ` +
 				`its compiled transport is "pi_host_relay", whose host owns the reviewer subprocess; ` +
-				`print the provider task with --materialize=true, run it in the host, ` +
-				`then submit the raw result with --input and the same binding`,
+				`use --execute=true for the Go-owned corrective retry route`,
 		},
 		{
 			// Same branch as above, different runtime: OpenCode has no

--- a/internal/cli/review_next_transition.go
+++ b/internal/cli/review_next_transition.go
@@ -470,6 +470,9 @@ func reviewProviderHostRelayRoleInput(binding ReviewTransitionBinding, role revi
 	input.Arguments = append(arguments,
 		ReviewTransitionArgument{Name: "agent", Value: string(runtime)},
 		ReviewTransitionArgument{Name: "execute", Value: "true"})
+	if meta, ok := reviewProviderRuntimeMetadataFor(role); ok {
+		input.Arguments = reviewProviderAppendRuntimeMetadataArguments(input.Arguments, meta)
+	}
 	return input, nil
 }
 
@@ -640,34 +643,16 @@ func reviewCaptureInput(binding ReviewTransitionBinding, lens string, order int,
 		case reviewProviderCaptureRuntime(runtime[0]):
 			input.Arguments = append(input.Arguments, ReviewTransitionArgument{Name: "agent", Value: string(runtime[0])})
 		case reviewProviderHostRelayMaterializeRuntime(runtime[0]):
-			// The Pi host relay learns the whole flow from this one input: the
-			// materialize arguments are only the prelude that prints the
-			// Go-issued opaque prompt bytes for its fresh locked-down reviewer
-			// subprocess, and the submission descriptor -- the same binding and
-			// runtime tokens with the raw result substituted into --input -- is
-			// what actually advances reviewing authority. Keeping the runtime in
-			// the provider-owned submission lets a terminal closure issue its exact
-			// runtime-bound STATUS continuation without host reconstruction.
-			// Snapshot only the binding arguments; runtime and materialize are appended after the submission is complete.
-			bindingArguments := input.Arguments
-			tokens := make([]string, 0, len(bindingArguments)+2)
-			for _, argument := range bindingArguments {
-				tokens = append(tokens, reviewTransitionArgumentToken(argument))
-			}
-			tokens = append(tokens,
-				reviewTransitionArgumentToken(ReviewTransitionArgument{Name: "agent", Value: string(runtime[0])}),
-				"--input="+reviewSubmissionValuePlaceholder,
-			)
-			input.Submission = &ReviewTransitionSubmission{
-				OperationToken: "capture-result", ArgumentTokens: tokens,
-				Value: &ReviewTransitionSubmissionValue{
-					Slot: "reviewer_result", Domain: "artifact_path_or_stdin", Schema: reviewReviewerSchemaID,
-					SubstitutionLocation: len(tokens) - 1,
-				},
-			}
+			// Keep the lens route inside the Go-owned provider contract. The host
+			// adapter invokes Pi and the shared capture retry admits raw bytes; this
+			// avoids the old materialize/--input split, which could not re-invoke the
+			// host after strict admission rejected its first payload.
 			input.Arguments = append(input.Arguments,
 				ReviewTransitionArgument{Name: "agent", Value: string(runtime[0])},
-				ReviewTransitionArgument{Name: "materialize", Value: "true"})
+				ReviewTransitionArgument{Name: "execute", Value: "true"})
+			if meta, ok := reviewProviderRuntimeMetadataFor(reviewerprovider.Role(reviewProviderRoleLens)); ok {
+				input.Arguments = reviewProviderAppendRuntimeMetadataArguments(input.Arguments, meta)
+			}
 		}
 	}
 	return input

--- a/internal/cli/review_next_transition_test.go
+++ b/internal/cli/review_next_transition_test.go
@@ -15,6 +15,7 @@ import (
 
 	jsonschema "github.com/santhosh-tekuri/jsonschema/v6"
 
+	"github.com/gentleman-programming/gentle-ai/v2/internal/model"
 	"github.com/gentleman-programming/gentle-ai/v2/internal/reviewtransaction"
 )
 
@@ -1017,3 +1018,232 @@ func reviewSchemaRegexpEngine(pattern string) (jsonschema.Regexp, error) {
 	}
 	return reviewSchemaRegexp{pattern: pattern, re: re}, nil
 }
+
+// transitionArgumentByName returns the value of the first argument whose name
+// matches, plus an "ok" flag that distinguishes a missing argument from an
+// empty one. It is the single read shape every metadata-bearing transition
+// test uses so the assertions stay mechanical.
+func transitionArgumentByName(arguments []ReviewTransitionArgument, name string) (string, bool) {
+	for _, argument := range arguments {
+		if argument.Name == name {
+			return argument.Value, true
+		}
+	}
+	return "", false
+}
+
+// trailingRuntimeMetadataArguments returns the trailing four-argument metadata
+// block a host-relay collect input appends to its base binding. It fails the
+// test when the tail is the wrong shape so the contract violation stays loud.
+func trailingRuntimeMetadataArguments(t *testing.T, arguments []ReviewTransitionArgument) []ReviewTransitionArgument {
+	t.Helper()
+	if len(arguments) < providerRuntimeMetadataArgumentCount {
+		t.Fatalf("transition has %d arguments, want at least %d for metadata tail", len(arguments), providerRuntimeMetadataArgumentCount)
+	}
+	tail := arguments[len(arguments)-providerRuntimeMetadataArgumentCount:]
+	names := []string{"provider_cost_version", "provider_model_runs_min", "provider_model_runs_max", "provider_retry_reasons"}
+	for index, argument := range tail {
+		if argument.Name != names[index] {
+			t.Fatalf("metadata tail[%d].Name = %q, want %q", index, argument.Name, names[index])
+		}
+	}
+	return tail
+}
+
+// TestReviewNextTransitionLensHostRelayCollectAppendsRuntimeMetadata is the
+// canonical collect lens host-relay contract: the rendered input carries the
+// existing --agent/--execute arguments plus the four canonical metadata
+// arguments at the end. The metadata block is the only admission signal a
+// parent uses to forecast a host-relay capture binding.
+func TestReviewNextTransitionLensHostRelayCollectAppendsRuntimeMetadata(t *testing.T) {
+	reviewEnabledHome(t)
+	t.Setenv(reviewPiHostRelayContractEnvironment, reviewPiHostRelayContract)
+	repo, started, _, _ := newArtifactReview(t, false)
+	status := hostReviewStatus(t, repo, started.LineageID, model.AgentPi)
+	if status.NextTransition == nil || status.NextTransition.Kind != reviewNextTransitionCollect ||
+		status.NextTransition.ReasonCode != "reviewer_results_required" || status.NextTransition.Collect == nil {
+		t.Fatalf("pi host relay lens transition = %#v", status.NextTransition)
+	}
+	input := soleHostCollectInput(t, status, reviewCaptureResultCaptureOperation)
+	if err := status.NextTransition.Validate(); err != nil {
+		t.Fatalf("pi host relay lens transition is invalid: %v", err)
+	}
+	if value, ok := transitionArgumentByName(input.Arguments, "agent"); !ok || value != string(model.AgentPi) {
+		t.Fatalf("lens agent argument = %q (present=%v), want %q", value, ok, model.AgentPi)
+	}
+	if value, ok := transitionArgumentByName(input.Arguments, "execute"); !ok || value != "true" {
+		t.Fatalf("lens execute argument = %q (present=%v), want \"true\"", value, ok)
+	}
+	tail := trailingRuntimeMetadataArguments(t, input.Arguments)
+	if value := tail[0].Value; value != reviewProviderRuntimeMetadataVersion {
+		t.Fatalf("lens metadata cost-version = %q, want %q", value, reviewProviderRuntimeMetadataVersion)
+	}
+	if value := tail[1].Value; value != "1" {
+		t.Fatalf("lens metadata model-runs-min = %q, want \"1\"", value)
+	}
+	if value := tail[2].Value; value == "" {
+		t.Fatalf("lens metadata model-runs-max is empty")
+	}
+	if !strings.Contains(tail[3].Value, "provider_admission_refused") ||
+		!strings.Contains(tail[3].Value, "provider_role_contract_violation") {
+		t.Fatalf("lens metadata retry-reasons = %q, want the canonical admission classes", tail[3].Value)
+	}
+}
+
+// TestReviewNextTransitionRefuterHostRelayCollectAppendsRuntimeMetadata pins
+// the same trailing block on the refuter capture operation. The Go-owned
+// capture retry admits raw bytes, so the metadata is the only truthful forecast
+// the host relay can publish for one binding.
+func TestReviewNextTransitionRefuterHostRelayCollectAppendsRuntimeMetadata(t *testing.T) {
+	reviewEnabledHome(t)
+	t.Setenv(reviewPiHostRelayContractEnvironment, reviewPiHostRelayContract)
+	repo, store, record, _ := piRefuterReview(t)
+	status := hostReviewStatus(t, repo, record.State.LineageID, model.AgentPi)
+	if status.NextTransition == nil || status.NextTransition.ReasonCode != "provider_refuter_required" {
+		t.Fatalf("pi host relay refuter transition = %#v", status.NextTransition)
+	}
+	input := soleHostCollectInput(t, status, reviewCaptureRefuterCaptureOperation)
+	if err := status.NextTransition.Validate(); err != nil {
+		t.Fatalf("pi host relay refuter transition is invalid: %v", err)
+	}
+	if value, ok := transitionArgumentByName(input.Arguments, "agent"); !ok || value != string(model.AgentPi) {
+		t.Fatalf("refuter agent argument = %q (present=%v), want %q", value, ok, model.AgentPi)
+	}
+	if value, ok := transitionArgumentByName(input.Arguments, "execute"); !ok || value != "true" {
+		t.Fatalf("refuter execute argument = %q (present=%v), want \"true\"", value, ok)
+	}
+	tail := trailingRuntimeMetadataArguments(t, input.Arguments)
+	if tail[0].Value != reviewProviderRuntimeMetadataVersion {
+		t.Fatalf("refuter metadata cost-version = %q, want %q", tail[0].Value, reviewProviderRuntimeMetadataVersion)
+	}
+	// Finalize the refuter slot so a subsequent re-collect stays eligible.
+	if _, err := store.Load(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// TestReviewNextTransitionValidationHostRelayCollectAppendsRuntimeMetadata
+// covers the targeted-validator host-relay collect operation. The metadata
+// block must appear in the same trailing position so a parent reading the
+// binding sees a canonical, role-agnostic shape.
+func TestReviewNextTransitionValidationHostRelayCollectAppendsRuntimeMetadata(t *testing.T) {
+	reviewEnabledHome(t)
+	t.Setenv(reviewPiHostRelayContractEnvironment, reviewPiHostRelayContract)
+	repo, lineage, request := providerCorrectionReadyWithoutVerificationEvidence(t)
+	status := hostReviewStatus(t, repo, lineage, model.AgentPi)
+	if status.NextTransition == nil || status.NextTransition.ReasonCode != "targeted_validation_required" {
+		t.Fatalf("pi host relay validator transition = %#v", status.NextTransition)
+	}
+	input := soleHostCollectInput(t, status, reviewCaptureValidationCaptureOperation)
+	if err := status.NextTransition.Validate(); err != nil {
+		t.Fatalf("pi host relay validator transition is invalid: %v", err)
+	}
+	if value, ok := transitionArgumentByName(input.Arguments, "agent"); !ok || value != string(model.AgentPi) {
+		t.Fatalf("validator agent argument = %q (present=%v), want %q", value, ok, model.AgentPi)
+	}
+	if value, ok := transitionArgumentByName(input.Arguments, "execute"); !ok || value != "true" {
+		t.Fatalf("validator execute argument = %q (present=%v), want \"true\"", value, ok)
+	}
+	if value, ok := transitionArgumentByName(input.Arguments, "request-hash"); !ok || value != request.RequestHash {
+		t.Fatalf("validator request-hash = %q (present=%v), want %q", value, ok, request.RequestHash)
+	}
+	tail := trailingRuntimeMetadataArguments(t, input.Arguments)
+	if tail[0].Value != reviewProviderRuntimeMetadataVersion {
+		t.Fatalf("validator metadata cost-version = %q, want %q", tail[0].Value, reviewProviderRuntimeMetadataVersion)
+	}
+}
+
+// TestReviewNextTransitionValidateRejectsMalformedLensHostRelayMetadata is the
+// refusal path: a lens host-relay collect input whose trailing metadata block
+// carries an unknown version must fail closed with the canonical parser
+// refusal, never silently accept the divergence.
+func TestReviewNextTransitionValidateRejectsMalformedLensHostRelayMetadata(t *testing.T) {
+	reviewEnabledHome(t)
+	t.Setenv(reviewPiHostRelayContractEnvironment, reviewPiHostRelayContract)
+	repo, started, _, _ := newArtifactReview(t, false)
+	status := hostReviewStatus(t, repo, started.LineageID, model.AgentPi)
+	if status.NextTransition == nil || status.NextTransition.Collect == nil {
+		t.Fatalf("missing pi host relay lens transition: %#v", status.NextTransition)
+	}
+	input := status.NextTransition.Collect.Inputs[0]
+	for index := len(input.Arguments) - providerRuntimeMetadataArgumentCount; index < len(input.Arguments); index++ {
+		if input.Arguments[index].Name == "provider_cost_version" {
+			input.Arguments[index].Value = "gentle-ai.review-provider-runtime-cost/v9"
+		}
+	}
+	if err := status.NextTransition.Validate(); err == nil ||
+		!strings.Contains(err.Error(), "unsupported provider_cost_version") {
+		t.Fatalf("malformed lens metadata err = %v, want unsupported provider_cost_version refusal", err)
+	}
+}
+
+// TestReviewNextTransitionValidateRejectsMalformedRefuterHostRelayMetadata
+// applies the same parser-refusal contract to the refuter capture operation.
+func TestReviewNextTransitionValidateRejectsMalformedRefuterHostRelayMetadata(t *testing.T) {
+	reviewEnabledHome(t)
+	t.Setenv(reviewPiHostRelayContractEnvironment, reviewPiHostRelayContract)
+	repo, _, record, _ := piRefuterReview(t)
+	status := hostReviewStatus(t, repo, record.State.LineageID, model.AgentPi)
+	if status.NextTransition == nil || status.NextTransition.Collect == nil {
+		t.Fatalf("missing pi host relay refuter transition: %#v", status.NextTransition)
+	}
+	input := status.NextTransition.Collect.Inputs[0]
+	for index := len(input.Arguments) - providerRuntimeMetadataArgumentCount; index < len(input.Arguments); index++ {
+		if input.Arguments[index].Name == "provider_model_runs_max" {
+			input.Arguments[index].Value = "0"
+		}
+	}
+	if err := status.NextTransition.Validate(); err == nil ||
+		!strings.Contains(err.Error(), "provider_model_runs_max must be >= provider_model_runs_min") {
+		t.Fatalf("malformed refuter metadata err = %v, want max>=min refusal", err)
+	}
+}
+
+// TestReviewNextTransitionValidateRejectsMalformedValidatorHostRelayMetadata
+// applies the same parser-refusal contract to the targeted-validator capture
+// operation.
+func TestReviewNextTransitionValidateRejectsMalformedValidatorHostRelayMetadata(t *testing.T) {
+	reviewEnabledHome(t)
+	t.Setenv(reviewPiHostRelayContractEnvironment, reviewPiHostRelayContract)
+	repo, lineage, _ := providerCorrectionReadyWithoutVerificationEvidence(t)
+	status := hostReviewStatus(t, repo, lineage, model.AgentPi)
+	if status.NextTransition == nil || status.NextTransition.Collect == nil {
+		t.Fatalf("missing pi host relay validator transition: %#v", status.NextTransition)
+	}
+	input := status.NextTransition.Collect.Inputs[0]
+	for index := len(input.Arguments) - providerRuntimeMetadataArgumentCount; index < len(input.Arguments); index++ {
+		if input.Arguments[index].Name == "provider_model_runs_min" {
+			input.Arguments[index].Value = "not-an-integer"
+		}
+	}
+	if err := status.NextTransition.Validate(); err == nil ||
+		!strings.Contains(err.Error(), "provider_model_runs_min is not a non-negative integer") {
+		t.Fatalf("malformed validator metadata err = %v, want min-not-integer refusal", err)
+	}
+}
+
+// TestReviewNextTransitionValidateAcceptsLensHostRelayWithoutMetadata is the
+// inherited transition: a host-relay collect input whose trailing block is
+// absent must validate unchanged, so existing transitions keep working
+// without a parallel metadata contract.
+func TestReviewNextTransitionValidateAcceptsLensHostRelayWithoutMetadata(t *testing.T) {
+	reviewEnabledHome(t)
+	t.Setenv(reviewPiHostRelayContractEnvironment, reviewPiHostRelayContract)
+	repo, started, _, _ := newArtifactReview(t, false)
+	status := hostReviewStatus(t, repo, started.LineageID, model.AgentPi)
+	if status.NextTransition == nil || status.NextTransition.Collect == nil {
+		t.Fatalf("missing pi host relay lens transition: %#v", status.NextTransition)
+	}
+	input := status.NextTransition.Collect.Inputs[0]
+	input.Arguments = input.Arguments[:len(input.Arguments)-providerRuntimeMetadataArgumentCount]
+	if err := status.NextTransition.Validate(); err != nil {
+		t.Fatalf("metadata-stripped lens host-relay transition rejected: %v", err)
+	}
+	if _, present := transitionArgumentByName(input.Arguments, "provider_cost_version"); present {
+		t.Fatal("stripped transition still carries provider_cost_version")
+	}
+}
+
+// touchRefs intentionally removed; the existing imports above are referenced
+// transitively by every test in this file, and a dead-reference block was
+// introducing noise the formatter then had to defend.

--- a/internal/cli/review_operation_contract.go
+++ b/internal/cli/review_operation_contract.go
@@ -386,16 +386,16 @@ var reviewPreflightSlotOccupiedReason = reviewPreflightReason{
 	NextAction: "review.status",
 }
 
-// reviewPreflightProviderCaptureRefusedReason classifies a non-lens provider
-// role capture (targeted validator or refuter) refused on both admission
-// attempts, including the single corrective re-invocation: the provider, not
-// the operator's request, produced malformed output twice, so
-// "correct_request" would be an actively wrong instruction (issue #4061).
-// Nothing was captured, and the bound slot is unchanged, so the way out is
-// the same STATUS re-query and relaunch every other capture refusal uses.
+// reviewPreflightProviderCaptureRefusedReason classifies any Go-owned provider
+// capture refused on both admission attempts, including the single corrective
+// re-invocation: the provider, not the operator's request, produced inadmissible
+// output twice, so "correct_request" would be an actively wrong instruction
+// (issues #4061, #4406, and #4422). Nothing was captured, and the bound slot is
+// unchanged, so the way out is the same STATUS re-query and relaunch every other
+// capture refusal uses.
 var reviewPreflightProviderCaptureRefusedReason = reviewPreflightReason{
 	Code:       "provider_capture_result_refused",
-	Message:    "The provider role capture result was refused on both admission attempts; the provider, not the request, produced a malformed result.",
+	Message:    "The provider capture result was refused on both admission attempts; the provider, not the request, produced inadmissible output.",
 	NextAction: "review.status",
 }
 

--- a/internal/cli/review_pi_host_relay_retry_test.go
+++ b/internal/cli/review_pi_host_relay_retry_test.go
@@ -1,0 +1,326 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/gentleman-programming/gentle-ai/v2/internal/model"
+	"github.com/gentleman-programming/gentle-ai/v2/internal/reviewerprovider"
+	"github.com/gentleman-programming/gentle-ai/v2/internal/reviewtransaction"
+)
+
+const piHostPrivateAbsoluteCitation = "/absolute/private.txt:1"
+
+func TestPiHostLensRetriesRejectedAbsoluteCitation(t *testing.T) {
+	reviewEnabledHome(t)
+	t.Setenv(reviewPiHostRelayContractEnvironment, reviewPiHostRelayContract)
+	repo, started, store, record := newArtifactReview(t, false)
+	lens := record.State.SelectedLenses[0]
+	valid := admittedReviewerResultForTest(t, repo, record, lens, 0)
+	invalid := valid
+	invalid.Evidence = []string{"reviewed " + piHostPrivateAbsoluteCitation}
+	validBytes := marshalFacadeTestJSON(t, valid)
+	invalidBytes := marshalFacadeTestJSON(t, invalid)
+
+	var prompts [][]byte
+	overrideProviderRoleHostAdapter(t, providerTestAdapterFunc(func(_ context.Context, invocation reviewerprovider.Invocation) ([]byte, error) {
+		prompts = append(prompts, invocation.Prompt())
+		if len(prompts) == 1 {
+			return invalidBytes, nil
+		}
+		return validBytes, nil
+	}))
+	status := hostReviewStatus(t, repo, started.LineageID, model.AgentPi)
+	input := soleHostCollectInput(t, status, reviewCaptureResultCaptureOperation)
+	args := append([]string{"capture-result"}, reviewTransitionInputTokens(t, repo, input)...)
+	if err := RunReview(args, io.Discard); err != nil {
+		t.Fatalf("host lens retry: %v", err)
+	}
+	if len(prompts) != 2 || !bytes.Contains(prompts[1], []byte(reviewProviderCorrectiveFeedbackHeader)) ||
+		!bytes.Contains(prompts[1], []byte("evidence_path_out_of_scope")) {
+		t.Fatalf("host lens prompts = %d, corrective admission feedback missing", len(prompts))
+	}
+	preserved := readRejectedResults(t, rejectedResultsDir(t, repo, record.State.LineageID))
+	if len(preserved) != 1 {
+		t.Fatalf("preserved rejected lens payloads = %d, want 1", len(preserved))
+	}
+	for _, envelope := range preserved {
+		assertRejectedEnvelope(t, envelope, record.State.LineageID, lens, 1, invalidBytes)
+	}
+	after, err := store.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !recordHasAdmittedRole(after.State, reviewtransaction.CompactRoleLens) {
+		t.Fatal("valid corrective lens result was not admitted")
+	}
+}
+
+func TestPiHostLensDoesNotNormalizeWrongSubjectHash(t *testing.T) {
+	reviewEnabledHome(t)
+	t.Setenv(reviewPiHostRelayContractEnvironment, reviewPiHostRelayContract)
+	repo, started, store, record := newArtifactReview(t, false)
+	lens := record.State.SelectedLenses[0]
+	valid := admittedReviewerResultForTest(t, repo, record, lens, 0)
+	wrongSubject := valid
+	wrongSubject.SubjectHash = record.State.InitialSnapshot.Identity
+	wrongBytes := marshalFacadeTestJSON(t, wrongSubject)
+	validBytes := marshalFacadeTestJSON(t, valid)
+
+	calls := 0
+	overrideProviderRoleHostAdapter(t, providerTestAdapterFunc(func(context.Context, reviewerprovider.Invocation) ([]byte, error) {
+		calls++
+		if calls == 1 {
+			return wrongBytes, nil
+		}
+		return validBytes, nil
+	}))
+	status := hostReviewStatus(t, repo, started.LineageID, model.AgentPi)
+	input := soleHostCollectInput(t, status, reviewCaptureResultCaptureOperation)
+	args := append([]string{"capture-result"}, reviewTransitionInputTokens(t, repo, input)...)
+	if err := RunReview(args, io.Discard); err != nil {
+		t.Fatalf("host lens strict raw retry: %v", err)
+	}
+	if calls != maxReviewerResultAdmissionAttempts {
+		t.Fatalf("wrong subject hash was normalized instead of rejected: calls=%d", calls)
+	}
+	preserved := readRejectedResults(t, rejectedResultsDir(t, repo, record.State.LineageID))
+	if len(preserved) != 1 {
+		t.Fatalf("preserved wrong-subject payloads = %d, want 1", len(preserved))
+	}
+	for _, envelope := range preserved {
+		assertRejectedEnvelope(t, envelope, record.State.LineageID, lens, 1, wrongBytes)
+	}
+	after, err := store.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !recordHasAdmittedRole(after.State, reviewtransaction.CompactRoleLens) {
+		t.Fatal("valid corrective result after wrong subject hash was not admitted")
+	}
+}
+
+func TestPiHostLensRefusesTwoAbsoluteCitationsWithoutMutationOrLeak(t *testing.T) {
+	reviewEnabledHome(t)
+	t.Setenv(reviewPiHostRelayContractEnvironment, reviewPiHostRelayContract)
+	repo, started, store, record := newArtifactReview(t, false)
+	lens := record.State.SelectedLenses[0]
+	invalid := admittedReviewerResultForTest(t, repo, record, lens, 0)
+	invalid.Evidence = []string{"reviewed " + piHostPrivateAbsoluteCitation}
+	invalidBytes := marshalFacadeTestJSON(t, invalid)
+
+	calls := 0
+	overrideProviderRoleHostAdapter(t, providerTestAdapterFunc(func(context.Context, reviewerprovider.Invocation) ([]byte, error) {
+		calls++
+		return invalidBytes, nil
+	}))
+	status := hostReviewStatus(t, repo, started.LineageID, model.AgentPi)
+	input := soleHostCollectInput(t, status, reviewCaptureResultCaptureOperation)
+	args := append([]string{"capture-result"}, reviewTransitionInputTokens(t, repo, input)...)
+	var output bytes.Buffer
+	runErr := RunReview(args, &output)
+	failure := decodeCaptureRefusalEnvelope(t, runErr, output.Bytes())
+	if failure.Code != reviewPreflightProviderCaptureRefusedReason.Code || failure.NextAction != "review.status" ||
+		failure.MutationOutcome != ReviewMutationNotStarted {
+		t.Fatalf("host lens refusal = %#v", failure)
+	}
+	if calls != maxReviewerResultAdmissionAttempts {
+		t.Fatalf("host lens attempts = %d, want %d", calls, maxReviewerResultAdmissionAttempts)
+	}
+	if strings.Contains(runErr.Error(), piHostPrivateAbsoluteCitation) || strings.Contains(output.String(), piHostPrivateAbsoluteCitation) ||
+		strings.Contains(output.String(), repo) {
+		t.Fatalf("private path escaped the public refusal: %v\n%s", runErr, output.String())
+	}
+	preserved := readRejectedResults(t, rejectedResultsDir(t, repo, record.State.LineageID))
+	if len(preserved) != maxReviewerResultAdmissionAttempts {
+		t.Fatalf("preserved rejected lens payloads = %d, want %d", len(preserved), maxReviewerResultAdmissionAttempts)
+	}
+	for _, envelope := range preserved {
+		assertRejectedEnvelope(t, envelope, record.State.LineageID, lens, envelope.Attempt, invalidBytes)
+	}
+	after, err := store.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if after.Revision != record.Revision || recordHasAdmittedRole(after.State, reviewtransaction.CompactRoleLens) {
+		t.Fatalf("two rejected lens results mutated authority: before=%s after=%s", record.Revision, after.Revision)
+	}
+	reoffered := hostReviewStatus(t, repo, started.LineageID, model.AgentPi)
+	_ = soleHostCollectInput(t, reoffered, reviewCaptureResultCaptureOperation)
+}
+
+func TestPiHostLensTransportErrorIsNotRetried(t *testing.T) {
+	reviewEnabledHome(t)
+	t.Setenv(reviewPiHostRelayContractEnvironment, reviewPiHostRelayContract)
+	repo, started, store, record := newArtifactReview(t, false)
+	calls := 0
+	overrideProviderRoleHostAdapter(t, providerTestAdapterFunc(func(context.Context, reviewerprovider.Invocation) ([]byte, error) {
+		calls++
+		return nil, errors.New("transport failed")
+	}))
+	status := hostReviewStatus(t, repo, started.LineageID, model.AgentPi)
+	input := soleHostCollectInput(t, status, reviewCaptureResultCaptureOperation)
+	args := append([]string{"capture-result"}, reviewTransitionInputTokens(t, repo, input)...)
+	runErr := RunReview(args, io.Discard)
+	if runErr == nil || !strings.Contains(runErr.Error(), "transport failed") || calls != 1 {
+		t.Fatalf("host lens transport failure: err=%v calls=%d", runErr, calls)
+	}
+	after, err := store.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if after.Revision != record.Revision {
+		t.Fatalf("transport failure mutated lens authority: before=%s after=%s", record.Revision, after.Revision)
+	}
+	if _, statErr := os.Stat(rejectedResultsDir(t, repo, record.State.LineageID)); !os.IsNotExist(statErr) {
+		t.Fatalf("transport failure preserved a reviewer result: %v", statErr)
+	}
+}
+
+func hostReviewStatus(t *testing.T, repo, lineage string, agent model.AgentID) ReviewTargetStatusResult {
+	t.Helper()
+	var output bytes.Buffer
+	if err := RunReview([]string{"status", "--cwd", repo, "--lineage", lineage, "--contract", ReviewIntegrationContractV2, "--agent", string(agent), "--next-transition"}, &output); err != nil {
+		t.Fatal(err)
+	}
+	var status ReviewTargetStatusResult
+	decodeStrictReviewJSON(t, output.Bytes(), &status)
+	return status
+}
+
+func soleHostCollectInput(t *testing.T, status ReviewTargetStatusResult, operation string) ReviewTransitionInput {
+	t.Helper()
+	if status.NextTransition == nil || status.NextTransition.Collect == nil || len(status.NextTransition.Collect.Inputs) != 1 {
+		t.Fatalf("missing sole host collect input: %#v", status.NextTransition)
+	}
+	input := status.NextTransition.Collect.Inputs[0]
+	if input.CaptureOperation != operation {
+		t.Fatalf("host collect operation = %q, want %q", input.CaptureOperation, operation)
+	}
+	return input
+}
+
+func TestPiHostRefuterRetriesTruncatedResult(t *testing.T) {
+	reviewEnabledHome(t)
+	t.Setenv(reviewPiHostRelayContractEnvironment, reviewPiHostRelayContract)
+	repo, store, record, handle := piRefuterReview(t)
+	request, err := reviewProviderNewRefuterRequest(t.Context(), repo, store.Dir, record.State, record.State.CapturePhaseRevision)
+	if err != nil {
+		t.Fatal(err)
+	}
+	valid := piRefuterRawResult(t, repo, store, record)
+	truncated := []byte(`{"refuter_request_hash":"` + request.RequestHash + `","results":[{"finding_id":"R3-001"`)
+	var prompts [][]byte
+	overrideProviderRoleHostAdapter(t, providerTestAdapterFunc(func(_ context.Context, invocation reviewerprovider.Invocation) ([]byte, error) {
+		prompts = append(prompts, invocation.Prompt())
+		if len(prompts) == 1 {
+			return truncated, nil
+		}
+		return valid, nil
+	}))
+	args := append([]string{"capture-refuter", "--cwd=" + repo}, piRefuterBinding(repo, record, handle)...)
+	args = append(args, "--agent", string(model.AgentPi), "--execute=true")
+	if err := RunReview(args, io.Discard); err != nil {
+		t.Fatalf("host refuter retry: %v", err)
+	}
+	if len(prompts) != 2 || !bytes.Contains(prompts[1], []byte(reviewProviderCorrectiveFeedbackHeader)) ||
+		!bytes.Contains(prompts[1], []byte("no complete JSON object")) {
+		t.Fatalf("host refuter prompts = %d, structural census feedback missing", len(prompts))
+	}
+	preserved := readRejectedResults(t, rejectedResultsDir(t, repo, record.State.LineageID))
+	if len(preserved) != 1 {
+		t.Fatalf("preserved rejected refuter payloads = %d, want 1", len(preserved))
+	}
+	for _, envelope := range preserved {
+		assertRejectedEnvelope(t, envelope, record.State.LineageID, reviewProviderRoleRefuter, 1, truncated)
+	}
+	after, err := store.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !recordHasAdmittedRole(after.State, reviewtransaction.CompactRoleRefuter) {
+		t.Fatal("valid corrective refuter result was not admitted")
+	}
+}
+
+func TestPiHostRefuterRefusesTwoTruncatedResultsWithoutMutation(t *testing.T) {
+	reviewEnabledHome(t)
+	t.Setenv(reviewPiHostRelayContractEnvironment, reviewPiHostRelayContract)
+	repo, store, record, handle := piRefuterReview(t)
+	request, err := reviewProviderNewRefuterRequest(t.Context(), repo, store.Dir, record.State, record.State.CapturePhaseRevision)
+	if err != nil {
+		t.Fatal(err)
+	}
+	truncated := []byte(`{"refuter_request_hash":"` + request.RequestHash + `","results":[{"finding_id":"R3-001"`)
+	calls := 0
+	overrideProviderRoleHostAdapter(t, providerTestAdapterFunc(func(context.Context, reviewerprovider.Invocation) ([]byte, error) {
+		calls++
+		return truncated, nil
+	}))
+	args := append([]string{"capture-refuter", "--cwd=" + repo}, piRefuterBinding(repo, record, handle)...)
+	args = append(args, "--agent", string(model.AgentPi), "--execute=true")
+	var output bytes.Buffer
+	runErr := RunReview(args, &output)
+	failure := decodeCaptureRefusalEnvelope(t, runErr, output.Bytes())
+	if failure.Code != reviewPreflightProviderCaptureRefusedReason.Code || failure.NextAction != "review.status" ||
+		failure.MutationOutcome != ReviewMutationNotStarted {
+		t.Fatalf("host refuter refusal = %#v", failure)
+	}
+	if calls != maxReviewerResultAdmissionAttempts {
+		t.Fatalf("host refuter attempts = %d, want %d", calls, maxReviewerResultAdmissionAttempts)
+	}
+	after, loadErr := store.Load()
+	if loadErr != nil {
+		t.Fatal(loadErr)
+	}
+	if after.Revision != record.Revision || recordHasAdmittedRole(after.State, reviewtransaction.CompactRoleRefuter) {
+		t.Fatal("two rejected refuter payloads mutated authority")
+	}
+	if len(readRejectedResults(t, rejectedResultsDir(t, repo, record.State.LineageID))) != maxReviewerResultAdmissionAttempts {
+		t.Fatal("both rejected refuter payloads were not preserved")
+	}
+	reoffered := hostReviewStatus(t, repo, record.State.LineageID, model.AgentPi)
+	_ = soleHostCollectInput(t, reoffered, reviewCaptureRefuterCaptureOperation)
+}
+
+func TestPiHostRefuterTransportErrorIsNotRetried(t *testing.T) {
+	reviewEnabledHome(t)
+	t.Setenv(reviewPiHostRelayContractEnvironment, reviewPiHostRelayContract)
+	repo, store, record, handle := piRefuterReview(t)
+	calls := 0
+	overrideProviderRoleHostAdapter(t, providerTestAdapterFunc(func(context.Context, reviewerprovider.Invocation) ([]byte, error) {
+		calls++
+		return nil, errors.New("transport failed")
+	}))
+	args := append([]string{"capture-refuter", "--cwd=" + repo}, piRefuterBinding(repo, record, handle)...)
+	args = append(args, "--agent", string(model.AgentPi), "--execute=true")
+	runErr := RunReview(args, io.Discard)
+	if runErr == nil || !strings.Contains(runErr.Error(), "transport failed") || calls != 1 {
+		t.Fatalf("host refuter transport failure: err=%v calls=%d", runErr, calls)
+	}
+	after, err := store.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if after.Revision != record.Revision {
+		t.Fatalf("transport failure mutated refuter authority: before=%s after=%s", record.Revision, after.Revision)
+	}
+	if _, statErr := os.Stat(rejectedResultsDir(t, repo, record.State.LineageID)); !os.IsNotExist(statErr) {
+		t.Fatalf("transport failure preserved a refuter result: %v", statErr)
+	}
+}
+
+func marshalFacadeTestJSON(t *testing.T, value any) []byte {
+	t.Helper()
+	payload, err := json.Marshal(value)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return payload
+}

--- a/internal/cli/review_provider_correction.go
+++ b/internal/cli/review_provider_correction.go
@@ -26,20 +26,25 @@ const (
 	reviewProviderCorrectiveFeedbackHeader = "GENTLE_AI_REVIEW_ADMISSION_FEEDBACK"
 )
 
-// reviewProviderCapture is everything one in-process lens capture needs to
-// invoke, admit, preserve, and name its continuation.
+// reviewProviderCapture is everything one Go-owned lens capture needs to
+// invoke, admit, preserve, and name its continuation. Host-relay execution sets
+// preserveRawPayload so strict admission sees exactly the provider's bytes.
 type reviewProviderCapture struct {
-	root    string
-	runtime model.AgentID
-	adapter reviewerprovider.Adapter
-	state   reviewtransaction.CompactState
-	frozen  reviewtransaction.FrozenCandidateContext
-	subject reviewtransaction.ArtifactSubject
+	root               string
+	runtime            model.AgentID
+	adapter            reviewerprovider.Adapter
+	state              reviewtransaction.CompactState
+	frozen             reviewtransaction.FrozenCandidateContext
+	subject            reviewtransaction.ArtifactSubject
+	preserveRawPayload bool
 }
 
 func (capture reviewProviderCapture) admit(ctx context.Context, raw []byte) (reviewProviderAdmittedResult, error) {
-	corrected := reviewProviderCorrectSubjectHashEcho(raw, capture.state.InitialSnapshot.Identity, capture.subject.SubjectHash)
-	return reviewProviderAdmitRaw(ctx, capture.root, capture.state, capture.state.CapturePhaseRevision, capture.frozen, capture.subject, corrected)
+	payload := raw
+	if !capture.preserveRawPayload {
+		payload = reviewProviderCorrectSubjectHashEcho(raw, capture.state.InitialSnapshot.Identity, capture.subject.SubjectHash)
+	}
+	return reviewProviderAdmitRaw(ctx, capture.root, capture.state, capture.state.CapturePhaseRevision, capture.frozen, capture.subject, payload)
 }
 
 // reviewProviderCorrectSubjectHashEcho rewrites a raw in-process reviewer

--- a/internal/cli/review_provider_materialize_test.go
+++ b/internal/cli/review_provider_materialize_test.go
@@ -222,7 +222,7 @@ func TestReviewCaptureResultMaterializeRefusals(t *testing.T) {
 	}
 }
 
-func TestNegotiatedStatusRendersPiHostRelayMaterializeCaptureInput(t *testing.T) {
+func TestNegotiatedStatusRendersPiHostRelayExecuteCaptureInput(t *testing.T) {
 	reviewEnabledHome(t)
 	t.Setenv(reviewPiHostRelayContractEnvironment, reviewPiHostRelayContract)
 	repo, _, record, _ := newCandidateInspectionReview(t, "candidate\n", true)
@@ -251,22 +251,11 @@ func TestNegotiatedStatusRendersPiHostRelayMaterializeCaptureInput(t *testing.T)
 	for _, argument := range input.Arguments {
 		tokens[argument.Name] = argument.Token
 	}
-	if tokens["agent"] != "--agent="+string(model.AgentPi) || tokens["materialize"] != "--materialize=true" {
+	if tokens["agent"] != "--agent="+string(model.AgentPi) || tokens["execute"] != "--execute=true" || tokens["materialize"] != "" {
 		t.Fatalf("pi host relay capture arguments = %#v", input.Arguments)
 	}
-	wantTokens := make([]string, 0, len(input.Arguments))
-	for _, argument := range input.Arguments {
-		if argument.Name != "materialize" {
-			wantTokens = append(wantTokens, argument.Token)
-		}
-	}
-	wantTokens = append(wantTokens, "--input={{value}}")
-	if input.Submission == nil || input.Submission.OperationToken != "capture-result" ||
-		!slices.Equal(input.Submission.ArgumentTokens, wantTokens) || len(input.Submission.Values) != 0 ||
-		input.Submission.Value == nil || input.Submission.Value.Slot != "reviewer_result" ||
-		input.Submission.Value.Domain != "artifact_path_or_stdin" || input.Submission.Value.Schema != reviewReviewerSchemaID ||
-		input.Submission.Value.SubstitutionLocation != len(wantTokens)-1 {
-		t.Fatalf("pi host relay submission = %#v, want tokens %v", input.Submission, wantTokens)
+	if input.Submission != nil {
+		t.Fatalf("pi host relay execute route must not carry caller submission: %#v", input.Submission)
 	}
 
 	var compiled bytes.Buffer

--- a/internal/cli/review_provider_role_capture.go
+++ b/internal/cli/review_provider_role_capture.go
@@ -75,6 +75,16 @@ func parseReviewProviderRoleCapture(command string, args []string, stdout io.Wri
 	runtimeAgent := flags.String("agent", "", "host-relay runtime identity, required for both --materialize and --execute")
 	materialize := flags.Bool("materialize", false, "print the exact Go-materialized opaque provider role task without capturing anything; mutually exclusive with --execute")
 	execute := flags.Bool("execute", false, "run the Go-owned locked-down pi process on the Go-materialized role request and capture its raw result")
+	// Provider-runtime metadata arguments (provider-cost-version,
+	// provider-model-runs-min, provider-model-runs-max, provider-retry-reasons)
+	// are emitted by the negotiated collect transition alongside the host-relay
+	// binding; they are accepted for the parser's argv shape only and never
+	// consulted here, since admission and retry stay Go-owned in
+	// reviewProviderCaptureWithOneCorrection.
+	_ = flags.String("provider-cost-version", "", "provider-owned runtime metadata, emitted by the negotiated collect transition; ignored at capture")
+	_ = flags.String("provider-model-runs-min", "", "provider-owned runtime metadata, emitted by the negotiated collect transition; ignored at capture")
+	_ = flags.String("provider-model-runs-max", "", "provider-owned runtime metadata, emitted by the negotiated collect transition; ignored at capture")
+	_ = flags.String("provider-retry-reasons", "", "provider-owned runtime metadata, emitted by the negotiated collect transition; ignored at capture")
 	if err := parseReviewFlags(flags, args); err != nil {
 		return nil, err
 	}
@@ -204,14 +214,8 @@ func RunReviewCaptureRefuter(args []string, stdout io.Writer) error {
 		if err := reviewProviderCaptureRefuterWithOneCorrection(ctx, binding, adapter, store, state, request); err != nil {
 			return err
 		}
-	} else {
-		raw, hostErr := reviewProviderRoleHostAdapter().Review(ctx, request.Invocation)
-		if hostErr != nil {
-			return reviewPreflightError(fmt.Errorf("invoke provider refuter: %w", hostErr))
-		}
-		if _, err := reviewProviderCaptureRefuterRaw(ctx, binding.root, store, state, state.CapturePhaseRevision, raw); err != nil {
-			return reviewPreflightError(err)
-		}
+	} else if err := reviewProviderCaptureRefuterWithOneCorrection(ctx, binding, reviewProviderRoleHostAdapter(), store, state, request); err != nil {
+		return err
 	}
 	currentRecord, currentErr := store.LoadContext(ctx)
 	if currentErr != nil {
@@ -296,11 +300,10 @@ type reviewProviderCaptureRefuterAdmission struct {
 	result facadeRefuterResult
 }
 
-// reviewProviderCaptureRefuterWithOneCorrection grants the compiled runtime
-// (claude, codex) the same single corrective re-invocation the lens role
-// already had (issue #4061): a malformed refuter document is retried once
-// with the exact admission error before it is durably captured. The Pi host
-// relay keeps its own reviewer process and is not routed through this path.
+// reviewProviderCaptureRefuterWithOneCorrection grants every Go-owned provider
+// runtime, including the Pi host relay, the same single corrective re-invocation
+// the lens role already had (issue #4061): a malformed refuter document is
+// retried once with the exact admission error before it is durably captured.
 func reviewProviderCaptureRefuterWithOneCorrection(ctx context.Context, binding *reviewProviderRoleCaptureBinding, adapter reviewerprovider.Adapter, store reviewtransaction.CompactStore, state reviewtransaction.CompactState, request reviewProviderRefuterRequest) error {
 	admit := func(_ context.Context, raw []byte) (reviewProviderCaptureRefuterAdmission, error) {
 		result, err := reviewProviderAdmitRefuterRaw(request, raw)

--- a/internal/cli/review_provider_runtime_metadata.go
+++ b/internal/cli/review_provider_runtime_metadata.go
@@ -1,0 +1,174 @@
+package cli
+
+import (
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/gentleman-programming/gentle-ai/v2/internal/reviewerprovider"
+)
+
+// Provider runtime cost metadata is the provider-owned, versioned extension that
+// lets a parent (gentle-pi) forecast a host-relay capture binding truthfully
+// without hardcoding any Go-owned retry count. A collect input carries these
+// arguments alongside its existing binding only when the runtime is the Pi host
+// relay, and only on the three collect capture operations that may re-invoke
+// the host (lens, refuter, targeted validator).
+//
+// The surface is intentionally tiny and additive:
+//
+//   --provider-cost-version   A schema URL the parent uses to recognize the
+//                             shape. The provider never silently extends this
+//                             in-place; every change is an explicit, named bump.
+//   --provider-model-runs-min The minimum number of underlying model runs the
+//                             provider commits to per slot. Always >= 1.
+//   --provider-model-runs-max The maximum number of underlying model runs the
+//                             provider commits to per slot. >= min and bounded
+//                             (lens/refuter/validator never exceed 2 in this
+//                             version). 0 means "min-only".
+//   --provider-retry-reason   The only admission class the provider will re-
+//                             invoke for. Strict admission failures and Go-owned
+//                             provider-role contract failures are the only
+//                             reasons that may appear here, and the enum is
+//                             explicit so the parent never has to infer.
+//
+// Admission and retry semantics stay exactly where they are: the capture
+// command still runs Go's existing bounded corrective retry unchanged. This
+// metadata only tells a parent how many host-relay invocations one
+// collect binding may authorize; it does not author or relax admission.
+const reviewProviderRuntimeMetadataVersion = "gentle-ai.review-provider-runtime-cost/v1"
+
+// providerRuntimeMetadataArgumentCount is the fixed width of one rendered
+// metadata block (one version, two run-count bounds, and one comma-joined
+// retry-reason list). It pins the trailing-argument tail a valid
+// host-relay-metadata collect input may carry.
+const providerRuntimeMetadataArgumentCount = 4
+
+// reviewProviderRuntimeMetadata is the parsed shape a parent reads off the
+// provider-issued collect transition. Each field maps 1:1 to the argv argument
+// of the same name (see reviewProviderRenderRuntimeMetadataArguments).
+type reviewProviderRuntimeMetadata struct {
+	Version      string
+	ModelRunsMin int
+	ModelRunsMax int
+	// RetryReasons lists the exact admission classes that may trigger a
+	// corrective re-invocation. Empty means "no metadata, no extra runs".
+	RetryReasons []string
+}
+
+// reviewProviderRuntimeMetadataFor returns the metadata the provider renders on
+// a host-relay collect binding, or the zero value when no metadata applies.
+//
+// Metadata only applies to the three collect capture operations that may run
+// the corrective retry (lens, refuter, targeted validator); it never applies
+// to compiled-run capture flows, which carry no host-relay relay.
+func reviewProviderRuntimeMetadataFor(role reviewerprovider.Role) (reviewProviderRuntimeMetadata, bool) {
+	if role != reviewerprovider.RoleLens && role != reviewerprovider.RoleRefuter && role != reviewerprovider.RoleTargetedValidator {
+		return reviewProviderRuntimeMetadata{}, false
+	}
+	minRuns, maxRuns := 1, maxReviewerResultAdmissionAttempts
+	return reviewProviderRuntimeMetadata{
+		Version:      reviewProviderRuntimeMetadataVersion,
+		ModelRunsMin: minRuns,
+		ModelRunsMax: maxRuns,
+		RetryReasons: []string{
+			"provider_admission_refused",
+			"provider_role_contract_violation",
+		},
+	}, true
+}
+
+// reviewProviderRenderRuntimeMetadataArguments converts one metadata record
+// into the canonical argv arguments the parent must echo verbatim on the
+// collect input. The arguments are emitted after the existing lens/order
+// binding arguments and before the runtime-specific provider arguments
+// (--agent, --execute) so a parent that does not recognize the schema can
+// still parse the binding without crashing on unknown names.
+//
+// All four argument names are unique on purpose: the Go-owned
+// `reviewTransitionArgumentMap` rejects duplicate names anywhere on a collect
+// input, and bundling the retry reasons under a single CSV-suffixed argument
+// keeps every name distinct while still letting a parent recover the full
+// list through the standard argv parser.
+func reviewProviderRenderRuntimeMetadataArguments(meta reviewProviderRuntimeMetadata) []ReviewTransitionArgument {
+	if meta.Version == "" {
+		return nil
+	}
+	return []ReviewTransitionArgument{
+		{Name: "provider_cost_version", Value: meta.Version},
+		{Name: "provider_model_runs_min", Value: strconv.Itoa(meta.ModelRunsMin)},
+		{Name: "provider_model_runs_max", Value: strconv.Itoa(meta.ModelRunsMax)},
+		{Name: "provider_retry_reasons", Value: strings.Join(meta.RetryReasons, ",")},
+	}
+}
+
+// reviewProviderParseRuntimeMetadataArguments is the symmetrical reader a
+// parent (and the provider's own transition validator) uses to recover the
+// metadata record off a collect transition. The retry reasons are decoded out
+// of one comma-separated argument so the collect envelope stays duplicate-name
+// free; an empty value is the no-metadata signal and yields an empty reasons
+// slice.
+func reviewProviderParseRuntimeMetadataArguments(arguments []ReviewTransitionArgument) (reviewProviderRuntimeMetadata, bool, error) {
+	var (
+		hasVersion bool
+		version    string
+		minRuns    = -1
+		maxRuns    = -1
+		reasons    []string
+	)
+	for _, argument := range arguments {
+		switch argument.Name {
+		case "provider_cost_version":
+			hasVersion = true
+			version = strings.TrimSpace(argument.Value)
+		case "provider_model_runs_min":
+			n, err := strconv.Atoi(argument.Value)
+			if err != nil || n < 0 {
+				return reviewProviderRuntimeMetadata{}, false, fmt.Errorf("provider_model_runs_min is not a non-negative integer: %s", argument.Value) // refusal:by-design operator-knowledge: the provider-issued metadata block must carry an integer min, so re-query the negotiate transition to obtain a valid block
+			}
+			minRuns = n
+		case "provider_model_runs_max":
+			n, err := strconv.Atoi(argument.Value)
+			if err != nil || n < 0 {
+				return reviewProviderRuntimeMetadata{}, false, fmt.Errorf("provider_model_runs_max is not a non-negative integer: %s", argument.Value) // refusal:by-design operator-knowledge: the provider-issued metadata block must carry an integer max, so re-query the negotiate transition to obtain a valid block
+			}
+			maxRuns = n
+		case "provider_retry_reasons":
+			for _, reason := range strings.Split(argument.Value, ",") {
+				trimmed := strings.TrimSpace(reason)
+				if trimmed != "" {
+					reasons = append(reasons, trimmed)
+				}
+			}
+		}
+	}
+	if !hasVersion {
+		return reviewProviderRuntimeMetadata{}, false, nil
+	}
+	if version != reviewProviderRuntimeMetadataVersion {
+		return reviewProviderRuntimeMetadata{}, false, fmt.Errorf("unsupported provider_cost_version %q", version) // refusal:by-design operator-knowledge: only the provider-issued metadata schema is admitted, so refresh gentle-ai and re-query gentle-ai review status --cwd <repo> --contract gentle-ai.review-integration/v2 --next-transition
+	}
+	if minRuns < 0 || maxRuns < 0 {
+		return reviewProviderRuntimeMetadata{}, false, errors.New("provider_cost_version requires provider_model_runs_min and provider_model_runs_max") // refusal:by-design operator-knowledge: the metadata block must carry both bounds, so re-query the negotiate transition to obtain a valid block
+	}
+	if minRuns < 1 {
+		return reviewProviderRuntimeMetadata{}, false, errors.New("provider_model_runs_min must be >= 1") // refusal:by-design operator-knowledge: a zero-or-negative min run bound would silently authorize no underlying model run
+	}
+	if maxRuns < minRuns {
+		return reviewProviderRuntimeMetadata{}, false, errors.New("provider_model_runs_max must be >= provider_model_runs_min") // refusal:by-design operator-knowledge: the max bound is a truthful forecast upper, never below the committed min
+	}
+	return reviewProviderRuntimeMetadata{
+		Version:      version,
+		ModelRunsMin: minRuns,
+		ModelRunsMax: maxRuns,
+		RetryReasons: reasons,
+	}, true, nil
+}
+
+// reviewProviderAppendRuntimeMetadataArguments appends the metadata arguments
+// to an existing argv builder. Returns the same slice unchanged when the
+// metadata record is empty.
+func reviewProviderAppendRuntimeMetadataArguments(arguments []ReviewTransitionArgument, meta reviewProviderRuntimeMetadata) []ReviewTransitionArgument {
+	return append(arguments, reviewProviderRenderRuntimeMetadataArguments(meta)...)
+}

--- a/internal/cli/review_provider_runtime_metadata_test.go
+++ b/internal/cli/review_provider_runtime_metadata_test.go
@@ -1,0 +1,251 @@
+package cli
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/gentleman-programming/gentle-ai/v2/internal/reviewerprovider"
+)
+
+// TestReviewProviderRuntimeMetadataRenderParseRoundtrip pins the canonical
+// argv projection for every role that publishes metadata, and asserts the
+// inverse parse recovers the exact record the renderer wrote.
+func TestReviewProviderRuntimeMetadataRenderParseRoundtrip(t *testing.T) {
+	for _, role := range []reviewerprovider.Role{
+		reviewerprovider.RoleLens,
+		reviewerprovider.RoleRefuter,
+		reviewerprovider.RoleTargetedValidator,
+	} {
+		t.Run(string(role), func(t *testing.T) {
+			meta, ok := reviewProviderRuntimeMetadataFor(role)
+			if !ok {
+				t.Fatalf("role %q must publish metadata", role)
+			}
+			if meta.Version != reviewProviderRuntimeMetadataVersion {
+				t.Fatalf("role %q version = %q, want %q", role, meta.Version, reviewProviderRuntimeMetadataVersion)
+			}
+			if meta.ModelRunsMin < 1 {
+				t.Fatalf("role %q min = %d, want >= 1", role, meta.ModelRunsMin)
+			}
+			if meta.ModelRunsMax < meta.ModelRunsMin {
+				t.Fatalf("role %q max = %d, want >= min (%d)", role, meta.ModelRunsMax, meta.ModelRunsMin)
+			}
+			if len(meta.RetryReasons) == 0 {
+				t.Fatalf("role %q must publish at least one retry reason", role)
+			}
+			rendered := reviewProviderRenderRuntimeMetadataArguments(meta)
+			if len(rendered) != providerRuntimeMetadataArgumentCount {
+				t.Fatalf("role %q rendered = %d args, want %d", role, len(rendered), providerRuntimeMetadataArgumentCount)
+			}
+			got, present, err := reviewProviderParseRuntimeMetadataArguments(rendered)
+			if err != nil {
+				t.Fatalf("role %q parse: %v", role, err)
+			}
+			if !present {
+				t.Fatalf("role %q parser must treat its own render as present", role)
+			}
+			if !reflect.DeepEqual(got, meta) {
+				t.Fatalf("role %q roundtrip lost fidelity: got %#v want %#v", role, got, meta)
+			}
+		})
+	}
+}
+
+// TestReviewProviderRuntimeMetadataRenderUsesDistinctNames pins the four
+// argument names that go on every collect binding. The Go-owned argument map
+// rejects duplicates, so each name in the trailing metadata block must remain
+// unique within the binding and must not collide with the binding arguments
+// the provider already renders above it.
+func TestReviewProviderRuntimeMetadataRenderUsesDistinctNames(t *testing.T) {
+	meta, ok := reviewProviderRuntimeMetadataFor(reviewerprovider.RoleLens)
+	if !ok {
+		t.Fatal("lens must publish metadata")
+	}
+	seen := map[string]bool{}
+	for _, argument := range reviewProviderRenderRuntimeMetadataArguments(meta) {
+		if seen[argument.Name] {
+			t.Fatalf("duplicate metadata argument name %q", argument.Name)
+		}
+		seen[argument.Name] = true
+	}
+	want := []string{"provider_cost_version", "provider_model_runs_min", "provider_model_runs_max", "provider_retry_reasons"}
+	got := make([]string, 0, len(want))
+	for _, argument := range reviewProviderRenderRuntimeMetadataArguments(meta) {
+		got = append(got, argument.Name)
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("metadata argument names = %v, want %v", got, want)
+	}
+}
+
+// TestReviewProviderRuntimeMetadataParserRejectsUnknownVersion fails closed on
+// any version the provider does not recognize: the parent and the validator
+// must never silently extend the schema in-place.
+func TestReviewProviderRuntimeMetadataParserRejectsUnknownVersion(t *testing.T) {
+	arguments := []ReviewTransitionArgument{
+		{Name: "provider_cost_version", Value: "gentle-ai.review-provider-runtime-cost/v9"},
+		{Name: "provider_model_runs_min", Value: "1"},
+		{Name: "provider_model_runs_max", Value: "1"},
+		{Name: "provider_retry_reasons", Value: "provider_admission_refused"},
+	}
+	_, _, err := reviewProviderParseRuntimeMetadataArguments(arguments)
+	if err == nil || !strings.Contains(err.Error(), "unsupported provider_cost_version") {
+		t.Fatalf("unknown version err = %v, want unsupported provider_cost_version", err)
+	}
+}
+
+// TestReviewProviderRuntimeMetadataParserRejectsInvalidBounds fails closed on
+// any bound that violates the min/max invariants a parent would otherwise have
+// to re-derive from runtime counters.
+func TestReviewProviderRuntimeMetadataParserRejectsInvalidBounds(t *testing.T) {
+	cases := []struct {
+		name     string
+		min, max string
+		wantErr  string
+	}{
+		{name: "min zero", min: "0", max: "2", wantErr: "provider_model_runs_min must be >= 1"},
+		{name: "max below min", min: "2", max: "1", wantErr: "provider_model_runs_max must be >= provider_model_runs_min"},
+		{name: "min not integer", min: "abc", max: "2", wantErr: "provider_model_runs_min is not a non-negative integer"},
+		{name: "max not integer", min: "1", max: "x", wantErr: "provider_model_runs_max is not a non-negative integer"},
+		{name: "missing min", min: "", max: "2", wantErr: "provider_model_runs_min is not a non-negative integer"},
+	}
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			arguments := []ReviewTransitionArgument{
+				{Name: "provider_cost_version", Value: reviewProviderRuntimeMetadataVersion},
+				{Name: "provider_model_runs_min", Value: tt.min},
+				{Name: "provider_model_runs_max", Value: tt.max},
+				{Name: "provider_retry_reasons", Value: "provider_admission_refused"},
+			}
+			_, _, err := reviewProviderParseRuntimeMetadataArguments(arguments)
+			if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("invalid bounds err = %v, want substring %q", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+// TestReviewProviderRuntimeMetadataForUnlistedRoles confirms that roles outside
+// the three-collect-operation contract surface return the zero value with no
+// metadata rendered. Nothing else may project a cost block on a host binding.
+func TestReviewProviderRuntimeMetadataForUnlistedRoles(t *testing.T) {
+	unlisted := []reviewerprovider.Role{
+		"",
+		"unknown-role",
+		"lens-helper",
+		"refuter-fallback",
+	}
+	for _, role := range unlisted {
+		t.Run(string(role), func(t *testing.T) {
+			meta, ok := reviewProviderRuntimeMetadataFor(role)
+			if ok {
+				t.Fatalf("unlisted role %q must not publish metadata, got %#v", role, meta)
+			}
+			if meta.Version != "" || meta.ModelRunsMin != 0 || meta.ModelRunsMax != 0 || meta.RetryReasons != nil {
+				t.Fatalf("unlisted role %q must return zero metadata, got %#v", role, meta)
+			}
+			rendered := reviewProviderRenderRuntimeMetadataArguments(meta)
+			if len(rendered) != 0 {
+				t.Fatalf("unlisted role %q render = %d args, want 0", role, len(rendered))
+			}
+		})
+	}
+}
+
+// TestReviewProviderAppendRuntimeMetadataArgumentsNoOpOnEmpty ensures the
+// appender is a no-op when the metadata record is empty, so callers that
+// unconditionally forward the resulting slice never inflate existing argv.
+func TestReviewProviderAppendRuntimeMetadataArgumentsNoOpOnEmpty(t *testing.T) {
+	base := []ReviewTransitionArgument{{Name: "agent", Value: "pi"}, {Name: "execute", Value: "true"}}
+	got := reviewProviderAppendRuntimeMetadataArguments(base, reviewProviderRuntimeMetadata{})
+	if len(got) != len(base) {
+		t.Fatalf("empty append grew the slice: got %d args, want %d", len(got), len(base))
+	}
+	if !reflect.DeepEqual(got, base) {
+		t.Fatalf("empty append mutated the slice: got %#v want %#v", got, base)
+	}
+}
+
+// TestReviewProviderAppendRuntimeMetadataArgumentsAppendsCanonicalBlock pins
+// the append order: existing arguments first, then the four canonical metadata
+// arguments. The provider render path relies on this ordering so a parent
+// reading the trailing tail off any collect input sees the canonical block.
+func TestReviewProviderAppendRuntimeMetadataArgumentsAppendsCanonicalBlock(t *testing.T) {
+	base := []ReviewTransitionArgument{{Name: "agent", Value: "pi"}, {Name: "execute", Value: "true"}}
+	meta, ok := reviewProviderRuntimeMetadataFor(reviewerprovider.RoleRefuter)
+	if !ok {
+		t.Fatal("refuter must publish metadata")
+	}
+	got := reviewProviderAppendRuntimeMetadataArguments(base, meta)
+	want := append([]ReviewTransitionArgument{}, base...)
+	want = append(want, reviewProviderRenderRuntimeMetadataArguments(meta)...)
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("append ordering diverged: got %#v want %#v", got, want)
+	}
+	if len(got)-len(base) != providerRuntimeMetadataArgumentCount {
+		t.Fatalf("appender added %d args, want %d", len(got)-len(base), providerRuntimeMetadataArgumentCount)
+	}
+}
+
+// TestReviewProviderParseRuntimeMetadataArgumentsAbsentVersion is the inherited
+// case: an input with no metadata block must round-trip as "not present" with
+// no error, so existing transitions that do not carry the trailing block
+// continue to validate.
+func TestReviewProviderParseRuntimeMetadataArgumentsAbsentVersion(t *testing.T) {
+	arguments := []ReviewTransitionArgument{{Name: "agent", Value: "pi"}, {Name: "execute", Value: "true"}}
+	meta, present, err := reviewProviderParseRuntimeMetadataArguments(arguments)
+	if err != nil {
+		t.Fatalf("absent metadata parse err = %v, want nil", err)
+	}
+	if present {
+		t.Fatalf("absent metadata present = true, want false")
+	}
+	if !reflect.DeepEqual(meta, reviewProviderRuntimeMetadata{}) {
+		t.Fatalf("absent metadata returned non-zero %#v", meta)
+	}
+}
+
+// TestReviewProviderParseRuntimeMetadataArgumentsDropsEmptyRetryReasons
+// guarantees the comma-joined retry-reasons argument never produces empty
+// entries when callers hand us a trailing comma or whitespace.
+func TestReviewProviderParseRuntimeMetadataArgumentsDropsEmptyRetryReasons(t *testing.T) {
+	arguments := []ReviewTransitionArgument{
+		{Name: "provider_cost_version", Value: reviewProviderRuntimeMetadataVersion},
+		{Name: "provider_model_runs_min", Value: "1"},
+		{Name: "provider_model_runs_max", Value: "2"},
+		{Name: "provider_retry_reasons", Value: " provider_admission_refused , , provider_role_contract_violation ,"},
+	}
+	meta, present, err := reviewProviderParseRuntimeMetadataArguments(arguments)
+	if err != nil {
+		t.Fatalf("retry-reasons parse err = %v", err)
+	}
+	if !present {
+		t.Fatal("retry-reasons parse present = false, want true")
+	}
+	want := []string{"provider_admission_refused", "provider_role_contract_violation"}
+	if !reflect.DeepEqual(meta.RetryReasons, want) {
+		t.Fatalf("retry-reasons = %#v, want %#v", meta.RetryReasons, want)
+	}
+}
+
+// TestReviewProviderParseRuntimeMetadataArgumentsAcceptsEmptyRetryReasons
+// confirms the parser accepts the v1 schema with an empty retry-reasons value
+// rather than treating the absence of reasons as a refusal. An empty reason
+// list simply means the metadata block carries no extra runs.
+func TestReviewProviderParseRuntimeMetadataArgumentsAcceptsEmptyRetryReasons(t *testing.T) {
+	arguments := []ReviewTransitionArgument{
+		{Name: "provider_cost_version", Value: reviewProviderRuntimeMetadataVersion},
+		{Name: "provider_model_runs_min", Value: "1"},
+		{Name: "provider_model_runs_max", Value: "1"},
+		{Name: "provider_retry_reasons", Value: ""},
+	}
+	meta, present, err := reviewProviderParseRuntimeMetadataArguments(arguments)
+	if err != nil {
+		t.Fatalf("empty retry-reasons parse err = %v", err)
+	}
+	if !present || len(meta.RetryReasons) != 0 {
+		t.Fatalf("empty retry-reasons metadata = %#v, present = %v", meta, present)
+	}
+}
+

--- a/internal/cli/review_status_contract.go
+++ b/internal/cli/review_status_contract.go
@@ -1198,22 +1198,27 @@ func (transition ReviewNextTransition) Validate() error {
 					argumentCount++
 				}
 				if hostRelayMaterialize {
-					// A host-relay capture input carries both --agent and
-					// --materialize=true: the host materializes first, then
-					// advances authority through the submission descriptor.
+					// The Pi host relay uses the Go-owned execute form. It invokes
+					// the exact materialized request and shares the bounded admission
+					// retry, so no caller-authored --input submission exists.
 					argumentCount += 2
-					expected := make([]string, 0, len(input.Arguments)-1)
-					for _, argument := range input.Arguments {
-						if argument.Name != "materialize" {
-							expected = append(expected, reviewTransitionArgumentToken(argument))
-						}
-					}
-					expected = append(expected, "--input="+reviewSubmissionValuePlaceholder)
-					if input.Submission == nil || !reflect.DeepEqual(input.Submission.ArgumentTokens, expected) {
-						return errors.New("host-relay capture transition submission does not advance the reviewed binding") // refusal:by-design world-action: only a provider code fix can make the rendered transition advance authority
+					if input.Submission != nil {
+						return errors.New("host-relay capture transition must not carry a caller submission") // refusal:by-design world-action: host execution and admission remain provider-owned
 					}
 				} else if input.Submission != nil {
 					return errors.New("collection transition submission placement is invalid") // refusal:by-design world-action: only a provider code fix can place a descriptor on a supported input
+				}
+				// When the lens host relay materializes, allow exactly the trailing
+				// provider-runtime metadata block; the parser rejects any shape that
+				// diverges from the canonical four-argument schema, so a hostile or
+				// stale envelope still fails closed with the same refusal an unknown
+				// version would produce.
+				if hostRelayMaterialize && len(arguments) > argumentCount {
+					metadataArguments := input.Arguments[argumentCount:]
+					if _, _, parseErr := reviewProviderParseRuntimeMetadataArguments(metadataArguments); parseErr != nil {
+						return fmt.Errorf("review capture transition host-relay metadata is invalid: %w", parseErr)
+					}
+					argumentCount += providerRuntimeMetadataArgumentCount
 				}
 				if len(arguments) != argumentCount || !reviewStartSupportedLens(arguments["lens"]) || orderErr != nil || order < 0 ||
 					!validReviewCapabilitySHA256(arguments["expected-revision"]) || !validReviewCapabilitySHA256(arguments["target"]) ||
@@ -1227,7 +1232,7 @@ func (transition ReviewNextTransition) Validate() error {
 					input.ArtifactSubject == nil || legacyTransport && input.ChangedPathManifest == nil ||
 					nativeGitTransport && arguments["subject-hash"] != input.ArtifactSubject.SubjectHash ||
 					providerRuntime != "" && !providerCapture && !hostRelayMaterialize ||
-					hostRelayMaterialize && arguments["materialize"] != "true" ||
+					hostRelayMaterialize && arguments["execute"] != "true" ||
 					legacyTransport && input.CandidateDiff == nil || nativeGitTransport && (!validReviewGitTree(input.BaseTree) || !validReviewGitTree(input.CandidateTree)) ||
 					(!legacyTransport && !nativeGitTransport) {
 					return errors.New("review capture transition lacks an exact repository and authority binding")
@@ -1268,7 +1273,12 @@ func (transition ReviewNextTransition) Validate() error {
 				// --agent and --execute=true. Go materializes the role
 				// request, spawns its own locked-down pi process, and admits
 				// the raw bytes, so no submission descriptor may exist for a
-				// caller to author a verdict through.
+				// caller to author a verdict through. The trailing
+				// provider-runtime metadata block (provider_cost_version,
+				// provider_model_runs_min/max, provider_retry_reasons) is the
+				// single shape a corrected retry render carries; the parser
+				// fails closed on any divergence, so a hostile or stale
+				// envelope still produces the canonical refusal.
 				providerRuntime := model.AgentID(arguments["agent"])
 				argumentCount, schema := 6, reviewRefuterSchemaID
 				if input.CaptureOperation == reviewCaptureValidationCaptureOperation {
@@ -1277,6 +1287,19 @@ func (transition ReviewNextTransition) Validate() error {
 				// Fail closed on the argument count BEFORE any arithmetic over
 				// it: a hostile envelope with a truncated (or empty) argument
 				// vector must produce this refusal, never a panic.
+				if len(input.Arguments) < argumentCount || len(arguments) < argumentCount {
+					return errors.New("provider role capture transition lacks an exact host-relay binding") // refusal:by-design world-action: only a provider code fix can make the rendered transition advance authority
+				}
+				if len(input.Arguments) > argumentCount {
+					metadataArguments := input.Arguments[argumentCount:]
+					if len(metadataArguments) != providerRuntimeMetadataArgumentCount {
+						return errors.New("provider role capture transition host-relay metadata block is invalid") // refusal:by-design world-action: only a provider code fix can make the rendered transition advance authority
+					}
+					if _, _, parseErr := reviewProviderParseRuntimeMetadataArguments(metadataArguments); parseErr != nil {
+						return fmt.Errorf("provider role capture transition host-relay metadata is invalid: %w", parseErr)
+					}
+					argumentCount += providerRuntimeMetadataArgumentCount
+				}
 				if len(input.Arguments) != argumentCount || len(arguments) != argumentCount {
 					return errors.New("provider role capture transition lacks an exact host-relay binding") // refusal:by-design world-action: only a provider code fix can make the rendered transition advance authority
 				}

--- a/internal/cli/review_submission_descriptor_test.go
+++ b/internal/cli/review_submission_descriptor_test.go
@@ -36,12 +36,11 @@ func TestReviewerCaptureDescriptorUsesCaptureResult(t *testing.T) {
 		RepositoryContext: "rctx1_" + strings.Repeat("c", 64),
 	}
 	input := reviewCaptureInput(binding, reviewtransaction.LensReliability, 0, nil, model.AgentPi)
-	if input.CaptureOperation != reviewCaptureResultCaptureOperation || input.Submission == nil ||
-		input.Submission.OperationToken != "capture-result" || input.Submission.Value == nil ||
-		input.Submission.Value.Slot != "reviewer_result" {
-		t.Fatalf("reviewer capture descriptor = %#v", input)
+	if input.CaptureOperation != reviewCaptureResultCaptureOperation || input.Submission != nil {
+		t.Fatalf("reviewer capture descriptor = %#v, want provider-owned execute route", input)
 	}
-	if err := input.Submission.validateCaptureResult(); err != nil {
-		t.Fatalf("current reviewer capture descriptor = %v", err)
+	arguments, err := reviewTransitionArgumentMap(input.Arguments)
+	if err != nil || arguments["agent"] != string(model.AgentPi) || arguments["execute"] != "true" {
+		t.Fatalf("reviewer capture arguments = %#v, want agent=pi and execute=true", input.Arguments)
 	}
 }


### PR DESCRIPTION
## What

Route the Pi host relay (capture-result and capture-refuter) through the existing one-correction retry path that compiled and in-process runtimes already use. Two provider issues motivated this:

- #4406 (evidence_path_out_of_scope): the materialize route preserved the rejected payload and reoffered the same slot; absolute citation paths produced an indefinite reload.
- #4422 (refuter JSON truncated): the provider returned a truncated JSON; the Pi host relay had no corrective retry while compiled runtimes already had one.

The new `review_provider_runtime_metadata.go` publishes an explicit bound via the `gentle-ai.review-provider-runtime-cost/v1` block: `min`/`max` model runs and a closed `retry_reason` enum. STATUS validates it, rejects wider blocks (>=5 args), and falls back to legacy 1-run semantics when absent. Two failed captures return typed `provider_capture_result_refused`/`next_action=review.status`/`mutation_outcome=not_started` and reoffer the same slot.

## Behavior preserved

- Absolute paths and truncated JSON remain fail-closed; `referenceOutsideRepository` and `ExtractBoundedSingleJSONObject` are unchanged.
- Transport errors are not retried.
- The authority store never mutates until a capture is admitted.

## Validation

- `PATH=/home/jmon/.local/go1.25.10/bin:$PATH go build ./...`: clean
- `PATH=/home/jmon/.local/go1.25.10/bin:$PATH go vet ./internal/cli/...`: clean
- Focused `go test -run RuntimeMetadata`: PASS
- Full `go test ./internal/cli -count=1`: PASS

## Compatibility note

The Pi lens consumer contract changes from `materialize + --input` to `provider execute`; gentle-pi has the matching compat patch at #<https://github.com/dumbocan/gentle-pi/pull/number>. The bound metadata block is opt-in: if `provider_cost_version` is absent, legacy 1-run semantics continue to work, so the change can be staged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an execute-based capture flow for host-relay reviewers.
  - Added runtime metadata for provider cost limits, model-run bounds, and retry reasons.
  - Added corrective retries for rejected reviewer results.

- **Bug Fixes**
  - Improved validation and refusal messages for invalid or incomplete capture requests.
  - Preserved provider payloads during strict validation and prevented rejected results from altering review state.
  - Transport failures are no longer retried.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->