### PR TITLE
fix(review): preserve selected untracked correction scope

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,7 +84,8 @@ jobs:
             completed_once("j113-correction-removes-candidate-only-path") and
             completed_once("j114-last-reviewer-capture-closes-and-burns") and
             completed_once("j116-codex-committed-correction-runs-returned-status-continuation") and
-            completed_once("j123-rejected-provider-validator-starts-fresh-high-risk-review")
+            completed_once("j123-rejected-provider-validator-starts-fresh-high-risk-review") and
+            completed_once("j4435-selected-untracked-correction-continuation-is-selectorless")
           ' "$RUNNER_TEMP/bench-portable.json"
           "$RUNNER_TEMP/gentle-ai-bench" run --binary "$RUNNER_TEMP/gentle-ai" --only j105-compiled-provider-capture-retries-same-binding --out "$RUNNER_TEMP/bench-provider-capture.json"
           jq -e '

--- a/bench/journeys_intended_untracked.go
+++ b/bench/journeys_intended_untracked.go
@@ -357,6 +357,147 @@ func selectUntrackedCaptureAndResumeTerminal(r *journeyRun) error {
 	return nil
 }
 
+const (
+	selectedUntrackedCorrectionTrackedPath    = "internal/selected_correction.go"
+	selectedUntrackedCorrectionUntrackedPath  = "docs/selected-correction.md"
+	selectedUntrackedCorrectionUnselectedPath = "local-only.txt"
+)
+
+func selectedUntrackedCorrectionCandidate(sandbox *Sandbox) error {
+	if err := sandbox.write(filepath.Join(sandbox.Repo, selectedUntrackedCorrectionTrackedPath), "package selected\n\nfunc Value() int { return 1 }\n"); err != nil {
+		return err
+	}
+	if err := sandbox.git(sandbox.Repo, "add", "--", selectedUntrackedCorrectionTrackedPath); err != nil {
+		return err
+	}
+	if err := sandbox.write(filepath.Join(sandbox.Repo, selectedUntrackedCorrectionUntrackedPath), "# Selected correction input\n"); err != nil {
+		return err
+	}
+	return sandbox.write(filepath.Join(sandbox.Repo, selectedUntrackedCorrectionUnselectedPath), "local-only untracked state\n")
+}
+
+func startSelectedUntrackedCorrection(r *journeyRun) error {
+	start, _, err := frozenLineageSelectedStatus(r, "", selectedUntrackedCorrectionUntrackedPath)
+	if err != nil || start.NextTransition.Kind != "execute" || start.NextTransition.Execute.Operation != "review.start" ||
+		start.NextTransition.Execute.Command == "" {
+		return fmt.Errorf("selected untracked correction START = %+v, %v", start.NextTransition, err)
+	}
+	relay, err := runPrintedTransition(r, start)
+	if err != nil {
+		return err
+	}
+	granted, err := resolveAtomicStartConsentAt(r, r.sandbox.Repo, start, relay)
+	if err != nil {
+		return err
+	}
+	if err := rememberLineage(r.sandbox, granted); err != nil || r.sandbox.Lineage == "" {
+		return fmt.Errorf("selected untracked correction granted START = lineage %q: %v", r.sandbox.Lineage, err)
+	}
+	status, _, err := frozenLineageStatus(r, r.sandbox.Lineage)
+	if err != nil || status.Authority.LineageID != r.sandbox.Lineage || status.Authority.State != "reviewing" ||
+		status.TargetIdentity == "" || status.NextTransition.Kind != "collect" ||
+		status.NextTransition.ReasonCode != "reviewer_results_required" || len(status.NextTransition.Collect.Inputs) == 0 ||
+		len(status.paths()) != 2 || !slices.Contains(status.paths(), selectedUntrackedCorrectionTrackedPath) ||
+		!slices.Contains(status.paths(), selectedUntrackedCorrectionUntrackedPath) {
+		return fmt.Errorf("selected untracked correction reviewing STATUS = authority=%+v target=%q transition=%+v err=%v", status.Authority, status.TargetIdentity, status.NextTransition, err)
+	}
+	r.sandbox.Scratch["j4435-target"] = status.TargetIdentity
+	return nil
+}
+
+func captureSelectedUntrackedCorrectionFinding(r *journeyRun) error {
+	var terminal Observation
+	for capture := 0; capture < 8; capture++ {
+		status, _, err := frozenLineageStatus(r, r.sandbox.Lineage)
+		if err != nil {
+			return err
+		}
+		if status.Authority.LineageID != r.sandbox.Lineage || status.Authority.State != "reviewing" ||
+			status.TargetIdentity != r.sandbox.Scratch["j4435-target"] || status.NextTransition.Kind != "collect" ||
+			status.NextTransition.ReasonCode != "reviewer_results_required" || len(status.NextTransition.Collect.Inputs) == 0 {
+			return fmt.Errorf("selected untracked correction reviewer STATUS = authority=%+v target=%q transition=%+v", status.Authority, status.TargetIdentity, status.NextTransition)
+		}
+		input := status.NextTransition.Collect.Inputs[0]
+		if input.Name != "reviewer_result" || input.CaptureOperation != "review.capture-result" || input.ArtifactSubject.SubjectHash == "" ||
+			status.argument("lineage") != r.sandbox.Lineage || status.argument("target") != r.sandbox.Scratch["j4435-target"] ||
+			status.argument("expected-revision") == "" || status.argument("lens") == "" || status.argument("order") == "" {
+			return fmt.Errorf("selected untracked correction reviewer binding = %+v", input)
+		}
+		payload, err := synthesizeReviewerResult(input.ArtifactSubject.SubjectHash, status.paths())
+		if err != nil {
+			return err
+		}
+		if capture == 0 {
+			payload, err = json.Marshal(map[string]any{
+				"subject_hash": input.ArtifactSubject.SubjectHash,
+				"inspection":   map[string]any{"status": "completed", "paths": status.paths()},
+				"findings": []any{map[string]any{
+					"location": "internal/selected_correction.go:3", "severity": "CRITICAL", "claim": "selected candidate returns the wrong value",
+					"proof_refs":     []string{"internal/selected_correction.go:3 is introduced by the selected candidate"},
+					"evidence_class": "deterministic", "causal_disposition": "introduced",
+				}},
+				"evidence": []string{"the frozen selected candidate returns 1 instead of the required value"},
+			})
+			if err != nil {
+				return err
+			}
+		}
+		path, err := writeScratch(r.sandbox, fmt.Sprintf("j4435-reviewer-%d.json", capture), payload)
+		if err != nil {
+			return err
+		}
+		terminal = r.run([]string{
+			"review", "capture-result", "--cwd", r.sandbox.Repo,
+			"--lineage", status.argument("lineage"), "--target", status.argument("target"),
+			"--expected-revision", status.argument("expected-revision"), "--lens", status.argument("lens"),
+			"--order", status.argument("order"), "--input", path,
+		}, true)
+		if terminal.ExitCode != 0 {
+			return fmt.Errorf("capture selected untracked correction reviewer %d: %s", capture, firstLine(terminal.Stderr))
+		}
+		var closure lastEventClosure
+		if err := json.Unmarshal([]byte(strings.TrimSpace(terminal.Stdout)), &closure); err != nil {
+			return fmt.Errorf("decode selected untracked correction closure: %w", err)
+		}
+		if closure.State == "correction_required" {
+			if closure.LineageID != r.sandbox.Lineage || closure.StatusContinuation == nil || closure.StatusContinuation.Operation != "review.status" {
+				return fmt.Errorf("selected untracked correction closure = %+v", closure)
+			}
+			r.sandbox.Scratch["j4435-closure"] = terminal.Stdout
+			return nil
+		}
+	}
+	return fmt.Errorf("selected untracked correction reviewer captures did not reach correction_required: %s", terminal.Stdout)
+}
+
+func executeSelectorlessSelectedUntrackedCorrectionContinuation(r *journeyRun) error {
+	closure := Observation{Stdout: r.sandbox.Scratch["j4435-closure"]}
+	var result lastEventClosure
+	if err := json.Unmarshal([]byte(strings.TrimSpace(closure.Stdout)), &result); err != nil {
+		return fmt.Errorf("decode selected untracked correction continuation: %w", err)
+	}
+	if result.LineageID != r.sandbox.Lineage || result.StatusContinuation == nil || result.StatusContinuation.Operation != "review.status" {
+		return fmt.Errorf("selected untracked correction continuation = %+v", result)
+	}
+	for _, argument := range result.StatusContinuation.Arguments {
+		for _, forbidden := range []string{"--untracked-scope", "--expected-untracked-inventory", "--intended-untracked"} {
+			if strings.HasPrefix(argument.Token, forbidden+"=") || argument.Token == forbidden {
+				return fmt.Errorf("selected untracked correction continuation leaked selector %q", argument.Token)
+			}
+		}
+	}
+	status, continued, err := correctionStatusFromLastEventCapture(r, closure)
+	if err != nil || !continued {
+		return fmt.Errorf("execute selected untracked correction continuation: continued=%t err=%v", continued, err)
+	}
+	if status.Authority.LineageID != r.sandbox.Lineage || status.Authority.State != "correction_required" ||
+		status.TargetIdentity != r.sandbox.Scratch["j4435-target"] || status.NextTransition.Kind != "collect" ||
+		status.NextTransition.ReasonCode != "correction_plan_required" {
+		return fmt.Errorf("selected untracked correction continuation STATUS = authority=%+v target=%q transition=%+v", status.Authority, status.TargetIdentity, status.NextTransition)
+	}
+	return nil
+}
+
 func intendedUntrackedJourneys() []Journey {
 	return []Journey{
 		{
@@ -368,6 +509,19 @@ func intendedUntrackedJourneys() []Journey {
 				{Name: "fixture: repository", Fixture: baseRepo},
 				{Name: "fixture: mixed tracked and intended/unrelated untracked files", Fixture: mixedIntendedUntrackedCandidate},
 				{Name: "STATUS collects selection and printed START freezes only chosen paths", Requires: intendedUntrackedStatusCapability, Composite: selectIntendedUntrackedAndRunPrintedStart},
+			},
+		},
+		{
+			ID:     "j4435-selected-untracked-correction-continuation-is-selectorless",
+			Review: reviewOptedIn,
+			Title:  "#4435: selected untracked correction continuation omits selection selectors and preserves its frozen target",
+			Source: "#4435: the selected-untracked admission is frozen at START, so correction STATUS resumes only through its exact lineage",
+			Steps: []Step{
+				{Name: "fixture: repository", Fixture: baseRepo},
+				{Name: "fixture: tracked and selected untracked correction candidate", Fixture: selectedUntrackedCorrectionCandidate},
+				{Name: "negotiate v2 selected-untracked START and grant its published consent invocation", Requires: frozenLineageStatusCapability, Composite: startSelectedUntrackedCorrection},
+				{Name: "capture a deterministic introduced CRITICAL finding through correction-required", Requires: captureResultCapability, Composite: captureSelectedUntrackedCorrectionFinding},
+				{Name: "execute the selectorless returned STATUS continuation and retain the frozen lineage and target", Requires: frozenLineageStatusCapability, Composite: executeSelectorlessSelectedUntrackedCorrectionContinuation},
 			},
 		},
 		{

--- a/bench/review_declarations.go
+++ b/bench/review_declarations.go
@@ -65,6 +65,7 @@ var coreJourneyReviewModes = map[string]ReviewPrecondition{
 	"j42-kill-switch-versus-sdd-archive":                                        reviewOptedIn,
 	"j43-recovery-guard-rails-as-an-operator-meets-them":                        reviewOptedIn,
 	"j44-corrected-current-changes-delivery":                                    reviewOptedIn,
+	"j4435-selected-untracked-correction-continuation-is-selectorless":          reviewOptedIn,
 	"j44-sdd-historical-requirement-stale-pass":                                 reviewOptedIn,
 	"j45-completed-final-verification-retry":                                    reviewOptedIn,
 	"j46-correction-required-staged-recovery":                                   reviewOptedIn,

--- a/bench/testdata/journeys.manifest
+++ b/bench/testdata/journeys.manifest
@@ -40,6 +40,7 @@ j4040-untracked-inventory-recovery-loop
 j41-kill-switch-versus-sdd-pre-verify
 j42-kill-switch-versus-sdd-archive
 j44-sdd-historical-requirement-stale-pass
+j4435-selected-untracked-correction-continuation-is-selectorless
 j47-disabled-mode-archives-discovered-scope-changed-authority
 j49-status-without-cwd-honors-kill-switch
 j51-negotiated-status-correction-continuation

--- a/internal/cli/review_correction_untracked_binding_test.go
+++ b/internal/cli/review_correction_untracked_binding_test.go
@@ -3,6 +3,9 @@ package cli
 import (
 	"bytes"
 	"context"
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/gentleman-programming/gentle-ai/v2/internal/reviewtransaction"
@@ -86,5 +89,123 @@ func TestNegotiatedStatusPreservesUntrackedBindingThroughCorrectionLineage(t *te
 				}
 			}
 		}
+	}
+}
+
+// TestSelectorlessStatusPreservesIntendedUntrackedBindingBeforeCorrectionPlan
+// reproduces #4435's first dead end: after a selected-untracked review enters
+// correction_required, the provider-published selectorless STATUS continuation
+// must retain the frozen selection rather than demanding a new declaration.
+func TestSelectorlessStatusPreservesIntendedUntrackedBindingBeforeCorrectionPlan(t *testing.T) {
+	reviewEnabledHome(t)
+	repo := initReviewCLIRepo(t)
+	const lineage = "correction-untracked-selectorless-status-4435"
+	writeReviewStartCandidate(t, repo, "candidate.go", "package candidate\n\nfunc value() int { return 1 }\n", 0o644)
+	writeUndeclaredWorkspaceFile(t, repo, "notes.txt", "untracked but explicitly selected\n", 0o644)
+	writeUndeclaredWorkspaceFile(t, repo, "local-only.txt", "eligible but deliberately unselected\n", 0o644)
+
+	_, digest, err := (reviewtransaction.SnapshotBuilder{Repo: repo}).IntendedUntrackedInventory(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	startedBytes, err := runLegacyFacadeStartForTestBytes(t, []string{
+		"--cwd", repo, "--lineage", lineage,
+		"--untracked-scope=select", "--expected-untracked-inventory=" + digest, "--intended-untracked", "notes.txt",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var started ReviewFacadeStartResult
+	decodeStrictReviewJSON(t, startedBytes, &started)
+	if len(started.SelectedLenses) != 1 {
+		t.Fatalf("started lenses = %v, want exactly one selected lens", started.SelectedLenses)
+	}
+
+	var closureOutput bytes.Buffer
+	captureCLIReviewerResultWithFindings(t, repo, started, 0, []facadeFinding{{
+		Location: "candidate.go:1", Severity: "CRITICAL", Claim: "candidate exposes the wrong behavior",
+		ProofRefs:     []string{"exact changed hunk", "reproduced candidate failure"},
+		EvidenceClass: reviewtransaction.EvidenceDeterministic, CausalDisposition: reviewtransaction.CausalIntroduced,
+	}}, &closureOutput)
+
+	var closure reviewLastEventClosureResult
+	decodeStrictReviewJSON(t, closureOutput.Bytes(), &closure)
+	if closure.Schema != reviewLastEventClosureSchema || closure.Operation != "review/capture-result" ||
+		closure.LineageID != lineage || closure.State != reviewtransaction.StateCorrectionRequired {
+		t.Fatalf("selectorless final capture closure = %#v, want correction_required closure", closure)
+	}
+	if closure.StatusContinuation == nil {
+		t.Fatalf("selectorless final capture closure lacks status_continuation: %s", closureOutput.String())
+	}
+	continuation := closure.StatusContinuation
+	if continuation.Operation != "review.status" {
+		t.Fatalf("selectorless status continuation operation = %q, want review.status", continuation.Operation)
+	}
+	for _, argument := range continuation.Arguments {
+		for _, forbidden := range []string{"--untracked-scope", "--expected-untracked-inventory", "--intended-untracked"} {
+			if argument.Token == forbidden || strings.HasPrefix(argument.Token, forbidden+"=") {
+				t.Fatalf("selectorless status continuation leaks %q: %#v", forbidden, continuation.Arguments)
+			}
+		}
+	}
+
+	store, err := reviewtransaction.CompactAuthoritativeStore(context.Background(), repo, lineage)
+	if err != nil {
+		t.Fatal(err)
+	}
+	record, err := store.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Replay only the operation and opaque tokens the final reviewer capture
+	// published; reconstructing STATUS would hide a malformed continuation.
+	statusArgs := []string{strings.TrimPrefix(continuation.Operation, "review.")}
+	for _, argument := range continuation.Arguments {
+		statusArgs = append(statusArgs, argument.Token)
+	}
+	var statusOutput bytes.Buffer
+	if err := RunReview(statusArgs, &statusOutput); err != nil {
+		t.Fatalf("run selectorless status continuation unchanged: %v\n%s", err, statusOutput.String())
+	}
+	var status ReviewTargetStatusResult
+	decodeStrictReviewJSON(t, statusOutput.Bytes(), &status)
+	if status.Authority == nil || status.Authority.LineageID != lineage || status.Authority.State != reviewtransaction.StateCorrectionRequired {
+		t.Fatalf("selectorless STATUS authority = %#v, want correction_required authority for lineage %q", status.Authority, lineage)
+	}
+	if status.NextTransition == nil || status.NextTransition.Kind != reviewNextTransitionCollect ||
+		status.NextTransition.ReasonCode != "correction_plan_required" || status.NextTransition.CorrectionRequest == nil {
+		t.Fatalf("selectorless STATUS transition = %#v, want collect/correction_plan_required", status.NextTransition)
+	}
+
+	request := status.NextTransition.CorrectionRequest
+	if status.TargetIdentity != record.State.CurrentSnapshot.Identity || request.TargetIdentity != record.State.CurrentSnapshot.Identity {
+		t.Fatalf("selectorless STATUS target bindings = status %q, correction request %q, want %q", status.TargetIdentity, request.TargetIdentity, record.State.CurrentSnapshot.Identity)
+	}
+	if status.Authority.Revision != record.Revision {
+		t.Fatalf("selectorless STATUS authority revision = %q, want %q", status.Authority.Revision, record.Revision)
+	}
+	if request.ExpectedRevision != record.State.CapturePhaseRevision {
+		t.Fatalf("correction request capture-phase revision = %q, want %q", request.ExpectedRevision, record.State.CapturePhaseRevision)
+	}
+	if request.LineageID != lineage {
+		t.Fatalf("correction request lineage = %q, want %q", request.LineageID, lineage)
+	}
+
+	// Losing one frozen selected path is real scope drift. Extra unselected paths
+	// may remain outside the candidate, but they must not stand in for the missing
+	// selected path when the same continuation is re-entered.
+	if err := os.Remove(filepath.Join(repo, "notes.txt")); err != nil {
+		t.Fatal(err)
+	}
+	statusOutput.Reset()
+	if err := RunReview(statusArgs, &statusOutput); err != nil {
+		t.Fatalf("run continuation after selected path removal: %v\n%s", err, statusOutput.String())
+	}
+	var missingSelected ReviewTargetStatusResult
+	decodeStrictReviewJSON(t, statusOutput.Bytes(), &missingSelected)
+	if missingSelected.NextTransition == nil || missingSelected.NextTransition.Kind != reviewNextTransitionCollect ||
+		missingSelected.NextTransition.ReasonCode != "intended_untracked_selection_required" {
+		t.Fatalf("missing selected path transition = %#v, want intended_untracked_selection_required", missingSelected.NextTransition)
 	}
 }

--- a/internal/cli/review_facade.go
+++ b/internal/cli/review_facade.go
@@ -939,19 +939,19 @@ func runReviewStatus(ctx context.Context, args []string, stdout io.Writer) error
 					// Only an approved compact authority that still owns its
 					// acknowledgement can resume its immutable terminal target. A
 					// correction-required authority that already froze a non-empty
-					// intended-untracked SELECTION resumes it too, but only while the
-					// live workspace's eligible untracked population is still exactly
-					// that declared set: the exact bound STATUS continuation
+					// intended-untracked SELECTION resumes it too while every selected
+					// path remains eligible. Additional unselected paths stay outside
+					// the immutable target and cannot expand a bounded correction: the
+					// exact bound STATUS continuation
 					// `review.capture-correction-plan` itself returns carries no
 					// untracked-scope flags, so demanding a fresh declaration on that
 					// plain re-entry dead-ended the correction lineage and bound the
 					// resulting collect input to a different (live, declaration-less)
 					// target identity than the one the authority is bound to (issue
-					// #3849). A frozen EXCLUDE declaration (empty selection) is left
-					// alone here -- it is indistinguishable on its own from "nothing
-					// was ever declared", and a brand new untracked artifact appearing
-					// mid-correction must still force a fresh declaration exactly as
-					// before (design intent: "detect new untracked artifacts").
+					// #3849 and #4435). A frozen EXCLUDE declaration (empty selection)
+					// is left alone here because it is indistinguishable on its own from
+					// "nothing was ever declared"; that path still requires a fresh live
+					// declaration when eligible untracked files exist.
 					_, pendingApproval := reviewtransaction.PendingApprovedCompactAcknowledgement(record)
 					resumeCorrectionUntracked := false
 					declaredUntracked := record.State.InitialSnapshot.IntendedUntracked
@@ -960,7 +960,7 @@ func runReviewStatus(ctx context.Context, args []string, stdout io.Writer) error
 						if inventoryErr != nil {
 							return reviewPreflightError(inventoryErr)
 						}
-						resumeCorrectionUntracked = reviewSameUntrackedPaths(inventory, declaredUntracked)
+						resumeCorrectionUntracked = reviewUntrackedInventoryContainsSelection(inventory, declaredUntracked)
 					}
 					if pendingApproval || resumeCorrectionUntracked {
 						intendedScope = reviewIntendedUntrackedScope{

--- a/internal/cli/review_intended_untracked.go
+++ b/internal/cli/review_intended_untracked.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"sort"
 	"strings"
 
 	"github.com/gentleman-programming/gentle-ai/v2/internal/model"
@@ -150,21 +149,20 @@ func reviewIntendedUntrackedCollection(status ReviewTargetStatusResult, scope re
 	return reviewCollectTransition("intended_untracked_selection_required", input)
 }
 
-// reviewSameUntrackedPaths reports whether two path lists name exactly the
-// same set, independent of order. Both `IntendedUntrackedInventory` and a
-// stored `IntendedUntracked` selection are canonicalized and sorted at their
-// own source, but this comparison does not depend on that: it sorts its own
-// copies so a caller never has to reason about either side's ordering.
-func reviewSameUntrackedPaths(left, right []string) bool {
-	if len(left) != len(right) {
+// reviewUntrackedInventoryContainsSelection reports whether every frozen
+// selected path remains eligible in the live untracked inventory. Additional
+// unselected paths stay outside the immutable review target and therefore do
+// not invalidate a correction lineage that never had authority to add them.
+func reviewUntrackedInventoryContainsSelection(inventory, selected []string) bool {
+	if len(selected) == 0 || len(inventory) < len(selected) {
 		return false
 	}
-	sortedLeft := append([]string{}, left...)
-	sortedRight := append([]string{}, right...)
-	sort.Strings(sortedLeft)
-	sort.Strings(sortedRight)
-	for index, path := range sortedLeft {
-		if path != sortedRight[index] {
+	available := make(map[string]struct{}, len(inventory))
+	for _, path := range inventory {
+		available[path] = struct{}{}
+	}
+	for _, path := range selected {
+		if _, ok := available[path]; !ok {
 			return false
 		}
 	}


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #4435

---

## 🏷️ PR Type

- [x] `type:bug` — Bug fix (non-breaking change that fixes an issue)
- [ ] `type:feature` — New feature (non-breaking change that adds functionality)
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring (no functional changes)
- [ ] `type:chore` — Build, CI, or tooling changes
- [ ] `type:breaking-change` — Breaking change (fix or feature that changes existing behavior)

---

## 📝 Summary

Preserve a correction-required lineage's frozen intended-untracked selection when the live eligible inventory also contains deliberately unselected paths. Those extra paths remain outside the immutable candidate instead of forcing a false selection/recovery detour.

---

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/cli/review_facade.go` | Resume correction scope when every frozen selected path remains eligible. |
| `internal/cli/review_intended_untracked.go` | Replace exact inventory equality with selected-path containment. |
| `internal/cli/review_correction_untracked_binding_test.go` | Cover subset selection and selected-path removal negative control. |
| `bench/journeys_intended_untracked.go` | Add driven regression `j4435` executing the published continuation unchanged. |
| CI/corpus registration | Require the new journey in portable benchmark evidence. |

---

## 🤖 AI Assistance

- [ ] **None** — No material AI assistance was used.
- [x] **Material assistance used** — Complete all applicable declaration fields below.

**Tool/model (if known):** Pi coding agent with OpenAI Codex

**Material scope:** Issue triage, root-cause analysis, strict TDD implementation, benchmark journey, verification, and native bounded review orchestration.

**Verification performed:** Release-vs-candidate driven proof, focused and full uncached Go tests, bench corpus checks, Docker E2E, and four-lens native review.

---

## 🧪 Test Plan

- [x] `go test ./... -count=1`
- [x] `go run ./internal/gofmtcheck`
- [x] `cd bench && go vet ./... && go test ./...`
- [x] `cd e2e && ./docker-test.sh` — 3/3 distributions passed; 79 passed, 0 failed, 2 skipped each
- [x] Driven `j4435-selected-untracked-correction-continuation-is-selectorless`

Driven evidence:

- Official `v2.7.0`: `0 completed, 0 unsupported, 1 failed`; STATUS returned `intended_untracked_selection_required`.
- Candidate: `1 completed, 0 unsupported, 0 failed`; STATUS returned `correction_plan_required` for the frozen lineage and target.

---

## ✅ Contributor Checklist

- [x] PR is linked to an issue with `status:approved`
- [x] PR stays within 400 changed lines (324 additions + deletions)
- [x] Exactly one `type:*` label is applied
- [x] Unit tests pass
- [x] Go format passes
- [x] E2E tests pass
- [x] Benchmark validation completed
- [x] Documentation is not required for this contract correction
- [x] Commits follow Conventional Commits
- [x] I understand, reviewed, and take responsibility for the complete submission
- [x] Material AI assistance is declared
- [x] Commits contain no `Co-Authored-By` trailers

---

## 💬 Notes for Reviewers

The previous guard compared the complete eligible untracked inventory with the selected subset. That made any deliberately unselected eligible path look like scope drift. The correction relaxes only that comparison: every frozen selected path must remain eligible, selected content drift remains bound by snapshot identity, and removal of a selected path still fails closed into fresh selection.

Native review `review-7eb91b15c4e2325f` completed four lenses and burned approved authority for target `sha256:c067c730d4b3ff4729f93f316a875f102898f607b5ec744fcc47869bb1bea65e`. One readability suggestion was informational and non-blocking.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Review corrections for selected untracked files now resume using the original intended targets, even when additional unselected files appear.
  * Continuations preserve the original review lineage and avoid leaking selection details.
  * If a selected file is removed, the review now requests a fresh intended-untracked declaration instead of substituting another file.
  * Added coverage to verify these review and correction behaviors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->