### PR TITLE
feat(collector): store runtime observations

### DIFF
--- a/deploy/telemetry/grafana/dashboards/gentle-ai-usage.json
+++ b/deploy/telemetry/grafana/dashboards/gentle-ai-usage.json
@@ -10,11 +10,58 @@
   "refresh": "5m",
   "panels": [
     {
+      "id": 19, "title": "Runtime observations",
+      "type": "row", "collapsed": false, "panels": [],
+      "gridPos": { "x": 0, "y": 0, "w": 24, "h": 1 }
+    },
+    {
+      "id": 20, "title": "Runtime overview",
+      "description": "Retained runtime observations received within the dashboard time range (inclusive collector receipt time, not client activity time). Observations are not sessions, users or people. Occurrence sums include integer reports only; total tokens are explicitly reported, never inferred. Error observations exclude category none and include unknown. Missing values are not zero. No prompts, paths or identities.",
+      "type": "stat",
+      "gridPos": { "x": 0, "y": 1, "w": 24, "h": 5 },
+      "datasource": { "type": "frser-sqlite-datasource", "uid": "gentle-telemetry-sqlite" },
+      "targets": [{
+        "refId": "A", "queryType": "table",
+        "queryText": "SELECT COUNT(*) AS \"Received observations\", SUM(CASE WHEN json_type(r.row_json, '$.responses') = 'integer' THEN json_extract(r.row_json, '$.responses') END) AS \"Response occurrences\", SUM(CASE WHEN json_type(r.row_json, '$.launches') = 'integer' THEN json_extract(r.row_json, '$.launches') END) AS \"Launch occurrences\", SUM(CASE WHEN json_extract(r.row_json, '$.total_tokens.reported') > 0 THEN json_extract(r.row_json, '$.total_tokens.sum') END) AS \"Reported total tokens\", SUM(CASE WHEN json_extract(r.row_json, '$.error_category') <> 'none' THEN 1 ELSE 0 END) AS \"Error observations\" FROM runtime_rows r JOIN runtime_deliveries d ON d.delivery_id = r.delivery_id WHERE d.received_at >= ${__from} * 1000000 AND d.received_at <= ${__to} * 1000000 HAVING COUNT(*) > 0",
+        "rawQueryText": "SELECT COUNT(*) AS \"Received observations\", SUM(CASE WHEN json_type(r.row_json, '$.responses') = 'integer' THEN json_extract(r.row_json, '$.responses') END) AS \"Response occurrences\", SUM(CASE WHEN json_type(r.row_json, '$.launches') = 'integer' THEN json_extract(r.row_json, '$.launches') END) AS \"Launch occurrences\", SUM(CASE WHEN json_extract(r.row_json, '$.total_tokens.reported') > 0 THEN json_extract(r.row_json, '$.total_tokens.sum') END) AS \"Reported total tokens\", SUM(CASE WHEN json_extract(r.row_json, '$.error_category') <> 'none' THEN 1 ELSE 0 END) AS \"Error observations\" FROM runtime_rows r JOIN runtime_deliveries d ON d.delivery_id = r.delivery_id WHERE d.received_at >= ${__from} * 1000000 AND d.received_at <= ${__to} * 1000000 HAVING COUNT(*) > 0"
+      }],
+      "options": { "orientation": "horizontal", "textMode": "value_and_name", "graphMode": "none", "reduceOptions": { "values": false, "calcs": ["lastNotNull"], "fields": "" } },
+      "fieldConfig": { "defaults": { "min": 0, "noValue": "Not reported", "decimals": 0 }, "overrides": [] }
+    },
+    {
+      "id": 21, "title": "Reported tokens",
+      "description": "Reported token sums within inclusive collector receipt-time bounds. Model observation shows tool host · provider/model · model evidence; Effort shows selected → effective effort. Groups retain every underlying dimension. Each metric includes only its own reported values. Total is explicitly reported, never added from overlapping categories. — means not reported; it is not zero. Reported zero remains zero. Cache write displays cache creation tokens. See Token coverage for reported/unavailable/unsupported counts. At most 1000 combinations in label order.",
+      "type": "table",
+      "gridPos": { "x": 0, "y": 22, "w": 24, "h": 10 },
+      "datasource": { "type": "frser-sqlite-datasource", "uid": "gentle-telemetry-sqlite" },
+      "targets": [{
+        "refId": "A", "queryType": "table",
+        "queryText": "SELECT json_extract(d.canonical_payload, '$.host') || ' · ' || json_extract(r.row_json, '$.model.provider') || '/' || json_extract(r.row_json, '$.model.id') || ' · ' || json_extract(r.row_json, '$.model_evidence') AS \"Model observation\", json_extract(r.row_json, '$.selected_effort') || ' → ' || json_extract(r.row_json, '$.effective_effort') AS \"Selected → effective\", SUM(CASE WHEN json_extract(r.row_json, '$.input_tokens.reported') > 0 THEN json_extract(r.row_json, '$.input_tokens.sum') END) AS Input, SUM(CASE WHEN json_extract(r.row_json, '$.output_tokens.reported') > 0 THEN json_extract(r.row_json, '$.output_tokens.sum') END) AS Output, SUM(CASE WHEN json_extract(r.row_json, '$.cache_read_tokens.reported') > 0 THEN json_extract(r.row_json, '$.cache_read_tokens.sum') END) AS \"Cache read\", SUM(CASE WHEN json_extract(r.row_json, '$.cache_creation_tokens.reported') > 0 THEN json_extract(r.row_json, '$.cache_creation_tokens.sum') END) AS \"Cache creation\", SUM(CASE WHEN json_extract(r.row_json, '$.reasoning_tokens.reported') > 0 THEN json_extract(r.row_json, '$.reasoning_tokens.sum') END) AS Reasoning, SUM(CASE WHEN json_extract(r.row_json, '$.total_tokens.reported') > 0 THEN json_extract(r.row_json, '$.total_tokens.sum') END) AS Total FROM runtime_rows r JOIN runtime_deliveries d ON d.delivery_id = r.delivery_id WHERE d.received_at >= ${__from} * 1000000 AND d.received_at <= ${__to} * 1000000 GROUP BY json_extract(d.canonical_payload, '$.host'), json_extract(r.row_json, '$.model.provider'), json_extract(r.row_json, '$.model.id'), json_extract(r.row_json, '$.model_evidence'), json_extract(r.row_json, '$.selected_effort'), json_extract(r.row_json, '$.effective_effort') ORDER BY 1, 2 LIMIT 1000",
+        "rawQueryText": "SELECT json_extract(d.canonical_payload, '$.host') || ' · ' || json_extract(r.row_json, '$.model.provider') || '/' || json_extract(r.row_json, '$.model.id') || ' · ' || json_extract(r.row_json, '$.model_evidence') AS \"Model observation\", json_extract(r.row_json, '$.selected_effort') || ' → ' || json_extract(r.row_json, '$.effective_effort') AS \"Selected → effective\", SUM(CASE WHEN json_extract(r.row_json, '$.input_tokens.reported') > 0 THEN json_extract(r.row_json, '$.input_tokens.sum') END) AS Input, SUM(CASE WHEN json_extract(r.row_json, '$.output_tokens.reported') > 0 THEN json_extract(r.row_json, '$.output_tokens.sum') END) AS Output, SUM(CASE WHEN json_extract(r.row_json, '$.cache_read_tokens.reported') > 0 THEN json_extract(r.row_json, '$.cache_read_tokens.sum') END) AS \"Cache read\", SUM(CASE WHEN json_extract(r.row_json, '$.cache_creation_tokens.reported') > 0 THEN json_extract(r.row_json, '$.cache_creation_tokens.sum') END) AS \"Cache creation\", SUM(CASE WHEN json_extract(r.row_json, '$.reasoning_tokens.reported') > 0 THEN json_extract(r.row_json, '$.reasoning_tokens.sum') END) AS Reasoning, SUM(CASE WHEN json_extract(r.row_json, '$.total_tokens.reported') > 0 THEN json_extract(r.row_json, '$.total_tokens.sum') END) AS Total FROM runtime_rows r JOIN runtime_deliveries d ON d.delivery_id = r.delivery_id WHERE d.received_at >= ${__from} * 1000000 AND d.received_at <= ${__to} * 1000000 GROUP BY json_extract(d.canonical_payload, '$.host'), json_extract(r.row_json, '$.model.provider'), json_extract(r.row_json, '$.model.id'), json_extract(r.row_json, '$.model_evidence'), json_extract(r.row_json, '$.selected_effort'), json_extract(r.row_json, '$.effective_effort') ORDER BY 1, 2 LIMIT 1000"
+      }],
+      "options": { "showHeader": true, "cellHeight": "sm", "enablePagination": true },
+      "fieldConfig": { "defaults": { "min": 0, "decimals": 0, "noValue": "Not reported", "custom": { "minWidth": 80 } }, "overrides": [{ "matcher": { "id": "byName", "options": "Model observation" }, "properties": [{ "id": "custom.width", "value": 340 }] }, { "matcher": { "id": "byName", "options": "Selected → effective" }, "properties": [{ "id": "custom.width", "value": 180 }] }, { "matcher": { "id": "byRegexp", "options": "^(Input|Output|Cache read|Cache creation|Reasoning|Total)$" }, "properties": [{ "id": "mappings", "value": [{ "type": "special", "options": { "match": "null", "result": { "text": "—" } } }] }] }, { "matcher": { "id": "byName", "options": "Cache creation" }, "properties": [{ "id": "displayName", "value": "Cache write" }] }] }
+    },
+    {
+      "id": 22, "title": "Error observations",
+      "description": "Observation counts by bounded error category in the selected receipt-time range, not failed response counts or an error rate. Category none is excluded; unknown is retained without inferring a cause. No error text. At most 1000 groups in label order.",
+      "type": "barchart",
+      "gridPos": { "x": 0, "y": 40, "w": 12, "h": 7 },
+      "datasource": { "type": "frser-sqlite-datasource", "uid": "gentle-telemetry-sqlite" },
+      "targets": [{
+        "refId": "A", "queryType": "table",
+        "queryText": "SELECT json_extract(r.row_json, '$.error_category') AS Category, COUNT(*) AS Observations FROM runtime_rows r JOIN runtime_deliveries d ON d.delivery_id = r.delivery_id WHERE d.received_at >= ${__from} * 1000000 AND d.received_at <= ${__to} * 1000000 AND json_extract(r.row_json, '$.error_category') <> 'none' GROUP BY Category ORDER BY Category LIMIT 1000",
+        "rawQueryText": "SELECT json_extract(r.row_json, '$.error_category') AS Category, COUNT(*) AS Observations FROM runtime_rows r JOIN runtime_deliveries d ON d.delivery_id = r.delivery_id WHERE d.received_at >= ${__from} * 1000000 AND d.received_at <= ${__to} * 1000000 AND json_extract(r.row_json, '$.error_category') <> 'none' GROUP BY Category ORDER BY Category LIMIT 1000"
+      }],
+      "options": { "orientation": "horizontal", "legend": { "showLegend": false } },
+      "fieldConfig": { "defaults": { "min": 0, "decimals": 0 }, "overrides": [] }
+    },
+    {
       "id": 10,
       "title": "Installs today (UTC)",
       "description": "Distinct install ids that sent an install event since 00:00 UTC today, read live from the events table (the rollup panels below lag one day).",
       "type": "stat",
-      "gridPos": { "x": 0, "y": 0, "w": 4, "h": 8 },
+      "gridPos": { "x": 0, "y": 48, "w": 4, "h": 8 },
       "datasource": { "type": "frser-sqlite-datasource", "uid": "gentle-telemetry-sqlite" },
       "targets": [
         {
@@ -31,7 +78,7 @@
       "title": "Heartbeats today (UTC)",
       "description": "Heartbeat events received since 00:00 UTC today: installs that were used again after their first report.",
       "type": "stat",
-      "gridPos": { "x": 4, "y": 0, "w": 4, "h": 8 },
+      "gridPos": { "x": 4, "y": 48, "w": 4, "h": 8 },
       "datasource": { "type": "frser-sqlite-datasource", "uid": "gentle-telemetry-sqlite" },
       "targets": [
         {
@@ -48,7 +95,7 @@
       "title": "Platforms today",
       "description": "Distinct installs seen today by operating system, live from the events table.",
       "type": "bargauge",
-      "gridPos": { "x": 8, "y": 0, "w": 5, "h": 8 },
+      "gridPos": { "x": 8, "y": 48, "w": 5, "h": 8 },
       "datasource": { "type": "frser-sqlite-datasource", "uid": "gentle-telemetry-sqlite" },
       "targets": [
         {
@@ -66,7 +113,7 @@
       "title": "Installs per hour (last 48 h)",
       "description": "New install events per UTC hour over the last 48 hours, live from the events table.",
       "type": "timeseries",
-      "gridPos": { "x": 13, "y": 0, "w": 11, "h": 8 },
+      "gridPos": { "x": 13, "y": 48, "w": 11, "h": 8 },
       "datasource": { "type": "frser-sqlite-datasource", "uid": "gentle-telemetry-sqlite" },
       "targets": [
         {
@@ -84,7 +131,7 @@
       "title": "Unique installs per month (12 months)",
       "description": "Distinct install ids active in each of the last 12 calendar months: live from the events table for the retention window, from rollups_daily.active_install beyond it. Matches GET /v1/summary's installs_per_month.",
       "type": "barchart",
-      "gridPos": { "x": 0, "y": 8, "w": 12, "h": 8 },
+      "gridPos": { "x": 0, "y": 56, "w": 12, "h": 8 },
       "datasource": { "type": "frser-sqlite-datasource", "uid": "gentle-telemetry-sqlite" },
       "targets": [
         {
@@ -101,7 +148,7 @@
       "title": "Weekly active installs (12 weeks)",
       "description": "Distinct install ids active per week, from rollups_daily.active_install. Uses SQLite's strftime('%W') (Monday-based week-of-year); this can disagree with the API's ISO week numbering right at a year boundary, so treat this as a trend view rather than a byte-for-byte match to /v1/summary.",
       "type": "barchart",
-      "gridPos": { "x": 12, "y": 8, "w": 12, "h": 8 },
+      "gridPos": { "x": 12, "y": 56, "w": 12, "h": 8 },
       "datasource": { "type": "frser-sqlite-datasource", "uid": "gentle-telemetry-sqlite" },
       "targets": [
         {
@@ -118,7 +165,7 @@
       "title": "Agent distribution (trailing 30 days)",
       "description": "Install-days per agent over the trailing 30 rolled-up days: an install active on 10 different days contributes 10, once per day it reported that agent. Not distinct installs. Matches GET /v1/summary's agent_distribution.",
       "type": "bargauge",
-      "gridPos": { "x": 0, "y": 16, "w": 8, "h": 8 },
+      "gridPos": { "x": 0, "y": 64, "w": 8, "h": 8 },
       "datasource": { "type": "frser-sqlite-datasource", "uid": "gentle-telemetry-sqlite" },
       "targets": [
         {
@@ -136,7 +183,7 @@
       "title": "Component distribution (trailing 30 days)",
       "description": "Install-days per component over the trailing 30 rolled-up days, same install-days semantics as agent distribution. Matches GET /v1/summary's component_distribution.",
       "type": "bargauge",
-      "gridPos": { "x": 8, "y": 16, "w": 8, "h": 8 },
+      "gridPos": { "x": 8, "y": 64, "w": 8, "h": 8 },
       "datasource": { "type": "frser-sqlite-datasource", "uid": "gentle-telemetry-sqlite" },
       "targets": [
         {
@@ -154,7 +201,7 @@
       "title": "RDD enabled ratio (trailing 30 days)",
       "description": "Share of install-days over the trailing 30 rolled-up days reporting rdd_enabled=true. Matches GET /v1/summary's rdd_enabled_ratio.",
       "type": "stat",
-      "gridPos": { "x": 16, "y": 16, "w": 8, "h": 8 },
+      "gridPos": { "x": 16, "y": 64, "w": 8, "h": 8 },
       "datasource": { "type": "frser-sqlite-datasource", "uid": "gentle-telemetry-sqlite" },
       "fieldConfig": { "defaults": { "unit": "percentunit", "min": 0, "max": 1 }, "overrides": [] },
       "targets": [
@@ -171,7 +218,7 @@
       "title": "Version distribution (trailing 30 days)",
       "description": "Install-days per reported version over the trailing 30 rolled-up days. A useful proxy for upgrade lag. Matches GET /v1/summary's version_distribution.",
       "type": "bargauge",
-      "gridPos": { "x": 0, "y": 24, "w": 12, "h": 8 },
+      "gridPos": { "x": 0, "y": 72, "w": 12, "h": 8 },
       "datasource": { "type": "frser-sqlite-datasource", "uid": "gentle-telemetry-sqlite" },
       "targets": [
         {
@@ -189,7 +236,7 @@
       "title": "Events per day",
       "description": "Raw event volume (install + heartbeat), bounded by --retention-days: older raw rows are purged, so this panel only ever shows the retention window, unlike the rollup-backed panels above which cover full history.",
       "type": "timeseries",
-      "gridPos": { "x": 12, "y": 24, "w": 12, "h": 8 },
+      "gridPos": { "x": 12, "y": 72, "w": 12, "h": 8 },
       "datasource": { "type": "frser-sqlite-datasource", "uid": "gentle-telemetry-sqlite" },
       "targets": [
         {
@@ -206,7 +253,7 @@
       "title": "npm downloads per day (gentle-pi, gentle-engram)",
       "description": "Daily download counts from the npm registry's public API (api.npmjs.org) — a public count, not telemetry from any gentle-ai install. Matches GET /v1/summary's downloads.npm. The gentle_pi and gentle_engram columns mirror the collector's default --npm-package list; any other package it is configured to fetch lands in other_packages so nothing is silently dropped.",
       "type": "timeseries",
-      "gridPos": { "x": 0, "y": 32, "w": 12, "h": 8 },
+      "gridPos": { "x": 0, "y": 80, "w": 12, "h": 8 },
       "datasource": { "type": "frser-sqlite-datasource", "uid": "gentle-telemetry-sqlite" },
       "targets": [
         {
@@ -223,7 +270,7 @@
       "title": "gentle-ai release downloads (cumulative per tag)",
       "description": "Cumulative GitHub release asset download counts per tag, from the public GitHub API (api.github.com) — a public count, not telemetry from any gentle-ai install. Each bar is the latest known total for that tag, not a per-day delta. Matches GET /v1/summary's downloads.github.",
       "type": "bargauge",
-      "gridPos": { "x": 12, "y": 32, "w": 12, "h": 8 },
+      "gridPos": { "x": 12, "y": 80, "w": 12, "h": 8 },
       "datasource": { "type": "frser-sqlite-datasource", "uid": "gentle-telemetry-sqlite" },
       "targets": [
         {
@@ -241,7 +288,7 @@
       "title": "Agents declared today",
       "description": "Distinct installs seen today that declare each agent, live from the events table (json_each over agents_json). One install can declare several agents.",
       "type": "bargauge",
-      "gridPos": { "x": 0, "y": 40, "w": 24, "h": 8 },
+      "gridPos": { "x": 0, "y": 88, "w": 24, "h": 8 },
       "datasource": { "type": "frser-sqlite-datasource", "uid": "gentle-telemetry-sqlite" },
       "targets": [
         {
@@ -253,6 +300,71 @@
       ],
       "options": { "orientation": "horizontal", "displayMode": "basic", "showUnfilled": true, "reduceOptions": { "values": true, "calcs": ["lastNotNull"], "fields": "" } },
       "fieldConfig": { "defaults": { "min": 0 }, "overrides": [] }
+    },
+    {
+      "id": 15,
+      "title": "Responses by model",
+      "description": "Response occurrences in the selected receipt-time range, not client activity time. Response evidence identifies the model reported by a response; selected evidence is configuration only, not proof of execution. Public model and host labels only. At most 1000 groups in label order.",
+      "type": "barchart",
+      "gridPos": { "x": 0, "y": 6, "w": 24, "h": 8 },
+      "datasource": { "type": "frser-sqlite-datasource", "uid": "gentle-telemetry-sqlite" },
+      "targets": [{
+        "refId": "A", "queryType": "table",
+        "queryText": "SELECT json_extract(r.row_json, '$.model.provider') || '/' || json_extract(r.row_json, '$.model.id') || ' · ' || json_extract(r.row_json, '$.model_evidence') || ' · ' || json_extract(d.canonical_payload, '$.host') AS Model, SUM(json_extract(r.row_json, '$.responses')) AS Responses FROM runtime_rows r JOIN runtime_deliveries d ON d.delivery_id = r.delivery_id WHERE d.received_at >= ${__from} * 1000000 AND d.received_at <= ${__to} * 1000000 AND json_type(r.row_json, '$.responses') = 'integer' GROUP BY Model ORDER BY Model LIMIT 1000",
+        "rawQueryText": "SELECT json_extract(r.row_json, '$.model.provider') || '/' || json_extract(r.row_json, '$.model.id') || ' · ' || json_extract(r.row_json, '$.model_evidence') || ' · ' || json_extract(d.canonical_payload, '$.host') AS Model, SUM(json_extract(r.row_json, '$.responses')) AS Responses FROM runtime_rows r JOIN runtime_deliveries d ON d.delivery_id = r.delivery_id WHERE d.received_at >= ${__from} * 1000000 AND d.received_at <= ${__to} * 1000000 AND json_type(r.row_json, '$.responses') = 'integer' GROUP BY Model ORDER BY Model LIMIT 1000"
+      }],
+      "options": { "orientation": "horizontal", "xTickLabelMaxLength": 45, "legend": { "showLegend": false }, "tooltip": { "mode": "single" } },
+      "fieldConfig": { "defaults": { "min": 0, "noValue": "Not reported" }, "overrides": [] }
+    },
+    {
+      "id": 16, "title": "Usage by agent, model, and effort",
+      "description": "Integer occurrences from observations within inclusive collector receipt-time bounds; these are not sessions, users or people. Responses and launches are separate independent sums, including orchestrator responses and subagent launches. Labels show public agent class/kind, host · provider/model · model evidence, and selected → effective effort, grouped by every dimension. Response evidence identifies the model reported by a response. Selected evidence identifies the configured model, not proof that it ran. Effective effort is never inferred from selected effort. unknown is retained without identity inference. No custom or private names. — means not reported; it is not zero. Groups without either integer count are excluded. At most 1000 groups, ranked by total available occurrences only, then stable agent/model/effort labels; no combined metric is displayed.",
+      "type": "table",
+      "gridPos": { "x": 0, "y": 14, "w": 24, "h": 8 },
+      "datasource": { "type": "frser-sqlite-datasource", "uid": "gentle-telemetry-sqlite" },
+      "targets": [{
+        "refId": "A", "queryType": "table",
+        "queryText": "SELECT json_extract(r.row_json, '$.agent_class') || ' / ' || json_extract(r.row_json, '$.agent_kind') AS \"Agent observation\", json_extract(d.canonical_payload, '$.host') || ' · ' || json_extract(r.row_json, '$.model.provider') || '/' || json_extract(r.row_json, '$.model.id') || ' · ' || json_extract(r.row_json, '$.model_evidence') AS \"Model observation\", json_extract(r.row_json, '$.selected_effort') || ' → ' || json_extract(r.row_json, '$.effective_effort') AS \"Selected → effective\", SUM(CASE WHEN json_type(r.row_json, '$.responses') = 'integer' THEN json_extract(r.row_json, '$.responses') END) AS Responses, SUM(CASE WHEN json_type(r.row_json, '$.launches') = 'integer' THEN json_extract(r.row_json, '$.launches') END) AS Launches FROM runtime_rows r JOIN runtime_deliveries d ON d.delivery_id = r.delivery_id WHERE d.received_at >= ${__from} * 1000000 AND d.received_at <= ${__to} * 1000000 AND (json_type(r.row_json, '$.responses') = 'integer' OR json_type(r.row_json, '$.launches') = 'integer') GROUP BY json_extract(r.row_json, '$.agent_class'), json_extract(r.row_json, '$.agent_kind'), json_extract(d.canonical_payload, '$.host'), json_extract(r.row_json, '$.model.provider'), json_extract(r.row_json, '$.model.id'), json_extract(r.row_json, '$.model_evidence'), json_extract(r.row_json, '$.selected_effort'), json_extract(r.row_json, '$.effective_effort') ORDER BY COALESCE(Responses, 0) + COALESCE(Launches, 0) DESC, \"Agent observation\" ASC, \"Model observation\" ASC, \"Selected → effective\" ASC LIMIT 1000",
+        "rawQueryText": "SELECT json_extract(r.row_json, '$.agent_class') || ' / ' || json_extract(r.row_json, '$.agent_kind') AS \"Agent observation\", json_extract(d.canonical_payload, '$.host') || ' · ' || json_extract(r.row_json, '$.model.provider') || '/' || json_extract(r.row_json, '$.model.id') || ' · ' || json_extract(r.row_json, '$.model_evidence') AS \"Model observation\", json_extract(r.row_json, '$.selected_effort') || ' → ' || json_extract(r.row_json, '$.effective_effort') AS \"Selected → effective\", SUM(CASE WHEN json_type(r.row_json, '$.responses') = 'integer' THEN json_extract(r.row_json, '$.responses') END) AS Responses, SUM(CASE WHEN json_type(r.row_json, '$.launches') = 'integer' THEN json_extract(r.row_json, '$.launches') END) AS Launches FROM runtime_rows r JOIN runtime_deliveries d ON d.delivery_id = r.delivery_id WHERE d.received_at >= ${__from} * 1000000 AND d.received_at <= ${__to} * 1000000 AND (json_type(r.row_json, '$.responses') = 'integer' OR json_type(r.row_json, '$.launches') = 'integer') GROUP BY json_extract(r.row_json, '$.agent_class'), json_extract(r.row_json, '$.agent_kind'), json_extract(d.canonical_payload, '$.host'), json_extract(r.row_json, '$.model.provider'), json_extract(r.row_json, '$.model.id'), json_extract(r.row_json, '$.model_evidence'), json_extract(r.row_json, '$.selected_effort'), json_extract(r.row_json, '$.effective_effort') ORDER BY COALESCE(Responses, 0) + COALESCE(Launches, 0) DESC, \"Agent observation\" ASC, \"Model observation\" ASC, \"Selected → effective\" ASC LIMIT 1000"
+      }],
+      "options": { "cellHeight": "sm", "showHeader": true },
+      "fieldConfig": {
+        "defaults": { "min": 0, "decimals": 0, "custom": { "minWidth": 100 } },
+        "overrides": [
+          { "matcher": { "id": "byName", "options": "Agent observation" }, "properties": [{ "id": "custom.width", "value": 240 }] },
+          { "matcher": { "id": "byName", "options": "Model observation" }, "properties": [{ "id": "custom.width", "value": 360 }] },
+          { "matcher": { "id": "byName", "options": "Selected → effective" }, "properties": [{ "id": "custom.width", "value": 200 }] },
+          { "matcher": { "id": "byRegexp", "options": "^(Responses|Launches)$" }, "properties": [{ "id": "custom.width", "value": 120 }, { "id": "mappings", "value": [{ "type": "special", "options": { "match": "null", "result": { "text": "—" } } }] }] }
+        ]
+      }
+    },
+    {
+      "id": 17, "title": "Token coverage",
+      "description": "Exact reported, unavailable and unsupported observation counts for each token metric in the selected receipt-time range. Coverage is not a token sum. Reported zero is still reported; metrics are independent.",
+      "type": "table",
+      "gridPos": { "x": 0, "y": 32, "w": 24, "h": 8 },
+      "datasource": { "type": "frser-sqlite-datasource", "uid": "gentle-telemetry-sqlite" },
+      "targets": [{
+        "refId": "A", "queryType": "table",
+        "queryText": "SELECT CASE t.key WHEN 'input_tokens' THEN 'Input' WHEN 'output_tokens' THEN 'Output' WHEN 'cache_read_tokens' THEN 'Cache read' WHEN 'cache_creation_tokens' THEN 'Cache creation' WHEN 'reasoning_tokens' THEN 'Reasoning' WHEN 'total_tokens' THEN 'Total' END AS Metric, SUM(json_extract(t.value, '$.reported')) AS Reported, SUM(json_extract(t.value, '$.unavailable')) AS Unavailable, SUM(json_extract(t.value, '$.unsupported')) AS Unsupported FROM runtime_rows r JOIN runtime_deliveries d ON d.delivery_id = r.delivery_id JOIN json_each(r.row_json) t WHERE d.received_at >= ${__from} * 1000000 AND d.received_at <= ${__to} * 1000000 AND t.key IN ('input_tokens', 'output_tokens', 'cache_read_tokens', 'cache_creation_tokens', 'reasoning_tokens', 'total_tokens') GROUP BY t.key ORDER BY t.key LIMIT 1000",
+        "rawQueryText": "SELECT CASE t.key WHEN 'input_tokens' THEN 'Input' WHEN 'output_tokens' THEN 'Output' WHEN 'cache_read_tokens' THEN 'Cache read' WHEN 'cache_creation_tokens' THEN 'Cache creation' WHEN 'reasoning_tokens' THEN 'Reasoning' WHEN 'total_tokens' THEN 'Total' END AS Metric, SUM(json_extract(t.value, '$.reported')) AS Reported, SUM(json_extract(t.value, '$.unavailable')) AS Unavailable, SUM(json_extract(t.value, '$.unsupported')) AS Unsupported FROM runtime_rows r JOIN runtime_deliveries d ON d.delivery_id = r.delivery_id JOIN json_each(r.row_json) t WHERE d.received_at >= ${__from} * 1000000 AND d.received_at <= ${__to} * 1000000 AND t.key IN ('input_tokens', 'output_tokens', 'cache_read_tokens', 'cache_creation_tokens', 'reasoning_tokens', 'total_tokens') GROUP BY t.key ORDER BY t.key LIMIT 1000"
+      }],
+      "options": { "cellHeight": "sm", "showHeader": true },
+      "fieldConfig": { "defaults": { "custom": { "minWidth": 80 }, "noValue": "Not reported" }, "overrides": [] }
+    },
+    {
+      "id": 18, "title": "Measured duration",
+      "description": "Sum of measured milliseconds, separately for request and message timing in the selected receipt-time range. Not per-response latency. Unavailable timing is excluded, never shown as zero. No data means no measurements.",
+      "type": "barchart",
+      "gridPos": { "x": 12, "y": 40, "w": 12, "h": 7 },
+      "datasource": { "type": "frser-sqlite-datasource", "uid": "gentle-telemetry-sqlite" },
+      "targets": [{
+        "refId": "A", "queryType": "table",
+        "queryText": "SELECT json_extract(r.row_json, '$.duration.kind') AS Timing, SUM(json_extract(r.row_json, '$.duration.sum_ms')) AS Milliseconds FROM runtime_rows r JOIN runtime_deliveries d ON d.delivery_id = r.delivery_id WHERE d.received_at >= ${__from} * 1000000 AND d.received_at <= ${__to} * 1000000 AND json_extract(r.row_json, '$.duration.measured_count') > 0 AND json_extract(r.row_json, '$.duration.kind') IN ('request', 'message') GROUP BY Timing ORDER BY Timing LIMIT 1000",
+        "rawQueryText": "SELECT json_extract(r.row_json, '$.duration.kind') AS Timing, SUM(json_extract(r.row_json, '$.duration.sum_ms')) AS Milliseconds FROM runtime_rows r JOIN runtime_deliveries d ON d.delivery_id = r.delivery_id WHERE d.received_at >= ${__from} * 1000000 AND d.received_at <= ${__to} * 1000000 AND json_extract(r.row_json, '$.duration.measured_count') > 0 AND json_extract(r.row_json, '$.duration.kind') IN ('request', 'message') GROUP BY Timing ORDER BY Timing LIMIT 1000"
+      }],
+      "options": { "orientation": "horizontal", "legend": { "showLegend": false } },
+      "fieldConfig": { "defaults": { "unit": "ms", "min": 0, "noValue": "No measurements" }, "overrides": [] }
     }
   ]
 }

--- a/docs/telemetry-collector.md
+++ b/docs/telemetry-collector.md
@@ -68,11 +68,37 @@ constraints. The result is a dataset that is statistical only: no field in
 it can carry user-authored text, which is what makes it safe to aggregate
 and report on in the first place.
 
+## Runtime observations
+
+`POST /v1/runtime-events` accepts the separate
+[runtime event schema](../contracts/telemetry/runtime/v1/schemas/event.schema.json):
+exactly `schema`, `registry`, a fresh independent `delivery_id`, `host`, and public
+`rows`, bounded to 16 KiB and 32 rows. No batch/session/task/install/user identity,
+activity timestamp, private name, prompt, code, path, or raw error is accepted.
+See [runtime fields and native command](telemetry.md#runtime-metrics-one-attempt-no-client-storage).
+
+Native clients send once over HTTPS, without redirects, with a 3-second network
+budget and bounded acknowledgement. Failure discards metrics; no client queue,
+outbox, retry, cooldown, daemon, or migration cleanup exists. Server deduplication
+remains defensive: HTTP 200 returns exactly
+`{"schema":"gentle-ai.telemetry-runtime-delivery/v1","decision":"stored"}` or
+`duplicate`. A conflicting identity returns 409; invalid, oversized, rate-limited,
+and unavailable requests return 400, 413, 429, and 500 respectively. Clients do
+not retry any of them or retain the event after a lost response.
+
+Existing SQLite `runtime_deliveries`/`runtime_rows`, `user_version=1`, transactional
+storage, shared rate limiting, and startup/daily retention remain unchanged.
+`received_at` is delivery time, not activity time. Existing `--retention-days`
+purges whole deliveries strictly before the UTC cutoff; deduplication ends when
+the corresponding delivery is purged. No runtime daily rollup, new scheduler,
+production configuration change, or deployment is included.
+
 ## HTTP API
 
 | Endpoint | Method | Auth | Notes |
 |---|---|---|---|
 | `/v1/events` | POST | none | Body ≤ 4 KiB, strict schema validation, per-IP rate limit. `202` on accept, `400` invalid, `413` oversize, `429` rate-limited. |
+| `/v1/runtime-events` | POST | none | Body ≤ 16 KiB; strict public observations. `200` with `stored`/`duplicate`; one client attempt only. |
 | `/v1/summary` | GET | `Authorization: Bearer <token>` | Returns the JSON described below. `401` without a valid token. |
 | `/healthz` | GET | none | Liveness check for the reverse proxy / process supervisor. |
 
@@ -449,6 +475,42 @@ curl -sH "Authorization: Bearer $(sudo cat /etc/gentle-telemetry/summary.token)"
 - **Upgrade lag**: `version_distribution`.
 
 ## Grafana dashboards
+
+### Runtime received observations
+
+Four runtime tables read retained `runtime_rows` joined to `runtime_deliveries`:
+
+| Panel | Values grouped by UTC receipt day |
+|---|---|
+| Runtime received observations — responses | Response occurrences by public provider/model, model evidence, and tool host |
+| Runtime received observations — launches | Launch occurrences by agent class, selected effort, and separately effective effort |
+| Runtime received observations — tokens and coverage | Six independent token sums, each with reported/unavailable/unsupported counts |
+| Runtime received observations — duration and errors | Measured count and millisecond sum by request/message/unavailable kind and error category |
+
+These are received observations, not complete consumption or reconstructed
+sessions. A null token sum means no reported values; a reported zero remains zero.
+`total_tokens` is never derived from other fields. Duration sums with no measured
+observations are null; timing kinds are never combined into a latency estimate.
+Occurrence sums include only reported integers, never coercing `unsupported` to
+zero. SQLite uses floating-point arithmetic for fractional duration sums; these
+are not arbitrary-precision decimal totals. Integer sums retain SQLite's signed
+64-bit limit, and Grafana numeric display may round very large values.
+
+The dashboard range applies inclusive bounds to server receipt time:
+`d.received_at >= ${__from} * 1000000 AND d.received_at <= ${__to} * 1000000`.
+Grafana supplies milliseconds; storage uses signed Unix nanoseconds. Whole
+millisecond bounds from 0 through 9223372036854 (2262-04-11 UTC) multiply exactly
+as SQLite integers. Use ranges within that supported epoch, not later dates.
+UTC day grouping converts nanoseconds to seconds, as the existing dashboard does.
+Each table returns at most 1000 groups in receipt-day order; narrow the range if
+that limit is reached. Empty ranges show no observations, not synthetic zeros.
+
+The existing service retains raw observations for 90 days and purges them through
+the existing retention job. These panels add no durable daily aggregates or
+retention setting. SQL and JSON1 are tested against the actual dashboard queries
+with the collector's SQLite driver; no production Grafana deployment is required.
+
+### Grafana setup
 
 `--with-grafana` installs Grafana OSS (free, self-hosted) on the same VPS
 with a read-only view over the collector's own SQLite database — no second

--- a/internal/cli/telemetry_runtime_collector_test.go
+++ b/internal/cli/telemetry_runtime_collector_test.go
@@ -1,0 +1,35 @@
+package cli
+
+import (
+	"bytes"
+	"net/http"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/gentleman-programming/gentle-ai/v2/internal/telemetrycollector"
+)
+
+func TestTelemetryRuntimeCollectorCompatibility(t *testing.T) {
+	home := runtimeCLIHome(t)
+	before := runtimeCLIDisk(t, home)
+	// Collector persistence belongs to the server, outside the client HOME/XDG.
+	storage, err := telemetrycollector.OpenStorage(filepath.Join(t.TempDir(), "collector.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = storage.Close() })
+	mux := (&telemetrycollector.Server{Storage: storage, Limiter: telemetrycollector.NewRateLimiter(100)}).NewMux()
+	requests := 0
+	runtimeCLIServer(t, func(w http.ResponseWriter, r *http.Request) { requests++; mux.ServeHTTP(w, r) })
+	for _, tc := range []struct{ route, input string }{{"send", string(runtimeCLIFixture())}, {"opencode", completedOpenCodeEnvelope}} {
+		var out bytes.Buffer
+		if err := runTelemetryRuntimeInput([]string{tc.route, "--json"}, &out, strings.NewReader(tc.input)); err != nil || !strings.Contains(out.String(), `"stored"`) {
+			t.Fatal("collector did not commit simplified event", out.String(), err)
+		}
+	}
+	if requests != 2 || !reflect.DeepEqual(before, runtimeCLIDisk(t, home)) {
+		t.Fatal("wrong request count or client disk mutation")
+	}
+}

--- a/internal/telemetrycollector/handlers.go
+++ b/internal/telemetrycollector/handlers.go
@@ -32,6 +32,7 @@ type Server struct {
 func (s *Server) NewMux() *http.ServeMux {
 	mux := http.NewServeMux()
 	mux.HandleFunc("POST /v1/events", s.handleEvents)
+	mux.HandleFunc("POST /v1/runtime-events", s.handleRuntimeEvents)
 	mux.HandleFunc("GET /v1/summary", s.handleSummary)
 	mux.HandleFunc("GET /healthz", s.handleHealthz)
 	return mux

--- a/internal/telemetrycollector/maintenance.go
+++ b/internal/telemetrycollector/maintenance.go
@@ -9,8 +9,10 @@ import (
 // RunMaintenance performs one cycle of the collector's daily job: it rolls
 // up every UTC day from the last rolled day (or the oldest raw event, if
 // nothing has ever been rolled up) through yesterday — catching up in one
-// run after the process was down for a while — and purges raw events older
-// than retentionDays.
+// run after the process was down for a while — and purges legacy raw events and
+// whole runtime deliveries older than retentionDays. Runtime-only databases
+// still reach purge when the legacy rollup range is empty. Runtime observations
+// are not rolled up here; their age is server receipt time, not activity time.
 //
 // Each day's rollup runs with context.WithoutCancel(ctx), so a cancelled
 // ctx (e.g. SIGTERM) never interrupts a day already in progress: that day's

--- a/internal/telemetrycollector/runtime_dashboard_test.go
+++ b/internal/telemetrycollector/runtime_dashboard_test.go
@@ -142,7 +142,7 @@ func TestRuntimeDashboard(t *testing.T) {
 	to := time.Date(2026, 1, 2, 0, 0, 0, 0, time.UTC).UnixMilli()
 	metrics := []string{"input_tokens", "output_tokens", "cache_read_tokens", "cache_creation_tokens", "reasoning_tokens", "total_tokens"}
 	// Two observations share a delivery; receipt time, not a client date, groups them.
-	for i, ns := range []int64{from*1000000 - 1, from*1000000, to*1000000, to*1000000 + 1} {
+	for i, ns := range []int64{from*1000000 - 1, from * 1000000, to * 1000000, to*1000000 + 1} {
 		if _, err := s.db.Exec(`INSERT INTO runtime_deliveries VALUES (?, ?, '{"host":"codex"}')`, fmt.Sprint(i), ns); err != nil {
 			t.Fatal(err)
 		}

--- a/internal/telemetrycollector/runtime_dashboard_test.go
+++ b/internal/telemetrycollector/runtime_dashboard_test.go
@@ -1,0 +1,420 @@
+package telemetrycollector
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestRuntimeDashboard(t *testing.T) {
+	data, err := os.ReadFile("../../deploy/telemetry/grafana/dashboards/gentle-ai-usage.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var dashboard struct {
+		Panels []struct {
+			ID          int
+			Title       string
+			Type        string
+			Description string
+			GridPos     struct{ X, Y, W, H int }
+			Datasource  struct{ UID string }
+			Targets     []struct{ QueryText, RawQueryText string }
+			FieldConfig map[string]any
+		}
+	}
+	if err := json.Unmarshal(data, &dashboard); err != nil {
+		t.Fatal(err)
+	}
+	wantRuntimeGrid := map[int][4]int{
+		19: {0, 0, 24, 1}, 20: {0, 1, 24, 5},
+		15: {0, 6, 24, 8}, 16: {0, 14, 24, 8},
+		21: {0, 22, 24, 10}, 17: {0, 32, 24, 8},
+		22: {0, 40, 12, 7}, 18: {12, 40, 12, 7},
+	}
+	for i, panel := range dashboard.Panels {
+		g := panel.GridPos
+		if want, ok := wantRuntimeGrid[panel.ID]; ok {
+			if got := [4]int{g.X, g.Y, g.W, g.H}; got != want {
+				t.Errorf("panel %d grid = %v; want %v", panel.ID, got, want)
+			}
+			delete(wantRuntimeGrid, panel.ID)
+		}
+		for _, other := range dashboard.Panels[:i] {
+			o := other.GridPos
+			if g.X < o.X+o.W && o.X < g.X+g.W && g.Y < o.Y+o.H && o.Y < g.Y+g.H {
+				t.Errorf("panels %d and %d overlap", panel.ID, other.ID)
+			}
+		}
+	}
+	if len(wantRuntimeGrid) != 0 {
+		t.Fatalf("missing runtime panels: %v", wantRuntimeGrid)
+	}
+	runtimeQueries := 0
+	for _, panel := range dashboard.Panels {
+		for _, target := range panel.Targets {
+			if target.QueryText != target.RawQueryText {
+				t.Fatalf("panel %d: query texts differ", panel.ID)
+			}
+		}
+		if panel.ID < 15 {
+			if panel.GridPos.Y < 48 {
+				t.Fatalf("legacy panel %d precedes runtime section", panel.ID)
+			}
+			continue
+		}
+		if panel.ID == 19 {
+			if panel.Type != "row" || panel.GridPos.Y != 0 {
+				t.Fatal("runtime section must start at top")
+			}
+			continue
+		}
+		runtimeQueries++
+		if panel.Description == "" || panel.Datasource.UID != "gentle-telemetry-sqlite" || panel.GridPos.Y+panel.GridPos.H > 47 {
+			t.Fatalf("runtime panel %d: missing context, datasource or top layout", panel.ID)
+		}
+		if panel.ID == 16 {
+			if panel.Type != "table" || panel.Title != "Usage by agent, model, and effort" {
+				t.Error("usage panel must be a dimensional table")
+			}
+			for _, phrase := range []string{"receipt-time", "Responses and launches are separate", "— means not reported; it is not zero", "not sessions, users or people", "Response evidence", "Selected evidence", "Effective effort is never inferred", "unknown", "without identity inference", "No custom or private names"} {
+				if !strings.Contains(panel.Description, phrase) {
+					t.Errorf("launch description missing %q", phrase)
+				}
+			}
+			for _, target := range panel.Targets {
+				if !strings.HasSuffix(target.QueryText, `ORDER BY COALESCE(Responses, 0) + COALESCE(Launches, 0) DESC, "Agent observation" ASC, "Model observation" ASC, "Selected → effective" ASC LIMIT 1000`) {
+					t.Error("launch combinations must be bounded and sorted by count then label")
+				}
+				group := strings.SplitN(target.QueryText, "GROUP BY", 2)
+				for _, dimension := range []string{"agent_class", "agent_kind", "host", "model.provider", "model.id", "model_evidence", "selected_effort", "effective_effort"} {
+					if len(group) != 2 || !strings.Contains(group[1], "$."+dimension+"'") {
+						t.Errorf("launch grouping missing %s", dimension)
+					}
+				}
+			}
+		}
+		if panel.ID == 21 {
+			if panel.Type != "table" {
+				t.Fatal("reported tokens must be a full-width dimensional table")
+			}
+			var wantConfig map[string]any
+			if err := json.Unmarshal([]byte(`{
+				"defaults": {"min": 0, "decimals": 0, "noValue": "Not reported", "custom": {"minWidth": 80}},
+				"overrides": [
+					{"matcher": {"id": "byName", "options": "Model observation"}, "properties": [{"id": "custom.width", "value": 340}]},
+					{"matcher": {"id": "byName", "options": "Selected → effective"}, "properties": [{"id": "custom.width", "value": 180}]},
+					{"matcher": {"id": "byRegexp", "options": "^(Input|Output|Cache read|Cache creation|Reasoning|Total)$"}, "properties": [{"id": "mappings", "value": [{"type": "special", "options": {"match": "null", "result": {"text": "—"}}}]}]},
+					{"matcher": {"id": "byName", "options": "Cache creation"}, "properties": [{"id": "displayName", "value": "Cache write"}]}
+				]
+			}`), &wantConfig); err != nil {
+				t.Fatal(err)
+			}
+			if !reflect.DeepEqual(panel.FieldConfig, wantConfig) {
+				t.Errorf("reported token config = %v; want compact null mapping and Cache write display header", panel.FieldConfig)
+			}
+			if !strings.Contains(panel.Description, "— means not reported; it is not zero") {
+				t.Error("reported token description must explain the null display")
+			}
+		}
+		if panel.ID != 16 && panel.ID != 17 && panel.ID != 21 && panel.Type != "barchart" && panel.Type != "stat" {
+			t.Fatalf("runtime panel %d exposes raw columns", panel.ID)
+		}
+		for _, target := range panel.Targets {
+			if strings.Contains(target.QueryText, "GROUP BY") && !strings.HasSuffix(target.QueryText, "LIMIT 1000") {
+				t.Fatalf("runtime panel %d: unbounded groups", panel.ID)
+			}
+		}
+	}
+	if runtimeQueries != 7 {
+		t.Fatalf("expected to execute all seven runtime queries, found %d", runtimeQueries)
+	}
+	s, err := OpenStorage(":memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer s.Close()
+	from := time.Date(2026, 1, 1, 23, 0, 0, 0, time.UTC).UnixMilli()
+	to := time.Date(2026, 1, 2, 0, 0, 0, 0, time.UTC).UnixMilli()
+	metrics := []string{"input_tokens", "output_tokens", "cache_read_tokens", "cache_creation_tokens", "reasoning_tokens", "total_tokens"}
+	// Two observations share a delivery; receipt time, not a client date, groups them.
+	for i, ns := range []int64{from*1000000 - 1, from*1000000, to*1000000, to*1000000 + 1} {
+		if _, err := s.db.Exec(`INSERT INTO runtime_deliveries VALUES (?, ?, '{"host":"codex"}')`, fmt.Sprint(i), ns); err != nil {
+			t.Fatal(err)
+		}
+		count := 1
+		if i == 1 {
+			count = 2
+		}
+		for ordinal := 0; ordinal < count; ordinal++ {
+			kind, category, measured, duration := "request", "none", 1, 12.5
+			coverage := "reported"
+			if ordinal == 1 {
+				kind, category, measured, duration, coverage = "unavailable", "unknown", 0, 0, "unsupported"
+			} else if i == 2 {
+				kind, category, duration, coverage = "message", "api", 7.25, "unavailable"
+			}
+			row := map[string]any{
+				"model":          map[string]string{"provider": "openai", "id": "gpt-5"},
+				"model_evidence": "response", "agent_class": "unknown", "agent_kind": "unknown",
+				"selected_effort": "high", "effective_effort": "unavailable",
+				"responses": 2, "launches": 3, "error_category": category,
+				"duration": map[string]any{"kind": kind, "measured_count": measured, "sum_ms": duration},
+			}
+			if ordinal == 1 {
+				row["duration"].(map[string]any)["sum_ms"] = nil
+				row["launches"] = nil
+				row["responses"] = nil
+				row["model"] = map[string]string{"provider": "openai", "id": "null-only"}
+				row["agent_class"] = "null-only"
+			}
+			if i == 2 {
+				row["responses"], row["launches"] = "unsupported", "unsupported"
+				row["model"] = map[string]string{"provider": "openai", "id": "gpt-4"}
+				row["selected_effort"], row["effective_effort"] = "low", "low"
+			}
+			for index, metric := range metrics {
+				// Nonzero unreported sums must never leak into usage.
+				token := map[string]int{"reported": 0, "unavailable": 0, "unsupported": 0, "sum": 99}
+				token[coverage] = 1
+				if coverage == "reported" {
+					token["sum"] = index // Includes explicitly reported zero; total is not inferred.
+				}
+				row[metric] = token
+			}
+			raw, err := json.Marshal(row)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if _, err := s.db.Exec(`INSERT INTO runtime_rows VALUES (?, ?, ?)`, fmt.Sprint(i), ordinal, string(raw)); err != nil {
+				t.Fatal(err)
+			}
+		}
+	}
+	var tokenRows [][]any
+	for _, index := range []int{3, 2, 0, 1, 4, 5} {
+		label := []string{"Input", "Output", "Cache read", "Cache creation", "Reasoning", "Total"}[index]
+		tokenRows = append(tokenRows, []any{label, int64(1), int64(1), int64(1)})
+	}
+	for _, tc := range []struct {
+		title string
+		want  [][]any
+	}{
+		{"Runtime overview", [][]any{{int64(3), int64(2), int64(3), int64(5), int64(2)}}},
+		{"Responses by model", [][]any{{"openai/gpt-5 · response · codex", int64(2)}}},
+		{"Usage by agent, model, and effort", [][]any{{"unknown / unknown", "codex · openai/gpt-5 · response", "high → unavailable", int64(2), int64(3)}}},
+		{"Token coverage", tokenRows},
+		{"Reported tokens", [][]any{
+			{"codex · openai/gpt-4 · response", "low → low", nil, nil, nil, nil, nil, nil},
+			{"codex · openai/gpt-5 · response", "high → unavailable", int64(0), int64(1), int64(2), int64(3), int64(4), int64(5)},
+			{"codex · openai/null-only · response", "high → unavailable", nil, nil, nil, nil, nil, nil},
+		}},
+		{"Error observations", [][]any{{"api", int64(1)}, {"unknown", int64(1)}}},
+		{"Measured duration", [][]any{{"message", 7.25}, {"request", 12.5}}},
+	} {
+		t.Run(tc.title, func(t *testing.T) {
+			query, found := "", 0
+			for _, panel := range dashboard.Panels {
+				if panel.Title != tc.title {
+					continue
+				}
+				found++
+				if len(panel.Targets) != 1 || panel.Targets[0].QueryText != panel.Targets[0].RawQueryText {
+					t.Fatal("expected one identical queryText/rawQueryText pair")
+				}
+				query = panel.Targets[0].QueryText
+			}
+			if found != 1 {
+				t.Fatalf("expected one runtime panel, found %d", found)
+			}
+			bounds := "d.received_at >= ${__from} * 1000000 AND d.received_at <= ${__to} * 1000000"
+			if !strings.Contains(query, bounds) {
+				t.Fatal("missing inclusive nanosecond receipt bounds")
+			}
+			emptyQuery := strings.NewReplacer("${__from}", "0", "${__to}", "0").Replace(query)
+			query = strings.NewReplacer("${__from}", fmt.Sprint(from), "${__to}", fmt.Sprint(to)).Replace(query)
+			rows, err := s.db.Query(query)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer rows.Close()
+			columns, err := rows.Columns()
+			if err != nil {
+				t.Fatal(err)
+			}
+			if tc.title == "Usage by agent, model, and effort" {
+				wantColumns := []string{"Agent observation", "Model observation", "Selected → effective", "Responses", "Launches"}
+				if !reflect.DeepEqual(columns, wantColumns) {
+					t.Fatalf("columns = %v; want %v", columns, wantColumns)
+				}
+			}
+			if tc.title == "Reported tokens" {
+				wantColumns := []string{"Model observation", "Selected → effective", "Input", "Output", "Cache read", "Cache creation", "Reasoning", "Total"}
+				if !reflect.DeepEqual(columns, wantColumns) {
+					t.Fatalf("columns (%d) = %v; want exactly %v", len(columns), columns, wantColumns)
+				}
+			}
+			var got [][]any
+			for rows.Next() {
+				values, pointers := make([]any, len(columns)), make([]any, len(columns))
+				for i := range values {
+					pointers[i] = &values[i]
+				}
+				if err := rows.Scan(pointers...); err != nil {
+					t.Fatal(err)
+				}
+				got = append(got, values)
+			}
+			if err := rows.Err(); err != nil {
+				t.Fatal(err)
+			}
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Fatalf("got %#v; want %#v", got, tc.want)
+			}
+			rows.Close()
+			empty, err := s.db.Query(emptyQuery)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer empty.Close()
+			if empty.Next() || empty.Err() != nil {
+				t.Fatalf("empty receipt range must not invent zeros: %v", empty.Err())
+			}
+		})
+	}
+	t.Run("independent usage reports", func(t *testing.T) {
+		// Isolate usage fixtures so other runtime panel expectations stay unchanged.
+		tx, err := s.db.Begin()
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer tx.Rollback()
+		for i, report := range []struct{ agent, evidence, responses, launches string }{
+			{"orchestrator", "response", "7", "null"},
+			{"orchestrator", "response", "2", `"unsupported"`},
+			{"subagent", "selected", "null", "6"},
+			{"subagent", "selected", `"unsupported"`, "1"},
+			{"zero", "response", "0", "1.5"},
+			{"zero-launch", "selected", "true", "0"},
+			{"excluded", "selected", "1.5", `"unsupported"`},
+		} {
+			raw := fmt.Sprintf(`{"agent_class":%q,"agent_kind":"unknown","model":{"provider":"openai","id":"gpt-5"},"model_evidence":%q,"selected_effort":"high","effective_effort":"unavailable","responses":%s,"launches":%s}`, report.agent, report.evidence, report.responses, report.launches)
+			// Upper bound must be included, as must the original lower-bound row.
+			if _, err := tx.Exec(`INSERT INTO runtime_rows VALUES ('2', ?, ?)`, i+10, raw); err != nil {
+				t.Fatal(err)
+			}
+		}
+		for _, panel := range dashboard.Panels {
+			if panel.ID != 16 {
+				continue
+			}
+			query := strings.NewReplacer("${__from}", fmt.Sprint(from), "${__to}", fmt.Sprint(to)).Replace(panel.Targets[0].QueryText)
+			rows, err := tx.Query(query)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer rows.Close()
+			var got [][]any
+			for rows.Next() {
+				var agent, model, effort string
+				var responses, launches any
+				if err := rows.Scan(&agent, &model, &effort, &responses, &launches); err != nil {
+					t.Fatal(err)
+				}
+				got = append(got, []any{agent, model, effort, responses, launches})
+			}
+			if err := rows.Err(); err != nil {
+				t.Fatal(err)
+			}
+			want := [][]any{
+				{"orchestrator / unknown", "codex · openai/gpt-5 · response", "high → unavailable", int64(9), nil},
+				{"subagent / unknown", "codex · openai/gpt-5 · selected", "high → unavailable", nil, int64(7)},
+				{"unknown / unknown", "codex · openai/gpt-5 · response", "high → unavailable", int64(2), int64(3)},
+				{"zero / unknown", "codex · openai/gpt-5 · response", "high → unavailable", int64(0), nil},
+				{"zero-launch / unknown", "codex · openai/gpt-5 · selected", "high → unavailable", nil, int64(0)},
+			}
+			if !reflect.DeepEqual(got, want) {
+				t.Fatalf("usage rows = %#v; want %#v", got, want)
+			}
+		}
+	})
+	t.Run("unavailable-only range", func(t *testing.T) {
+		if _, err := s.db.Exec(`UPDATE runtime_rows SET row_json = json_set(row_json,
+			'$.responses', NULL, '$.launches', NULL,
+			'$.duration.kind', 'unavailable', '$.duration.measured_count', 0, '$.duration.sum_ms', NULL,
+			'$.total_tokens.reported', 0, '$.total_tokens.sum', NULL)`); err != nil {
+			t.Fatal(err)
+		}
+		for _, panel := range dashboard.Panels {
+			if panel.ID != 15 && panel.ID != 16 && panel.ID != 18 && panel.ID != 20 && panel.ID != 21 {
+				continue
+			}
+			query := strings.NewReplacer("${__from}", fmt.Sprint(from), "${__to}", fmt.Sprint(to)).Replace(panel.Targets[0].QueryText)
+			rows, err := s.db.Query(query)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if panel.ID == 20 {
+				if !rows.Next() {
+					t.Fatal("missing received observations")
+				}
+				var observations, errors int64
+				var responses, launches, tokens any
+				if err := rows.Scan(&observations, &responses, &launches, &tokens, &errors); err != nil {
+					t.Fatal(err)
+				}
+				if observations != 3 || errors != 2 || responses != nil || launches != nil || tokens != nil {
+					t.Fatal("unavailable reports must not become zero or erase observations")
+				}
+			} else if panel.ID == 21 {
+				count := 0
+				for rows.Next() {
+					var model, effort string
+					var input, output, read, creation, reasoning, total any
+					if err := rows.Scan(&model, &effort, &input, &output, &read, &creation, &reasoning, &total); err != nil {
+						t.Fatal(err)
+					}
+					if total != nil {
+						t.Fatal("unreported total must stay null even when categories are reported")
+					}
+					if model == "codex · openai/gpt-5 · response" && (input != int64(0) || output != int64(1) || reasoning != int64(4)) {
+						t.Fatal("missing total must not erase independently reported categories")
+					}
+					count++
+				}
+				if count != 3 {
+					t.Fatalf("got %d combinations; want 3", count)
+				}
+			} else if rows.Next() {
+				t.Fatalf("%s invented a distribution or zero latency", panel.Title)
+			}
+			if err := rows.Err(); err != nil {
+				t.Fatal(err)
+			}
+			rows.Close()
+		}
+	})
+}
+
+func TestRuntimeDashboardEpochBounds(t *testing.T) {
+	s, err := OpenStorage(":memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer s.Close()
+	// Largest whole millisecond representable in signed Unix nanoseconds.
+	for _, ms := range []int64{0, 1767312000000, 9223372036854} {
+		var kind string
+		var ns int64
+		if err := s.db.QueryRow(`SELECT typeof(? * 1000000), ? * 1000000`, ms, ms).Scan(&kind, &ns); err != nil {
+			t.Fatal(err)
+		}
+		if kind != "integer" || ns != ms*1000000 {
+			t.Fatalf("epoch conversion overflow: %d => %s %d", ms, kind, ns)
+		}
+	}
+}

--- a/internal/telemetrycollector/runtime_event_test.go
+++ b/internal/telemetrycollector/runtime_event_test.go
@@ -1,0 +1,149 @@
+package telemetrycollector
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/gentleman-programming/gentle-ai/v2/internal/telemetry"
+	"github.com/santhosh-tekuri/jsonschema/v6"
+)
+
+func runtimeFixture() []byte {
+	token := `{"reported":1,"unavailable":2,"unsupported":3,"sum":999999999999}`
+	row := `{"model":{"provider":"openai","id":"gpt-5.4"},"model_evidence":"response","agent_kind":"built_in","agent_class":"sdd-apply","selected_effort":"minimal","effective_effort":"unavailable","launches":null,"responses":6,`
+	for _, key := range []string{"input_tokens", "output_tokens", "cache_read_tokens", "cache_creation_tokens", "reasoning_tokens", "total_tokens"} {
+		row += `"` + key + `":` + token + `,`
+	}
+	row += `"error_category":"none","duration":{"kind":"message","measured_count":2,"sum_ms":1.25}}`
+	return []byte(`{"schema":"gentle-ai.telemetry-runtime-event/v1","registry":1,"delivery_id":"0123456789abcdef0123456789abcdef","host":"pi","rows":[` + row + `]}`)
+}
+
+func TestRuntimeEventContract(t *testing.T) {
+	compiler := jsonschema.NewCompiler()
+	const base = "https://runtime.test/"
+	for _, file := range []string{"aggregate.schema.json", "event.schema.json"} {
+		raw, err := os.ReadFile("../../contracts/telemetry/runtime/v1/schemas/" + file)
+		if err != nil {
+			t.Fatal(err)
+		}
+		doc, err := jsonschema.UnmarshalJSON(bytes.NewReader(raw))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := compiler.AddResource(base+file, doc); err != nil {
+			t.Fatal(err)
+		}
+	}
+	schema, err := compiler.Compile(base + "event.schema.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	ackSchema, err := compiler.Compile(base + "event.schema.json#/$defs/delivery")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, decision := range []string{"stored", "duplicate", "disabled"} {
+		doc := map[string]any{"schema": telemetry.RuntimeDeliverySchema, "decision": decision}
+		if err := ackSchema.Validate(doc); (err == nil) != (decision != "disabled") {
+			t.Fatalf("ack %s: %v", decision, err)
+		}
+		doc["delivery_id"] = "private-canary"
+		if err := ackSchema.Validate(doc); err == nil {
+			t.Fatal("ack accepts extra identity")
+		}
+	}
+	valid := string(runtimeFixture())
+	cases := []struct {
+		name, raw string
+		valid     bool
+	}{
+		{"valid", valid, true},
+		{"opencode sanitized", strings.Replace(valid, `{"provider":"openai","id":"gpt-5.4"}`, `{"provider":"opencode","id":"custom"}`, 1), true},
+		{"opencode raw model", strings.Replace(valid, `{"provider":"openai","id":"gpt-5.4"}`, `{"provider":"opencode","id":"PRIVATE_MODEL"}`, 1), false},
+		{"opencode other registry model", strings.Replace(valid, `{"provider":"openai","id":"gpt-5.4"}`, `{"provider":"opencode","id":"gpt-5.4"}`, 1), false},
+		{"private provider custom", strings.Replace(valid, `{"provider":"openai","id":"gpt-5.4"}`, `{"provider":"PRIVATE_PROVIDER","id":"custom"}`, 1), false},
+		{"opencode case", strings.Replace(valid, `{"provider":"openai","id":"gpt-5.4"}`, `{"provider":"OpenCode","id":"custom"}`, 1), false},
+		{"numeric equivalent", strings.ReplaceAll(valid, `"registry":1`, `"registry":1e0`), true},
+		{"local identity", strings.Replace(valid, "delivery_id", "batch_id", 1), false},
+		{"wrong registry", strings.Replace(valid, `"registry":1`, `"registry":2`, 1), false},
+		{"uppercase identity", strings.Replace(valid, "0123456789abcdef0123456789abcdef", "0123456789ABCDEF0123456789ABCDEF", 1), false},
+		{"unknown host", strings.Replace(valid, `"host":"pi"`, `"host":"private-host"`, 1), false},
+		{"missing class", strings.Replace(valid, `"agent_class":"sdd-apply",`, "", 1), false},
+		{"unknown effort", strings.Replace(valid, `"minimal"`, `"private-effort"`, 1), false},
+		{"raw error", strings.Replace(valid, `"error_category":"none"`, `"error_category":"/private/canary"`, 1), false},
+		{"unmeasured duration", strings.Replace(valid, `"measured_count":2`, `"measured_count":0`, 1), false},
+		{"wrong casing", strings.Replace(valid, "agent_class", "Agent_Class", 1), false},
+		{"private model", strings.Replace(valid, "gpt-5.4", "/private/canary", 1), false},
+		{"joined class", strings.Replace(valid, "sdd-apply", "sdd-apply|worker", 1), false},
+		{"scalar coverage", strings.Replace(valid, `"input_tokens":{"reported":1,"unavailable":2,"unsupported":3,"sum":999999999999}`, `"input_tokens":12`, 1), false},
+		{"unobserved sum", strings.ReplaceAll(valid, `"reported":1`, `"reported":0`), false},
+	}
+	for _, key := range []string{"localbatch_id", "local_batch_id", "install_id", "session_id", "path", "raw_error", "otlp"} {
+		cases = append(cases, struct {
+			name, raw string
+			valid     bool
+		}{key, strings.Replace(valid, `"host":"pi"`, `"host":"pi","`+key+`":"/private/canary"`, 1), false})
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			event, err := telemetry.ParseRuntimeEvent([]byte(tc.raw))
+			if (err == nil) != tc.valid {
+				t.Fatalf("parser valid=%v err=%v", tc.valid, err)
+			}
+			if err != nil && strings.Contains(err.Error(), "canary") {
+				t.Fatal("private error echoed")
+			}
+			doc, err := jsonschema.UnmarshalJSON(strings.NewReader(tc.raw))
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err := schema.Validate(doc); (err == nil) != tc.valid {
+				t.Fatalf("schema valid=%v err=%v", tc.valid, err)
+			}
+			if tc.valid && string(event.Registry) != "1" {
+				t.Fatal("registry not canonical")
+			}
+		})
+	}
+	for _, raw := range []string{
+		strings.Replace(valid, `"host":"pi"`, `"host":"pi","host":"pi"`, 1),
+		strings.Replace(valid, `"reported":1`, `"reported":1,"reported":1`, 1),
+		valid + ` {}`, strings.Repeat(" ", telemetry.RuntimeMaxBytes) + valid,
+	} {
+		if _, err := telemetry.ParseRuntimeEvent([]byte(raw)); err == nil {
+			t.Fatal("accepted duplicate, trailing or oversize JSON")
+		}
+	}
+	event, err := telemetry.ParseRuntimeEvent(runtimeFixture())
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, count := range []int{0, 32, 33} {
+		expanded := event
+		expanded.Rows = make([]telemetry.RuntimeRow, count)
+		for i := range expanded.Rows {
+			expanded.Rows[i] = event.Rows[0]
+		}
+		raw, _ := json.Marshal(expanded)
+		// The byte limit is independent of the schema's row count limit.
+		_, parseErr := telemetry.ParseRuntimeEvent(raw)
+		doc, err := jsonschema.UnmarshalJSON(bytes.NewReader(raw))
+		if err != nil {
+			t.Fatal(err)
+		}
+		schemaErr := schema.Validate(doc)
+		if (schemaErr == nil) != (count == 32) {
+			t.Fatalf("schema row bound %d: %v", count, schemaErr)
+		}
+		if parseErr == nil {
+			t.Fatalf("accepted empty or oversized %d-row fixture", count)
+		}
+	}
+	canonical, _ := json.Marshal(event)
+	if bytes.Contains(canonical, []byte("batch_id")) {
+		t.Fatal("local identity in transport")
+	}
+}

--- a/internal/telemetrycollector/runtime_handlers.go
+++ b/internal/telemetrycollector/runtime_handlers.go
@@ -1,0 +1,49 @@
+package telemetrycollector
+
+import (
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+
+	"github.com/gentleman-programming/gentle-ai/v2/internal/telemetry"
+)
+
+func (s *Server) handleRuntimeEvents(w http.ResponseWriter, r *http.Request) {
+	// Reuse the install endpoint's shared, ephemeral abuse quota, never persist
+	// or log its peer key. No delivery ID is treated as authenticated identity.
+	if !s.Limiter.Allow(s.clientKey(r)) {
+		w.WriteHeader(http.StatusTooManyRequests)
+		return
+	}
+	body, err := io.ReadAll(io.LimitReader(r.Body, telemetry.RuntimeMaxBytes+1))
+	if err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+	if len(body) > telemetry.RuntimeMaxBytes {
+		w.WriteHeader(http.StatusRequestEntityTooLarge)
+		return
+	}
+	event, err := telemetry.ParseRuntimeEvent(body)
+	if err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+	decision, err := s.Storage.InsertRuntimeEvent(r.Context(), event, s.now())
+	if errors.Is(err, ErrRuntimeConflict) {
+		w.WriteHeader(http.StatusConflict)
+		return
+	}
+	if err != nil {
+		s.logger().Error("runtime telemetry storage failed", "reason", "storage_unavailable")
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	// No success before the storage transaction commits, including duplicates.
+	_ = json.NewEncoder(w).Encode(struct {
+		Schema   string `json:"schema"`
+		Decision string `json:"decision"`
+	}{telemetry.RuntimeDeliverySchema, decision})
+}

--- a/internal/telemetrycollector/runtime_handlers_test.go
+++ b/internal/telemetrycollector/runtime_handlers_test.go
@@ -1,0 +1,120 @@
+package telemetrycollector
+
+import (
+	"bytes"
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+)
+
+func TestRuntimeHandleEvents(t *testing.T) {
+	s, err := OpenStorage(filepath.Join(t.TempDir(), "events.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer s.Close()
+	var logs bytes.Buffer
+	server := &Server{Storage: s, Limiter: NewRateLimiter(100), Logger: slog.New(slog.NewJSONHandler(&logs, nil))}
+	mux := server.NewMux()
+	send := func(path, body string) *httptest.ResponseRecorder {
+		r := httptest.NewRequest(http.MethodPost, path, strings.NewReader(body))
+		r.RemoteAddr = "192.0.2.123:4321"
+		w := httptest.NewRecorder()
+		mux.ServeHTTP(w, r)
+		return w
+	}
+	valid := string(runtimeFixture())
+	for _, tc := range []struct {
+		name, body string
+		status     int
+		decision   string
+	}{
+		{"stored", valid, 200, "stored"},
+		{"canonical duplicate", strings.ReplaceAll(valid, `"sum_ms":1.25`, `"sum_ms":125e-2`), 200, "duplicate"},
+		{"changed", strings.Replace(valid, `"host":"pi"`, `"host":"codex"`, 1), 409, ""},
+		{"invalid", `{"path":"/private/canary"}`, 400, ""},
+		{"oversize", strings.Repeat(" ", 16385), 413, ""},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			w := send("/v1/runtime-events", tc.body)
+			if w.Code != tc.status {
+				t.Fatalf("status %d, want %d", w.Code, tc.status)
+			}
+			if tc.decision != "" {
+				var ack map[string]string
+				if err := json.Unmarshal(w.Body.Bytes(), &ack); err != nil {
+					t.Fatal(err)
+				}
+				if len(ack) != 2 || ack["schema"] != "gentle-ai.telemetry-runtime-delivery/v1" || ack["decision"] != tc.decision {
+					t.Fatalf("ack %v", ack)
+				}
+				if w.Header().Get("Content-Type") != "application/json" {
+					t.Fatal("missing JSON content type")
+				}
+			} else if w.Body.Len() != 0 {
+				t.Fatal("error content leaked")
+			}
+		})
+	}
+	if w := send("/v1/events", valid); w.Code != 400 {
+		t.Fatalf("legacy endpoint accepted runtime: %d", w.Code)
+	}
+	// Both routes share the existing per-peer in-memory limiter; no new auth.
+	server.Limiter = NewRateLimiter(1)
+	if w := send("/v1/runtime-events", valid); w.Code != 200 {
+		t.Fatal(w.Code)
+	}
+	if w := send("/v1/events", valid); w.Code != 429 {
+		t.Fatalf("shared rate quota: %d", w.Code)
+	}
+	server.Limiter = NewRateLimiter(100)
+	if _, err := s.db.Exec(`CREATE TRIGGER fail_runtime BEFORE INSERT ON runtime_rows BEGIN SELECT RAISE(ABORT,'private-canary'); END`); err != nil {
+		t.Fatal(err)
+	}
+	fresh := strings.Replace(valid, "0123456789abcdef0123456789abcdef", "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", 1)
+	if w := send("/v1/runtime-events", fresh); w.Code != 500 || w.Body.Len() != 0 {
+		t.Fatalf("storage failure acknowledged: %d %s", w.Code, w.Body)
+	}
+	if strings.Contains(logs.String(), "canary") || strings.Contains(logs.String(), "192.0.2.123") || strings.Contains(logs.String(), "delivery_id") {
+		t.Fatal("private data logged")
+	}
+}
+
+func TestRuntimeHandleEventsConcurrent(t *testing.T) {
+	s, err := OpenStorage(filepath.Join(t.TempDir(), "events.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer s.Close()
+	mux := (&Server{Storage: s, Limiter: NewRateLimiter(100)}).NewMux()
+	results := make(chan string, 8)
+	var wg sync.WaitGroup
+	for i := 0; i < 8; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			w := httptest.NewRecorder()
+			mux.ServeHTTP(w, httptest.NewRequest(http.MethodPost, "/v1/runtime-events", bytes.NewReader(runtimeFixture())))
+			var ack map[string]string
+			if err := json.Unmarshal(w.Body.Bytes(), &ack); err != nil || w.Code != 200 {
+				results <- "failed"
+				return
+			}
+			results <- ack["decision"]
+		}()
+	}
+	wg.Wait()
+	close(results)
+	counts := map[string]int{}
+	for result := range results {
+		counts[result]++
+	}
+	if counts["stored"] != 1 || counts["duplicate"] != 7 || len(counts) != 2 {
+		t.Fatalf("concurrent decisions %v", counts)
+	}
+}

--- a/internal/telemetrycollector/runtime_retention.go
+++ b/internal/telemetrycollector/runtime_retention.go
@@ -1,0 +1,23 @@
+package telemetrycollector
+
+import (
+	"context"
+	"database/sql"
+	"time"
+)
+
+// purgeRuntimeOlderThan participates in the existing raw-retention transaction.
+// Child rows have no independent age: remove the whole delivery, children first.
+// Deleting its identity deliberately ends dedupe; a late retry can count again.
+func purgeRuntimeOlderThan(ctx context.Context, tx *sql.Tx, cutoff time.Time) error {
+	for _, query := range []string{
+		`DELETE FROM runtime_rows WHERE delivery_id IN
+		 (SELECT delivery_id FROM runtime_deliveries WHERE received_at < ?)`,
+		`DELETE FROM runtime_deliveries WHERE received_at < ?`,
+	} {
+		if _, err := tx.ExecContext(ctx, query, receivedAtKey(cutoff)); err != nil {
+			return errRuntimeStorage
+		}
+	}
+	return nil
+}

--- a/internal/telemetrycollector/runtime_retention_test.go
+++ b/internal/telemetrycollector/runtime_retention_test.go
@@ -1,0 +1,177 @@
+package telemetrycollector
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/gentleman-programming/gentle-ai/v2/internal/telemetry"
+)
+
+func insertRetentionDelivery(t *testing.T, s *Storage, id int, received time.Time) telemetry.RuntimeEvent {
+	t.Helper()
+	ev, err := telemetry.ParseRuntimeEvent(runtimeFixture())
+	if err != nil {
+		t.Fatal(err)
+	}
+	ev.DeliveryID = fmt.Sprintf("%032x", id)
+	// More than one observation row proves whole deliveries are removed.
+	ev.Rows = append(ev.Rows, ev.Rows[0])
+	if decision, err := s.InsertRuntimeEvent(context.Background(), ev, received); err != nil || decision != "stored" {
+		t.Fatalf("insert: %q %v", decision, err)
+	}
+	return ev
+}
+
+func assertRetentionCounts(t *testing.T, s *Storage, legacy, deliveries, rows int) {
+	t.Helper()
+	var gotLegacy, gotDeliveries, gotRows, orphans int
+	err := s.db.QueryRow(`SELECT (SELECT count(*) FROM events),
+	 (SELECT count(*) FROM runtime_deliveries), (SELECT count(*) FROM runtime_rows),
+	 (SELECT count(*) FROM runtime_rows AS r LEFT JOIN runtime_deliveries AS d
+	  ON r.delivery_id=d.delivery_id WHERE d.delivery_id IS NULL)`).Scan(&gotLegacy, &gotDeliveries, &gotRows, &orphans)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if gotLegacy != legacy || gotDeliveries != deliveries || gotRows != rows || orphans != 0 {
+		t.Fatalf("legacy/deliveries/rows/orphans = %d/%d/%d/%d, want %d/%d/%d/0", gotLegacy, gotDeliveries, gotRows, orphans, legacy, deliveries, rows)
+	}
+}
+
+func TestRuntimePurgeCutoffAndDedupeExpiry(t *testing.T) {
+	s := openTestStorage(t)
+	ctx := context.Background()
+	cutoff := time.Date(2026, 6, 14, 0, 0, 0, 0, time.UTC)
+	old := insertRetentionDelivery(t, s, 1, cutoff.Add(-time.Nanosecond))
+	insertRetentionDelivery(t, s, 2, cutoff)
+	insertRetentionDelivery(t, s, 3, cutoff.Add(time.Nanosecond))
+	for _, received := range []time.Time{cutoff.Add(-time.Nanosecond), cutoff} {
+		if err := s.InsertEvent(ctx, mustParse(t, validInstallEvent), received); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if _, err := s.db.Exec(`INSERT INTO rollups_daily VALUES ('2026-06-01','retention-test','preserved',17)`); err != nil {
+		t.Fatal(err)
+	}
+	// A retry today must not extend the original retention deadline.
+	if decision, err := s.InsertRuntimeEvent(ctx, old, cutoff.Add(time.Hour)); err != nil || decision != "duplicate" {
+		t.Fatalf("retry: %q %v", decision, err)
+	}
+	purged, err := s.PurgeOlderThan(ctx, cutoff.In(time.FixedZone("west", -7*60*60)))
+	if err != nil || purged != 1 {
+		t.Fatalf("legacy-only purge count: %d %v", purged, err)
+	}
+	assertRetentionCounts(t, s, 1, 2, 4)
+	var value, version int
+	if err := s.db.QueryRow(`SELECT value FROM rollups_daily WHERE metric='retention-test'`).Scan(&value); err != nil || value != 17 {
+		t.Fatalf("rollup changed: %d %v", value, err)
+	}
+	if err := s.db.QueryRow(`PRAGMA user_version`).Scan(&version); err != nil || version != 1 {
+		t.Fatalf("schema changed: %d %v", version, err)
+	}
+	if count, err := s.PurgeOlderThan(ctx, cutoff); err != nil || count != 0 {
+		t.Fatalf("repeat purge: %d %v", count, err)
+	}
+	// No infinite tombstones: an expired identity is no longer recognized.
+	if decision, err := s.InsertRuntimeEvent(ctx, old, cutoff.Add(time.Hour)); err != nil || decision != "stored" {
+		t.Fatalf("expired retry: %q %v", decision, err)
+	}
+	assertRetentionCounts(t, s, 1, 3, 6)
+}
+
+func TestRuntimePurgeRollback(t *testing.T) {
+	for _, stage := range []string{"legacy", "child", "parent", "commit"} {
+		t.Run(stage, func(t *testing.T) {
+			s := openTestStorage(t)
+			ctx := context.Background()
+			cutoff := time.Date(2026, 6, 14, 0, 0, 0, 0, time.UTC)
+			insertRetentionDelivery(t, s, 1, cutoff.Add(-time.Hour))
+			insertRetentionDelivery(t, s, 2, cutoff)
+			if err := s.InsertEvent(ctx, mustParse(t, validInstallEvent), cutoff.Add(-time.Hour)); err != nil {
+				t.Fatal(err)
+			}
+			var setup string
+			switch stage {
+			case "legacy":
+				setup = `CREATE TRIGGER fail_purge BEFORE DELETE ON events BEGIN SELECT RAISE(ABORT,'test failure'); END`
+			case "child":
+				setup = `CREATE TRIGGER fail_purge BEFORE DELETE ON runtime_rows BEGIN SELECT RAISE(ABORT,'test failure'); END`
+			case "parent":
+				setup = `CREATE TRIGGER fail_purge BEFORE DELETE ON runtime_deliveries BEGIN SELECT RAISE(ABORT,'test failure'); END`
+			case "commit":
+				setup = `CREATE TABLE retention_probe (id TEXT REFERENCES runtime_deliveries(delivery_id) DEFERRABLE INITIALLY DEFERRED);
+				 CREATE TRIGGER fail_purge AFTER DELETE ON runtime_deliveries BEGIN INSERT INTO retention_probe VALUES ('missing'); END`
+			}
+			if _, err := s.db.Exec(setup); err != nil {
+				t.Fatal(err)
+			}
+			if count, err := s.PurgeOlderThan(ctx, cutoff); err == nil || count != 0 {
+				t.Fatalf("failed purge reported committed count: %d %v", count, err)
+			}
+			assertRetentionCounts(t, s, 1, 2, 4)
+		})
+	}
+}
+
+func TestRuntimeMaintenanceWithoutLegacyEvents(t *testing.T) {
+	// Existing policy performs date arithmetic without a special zero/negative
+	// sentinel. Preserve it rather than introducing runtime-only validation.
+	for _, tc := range []struct{ days, cutoffDay int }{{2, 12}, {0, 14}, {-1, 15}} {
+		t.Run(fmt.Sprintf("days=%d", tc.days), func(t *testing.T) {
+			s := openTestStorage(t)
+			now := time.Date(2026, 6, 15, 1, 30, 0, 0, time.FixedZone("east", 2*60*60))
+			cutoff := time.Date(2026, 6, tc.cutoffDay, 0, 0, 0, 0, time.UTC)
+			insertRetentionDelivery(t, s, 1, cutoff.Add(-time.Nanosecond))
+			insertRetentionDelivery(t, s, 2, cutoff)
+			if err := RunMaintenance(context.Background(), s, now, tc.days); err != nil {
+				t.Fatal(err)
+			}
+			assertRetentionCounts(t, s, 0, 1, 2)
+		})
+	}
+}
+
+func TestRuntimeMaintenanceRollupFailureCanRetry(t *testing.T) {
+	s := openTestStorage(t)
+	ctx := context.Background()
+	now := time.Date(2026, 6, 14, 12, 0, 0, 0, time.UTC)
+	old := now.AddDate(0, 0, -3)
+	insertRetentionDelivery(t, s, 1, old)
+	if err := s.InsertEvent(ctx, mustParse(t, validInstallEvent), old); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := s.db.Exec(`CREATE TABLE maintenance_gate (enabled INTEGER);
+	 INSERT INTO maintenance_gate VALUES (1);
+	 CREATE TRIGGER fail_rollup BEFORE INSERT ON rollups_daily
+	 WHEN (SELECT enabled FROM maintenance_gate)=1 BEGIN SELECT RAISE(ABORT,'test failure'); END`); err != nil {
+		t.Fatal(err)
+	}
+	if err := RunMaintenance(ctx, s, now, 2); err == nil {
+		t.Fatal("rollup failure was ignored")
+	}
+	assertRetentionCounts(t, s, 1, 1, 2)
+	if _, err := s.db.Exec(`UPDATE maintenance_gate SET enabled=0`); err != nil {
+		t.Fatal(err)
+	}
+	if err := RunMaintenance(ctx, s, now, 2); err != nil {
+		t.Fatal(err)
+	}
+	assertRetentionCounts(t, s, 0, 0, 0)
+}
+
+func TestRuntimeMaintenanceCancellationCanRetry(t *testing.T) {
+	s := openTestStorage(t)
+	now := time.Date(2026, 6, 14, 12, 0, 0, 0, time.UTC)
+	insertRetentionDelivery(t, s, 1, now.AddDate(0, 0, -3))
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if err := RunMaintenance(ctx, s, now, 2); err == nil {
+		t.Fatal("cancelled runtime-only maintenance succeeded")
+	}
+	assertRetentionCounts(t, s, 0, 1, 2)
+	if err := RunMaintenance(context.Background(), s, now, 2); err != nil {
+		t.Fatal(err)
+	}
+	assertRetentionCounts(t, s, 0, 0, 0)
+}

--- a/internal/telemetrycollector/runtime_storage.go
+++ b/internal/telemetrycollector/runtime_storage.go
@@ -1,0 +1,190 @@
+package telemetrycollector
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"time"
+
+	"github.com/gentleman-programming/gentle-ai/v2/internal/telemetry"
+)
+
+var ErrRuntimeConflict = errors.New("runtime delivery identity conflict")
+var errRuntimeStorage = errors.New("runtime storage unavailable")
+var errRuntimeVersion = errors.New("unsupported collector database version")
+var errRuntimeSchema = errors.New("incompatible runtime storage schema")
+
+// This collector previously owned an unversioned database. Never downgrade an
+// unknown version or adopt pre-existing runtime tables. DDL and version commit
+// together; the legacy install/heartbeat tables are not rewritten.
+func migrateRuntimeStorage(db *sql.DB) error {
+	tx, err := db.Begin()
+	if err != nil {
+		return errRuntimeStorage
+	}
+	defer tx.Rollback()
+	var version int
+	if err := tx.QueryRow(`PRAGMA user_version`).Scan(&version); err != nil {
+		return errRuntimeStorage
+	}
+	switch version {
+	case 0:
+		if _, err := tx.Exec(`
+   CREATE TABLE runtime_deliveries (
+    delivery_id TEXT PRIMARY KEY,
+    received_at INTEGER NOT NULL,
+    canonical_payload TEXT NOT NULL CHECK(json_valid(canonical_payload))
+   );
+   CREATE TABLE runtime_rows (
+    delivery_id TEXT NOT NULL REFERENCES runtime_deliveries(delivery_id),
+    ordinal INTEGER NOT NULL,
+    row_json TEXT NOT NULL CHECK(json_valid(row_json)),
+    PRIMARY KEY(delivery_id, ordinal)
+   );
+   PRAGMA user_version=1;
+  `); err != nil {
+			return errRuntimeStorage
+		}
+	case 1:
+		if err := validateRuntimeStorage(tx); err != nil {
+			return err
+		}
+	default:
+		return errRuntimeVersion
+	}
+	// Both new database initialization and legacy upgrades are atomic. Existing
+	// v1 runtime tables must pass admission before any legacy DDL is applied.
+	if _, err := tx.Exec(schemaDDL); err != nil {
+		return errRuntimeStorage
+	}
+	if tx.Commit() != nil {
+		return errRuntimeStorage
+	}
+	return nil
+}
+
+// Validate semantic column and idempotency constraints, not sqlite_master's
+// formatting or autoindex names. Table-valued PRAGMAs take bound values; no
+// database-provided identifier is interpolated into SQL.
+func validateRuntimeStorage(tx *sql.Tx) error {
+	type column struct {
+		kind     string
+		required bool
+	}
+	for _, table := range []struct {
+		name    string
+		columns map[string]column
+		unique  []string
+	}{
+		{"runtime_deliveries", map[string]column{
+			"delivery_id": {"TEXT", false}, "received_at": {"INTEGER", true}, "canonical_payload": {"TEXT", true},
+		}, []string{"delivery_id"}},
+		{"runtime_rows", map[string]column{
+			"delivery_id": {"TEXT", true}, "ordinal": {"INTEGER", true}, "row_json": {"TEXT", true},
+		}, []string{"delivery_id", "ordinal"}},
+	} {
+		var count int
+		if err := tx.QueryRow(`SELECT count(*) FROM sqlite_master WHERE type='table' AND name=?`, table.name).Scan(&count); err != nil || count != 1 {
+			return errRuntimeSchema
+		}
+		rows, err := tx.Query(`SELECT name, upper(type), "notnull", hidden FROM pragma_table_xinfo(?)`, table.name)
+		if err != nil {
+			return errRuntimeSchema
+		}
+		seen, valid := 0, true
+		for rows.Next() {
+			var name, kind string
+			var required, hidden int
+			if err := rows.Scan(&name, &kind, &required, &hidden); err != nil {
+				rows.Close()
+				return errRuntimeSchema
+			}
+			want, ok := table.columns[name]
+			valid = valid && ok && kind == want.kind && hidden == 0 && (!want.required || required == 1)
+			seen++
+		}
+		err = rows.Err()
+		rows.Close()
+		if err != nil || !valid || seen != len(table.columns) {
+			return errRuntimeSchema
+		}
+		// Require full, non-expression BINARY uniqueness on precisely the key
+		// columns. Partial indexes or extra columns cannot guarantee dedupe.
+		first, last := table.unique[0], table.unique[len(table.unique)-1]
+		err = tx.QueryRow(`SELECT count(*) FROM pragma_index_list(?) AS i
+		 WHERE i."unique"=1 AND i.partial=0
+		 AND (SELECT count(*) FROM pragma_index_xinfo(i.name) WHERE key=1)=?
+		 AND (SELECT count(DISTINCT name) FROM pragma_index_xinfo(i.name)
+		      WHERE key=1 AND coll='BINARY' AND name IN (?,?))=?`,
+			table.name, len(table.unique), first, last, len(table.unique)).Scan(&count)
+		if err != nil || count < 1 {
+			return errRuntimeSchema
+		}
+	}
+	var links int
+	err := tx.QueryRow(`SELECT count(*) FROM pragma_foreign_key_list('runtime_rows')
+	 WHERE "table"='runtime_deliveries' AND "from"='delivery_id' AND "to"='delivery_id'
+	 AND seq=0 AND on_update='NO ACTION' AND on_delete='NO ACTION'
+	 AND (SELECT count(*) FROM pragma_foreign_key_list('runtime_rows'))=1`).Scan(&links)
+	if err != nil || links != 1 {
+		return errRuntimeSchema
+	}
+	return nil
+}
+
+// InsertRuntimeEvent acknowledges only committed deliveries. All stored JSON is
+// revalidated and canonicalized public data, never raw request bytes. Row JSON
+// preserves exact decimal timing and independent token coverage without floats.
+func (s *Storage) InsertRuntimeEvent(ctx context.Context, event telemetry.RuntimeEvent, receivedAt time.Time) (string, error) {
+	raw, err := json.Marshal(event)
+	if err != nil {
+		return "", telemetry.ErrRuntimeEvent
+	}
+	event, err = telemetry.ParseRuntimeEvent(raw)
+	if err != nil {
+		return "", err
+	}
+	canonical, err := json.Marshal(event)
+	if err != nil {
+		return "", telemetry.ErrRuntimeEvent
+	}
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return "", errRuntimeStorage
+	}
+	defer tx.Rollback()
+	result, err := tx.ExecContext(ctx, `INSERT INTO runtime_deliveries(delivery_id,received_at,canonical_payload) VALUES(?,?,?) ON CONFLICT(delivery_id) DO NOTHING`, event.DeliveryID, receivedAtKey(receivedAt), string(canonical))
+	if err != nil {
+		return "", errRuntimeStorage
+	}
+	inserted, err := result.RowsAffected()
+	if err != nil {
+		return "", errRuntimeStorage
+	}
+	decision := "stored"
+	if inserted == 0 {
+		var existing string
+		if err := tx.QueryRowContext(ctx, `SELECT canonical_payload FROM runtime_deliveries WHERE delivery_id=?`, event.DeliveryID).Scan(&existing); err != nil {
+			return "", errRuntimeStorage
+		}
+		if existing != string(canonical) {
+			return "", ErrRuntimeConflict
+		}
+		decision = "duplicate"
+	} else {
+		for i, row := range event.Rows {
+			canonicalRow, err := json.Marshal(row)
+			if err != nil {
+				return "", errRuntimeStorage
+			}
+			if _, err := tx.ExecContext(ctx, `INSERT INTO runtime_rows(delivery_id,ordinal,row_json) VALUES(?,?,?)`, event.DeliveryID, i, string(canonicalRow)); err != nil {
+				return "", errRuntimeStorage
+			}
+		}
+	}
+	if tx.Commit() != nil {
+		return "", errRuntimeStorage
+	}
+	return decision, nil
+}

--- a/internal/telemetrycollector/runtime_storage_test.go
+++ b/internal/telemetrycollector/runtime_storage_test.go
@@ -1,0 +1,355 @@
+package telemetrycollector
+
+import (
+	"bytes"
+	"context"
+	"database/sql"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/gentleman-programming/gentle-ai/v2/internal/telemetry"
+)
+
+func TestRuntimeStorageMigration(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "legacy.db")
+	db, err := sql.Open("sqlite", path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.Exec(schemaDDL); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.Exec(`INSERT INTO events VALUES (1, 123, 'install', 'legacy', 'v1', 'linux', 'amd64', '[]', '[]', 0, NULL)`); err != nil {
+		t.Fatal(err)
+	}
+	db.Close()
+	for i := 0; i < 2; i++ {
+		s, err := OpenStorage(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		var id string
+		var version int
+		if err := s.db.QueryRow(`SELECT install_id FROM events WHERE id=1`).Scan(&id); err != nil || id != "legacy" {
+			t.Fatalf("legacy data: %q %v", id, err)
+		}
+		if err := s.db.QueryRow(`PRAGMA user_version`).Scan(&version); err != nil || version != 1 {
+			t.Fatalf("version %d: %v", version, err)
+		}
+		s.Close()
+	}
+}
+
+func TestRuntimeStorageMigrationRollback(t *testing.T) {
+	for _, scenario := range []string{"collision", "future version"} {
+		t.Run(scenario, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "old.db")
+			db, err := sql.Open("sqlite", path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer db.Close()
+			setup := `CREATE TABLE runtime_rows (existing TEXT)`
+			wantVersion := 0
+			if scenario == "future version" {
+				setup = `PRAGMA user_version=42`
+				wantVersion = 42
+			}
+			if _, err := db.Exec(setup); err != nil {
+				t.Fatal(err)
+			}
+			if s, err := OpenStorage(path); err == nil {
+				s.Close()
+				t.Fatal("migration should fail closed")
+			}
+			var version, count int
+			if err := db.QueryRow(`PRAGMA user_version`).Scan(&version); err != nil {
+				t.Fatal(err)
+			}
+			if err := db.QueryRow(`SELECT count(*) FROM sqlite_master WHERE name='runtime_deliveries'`).Scan(&count); err != nil {
+				t.Fatal(err)
+			}
+			if version != wantVersion || count != 0 {
+				t.Fatalf("partial migration: version=%d tables=%d", version, count)
+			}
+		})
+	}
+}
+
+// Refusing a database must preserve bytes, schema, and existing contents, not
+// merely return an error after creating otherwise harmless legacy tables.
+func TestRuntimeStorageRefusalPreservesDatabase(t *testing.T) {
+	const deliveries = `CREATE TABLE runtime_deliveries (delivery_id TEXT PRIMARY KEY, received_at INTEGER NOT NULL, canonical_payload TEXT NOT NULL CHECK(json_valid(canonical_payload)));`
+	const rows = `CREATE TABLE runtime_rows (delivery_id TEXT NOT NULL REFERENCES runtime_deliveries(delivery_id), ordinal INTEGER NOT NULL, row_json TEXT NOT NULL CHECK(json_valid(row_json)), PRIMARY KEY(delivery_id,ordinal));`
+	for _, tc := range []struct{ name, setup string }{
+		{"unknown version", `PRAGMA user_version=7; PRAGMA journal_mode=WAL;`},
+		{"unversioned runtime collision", `CREATE TABLE runtime_rows (existing TEXT);`},
+		{"legacy DDL failure", `CREATE TABLE events (existing TEXT);`},
+		{"missing runtime tables", `PRAGMA user_version=1;`},
+		{"missing rows table", `PRAGMA user_version=1;` + deliveries},
+		{"missing column", `PRAGMA user_version=1;` + strings.Replace(deliveries, "received_at INTEGER NOT NULL,", "", 1) + rows},
+		{"missing delivery uniqueness", `PRAGMA user_version=1;` + strings.Replace(deliveries, "TEXT PRIMARY KEY", "TEXT", 1) + rows},
+		{"wrong unique columns", `PRAGMA user_version=1;` + strings.Replace(deliveries, "TEXT PRIMARY KEY", "TEXT", 1) + rows + `CREATE UNIQUE INDEX wrong_delivery ON runtime_deliveries(delivery_id,received_at);`},
+		{"nonbinary uniqueness", `PRAGMA user_version=1;` + strings.Replace(deliveries, "TEXT PRIMARY KEY", "TEXT", 1) + rows + `CREATE UNIQUE INDEX folded_delivery ON runtime_deliveries(delivery_id COLLATE NOCASE);`},
+		{"missing row uniqueness", `PRAGMA user_version=1;` + deliveries + strings.Replace(rows, ", PRIMARY KEY(delivery_id,ordinal)", "", 1)},
+		{"partial delivery uniqueness", `PRAGMA user_version=1;` + strings.Replace(deliveries, "TEXT PRIMARY KEY", "TEXT", 1) + rows + `CREATE UNIQUE INDEX partial_delivery ON runtime_deliveries(delivery_id) WHERE received_at>0;`},
+		{"wrong column type", `PRAGMA user_version=1;` + strings.Replace(deliveries, "received_at INTEGER", "received_at TEXT", 1) + rows},
+		{"nullable row identity", `PRAGMA user_version=1;` + deliveries + strings.Replace(rows, "delivery_id TEXT NOT NULL", "delivery_id TEXT", 1)},
+		{"missing foreign key", `PRAGMA user_version=1;` + deliveries + strings.Replace(rows, " REFERENCES runtime_deliveries(delivery_id)", "", 1)},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "refused.db")
+			db, err := sql.Open("sqlite", path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if _, err := db.Exec(`CREATE TABLE sentinel (value TEXT); INSERT INTO sentinel VALUES ('preserved');` + tc.setup); err != nil {
+				t.Fatal(err)
+			}
+			if err := db.Close(); err != nil {
+				t.Fatal(err)
+			}
+			beforeSchema := runtimeDatabaseSnapshot(t, path)
+			before, err := os.ReadFile(path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if s, err := OpenStorage(path); err == nil {
+				s.Close()
+				t.Error("incompatible database was accepted")
+			} else if tc.name == "unknown version" && !errors.Is(err, errRuntimeVersion) {
+				t.Errorf("expected explicit unsupported version error, got %v", err)
+			}
+			afterSchema := runtimeDatabaseSnapshot(t, path)
+			after, err := os.ReadFile(path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if beforeSchema != afterSchema {
+				t.Error("refusal changed sqlite_master, version, or sentinel contents")
+			}
+			if !bytes.Equal(before, after) {
+				t.Error("refusal changed database bytes")
+			}
+		})
+	}
+}
+
+func TestRuntimeStorageEquivalentSchema(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "equivalent.db")
+	db, err := sql.Open("sqlite", path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Reordered columns, lowercase declarations, and named unique indexes are
+	// semantically sufficient; admission must not compare DDL strings.
+	_, err = db.Exec(`PRAGMA user_version=1;
+	 CREATE TABLE runtime_deliveries (canonical_payload text not null CHECK(json_valid(canonical_payload)), received_at integer not null, delivery_id text);
+	 CREATE UNIQUE INDEX delivery_key ON runtime_deliveries(delivery_id);
+	 CREATE TABLE runtime_rows (row_json text not null CHECK(json_valid(row_json)), ordinal integer not null, delivery_id text not null REFERENCES runtime_deliveries(delivery_id));
+	 CREATE UNIQUE INDEX row_key ON runtime_rows(ordinal,delivery_id);`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatal(err)
+	}
+	s, err := OpenStorage(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer s.Close()
+	ev, err := telemetry.ParseRuntimeEvent(runtimeFixture())
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{"stored", "duplicate"} {
+		if got, err := s.InsertRuntimeEvent(context.Background(), ev, time.Unix(1, 0)); err != nil || got != want {
+			t.Fatalf("equivalent schema: %q %v", got, err)
+		}
+	}
+}
+
+func runtimeDatabaseSnapshot(t *testing.T, path string) string {
+	t.Helper()
+	db, err := sql.Open("sqlite", path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+	var snapshot string
+	err = db.QueryRow(`SELECT json_array(
+	 (SELECT user_version FROM pragma_user_version),
+	 (SELECT value FROM sentinel),
+	 (SELECT json_group_array(json_array(type,name,tbl_name,sql)) FROM
+	  (SELECT type,name,tbl_name,sql FROM sqlite_master ORDER BY type,name)))`).Scan(&snapshot)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return snapshot
+}
+
+func TestRuntimeStorageObservationMatrix(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "matrix.db")
+	s, err := OpenStorage(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ev, err := telemetry.ParseRuntimeEvent(runtimeFixture())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := s.InsertRuntimeEvent(context.Background(), ev, time.Unix(1, 0)); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.Close(); err != nil {
+		t.Fatal(err)
+	}
+	s, err = OpenStorage(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer s.Close()
+	if decision, err := s.InsertRuntimeEvent(context.Background(), ev, time.Unix(2, 0)); err != nil || decision != "duplicate" {
+		t.Fatalf("durable retry: %q %v", decision, err)
+	}
+	ev.DeliveryID = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+	if _, err := s.InsertRuntimeEvent(context.Background(), ev, time.Unix(3, 0)); err != nil {
+		t.Fatal(err)
+	}
+	var class string
+	var deliveries, responses, reported, unavailable, unsupported, sum int64
+	err = s.db.QueryRow(`SELECT json_extract(row_json,'$.agent_class'), count(*),
+	 sum(json_extract(row_json,'$.responses')), sum(json_extract(row_json,'$.input_tokens.reported')),
+	 sum(json_extract(row_json,'$.input_tokens.unavailable')), sum(json_extract(row_json,'$.input_tokens.unsupported')),
+	 sum(json_extract(row_json,'$.input_tokens.sum')) FROM runtime_rows GROUP BY json_extract(row_json,'$.agent_class')`).Scan(&class, &deliveries, &responses, &reported, &unavailable, &unsupported, &sum)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if class != "sdd-apply" || deliveries != 2 || responses != 12 || reported != 2 || unavailable != 4 || unsupported != 6 || sum != 1999999999998 {
+		t.Fatal("matrix lost aggregate observations or counted a retry")
+	}
+}
+
+func TestRuntimeStorageCommitFailure(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "commit.db")
+	s, err := OpenStorage(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer s.Close()
+	// Deferred foreign-key failure happens at COMMIT, after successful row writes.
+	if _, err := s.db.Exec(`CREATE TABLE commit_probe (id TEXT REFERENCES runtime_deliveries(delivery_id) DEFERRABLE INITIALLY DEFERRED);
+ CREATE TRIGGER fail_commit AFTER INSERT ON runtime_rows BEGIN INSERT INTO commit_probe VALUES ('missing'); END;`); err != nil {
+		t.Fatal(err)
+	}
+	ev, err := telemetry.ParseRuntimeEvent(runtimeFixture())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if decision, err := s.InsertRuntimeEvent(context.Background(), ev, time.Now()); err == nil || decision != "" {
+		t.Fatalf("failed commit acknowledged: %q %v", decision, err)
+	}
+	for _, table := range []string{"runtime_deliveries", "runtime_rows", "commit_probe"} {
+		var count int
+		if err := s.db.QueryRow(`SELECT count(*) FROM ` + table).Scan(&count); err != nil || count != 0 {
+			t.Fatalf("%s partial commit: %d %v", table, count, err)
+		}
+	}
+}
+
+func TestRuntimeStorageDelivery(t *testing.T) {
+	s, err := OpenStorage(filepath.Join(t.TempDir(), "runtime.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer s.Close()
+	ev, err := telemetry.ParseRuntimeEvent(runtimeFixture())
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx := context.Background()
+	now := time.Unix(123, 456)
+	var wg sync.WaitGroup
+	results := make(chan string, 8)
+	failures := make(chan error, 8)
+	for i := 0; i < 8; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			decision, err := s.InsertRuntimeEvent(ctx, ev, now)
+			results <- decision
+			failures <- err
+		}()
+	}
+	wg.Wait()
+	close(results)
+	close(failures)
+	for err := range failures {
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+	stored, duplicate := 0, 0
+	for decision := range results {
+		switch decision {
+		case "stored":
+			stored++
+		case "duplicate":
+			duplicate++
+		default:
+			t.Fatalf("decision %q", decision)
+		}
+	}
+	if stored != 1 || duplicate != 7 {
+		t.Fatalf("stored=%d duplicate=%d", stored, duplicate)
+	}
+	ev.Host = "codex"
+	if _, err := s.InsertRuntimeEvent(ctx, ev, now); !errors.Is(err, ErrRuntimeConflict) {
+		t.Fatalf("conflict: %v", err)
+	}
+	var deliveries, rows int
+	var received int64
+	if err := s.db.QueryRow(`SELECT count(*), received_at FROM runtime_deliveries`).Scan(&deliveries, &received); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.db.QueryRow(`SELECT count(*) FROM runtime_rows`).Scan(&rows); err != nil {
+		t.Fatal(err)
+	}
+	if deliveries != 1 || rows != 1 || received != receivedAtKey(now) {
+		t.Fatalf("delivery=%d rows=%d time=%d", deliveries, rows, received)
+	}
+	for _, metric := range []string{"input_tokens", "output_tokens", "cache_read_tokens", "cache_creation_tokens", "reasoning_tokens", "total_tokens"} {
+		var reported, unavailable, unsupported, sum int64
+		q := `SELECT json_extract(row_json,'$.` + metric + `.reported'),json_extract(row_json,'$.` + metric + `.unavailable'),json_extract(row_json,'$.` + metric + `.unsupported'),json_extract(row_json,'$.` + metric + `.sum') FROM runtime_rows`
+		if err := s.db.QueryRow(q).Scan(&reported, &unavailable, &unsupported, &sum); err != nil {
+			t.Fatal(err)
+		}
+		if reported != 1 || unavailable != 2 || unsupported != 3 || sum != 999999999999 {
+			t.Fatalf("lost %s coverage", metric)
+		}
+	}
+	var duration string
+	if err := s.db.QueryRow(`SELECT row_json FROM runtime_rows`).Scan(&duration); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(duration, `"sum_ms":125e-2`) {
+		t.Fatal("decimal timing not preserved")
+	}
+	// Force the row write to fail after the delivery header has been inserted.
+	if _, err := s.db.Exec(`CREATE TRIGGER reject_runtime BEFORE INSERT ON runtime_rows BEGIN SELECT RAISE(ABORT, 'private-canary'); END`); err != nil {
+		t.Fatal(err)
+	}
+	ev.DeliveryID = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	if decision, err := s.InsertRuntimeEvent(ctx, ev, now); err == nil || decision != "" {
+		t.Fatalf("failed write acknowledged: %q %v", decision, err)
+	}
+	if err := s.db.QueryRow(`SELECT count(*) FROM runtime_deliveries`).Scan(&deliveries); err != nil || deliveries != 1 {
+		t.Fatalf("partial write: %d %v", deliveries, err)
+	}
+}

--- a/internal/telemetrycollector/storage.go
+++ b/internal/telemetrycollector/storage.go
@@ -66,6 +66,13 @@ func OpenStorage(path string) (*Storage, error) {
 	}
 	db.SetMaxOpenConns(1)
 
+	// Admission precedes even persistent PRAGMAs: rejected databases must not
+	// acquire legacy tables or have their journal mode changed.
+	if err := migrateRuntimeStorage(db); err != nil {
+		db.Close()
+		return nil, err
+	}
+
 	for _, pragma := range []string{
 		"PRAGMA journal_mode=DELETE;",
 		"PRAGMA synchronous=NORMAL;",
@@ -76,11 +83,6 @@ func OpenStorage(path string) (*Storage, error) {
 			db.Close()
 			return nil, fmt.Errorf("apply pragma %q: %w", pragma, err)
 		}
-	}
-
-	if _, err := db.Exec(schemaDDL); err != nil {
-		db.Close()
-		return nil, fmt.Errorf("apply schema: %w", err)
 	}
 
 	return &Storage{db: db}, nil
@@ -292,15 +294,31 @@ type rollupRow struct {
 	Value int64
 }
 
-// PurgeOlderThan deletes raw events received before cutoff and reports how
-// many rows were removed. Rollups are never purged by this call: they are
-// the durable historical record once raw events age out.
+// PurgeOlderThan atomically deletes legacy events and whole runtime deliveries
+// received strictly before cutoff. Its count remains legacy events only, not
+// runtime rows, deliveries, observations, or people. Rollups are never purged.
+// Runtime delivery identities expire with their rows; retries do not renew age.
 func (s *Storage) PurgeOlderThan(ctx context.Context, cutoff time.Time) (int64, error) {
-	res, err := s.db.ExecContext(ctx, `DELETE FROM events WHERE received_at < ?`, receivedAtKey(cutoff))
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return 0, err
+	}
+	defer tx.Rollback()
+	res, err := tx.ExecContext(ctx, `DELETE FROM events WHERE received_at < ?`, receivedAtKey(cutoff))
 	if err != nil {
 		return 0, fmt.Errorf("purge events before %s: %w", cutoff, err)
 	}
-	return res.RowsAffected()
+	count, err := res.RowsAffected()
+	if err != nil {
+		return 0, err
+	}
+	if err := purgeRuntimeOlderThan(ctx, tx, cutoff); err != nil {
+		return 0, err
+	}
+	if err := tx.Commit(); err != nil {
+		return 0, errRuntimeStorage
+	}
+	return count, nil
 }
 
 // receivedAtKey and parseReceivedAtKey convert between time.Time and the


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #4446

## 🏷️ PR Type

- [x] `type:feature` — New feature

## 📝 Summary

Stores validated observations, applies retention, and visualizes host/model/agent/effort coverage.

## 📂 Changes

This child PR contains one coherent work unit with its tests and relevant documentation.

## 🧪 Test Plan

- Collector tests, race tests, JSON validation, SQLite queries, and Playwright passed locally.\n- CI is the final merge gate.

## ✅ Contributor Checklist

- [x] Linked issue has `status:approved`
- [x] Commit uses Conventional Commits
- [x] No `Co-Authored-By` trailer
- [ ] `size:exception` required: the unit is indivisible without separating behavior from its tests

## Chain Context

| Field | Value |
|-------|-------|
| Chain | Runtime telemetry observations |
| Tracker PR | #4447 |
| Position | 3 of 3 |
| Base | `feat/telemetry-runtime-metrics-02-delivery` |
| Depends on | previous child |
| Follow-up | None |
| Review budget | 1730 / 400; exception required because implementation, contract and tests form one behavior boundary |
| Starts at | feat/telemetry-runtime-metrics-02-delivery |
| Ends with | Stores validated observations, applies retention, and visualizes host/model/agent/effort coverage. |

### Chain Overview

```text
main
 └── #4447 tracker
      └── 3
```

### Scope
- Includes: Stores validated observations, applies retention, and visualizes host/model/agent/effort coverage.
- Excludes: later child work units.

### Autonomy
- [x] CI is expected to pass for this branch
- [x] One deliverable scope
- [x] Tests/documentation remain with behavior
