### PR TITLE
fix(sdd): fail fast on unsatisfiable artifact remediation

### DIFF
--- a/bench/journeys_sdd.go
+++ b/bench/journeys_sdd.go
@@ -83,6 +83,12 @@ type sddRuntimeStatus struct {
 		Change  string `json:"change"`
 		Lineage string `json:"lineage"`
 	} `json:"binding"`
+	LastReset *struct {
+		Revision           string `json:"revision"`
+		ResetCandidateTree string `json:"reset_candidate_tree"`
+		Reason             string `json:"reason"`
+		Actor              string `json:"actor"`
+	} `json:"last_reset"`
 	LastRescope *struct {
 		PreviousObjectiveID  string `json:"previous_objective_id"`
 		PreviousGeneration   int    `json:"previous_generation"`
@@ -196,6 +202,25 @@ func proveActiveAttempt(sandbox *Sandbox, ordinal int, evidenceRevision string) 
 			evidenceRevision, status.EvidenceRevision)
 	}
 	return nil
+}
+
+// proveActiveResetRemediationAttempt verifies the chain-bound failed evidence
+// after Reset. Reset deliberately clears the status-level evidence projection,
+// so the immutable failed attempt is the authoritative location for that fact.
+func proveActiveResetRemediationAttempt(sandbox *Sandbox, ordinal int, evidenceRevision string) error {
+	status, err := proveRuntime(sandbox)
+	if err != nil {
+		return err
+	}
+	if status.ActiveAttempt == nil || status.ActiveAttempt.Ordinal != ordinal || status.ActiveAttempt.Outcome != "running" {
+		return fmt.Errorf("fixture claims a running remediation ordinal %d but runtime reports active=%#v", ordinal, status.ActiveAttempt)
+	}
+	for _, attempt := range status.Attempts {
+		if attempt.Outcome == "failed" && attempt.EvidenceRevision == evidenceRevision {
+			return nil
+		}
+	}
+	return fmt.Errorf("fixture claims preserved failed evidence %q but runtime attempts are %#v", evidenceRevision, status.Attempts)
 }
 
 // ---------------------------------------------------------------------------
@@ -849,6 +874,60 @@ func sddBeginFailedUnmanagedVerification(r *journeyRun) error {
 	return nil
 }
 
+// sddUnmanagedUnchangedAcquireIsRejected proves #4415 at the public runtime
+// boundary: declaring failed evidence against the unchanged failed candidate is
+// refused before Begin, without minting a token or mutating the attempt chain.
+func sddUnmanagedUnchangedAcquireIsRejected(r *journeyRun) error {
+	before, err := proveRuntime(r.sandbox)
+	if err != nil {
+		return err
+	}
+	observation := r.run(append([]string{
+		"sdd-attempt", "acquire", "--cwd", r.sandbox.Repo, "--change", sddChange,
+		"--request-id", "bench-unmanaged-acquire-unchanged", "--remediates-evidence-revision", sddFailedEvidence,
+	}, sddUnmanagedObjective...), false)
+	var result sddCompactAttemptResult
+	if err := json.Unmarshal([]byte(strings.TrimSpace(observation.Stdout)), &result); err != nil {
+		return fmt.Errorf("parse unchanged remediation acquire: %w (stderr: %s)", err, firstLine(observation.Stderr))
+	}
+	if result.State != "blocked" || result.Reason != "remediation_unsatisfiable" || result.Token != "" {
+		return fmt.Errorf("unchanged remediation acquire = %#v exit=%d, want blocked/remediation_unsatisfiable without token", result, observation.ExitCode)
+	}
+	after, err := proveRuntime(r.sandbox)
+	if err != nil {
+		return err
+	}
+	if after.Revision != before.Revision || after.ActiveAttempt != nil || len(after.Attempts) != len(before.Attempts) {
+		return fmt.Errorf("unchanged remediation acquire mutated runtime: before=%#v after=%#v", before, after)
+	}
+	return nil
+}
+
+// sddUnmanagedResetChangedCandidate records the terminal candidate drift before
+// it opens a successor correction attempt. Reset is a maintainer operation: its
+// current CAS revision, reason, and actor must become durable LastReset evidence.
+func sddUnmanagedResetChangedCandidate(r *journeyRun) error {
+	before, err := readRuntimeStatus(r)
+	if err != nil {
+		return err
+	}
+	const reason = "the correction changed the terminal verification candidate"
+	const actor = "bench-maintainer"
+	r.run(sddAttemptArgs(r, "reset", before.Revision, "bench-unmanaged-reset-changed-candidate",
+		"--reason", reason, "--actor", actor), false)
+
+	after, err := readRuntimeStatus(r)
+	if err != nil {
+		return err
+	}
+	if after.Revision == before.Revision || after.LastReset == nil ||
+		after.LastReset.Revision != after.Revision || after.LastReset.ResetCandidateTree == "" ||
+		after.LastReset.Reason != reason || after.LastReset.Actor != actor || after.NextAction != "begin" {
+		return fmt.Errorf("audited correction reset did not publish the changed candidate and audit context: before=%#v after=%#v", before, after)
+	}
+	return nil
+}
+
 func sddUnmanagedAcquireCorrection(r *journeyRun) error {
 	observation := r.run(append([]string{
 		"sdd-attempt", "acquire", "--cwd", r.sandbox.Repo, "--change", sddChange,
@@ -895,14 +974,14 @@ func sddUnmanagedCorrectionRemainsBounded(r *journeyRun) error {
 	if err := sddUnmanagedSettle(r, "bench-unmanaged-unchanged", sddFailedEvidence, false); err != nil {
 		return err
 	}
-	return proveActiveAttempt(r.sandbox, 2, sddFailedEvidence)
+	return proveActiveResetRemediationAttempt(r.sandbox, 2, sddFailedEvidence)
 }
 
 func sddUnmanagedWrongEvidenceIsRejected(r *journeyRun) error {
 	if err := sddUnmanagedSettle(r, "bench-unmanaged-wrong-evidence", sddWrongEvidence, false); err != nil {
 		return err
 	}
-	return proveActiveAttempt(r.sandbox, 2, sddFailedEvidence)
+	return proveActiveResetRemediationAttempt(r.sandbox, 2, sddFailedEvidence)
 }
 
 func sddUnmanagedCorrectionCompletes(r *journeyRun) error {
@@ -1405,9 +1484,10 @@ func sddJourneys() []Journey {
 						}
 						return nil
 					})},
-				{Name: "acquire the one bounded correction", Requires: sddAttemptRemediationCapability, Composite: sddUnmanagedAcquireCorrection},
-				{Name: "unchanged candidate cannot satisfy correction", Requires: sddAttemptRemediationCapability, Composite: sddUnmanagedCorrectionRemainsBounded},
+				{Name: "unchanged candidate cannot acquire correction", Requires: sddAttemptRemediationCapability, Composite: sddUnmanagedUnchangedAcquireIsRejected},
 				{Name: "fixture: correction changes the candidate", Fixture: sddBoundedCorrection},
+				{Name: "audited reset records the changed correction candidate", Requires: sddAttemptResetCapability, Composite: sddUnmanagedResetChangedCandidate},
+				{Name: "acquire the one bounded correction after the audited reset", Requires: sddAttemptRemediationCapability, Composite: sddUnmanagedAcquireCorrection},
 				{Name: "wrong failed evidence cannot satisfy correction", Requires: sddAttemptRemediationCapability, Composite: sddUnmanagedWrongEvidenceIsRejected},
 				{Name: "settle the evidence-bound correction", Requires: sddAttemptRemediationCapability, Composite: sddUnmanagedCorrectionCompletes},
 				{Name: "replay cannot acquire another correction", Requires: sddAttemptRemediationCapability, Composite: sddUnmanagedReplayIsComplete},

--- a/internal/cli/sdd_attempt_test.go
+++ b/internal/cli/sdd_attempt_test.go
@@ -597,11 +597,6 @@ func TestRunSDDAttemptSettleRemediationEvidenceDropsEvidenceRevisionRequirement(
 	if failed.State != "proceed" {
 		t.Fatalf("failed settle = %#v", failed)
 	}
-	acquired2, _ := runCompactSDDAttempt(t, []string{
-		"acquire", "--cwd", repo, "--change", change, "--request-id", "cli-rem-acquire-2",
-		"--work-unit", "verify", "--evidence-goal", "prove CLI remediation evidence",
-		"--max-attempts", "5", "--max-changed-lines", "800", "--remediates-evidence-revision", failedEvidence,
-	})
 	trackedFile := filepath.Join(repo, "tracked.txt")
 	existing, err := os.ReadFile(trackedFile)
 	if err != nil {
@@ -610,6 +605,17 @@ func TestRunSDDAttemptSettleRemediationEvidenceDropsEvidenceRevisionRequirement(
 	if err := os.WriteFile(trackedFile, append(existing, []byte("corrected\n")...), 0o644); err != nil {
 		t.Fatal(err)
 	}
+	failedStatus := runSDDAttemptStatus(t, []string{"status", "--cwd", repo, "--change", change})
+	reset := runSDDAttemptStatus(t, []string{
+		"reset", "--cwd", repo, "--change", change, "--expected-revision", failedStatus.Revision,
+		"--request-id", "cli-rem-reset", "--reason", "maintainer records the corrected candidate", "--actor", "maintainer",
+	})
+	acquired2, _ := runCompactSDDAttempt(t, []string{
+		"acquire", "--cwd", repo, "--change", change, "--expected-revision", reset.Revision,
+		"--request-id", "cli-rem-acquire-2", "--work-unit", "verify",
+		"--evidence-goal", "prove CLI remediation evidence", "--max-attempts", "5", "--max-changed-lines", "800",
+		"--remediates-evidence-revision", failedEvidence,
+	})
 	evidence := `{"schema":"gentle-ai.remediation-evidence/v1","failed_evidence_revision":"` + failedEvidence + `",` +
 		`"commands":[{"command":"go test ./...","exit_code":0,"result":"293 passed"}],` +
 		`"runtime_harness":{"status":"not_applicable","na_reason":"no runtime harness because this change is test-only"},` +

--- a/internal/sddstatus/runtime_compact.go
+++ b/internal/sddstatus/runtime_compact.go
@@ -34,8 +34,10 @@ const (
 	// the caller declared a correction for failed evidence the immutable
 	// attempt chain does not hold unremediated (nothing failed, the failure
 	// was already corrected by a passed settlement, or a different revision
-	// was declared), so the settlement that declaration promises is
-	// structurally impossible and no token may be issued for it.
+	// was declared), or the candidate still equals the failed baseline without
+	// an audited reset/rescope authorizing an evidence-only retry. The settlement
+	// that declaration promises is structurally impossible and no token may be
+	// issued for it.
 	CompactBlockRemediationUnsatisfiable CompactBlockReason = "remediation_unsatisfiable"
 	// CompactBlockUndeclaredUntracked is the settlement-side untracked ruling
 	// block (#3881): the attempt authority is intact and unmutated, and what
@@ -122,8 +124,9 @@ type CompactAcquireRequest struct {
 	// intent Settle expresses through --remediates-evidence-revision (#2564).
 	// Before this, remediation intent was settle-only: an acquire whose
 	// eventual failed-evidence settlement was already structurally unsatisfiable
-	// (no unremediated failed evidence in the immutable attempt chain, or a
-	// different revision declared) still returned proceed, and the refusal
+	// (no unremediated failed evidence in the immutable attempt chain, a
+	// different revision declared, or an unchanged failed baseline without an
+	// audited evidence-only retry) still returned proceed, and the refusal
 	// only arrived after the correction work was done. Empty leaves every
 	// existing acquire path unchanged.
 	RemediatesEvidenceRevision string
@@ -295,11 +298,28 @@ func (store RuntimeStore) Acquire(ctx context.Context, request CompactAcquireReq
 		return result, nil
 	}
 	// A declared correction must be structurally settleable before it spends an
-	// attempt. Satisfiability is derived only from the immutable failed-evidence
-	// chain, so an audited reset remains a legitimate predecessor.
-	if request.RemediatesEvidenceRevision != "" &&
-		!failedEvidenceRemediationSettleable(replay.Status, request.RemediatesEvidenceRevision) {
-		return compactBlocked(CompactBlockRemediationUnsatisfiable, ""), nil
+	// attempt. The immutable failed-evidence chain owns the binding, while the
+	// existing candidate and audited-reset/rescope predicates decide whether an
+	// unchanged retry is already authorized. Calling Begin's read-only admission
+	// predicate here captures the exact candidate it would record without opening
+	// an attempt or issuing a token.
+	if request.RemediatesEvidenceRevision != "" {
+		if !failedEvidenceRemediationSettleable(replay.Status, request.RemediatesEvidenceRevision) {
+			return compactBlocked(CompactBlockRemediationUnsatisfiable, ""), nil
+		}
+		failed, _ := runtimeChainFailedAttempt(replay.Status.Attempts)
+		admission, admissionErr := store.runtimeBeginAdmission(ctx, replay.Status, begin)
+		if admissionErr != nil {
+			return store.compactMutationFailure(admissionErr, false, begin), nil
+		}
+		active := RuntimeAttempt{
+			BeginCandidateIdentity: admission.Snapshot.Identity,
+			BeginCandidateTree:     admission.Snapshot.CandidateTree,
+		}
+		if !runtimeEvidenceOnlyRetryAuthorized(replay.Status.LastReset, replay.Status.LastRescope, failed, admission.Snapshot.CandidateTree) &&
+			runtimeRemediationCandidateUnchanged(failed, active, admission.Snapshot.Identity, admission.Snapshot.CandidateTree) {
+			return compactBlocked(CompactBlockRemediationUnsatisfiable, ""), nil
+		}
 	}
 	// #4160: a caller-declared --expected-revision is CAS-checked against the
 	// live ledger revision before this fresh begin claims it -- the same
@@ -703,8 +723,8 @@ func compactBlockedExitText(reason CompactBlockReason, token string) string {
 			"` to your own `sdd-attempt acquire` call to continue that exact attempt, or to your " +
 			"`sdd-attempt settle` call to close it before starting a new one"
 	case CompactBlockRemediationUnsatisfiable:
-		return "this acquire declares a correction for failed evidence the attempt chain does not hold unremediated (nothing failed, the failure was already corrected by a passed settlement, or the declared revision differs from the chain's), so its settle could never succeed and no token is issued; run " +
-			"`gentle-ai sdd-attempt status --cwd <repo> --change <change>` to read the attempt chain and its most recent unremediated failed evidence, then either reissue this acquire declaring that exact revision, or drop --remediates-evidence-revision and continue through a fresh verification objective whose own failed settlement records new evidence a bounded correction can name"
+		return "this acquire declares a correction that cannot settle: the attempt chain either does not hold the declared failed evidence unremediated, or the candidate still matches the state that failed without an audited evidence-only retry; no token is issued. Run " +
+			"`gentle-ai sdd-attempt status --cwd <repo> --change <change>` to read the chain and candidate provenance, then correct the candidate and reissue this acquire through any reset or rescope the current objective requires; if an unchanged retry is justified, use an audited reset or rescope where structurally applicable before reissuing it"
 	default:
 		return ""
 	}

--- a/internal/sddstatus/runtime_compact_post_reset_verification_test.go
+++ b/internal/sddstatus/runtime_compact_post_reset_verification_test.go
@@ -60,8 +60,18 @@ func TestCompactSettlePassesFinalVerificationAfterResetAndDischargedRemediation(
 	}
 
 	// 2. A passed remediation discharges that failure.
-	remediation := acquire("post-reset-remediation-acquire", "payments-apply", "implement payments", runtimeTestHash('f'))
 	appendRuntimeLedgerFile(t, repo, "correction that converged\n")
+	resetStatus, err := store.Status()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.Reset(ctx, ResetObjectiveRequest{
+		ExpectedRevision: resetStatus.Revision, RequestID: "post-reset-remediation-authorization",
+		Reason: "maintainer authorized the changed correction candidate", Actor: "maintainer",
+	}); err != nil {
+		t.Fatalf("reset for changed correction candidate: %v", err)
+	}
+	remediation := acquire("post-reset-remediation-acquire", "payments-apply", "implement payments", runtimeTestHash('f'))
 	discharged := settle("post-reset-remediation-settle", remediation.Token, AttemptPassed, runtimeTestHash('b'), runtimeTestHash('f'))
 	if discharged.State != CompactStateComplete && discharged.State != CompactStateProceed {
 		t.Fatalf("remediation settle = %#v", discharged)

--- a/internal/sddstatus/runtime_compact_remediation_intent_test.go
+++ b/internal/sddstatus/runtime_compact_remediation_intent_test.go
@@ -103,13 +103,146 @@ func TestCompactAcquireRemediationIntentSurvivesAuditedReset(t *testing.T) {
 	}
 }
 
+// TestCompactAcquireRemediationIntentFailsFastBeforeBeginOnUnchangedCandidate
+// proves #4415's early boundary: an unchanged candidate cannot spend a new
+// remediation attempt before the later passing-settle guard would refuse it.
+// The refusal leaves the ledger untouched. A direct acquire after terminal
+// candidate drift remains maintainer-gated without mutation; only an audited
+// reset of that changed candidate admits the exact failed-evidence correction.
+func TestCompactAcquireRemediationIntentFailsFastBeforeBeginOnUnchangedCandidate(t *testing.T) {
+	repo := initRuntimeLedgerRepo(t)
+	store, failedEvidence, failed := seedFailedVerificationLedger(t, repo, "intent-unchanged-baseline", 2)
+	before := countRuntimeRecords(t, store.Dir)
+
+	blocked, err := store.Acquire(context.Background(), CompactAcquireRequest{
+		BeginAttemptRequest: BeginAttemptRequest{
+			RequestID: "unchanged-acquire", WorkUnit: "verify",
+			EvidenceGoal: "independent verification", MaxAttempts: 2, MaxChangedLines: 20,
+		},
+		RemediatesEvidenceRevision: failedEvidence,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if blocked.State != CompactStateBlocked || blocked.Reason != CompactBlockRemediationUnsatisfiable || blocked.Token != "" {
+		t.Fatalf("unchanged remediation-intent acquire = %#v, want blocked/%s without token", blocked, CompactBlockRemediationUnsatisfiable)
+	}
+	if !strings.Contains(blocked.Exit, "correct the candidate and reissue this acquire") || blocked.Detail != blocked.Exit {
+		t.Fatalf("unchanged remediation-intent exit = %#v, want the corrected-candidate continuation", blocked)
+	}
+	status, err := store.Status()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if status.Revision != failed.Revision || status.ActiveAttempt != nil || countRuntimeRecords(t, store.Dir) != before {
+		t.Fatalf("unchanged remediation-intent acquire mutated the ledger: status=%#v records=%d want=%d", status, countRuntimeRecords(t, store.Dir), before)
+	}
+
+	appendRuntimeLedgerFile(t, repo, "bounded correction changes the candidate\n")
+	directBefore, err := store.Status()
+	if err != nil {
+		t.Fatal(err)
+	}
+	directBeforeRecords := countRuntimeRecords(t, store.Dir)
+	direct, err := store.Acquire(context.Background(), CompactAcquireRequest{
+		BeginAttemptRequest: BeginAttemptRequest{
+			RequestID: "changed-acquire-without-reset", WorkUnit: "verify",
+			EvidenceGoal: "independent verification", MaxAttempts: 2, MaxChangedLines: 20,
+		},
+		RemediatesEvidenceRevision: failedEvidence,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	directAfter, err := store.Status()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if direct.State != CompactStateBlocked || direct.Reason != CompactBlockMaintainerDecision || direct.Token != "" ||
+		directAfter.Revision != directBefore.Revision || directAfter.ActiveAttempt != nil || countRuntimeRecords(t, store.Dir) != directBeforeRecords {
+		t.Fatalf("direct changed-candidate remediation acquire = %#v status=%#v records=%d, want maintainer decision without mutation", direct, directAfter, countRuntimeRecords(t, store.Dir))
+	}
+
+	const resetReason = "maintainer records the changed correction candidate before retry"
+	const resetActor = "maintainer"
+	reset, err := store.Reset(context.Background(), ResetObjectiveRequest{
+		ExpectedRevision: directAfter.Revision, RequestID: "changed-candidate-reset",
+		Reason: resetReason, Actor: resetActor,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if reset.LastReset == nil || reset.LastReset.Revision != reset.Revision ||
+		reset.LastReset.Reason != resetReason || reset.LastReset.Actor != resetActor {
+		t.Fatalf("changed-candidate reset omitted audit context: %#v", reset.LastReset)
+	}
+	changed, err := store.Acquire(context.Background(), CompactAcquireRequest{
+		BeginAttemptRequest: BeginAttemptRequest{
+			ExpectedRevision: reset.Revision, RequestID: "changed-acquire", WorkUnit: "verify",
+			EvidenceGoal: "independent verification", MaxAttempts: 2, MaxChangedLines: 20,
+		},
+		RemediatesEvidenceRevision: failedEvidence,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if changed.State != CompactStateProceed || changed.Token == "" {
+		t.Fatalf("changed remediation-intent acquire = %#v, want proceed with token after reset %s", changed, reset.Revision)
+	}
+}
+
+// TestCompactAcquireRemediationIntentSurvivesAuditedRescope keeps the other
+// evidence-only positive control at acquire: a rescope that records the failed
+// candidate with its actor and reason still authorizes one unchanged retry.
+func TestCompactAcquireRemediationIntentSurvivesAuditedRescope(t *testing.T) {
+	repo := initRuntimeLedgerRepo(t)
+	store, failedEvidence, failed := seedFailedVerificationLedger(t, repo, "intent-after-rescope", 2)
+	failedObjective := *failed.Objective
+	failedTree := failed.Attempts[len(failed.Attempts)-1].FinishCandidateTree
+
+	rescoped, err := store.Rescope(context.Background(), RescopeObjectiveRequest{
+		ExpectedRevision: failed.Revision, RequestID: "intent-rescope",
+		WorkUnit: "narrowed remediation", EvidenceGoal: "independent verification",
+		MaxAttempts: 2, MaxChangedLines: 10,
+		Reason: "maintainer authorized evidence-only retry", Actor: "maintainer",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if rescoped.LastRescope == nil || rescoped.LastRescope.PreviousObjectiveID != failedObjective.ID ||
+		rescoped.LastRescope.PreviousGeneration != failedObjective.Generation || rescoped.LastRescope.RescopeCandidateTree != failedTree {
+		t.Fatalf("audited rescope lost failed-candidate provenance: %#v", rescoped.LastRescope)
+	}
+
+	correction, err := store.Acquire(context.Background(), CompactAcquireRequest{
+		BeginAttemptRequest: BeginAttemptRequest{
+			RequestID: "rescope-acquire", WorkUnit: "narrowed remediation",
+			EvidenceGoal: "independent verification", MaxAttempts: 2, MaxChangedLines: 10,
+		},
+		RemediatesEvidenceRevision: failedEvidence,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if correction.State != CompactStateProceed || correction.Token == "" {
+		t.Fatalf("post-rescope chain-bound remediation-intent acquire = %#v, want proceed", correction)
+	}
+}
+
 // TestCompactAcquireRemediationIntentStillIssuesTokenForDirectCorrection holds
-// the direct path end to end, then proves the anti-laundering fail-fast: once
-// the failure's one correction settled, a later acquire declaring the same
-// evidence is refused before issuing a token.
+// the corrected-candidate path end to end, then proves the anti-laundering
+// fail-fast: once the failure's one correction settled, a later acquire
+// declaring the same evidence is refused before issuing a token.
 func TestCompactAcquireRemediationIntentStillIssuesTokenForDirectCorrection(t *testing.T) {
 	repo := initRuntimeLedgerRepo(t)
-	store, failedEvidence, _ := seedFailedVerificationLedger(t, repo, "intent-direct-correction", 2)
+	store, failedEvidence, failed := seedFailedVerificationLedger(t, repo, "intent-direct-correction", 2)
+	appendRuntimeLedgerFile(t, repo, "direct correction changes the candidate\n")
+	if _, err := store.Reset(context.Background(), ResetObjectiveRequest{
+		ExpectedRevision: failed.Revision, RequestID: "direct-reset-before-correction",
+		Reason: "maintainer records the changed correction candidate", Actor: "maintainer",
+	}); err != nil {
+		t.Fatal(err)
+	}
 
 	correction, err := store.Acquire(context.Background(), CompactAcquireRequest{
 		BeginAttemptRequest: BeginAttemptRequest{

--- a/internal/sddstatus/runtime_compact_test.go
+++ b/internal/sddstatus/runtime_compact_test.go
@@ -220,6 +220,17 @@ func TestCompactSettlePreservesFailedEvidenceAndReplay(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	appendRuntimeLedgerFile(t, repo, "bounded correction\n")
+	status, err := store.Status()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.Reset(context.Background(), ResetObjectiveRequest{
+		ExpectedRevision: status.Revision, RequestID: "correction-reset",
+		Reason: "maintainer authorized the changed correction candidate", Actor: "maintainer",
+	}); err != nil {
+		t.Fatalf("reset for changed correction candidate: %v", err)
+	}
 	acquired, err := store.Acquire(context.Background(), CompactAcquireRequest{BeginAttemptRequest: BeginAttemptRequest{
 		RequestID: "correction-acquire", WorkUnit: "verify", EvidenceGoal: "independent verification",
 		MaxAttempts: 2, MaxChangedLines: 20,
@@ -227,7 +238,6 @@ func TestCompactSettlePreservesFailedEvidenceAndReplay(t *testing.T) {
 	if err != nil || acquired.State != CompactStateProceed {
 		t.Fatalf("correction acquire = %#v err=%v", acquired, err)
 	}
-	appendRuntimeLedgerFile(t, repo, "bounded correction\n")
 	failNextCompactStoreSync(t, store)
 	before := countRuntimeRecords(t, store.Dir)
 	request := CompactSettleRequest{
@@ -244,7 +254,7 @@ func TestCompactSettlePreservesFailedEvidenceAndReplay(t *testing.T) {
 	if result.State != CompactStateComplete || result.Reason != "" || result.Token != "" {
 		t.Fatalf("compact remediation result = %#v", result)
 	}
-	status, err := store.Status()
+	status, err = store.Status()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -302,6 +312,17 @@ func TestCompactSettleDerivesEvidenceRevisionFromRemediationEvidence(t *testing.
 	}); err != nil {
 		t.Fatal(err)
 	}
+	appendRuntimeLedgerFile(t, repo, "bounded correction\n")
+	status, err := store.Status()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.Reset(context.Background(), ResetObjectiveRequest{
+		ExpectedRevision: status.Revision, RequestID: "correction-reset",
+		Reason: "maintainer authorized the changed correction candidate", Actor: "maintainer",
+	}); err != nil {
+		t.Fatalf("reset for changed correction candidate: %v", err)
+	}
 	acquired, err := store.Acquire(context.Background(), CompactAcquireRequest{BeginAttemptRequest: BeginAttemptRequest{
 		RequestID: "correction-acquire", WorkUnit: "verify", EvidenceGoal: "independent verification",
 		MaxAttempts: 2, MaxChangedLines: 20,
@@ -309,7 +330,6 @@ func TestCompactSettleDerivesEvidenceRevisionFromRemediationEvidence(t *testing.
 	if err != nil || acquired.State != CompactStateProceed {
 		t.Fatalf("correction acquire = %#v err=%v", acquired, err)
 	}
-	appendRuntimeLedgerFile(t, repo, "bounded correction\n")
 
 	evidence := remediationEvidenceFixture(failedEvidence)
 	wantRevision, err := DeriveRemediationEvidenceRevision(evidence, failedEvidence)
@@ -330,7 +350,7 @@ func TestCompactSettleDerivesEvidenceRevisionFromRemediationEvidence(t *testing.
 	if result.State != CompactStateComplete {
 		t.Fatalf("compact remediation-evidence result = %#v", result)
 	}
-	status, err := store.Status()
+	status, err = store.Status()
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/sddstatus/status.go
+++ b/internal/sddstatus/status.go
@@ -2023,6 +2023,7 @@ func nativeRuntimeInstructions(status Status, change string) []string {
 		fmt.Sprintf("After a failed or passed run, call `gentle-ai sdd-attempt settle --cwd %s --change %q --token \"<acquire-token>\" --request-id \"<unique-request-id>\" --outcome <passed|failed> --evidence-revision <sha256> --diagnosis \"<proven-diagnosis>\" --harness-disposition <reused|invalidated> --cleanup-evidence \"<evidence>\" --process-evidence \"<evidence>\"`.", pathquote.Quote(workspace), change),
 		fmt.Sprintf("After an interrupted run, call `gentle-ai sdd-attempt settle --cwd %s --change %q --token \"<acquire-token>\" --request-id \"<unique-request-id>\" --outcome interrupted --diagnosis \"<proven-diagnosis>\" --harness-disposition <reused|invalidated> --cleanup-evidence \"<evidence>\" --process-evidence \"<evidence>\"` and omit --evidence-revision.", pathquote.Quote(workspace), change),
 		"Treat settle state proceed as permission for another bounded acquire, blocked as a hard stop, and complete as terminal. Reset is exceptional, requires an explicit maintainer scope decision, and is never automatic.",
+		"After a terminal attempt's candidate drifts, run `gentle-ai sdd-attempt status` to obtain the current revision, then have a maintainer record that drift with an audited `gentle-ai sdd-attempt reset --expected-revision <the revision that status prints> --request-id \"<unique-request-id>\" --reason \"<why-the-candidate-drifted>\" --actor \"<actor>\"` before reacquire. Use `sdd-attempt rescope` only when its narrower-successor contract applies.",
 	}
 	if status.RemediationState.Required && status.RuntimeStatus != nil && status.RuntimeStatus.Objective != nil {
 		evidence, found := runtimeChainFailedEvidence(status.RuntimeStatus.Attempts)
@@ -2030,7 +2031,7 @@ func nativeRuntimeInstructions(status Status, change string) []string {
 			objective := status.RuntimeStatus.Objective
 			instructions = append(instructions,
 				fmt.Sprintf("For failed SDD evidence %s, run `gentle-ai sdd-attempt acquire --cwd %s --change %q --request-id \"<unique-request-id>\" --work-unit %q --evidence-goal %q --max-attempts %d --max-changed-lines %d --remediates-evidence-revision %s`.", evidence, pathquote.Quote(workspace), change, objective.WorkUnit, objective.EvidenceGoal, objective.MaxAttempts, objective.MaxChangedLines, evidence),
-				fmt.Sprintf("After the candidate changes, settle that token with `--remediates-evidence-revision %s`; fresh independent verification is required before archive.", evidence),
+				fmt.Sprintf("Correct the candidate before acquire. After a terminal candidate drift, run status and then the audited reset above before reissuing this acquire; use rescope only when its narrower-successor contract applies. After the candidate changes, settle that token with `--remediates-evidence-revision %s`; fresh independent verification is required before archive.", evidence),
 			)
 		}
 	}

--- a/internal/sddstatus/status_remediation_instructions_test.go
+++ b/internal/sddstatus/status_remediation_instructions_test.go
@@ -81,9 +81,9 @@ func TestStatusKeepsPrescribingChainBoundRemediationAfterReset(t *testing.T) {
 // TestStatusRendersResetRouteWhileRemediationNeedsADecision covers the wedge
 // every #1974 occurrence reported: failed evidence with an exhausted budget is
 // decision-required, so an immediate correction acquire would return
-// blocked/maintainer_decision. Status renders the audited reset route with
-// the exact current revision, and names the chain binding the post-reset
-// acquire must declare.
+// blocked/maintainer_decision. Status names the status-and-audited-reset route
+// with the current revision for terminal candidate drift, and names the chain
+// binding the post-reset acquire must declare.
 func TestStatusRendersResetRouteWhileRemediationNeedsADecision(t *testing.T) {
 	const change = "decision-required-advice"
 	repo := initRuntimeLedgerRepo(t)
@@ -96,8 +96,12 @@ func TestStatusRendersResetRouteWhileRemediationNeedsADecision(t *testing.T) {
 	if strings.Contains(joined, "bounded correction attempt: run") {
 		t.Fatalf("decision-required status still prescribes the blocked correction acquire:\n%s", joined)
 	}
-	if !strings.Contains(joined, "Remediation follows ordinary SDD failed-evidence accounting.") || strings.Contains(joined, "sdd-attempt reset") {
-		t.Fatalf("decision-required status did not keep remediation authority-free:\n%s", joined)
+	if !strings.Contains(joined, "Remediation follows ordinary SDD failed-evidence accounting.") ||
+		!strings.Contains(joined, "gentle-ai sdd-attempt status") ||
+		!strings.Contains(joined, "gentle-ai sdd-attempt reset") ||
+		!strings.Contains(joined, "--expected-revision <the revision that status prints>") ||
+		!strings.Contains(joined, "rescope` only when its narrower-successor contract applies") {
+		t.Fatalf("decision-required status did not name the audited candidate-drift reset route:\n%s", joined)
 	}
 	if !strings.Contains(joined, "--remediates-evidence-revision "+failedEvidence) {
 		t.Fatalf("decision-required status does not name the chain binding for the post-reset acquire:\n%s", joined)
@@ -125,6 +129,10 @@ func TestStatusStillPrescribesSatisfiableUnmanagedRemediation(t *testing.T) {
 	}
 	if !strings.Contains(joined, "--max-changed-lines 20 --remediates-evidence-revision "+failedEvidence) {
 		t.Fatalf("satisfiable acquire prescription does not declare the remediation intent:\n%s", joined)
+	}
+	if !strings.Contains(joined, "After a terminal candidate drift, run status and then the audited reset above") ||
+		!strings.Contains(joined, "rescope only when its narrower-successor contract applies") {
+		t.Fatalf("satisfiable status does not name the candidate-drift continuation:\n%s", joined)
 	}
 }
 


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #4415

---

## 🏷️ PR Type

- [x] `type:bug` — Bug fix (non-breaking change that fixes an issue)
- [ ] `type:feature`
- [ ] `type:docs`
- [ ] `type:refactor`
- [ ] `type:chore`
- [ ] `type:breaking-change`

---

## 📝 Summary

Prevent an artifact-only or evidence-only remediation from spending a runtime attempt that cannot truthfully settle. When the candidate still matches the failed baseline and no audited reset/rescope authorizes an unchanged retry, compact acquire now fails before `Begin` with `remediation_unsatisfiable` and no token or ledger mutation.

This takes the fail-fast alternative explicitly accepted by #4415. It does not treat external artifact edits, review bindings, or caller prose as settlement authority.

---

## 📂 Changes

| Area | What Changed |
|------|--------------|
| `internal/sddstatus/runtime_compact.go` | Preflight the exact remediation candidate before spending an attempt. |
| Runtime tests | Prove unchanged refusal, no mutation, audited reset/rescope positives, changed-candidate reset flow, replay, and legacy baseline handling. |
| Status instructions | Explain the executable reset/rescope continuation rather than promising an impossible acquire. |
| CLI fixture | Record the changed correction candidate with an audited reset before reacquire. |
| `bench/journeys_sdd.go` | Drive release-vs-candidate behavior through j63, including unchanged refusal and audited changed-candidate reset. |

---

## 🤖 AI Assistance

- [ ] **None**
- [x] **Material assistance used**

**Tool/model (if known):** Pi coding agent with OpenAI Codex

**Material scope:** Regression triage, strict TDD, runtime-ledger contract implementation, journey adaptation, verification, and native bounded review orchestration.

**Verification performed:** Baseline RED against official v2.7.0, candidate driven GREEN, focused and full uncached Go tests, bench validation, Docker E2E, and four-lens native review.

---

## 🧪 Test Plan

- [x] `go test ./... -count=1`
- [x] `go run ./internal/gofmtcheck`
- [x] `cd bench && go vet ./... && go test ./... -count=1`
- [x] `cd e2e && ./docker-test.sh` — Ubuntu, Arch, Fedora: 79 passed, 0 failed, 2 skipped per platform
- [x] Driven `j63-disabled-failed-verification-unmanaged-remediation`

Driven evidence:
- Official `v2.7.0`: `0 completed, 0 unsupported, 1 failed`; unchanged acquire incorrectly returned `proceed` with a token.
- Candidate: `1 completed, 0 unsupported, 0 failed`; unchanged acquire blocks before Begin, then an audited reset admits the changed correction candidate.

Strict RED was also reproduced by running the new focused test against production from `origin/main`: it returned `proceed` with a token instead of `blocked/remediation_unsatisfiable`.

---

## ✅ Contributor Checklist

- [x] Linked issue has `status:approved`
- [x] 348 changed lines, below the 400-line limit
- [x] Exactly one `type:*` label
- [x] Unit tests and format pass
- [x] E2E tests pass
- [x] Benchmark validation completed with driven execution
- [x] No documentation update required beyond executable status instructions
- [x] Conventional Commit; no `Co-Authored-By` trailer
- [x] Material AI assistance declared
- [x] I reviewed and take responsibility for the submission

---

## 💬 Notes for Reviewers

The security boundary remains narrow:
- exact unremediated failed evidence is still required;
- ordinary reacquire cannot authorize unchanged bytes;
- only audited Reset/Rescope can authorize an unchanged evidence-only retry;
- terminal candidate drift still requires an explicit audited transition;
- rejected preflight does not append a ledger record or mint a token.

Native review `review-939162b86530df83` approved all four lenses and burned authority for target `sha256:b452866b8e550594d93c7882aed40ef4826e30603fe0d9ea67972e88d07d8e50`. Advisory readability/resilience warnings were informational and did not open correction.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Remediation attempts are now rejected when the candidate remains unchanged after failed evidence, preventing invalid acquisitions and ledger mutations.
  - Remediation can resume after an authorized reset or applicable rescope, with evidence chains preserved correctly.
  - Reset operations now retain durable audit context and reopen the objective when appropriate.

- **Documentation**
  - Runtime status guidance now explains how to inspect candidate drift, perform an audited reset, and use rescoping only when its narrower-successor contract applies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->