### PR TITLE
fix(sdd): add audited supersede transition

### DIFF
--- a/internal/cli/sdd_attempt.go
+++ b/internal/cli/sdd_attempt.go
@@ -155,7 +155,7 @@ func runSDDAttempt(ctx context.Context, args []string, stdout io.Writer) error {
 	// --intended-untracked=x` into a select, or accept `--untracked-scope=bogus`.
 	var settlementUntracked *[]string
 	settlementInventory := ""
-	if (operation == "finish" || operation == "settle" || operation == "rescope") && declaredUntracked {
+	if (operation == "finish" || operation == "settle" || operation == "rescope" || operation == "supersede") && declaredUntracked {
 		if shapeErr := intendedUntrackedDeclarationShape(untrackedScope, intendedUntracked, expectedUntrackedInventory, expectedUntrackedInventory.value, reviewIntendedUntrackedInventoryCommand, "gentle-ai sdd-attempt "+operation); shapeErr != nil {
 			return shapeErr
 		}
@@ -223,6 +223,12 @@ func runSDDAttempt(ctx context.Context, args []string, stdout io.Writer) error {
 			MaxAttempts: *maxAttempts, MaxChangedLines: *maxChangedLines, Reason: *reason, Actor: *actor,
 			Relation:          sddstatus.RuntimeObjectiveRelation(*objectiveRelation),
 			IntendedUntracked: settlementUntracked, ExpectedUntrackedInventory: settlementInventory,
+		})
+	case "supersede":
+		result, err = store.Supersede(ctx, sddstatus.SupersedeObjectiveRequest{
+			ExpectedRevision: *expected, RequestID: *requestID, WorkUnit: *workUnit, EvidenceGoal: *evidenceGoal,
+			MaxAttempts: *maxAttempts, MaxChangedLines: *maxChangedLines, Reason: *reason, Actor: *actor,
+			Relation: sddstatus.RuntimeObjectiveRelation(*objectiveRelation), IntendedUntracked: settlementUntracked, ExpectedUntrackedInventory: settlementInventory,
 		})
 	case "repair":
 		result, err = store.RepairConsecutiveRescope(ctx, sddstatus.RepairConsecutiveRescopeRequest{
@@ -379,6 +385,20 @@ var sddAttemptOperationDefinitions = []sddAttemptOperationContract{
 		// terminal settlement, outside any active attempt, which the
 		// predecessor's recorded selection could never include. Omitting all
 		// three keeps replaying the predecessor's recorded selection.
+		{name: "untracked-scope", usage: "optional; declares a fresh successor selection instead of replaying history; select or exclude"},
+		{name: "expected-untracked-inventory", usage: "required with untracked-scope; inventory digest"},
+		{name: "intended-untracked", kind: sddAttemptRepeatableStringFlag, usage: "repeatable selected repo-relative untracked path"},
+	}},
+	{name: "supersede", purpose: "Open a distinct terminal zero-drift successor without claiming narrowing", flags: []sddAttemptFlagDefinition{
+		sddAttemptCWDFlag, sddAttemptChangeFlag,
+		{name: "expected-revision", required: true, usage: "required; exact sha256:<64 lowercase hex> runtime revision"},
+		{name: "request-id", required: true, usage: "required; lowercase idempotency key, at most 128 bytes"},
+		{name: "work-unit", required: true, usage: "required; declared successor label, at most 160 bytes"},
+		{name: "evidence-goal", required: true, usage: "required; declared successor objective, at most 240 bytes"},
+		{name: "max-attempts", kind: sddAttemptIntFlag, required: true, usage: "required; explicit limit 1..100, above carried attempts"},
+		{name: "max-changed-lines", kind: sddAttemptIntFlag, required: true, usage: "required; explicit limit 1..1000000, above carried lines"},
+		{name: "reason", required: true, usage: "required; trimmed single-line text, at most 500 bytes"}, {name: "actor", required: true, usage: "required; trimmed single-line text, at most 128 bytes"},
+		{name: "objective-relation", usage: "optional; remediation (default) or independent — independent suppresses inherited failed evidence observably"},
 		{name: "untracked-scope", usage: "optional; declares a fresh successor selection instead of replaying history; select or exclude"},
 		{name: "expected-untracked-inventory", usage: "required with untracked-scope; inventory digest"},
 		{name: "intended-untracked", kind: sddAttemptRepeatableStringFlag, usage: "repeatable selected repo-relative untracked path"},

--- a/internal/cli/sdd_attempt_test.go
+++ b/internal/cli/sdd_attempt_test.go
@@ -101,6 +101,16 @@ func TestRunSDDAttemptRescopeCarriesHistoryForwardThroughTheCLI(t *testing.T) {
 	}
 }
 
+func TestRunSDDAttemptSupersedeRoutesDistinctSuccessor(t *testing.T) {
+	repo, change := initReviewCLIRepo(t), "cli-supersede"
+	started := runSDDAttemptStatus(t, []string{"begin", "--cwd", repo, "--change", change, "--expected-revision=", "--request-id", "a-begin", "--work-unit", "verify-a", "--evidence-goal", "verify A", "--max-attempts", "2", "--max-changed-lines", "40"})
+	failed := runSDDAttemptStatus(t, []string{"finish", "--cwd", repo, "--change", change, "--expected-revision", started.Revision, "--request-id", "a-finish", "--outcome", "failed", "--evidence-revision", cliAttemptHash('a'), "--diagnosis", "distinct remediation", "--harness-disposition", "reused", "--cleanup-evidence", "unchanged", "--process-evidence", "none"})
+	superseded := runSDDAttemptStatus(t, []string{"supersede", "--cwd", repo, "--change", change, "--expected-revision", failed.Revision, "--request-id", "a-b", "--work-unit", "remediate-b", "--evidence-goal", "repair B", "--max-attempts", "3", "--max-changed-lines", "80", "--reason", "distinct remediation", "--actor", "maintainer"})
+	if superseded.LastSupersede == nil || superseded.Objective.WorkUnit != "remediate-b" || superseded.CumulativeAttempts != 1 {
+		t.Fatalf("CLI supersede = %#v", superseded)
+	}
+}
+
 func TestRunSDDAttemptRejectsMissingOrAmbiguousInputs(t *testing.T) {
 	repo := initReviewCLIRepo(t)
 	tests := []struct {
@@ -108,11 +118,11 @@ func TestRunSDDAttemptRejectsMissingOrAmbiguousInputs(t *testing.T) {
 		args []string
 		want string
 	}{
-		{name: "missing operation", args: nil, want: "requires status, begin, finish, handoff, reset, rescope, repair, acquire, settle, or grant"},
+		{name: "missing operation", args: nil, want: "requires status, begin, finish, handoff, reset, rescope, supersede, repair, acquire, settle, or grant"},
 		// The no-args refusal already enumerates every valid operation; the
 		// unknown-operation refusal must do the same instead of naming only
 		// the bad value with no route to the valid set.
-		{name: "unknown operation", args: []string{"begn"}, want: `unknown sdd-attempt operation "begn"; want one of status, begin, finish, handoff, reset, rescope, repair, acquire, settle, or grant`},
+		{name: "unknown operation", args: []string{"begn"}, want: `unknown sdd-attempt operation "begn"; want one of status, begin, finish, handoff, reset, rescope, supersede, repair, acquire, settle, or grant`},
 		{name: "missing change", args: []string{"status", "--cwd", repo}, want: "--change"},
 		{name: "unknown flag", args: []string{"status", "--cwd", repo, "--change", "thin", "--mystery"}, want: "flag provided but not defined"},
 		{name: "irrelevant flag", args: []string{"status", "--cwd", repo, "--change", "thin", "--outcome", "failed"}, want: "flag provided but not defined"},
@@ -169,7 +179,7 @@ func sddAttemptOutcome(args []string) string {
 // all four). Mirrors the reviewIntegrationGatesInOrder /
 // reviewIntegrationGateNames pattern in review_operation_contract.go.
 func TestSDDAttemptOperationsCanonicalSourceEnumeratesConsistently(t *testing.T) {
-	want := []string{"status", "begin", "finish", "handoff", "reset", "rescope", "repair", "acquire", "settle", "grant"}
+	want := []string{"status", "begin", "finish", "handoff", "reset", "rescope", "supersede", "repair", "acquire", "settle", "grant"}
 	if got := sddAttemptOperationNames(); !reflect.DeepEqual(got, want) {
 		t.Fatalf("sddAttemptOperationNames() = %v, want %v", got, want)
 	}
@@ -181,8 +191,8 @@ func TestSDDAttemptOperationsCanonicalSourceEnumeratesConsistently(t *testing.T)
 	if validSDDAttemptOperation("begn") {
 		t.Fatal(`validSDDAttemptOperation("begn") = true, want false`)
 	}
-	if got := joinSDDAttemptOperations(); got != "status, begin, finish, handoff, reset, rescope, repair, acquire, settle, or grant" {
-		t.Fatalf("joinSDDAttemptOperations() = %q, want %q", got, "status, begin, finish, handoff, reset, rescope, repair, acquire, settle, or grant")
+	if got := joinSDDAttemptOperations(); got != "status, begin, finish, handoff, reset, rescope, supersede, repair, acquire, settle, or grant" {
+		t.Fatalf("joinSDDAttemptOperations() = %q, want %q", got, "status, begin, finish, handoff, reset, rescope, supersede, repair, acquire, settle, or grant")
 	}
 }
 
@@ -275,6 +285,7 @@ func TestRunSDDAttemptHelpContractsCoverEveryOperation(t *testing.T) {
 		{"handoff", []string{"cwd", "change", "expected-revision", "request-id", "destination-worktree"}, []string{"registered linked worktree", "Git common directory"}},
 		{"reset", []string{"cwd", "change", "expected-revision", "request-id", "reason", "actor", "objective-relation"}, []string{"500 bytes", "128 bytes", "remediation (default)", "independent"}},
 		{"rescope", []string{"cwd", "change", "expected-revision", "request-id", "work-unit", "evidence-goal", "max-attempts", "max-changed-lines", "reason", "actor", "objective-relation", "untracked-scope", "expected-untracked-inventory", "intended-untracked"}, []string{"explicit limit", "cannot exceed current objective", "remediation (default)", "independent"}},
+		{"supersede", []string{"cwd", "change", "expected-revision", "request-id", "work-unit", "evidence-goal", "max-attempts", "max-changed-lines", "reason", "actor", "objective-relation", "untracked-scope", "expected-untracked-inventory", "intended-untracked"}, []string{"distinct terminal zero-drift", "above carried", "remediation (default)", "independent"}},
 		{"acquire", []string{"cwd", "change", "token", "expected-revision", "request-id", "work-unit", "evidence-goal", "max-attempts", "max-changed-lines", "remediates-evidence-revision", "untracked-scope", "expected-untracked-inventory", "intended-untracked"}, []string{"default 2", "default 200", "failed evidence correction"}},
 		{"repair", []string{"cwd", "change", "expected-revision", "request-id", "reason", "actor"}, []string{"unreadable sha256", "500 bytes", "128 bytes"}},
 		{"settle", []string{"cwd", "change", "token", "request-id", "outcome", "evidence-revision", "diagnosis", "harness-disposition", "cleanup-evidence", "process-evidence", "remediates-evidence-revision", "remediation-evidence", "untracked-scope", "expected-untracked-inventory", "intended-untracked"}, []string{"opaque token returned by acquire", "required for failed/passed; omit for interrupted"}},

--- a/internal/sddstatus/runtime_admission.go
+++ b/internal/sddstatus/runtime_admission.go
@@ -24,17 +24,24 @@ type runtimeBeginAdmissionResult struct {
 // successor has no attempt of its own yet, so its predecessor's recorded
 // selection is the sole inventory-validated scope that can reproduce it.
 func runtimeRescopeSuccessorIntendedUntracked(status RuntimeStatus) ([]string, bool) {
-	if status.Objective == nil || status.ActiveAttempt != nil || status.LastRescope == nil ||
-		status.LastRescope.ObjectiveID != status.Objective.ID || runtimeObjectiveHasRecordedAttempt(status) ||
-		len(status.Attempts) == 0 {
+	if status.Objective == nil || status.ActiveAttempt != nil || runtimeObjectiveHasRecordedAttempt(status) || len(status.Attempts) == 0 {
 		return nil, false
 	}
-	if status.LastRescope.IntendedUntracked != nil {
-		return slices.Clone(*status.LastRescope.IntendedUntracked), true
+	objectiveID, predecessorID, predecessorGeneration := "", "", 0
+	var intended *[]string
+	if status.LastRescope != nil && status.LastRescope.ObjectiveID == status.Objective.ID {
+		objectiveID, predecessorID, predecessorGeneration, intended = status.LastRescope.ObjectiveID, status.LastRescope.PreviousObjectiveID, status.LastRescope.PreviousGeneration, status.LastRescope.IntendedUntracked
+	} else if status.LastSupersede != nil && status.LastSupersede.ObjectiveID == status.Objective.ID {
+		objectiveID, predecessorID, predecessorGeneration, intended = status.LastSupersede.ObjectiveID, status.LastSupersede.PreviousObjectiveID, status.LastSupersede.PreviousGeneration, status.LastSupersede.IntendedUntracked
+	}
+	if objectiveID != status.Objective.ID {
+		return nil, false
+	}
+	if intended != nil {
+		return slices.Clone(*intended), true
 	}
 	predecessor := status.Attempts[len(status.Attempts)-1]
-	if predecessor.ObjectiveID != status.LastRescope.PreviousObjectiveID ||
-		predecessor.ObjectiveGeneration != status.LastRescope.PreviousGeneration ||
+	if predecessor.ObjectiveID != predecessorID || predecessor.ObjectiveGeneration != predecessorGeneration ||
 		predecessor.Outcome == AttemptRunning {
 		return nil, false
 	}
@@ -100,7 +107,7 @@ func (store RuntimeStore) runtimeBeginAdmission(
 		// Finish is the candidate provenance to chase.
 		generation = status.Objective.Generation
 		if runtimeObjectiveScopeChanged(status, request) {
-			return runtimeBeginAdmissionResult{}, store.runtimeObjectiveChangeRefusal(ctx, status)
+			return runtimeBeginAdmissionResult{}, store.runtimeObjectiveChangeRefusal(ctx, status, request)
 		}
 		last := status.Attempts[len(status.Attempts)-1]
 		if last.Outcome == AttemptRunning || last.FinishCandidateIdentity == "" || last.FinishCandidateTree == "" {
@@ -119,10 +126,10 @@ func (store RuntimeStore) runtimeBeginAdmission(
 			snapshot, err = captureRuntimeTerminalCandidate(ctx, store, last.BeginCandidateTree, intended)
 		}
 		if err == nil && (snapshot.Identity != last.FinishCandidateIdentity || snapshot.CandidateTree != last.FinishCandidateTree) {
-			return runtimeBeginAdmissionResult{}, store.runtimeObjectiveChangeRefusal(ctx, status)
+			return runtimeBeginAdmissionResult{}, store.runtimeObjectiveChangeRefusal(ctx, status, request)
 		}
 		if err == nil && !slices.Equal(request.IntendedUntracked, last.IntendedUntracked) {
-			return runtimeBeginAdmissionResult{}, store.runtimeObjectiveChangeRefusal(ctx, status)
+			return runtimeBeginAdmissionResult{}, store.runtimeObjectiveChangeRefusal(ctx, status, request)
 		}
 	case status.Objective != nil && !advancing:
 		// A freshly opened objective (Rescope) with no attempt recorded
@@ -137,11 +144,11 @@ func (store RuntimeStore) runtimeBeginAdmission(
 		// #2296 part 2's landmine) and wrongly refuse.
 		generation = status.Objective.Generation
 		if runtimeObjectiveScopeChanged(status, request) {
-			return runtimeBeginAdmissionResult{}, store.runtimeObjectiveChangeRefusal(ctx, status)
+			return runtimeBeginAdmissionResult{}, store.runtimeObjectiveChangeRefusal(ctx, status, request)
 		}
 		snapshot, err = captureRuntimeCandidate(ctx, store.Repo, request.IntendedUntracked)
 		if err == nil && (snapshot.Identity != status.Objective.InitialCandidateIdentity || snapshot.CandidateTree != status.Objective.InitialCandidateTree) {
-			return runtimeBeginAdmissionResult{}, store.runtimeObjectiveChangeRefusal(ctx, status)
+			return runtimeBeginAdmissionResult{}, store.runtimeObjectiveChangeRefusal(ctx, status, request)
 		}
 	default:
 		snapshot, err = captureRuntimeCandidate(ctx, store.Repo, request.IntendedUntracked)

--- a/internal/sddstatus/runtime_compact.go
+++ b/internal/sddstatus/runtime_compact.go
@@ -299,7 +299,7 @@ func (store RuntimeStore) Acquire(ctx context.Context, request CompactAcquireReq
 	}
 	// A declared correction must be structurally settleable before it spends an
 	// attempt. The immutable failed-evidence chain owns the binding, while the
-	// existing candidate and audited-reset/rescope predicates decide whether an
+	// existing candidate and audited reset/rescope/supersede predicates decide whether an
 	// unchanged retry is already authorized. Calling Begin's read-only admission
 	// predicate here captures the exact candidate it would record without opening
 	// an attempt or issuing a token.
@@ -316,7 +316,7 @@ func (store RuntimeStore) Acquire(ctx context.Context, request CompactAcquireReq
 			BeginCandidateIdentity: admission.Snapshot.Identity,
 			BeginCandidateTree:     admission.Snapshot.CandidateTree,
 		}
-		if !runtimeEvidenceOnlyRetryAuthorized(replay.Status.LastReset, replay.Status.LastRescope, failed, admission.Snapshot.CandidateTree) &&
+		if !runtimeEvidenceOnlyRetryAuthorized(replay.Status.LastReset, replay.Status.LastRescope, replay.Status.LastSupersede, failed, admission.Snapshot.CandidateTree) &&
 			runtimeRemediationCandidateUnchanged(failed, active, admission.Snapshot.Identity, admission.Snapshot.CandidateTree) {
 			return compactBlocked(CompactBlockRemediationUnsatisfiable, ""), nil
 		}

--- a/internal/sddstatus/runtime_ledger.go
+++ b/internal/sddstatus/runtime_ledger.go
@@ -1940,6 +1940,9 @@ func (store RuntimeStore) rescope(ctx context.Context, request RescopeObjectiveR
 			}
 			return runtimeRecord{}, ErrRuntimeRescopeNotAllowed
 		}
+		if supersede && request.WorkUnit == objective.WorkUnit && request.EvidenceGoal == objective.EvidenceGoal {
+			return runtimeRecord{}, ErrRuntimeSupersedeNotAllowed
+		}
 		last := status.Attempts[len(status.Attempts)-1]
 		// #3842: reconcile the replayed selection once and feed the SAME
 		// reconciled list to this drift capture and the fresh capture below,
@@ -2627,6 +2630,9 @@ func applyRuntimeRescopeEvent(replay *runtimeReplay, revision string, record run
 	objective := replay.Status.Objective
 	if replay.Status.ActiveAttempt != nil || objective == nil || !runtimeObjectiveRescopeStructurallyPermitted(replay.Status) {
 		return rejectRuntimeRecord("objective_rescope_valid_successor")
+	}
+	if supersede && event.WorkUnit == objective.WorkUnit && event.EvidenceGoal == objective.EvidenceGoal {
+		return rejectRuntimeRecord("objective_supersede_same_scope")
 	}
 	// The real narrowing guard runs FIRST and is recomputed against the
 	// REPLAYED objective, never against the record's own (possibly forged)

--- a/internal/sddstatus/runtime_ledger.go
+++ b/internal/sddstatus/runtime_ledger.go
@@ -41,6 +41,7 @@ const (
 	runtimeOperationFinish                   = "attempt/finish"
 	runtimeOperationReset                    = "objective/reset"
 	runtimeOperationRescope                  = "objective/rescope"
+	runtimeOperationSupersede                = "objective/supersede"
 	runtimeOperationRepairConsecutiveRescope = "objective/repair-consecutive-rescope"
 	runtimeOperationAdvance                  = "objective/advance"
 	runtimeOperationHandoff                  = "attempt/handoff"
@@ -106,7 +107,8 @@ var (
 	// (#2298, #2296 part 2's dead end). A decision-required or complete
 	// objective, an active attempt, a non-terminal last attempt, or a
 	// drifted candidate all still route to reset.
-	ErrRuntimeRescopeNotAllowed = errors.New("SDD runtime objective rescope requires no active attempt, an existing objective that is not decision-required or complete, and a terminal attempt whose candidate has NOT drifted; " + runtimeLedgerStatusPointer)
+	ErrRuntimeRescopeNotAllowed   = errors.New("SDD runtime objective rescope requires no active attempt, an existing objective that is not decision-required or complete, and a terminal attempt whose candidate has NOT drifted; " + runtimeLedgerStatusPointer)
+	ErrRuntimeSupersedeNotAllowed = errors.New("SDD runtime objective supersede requires no active attempt, an existing non-complete non-decision objective with its own terminal failed/interrupted attempt and zero candidate drift; " + runtimeLedgerStatusPointer)
 	// ErrRuntimeRescopeWidened is rescope's own sentinel (never a reused
 	// generic one): AUDITED NARROWING RESCOPE admits only max_attempts and
 	// max_changed_lines at or below the current objective's values. The
@@ -124,7 +126,8 @@ var (
 	// rescope could not widen. The successor must stay runnable, which the
 	// predecessor ceiling always still admits (an exhausted predecessor is
 	// decision-required, where rescope is structurally refused).
-	ErrRuntimeRescopeExhausted = errors.New("SDD runtime objective rescope must leave the successor runnable: max_attempts and max_changed_lines must exceed the carried cumulative charges; " + runtimeLedgerStatusPointer)
+	ErrRuntimeRescopeExhausted   = errors.New("SDD runtime objective rescope must leave the successor runnable: max_attempts and max_changed_lines must exceed the carried cumulative charges; " + runtimeLedgerStatusPointer)
+	ErrRuntimeSupersedeExhausted = errors.New("SDD runtime objective supersede must leave the successor runnable: max_attempts and max_changed_lines must exceed the carried cumulative charges; " + runtimeLedgerStatusPointer)
 	// ErrRuntimeWorktreeMismatch never travels alone either. Every return site
 	// wraps it with runtimeWorktreeMismatchRefusal, which names the exact
 	// --cwd that reproduces the binding Begin actually recorded (#2296 part
@@ -392,6 +395,22 @@ type RuntimeRescope struct {
 	// (runtimeRescopeSuccessorIntendedUntracked prefers this field).
 	IntendedUntracked *[]string `json:"intended_untracked,omitempty"`
 }
+type RuntimeSupersede struct {
+	Revision                   string                   `json:"revision"`
+	PreviousObjectiveID        string                   `json:"previous_objective_id"`
+	PreviousGeneration         int                      `json:"previous_generation"`
+	SupersedeCandidateIdentity string                   `json:"supersede_candidate_identity"`
+	SupersedeCandidateTree     string                   `json:"supersede_candidate_tree"`
+	ObjectiveID                string                   `json:"objective_id"`
+	WorkUnit                   string                   `json:"work_unit"`
+	EvidenceGoal               string                   `json:"evidence_goal"`
+	MaxAttempts                int                      `json:"max_attempts"`
+	MaxChangedLines            int                      `json:"max_changed_lines"`
+	Reason                     string                   `json:"reason"`
+	Actor                      string                   `json:"actor"`
+	Relation                   RuntimeObjectiveRelation `json:"relation,omitempty"`
+	IntendedUntracked          *[]string                `json:"intended_untracked,omitempty"`
+}
 
 type RuntimeRepair struct {
 	Revision         string `json:"revision"`
@@ -434,6 +453,7 @@ type RuntimeStatus struct {
 	LastReset              *RuntimeReset     `json:"last_reset,omitempty"`
 	LastAdvance            *RuntimeAdvance   `json:"last_advance,omitempty"`
 	LastRescope            *RuntimeRescope   `json:"last_rescope,omitempty"`
+	LastSupersede          *RuntimeSupersede `json:"last_supersede,omitempty"`
 	LastRepair             *RuntimeRepair    `json:"last_repair,omitempty"`
 	// GrantedRoots is the per-change edit-authority projection (#2540 S2):
 	// canonical absolute symlink-evaluated roots accumulated from grant
@@ -556,6 +576,20 @@ type RepairConsecutiveRescopeRequest struct {
 // defaulted when zero (normalizeRescopeObjectiveRequest requires >=1
 // explicitly): a narrowing operation must state its narrower ceiling, not
 // silently inherit DefaultRuntimeAttemptLimit/DefaultRuntimeChangedLines.
+type SupersedeObjectiveRequest struct {
+	ExpectedRevision           string                   `json:"expected_revision"`
+	RequestID                  string                   `json:"request_id"`
+	WorkUnit                   string                   `json:"work_unit"`
+	EvidenceGoal               string                   `json:"evidence_goal"`
+	MaxAttempts                int                      `json:"max_attempts"`
+	MaxChangedLines            int                      `json:"max_changed_lines"`
+	Reason                     string                   `json:"reason"`
+	Actor                      string                   `json:"actor"`
+	Relation                   RuntimeObjectiveRelation `json:"relation,omitempty"`
+	IntendedUntracked          *[]string                `json:"intended_untracked,omitempty"`
+	ExpectedUntrackedInventory string                   `json:"expected_untracked_inventory,omitempty"`
+}
+
 type RescopeObjectiveRequest struct {
 	ExpectedRevision string `json:"expected_revision"`
 	RequestID        string `json:"request_id"`
@@ -645,20 +679,21 @@ func (store RuntimeStore) ForInstance(instance string) (RuntimeStore, error) {
 }
 
 type runtimeRecord struct {
-	Schema           string               `json:"schema"`
-	Change           string               `json:"change"`
-	PreviousRevision string               `json:"previous_revision"`
-	Operation        string               `json:"operation"`
-	RequestID        string               `json:"request_id"`
-	RequestDigest    string               `json:"request_digest"`
-	Begin            *runtimeBeginEvent   `json:"begin,omitempty"`
-	Finish           *runtimeFinishEvent  `json:"finish,omitempty"`
-	Reset            *runtimeResetEvent   `json:"reset,omitempty"`
-	Rescope          *runtimeRescopeEvent `json:"rescope,omitempty"`
-	Repair           *runtimeRepairEvent  `json:"repair,omitempty"`
-	Advance          *runtimeAdvanceEvent `json:"advance,omitempty"`
-	Handoff          *RuntimeHandoff      `json:"handoff,omitempty"`
-	Grant            *runtimeGrantEvent   `json:"grant,omitempty"`
+	Schema           string                 `json:"schema"`
+	Change           string                 `json:"change"`
+	PreviousRevision string                 `json:"previous_revision"`
+	Operation        string                 `json:"operation"`
+	RequestID        string                 `json:"request_id"`
+	RequestDigest    string                 `json:"request_digest"`
+	Begin            *runtimeBeginEvent     `json:"begin,omitempty"`
+	Finish           *runtimeFinishEvent    `json:"finish,omitempty"`
+	Reset            *runtimeResetEvent     `json:"reset,omitempty"`
+	Rescope          *runtimeRescopeEvent   `json:"rescope,omitempty"`
+	Supersede        *runtimeSupersedeEvent `json:"supersede,omitempty"`
+	Repair           *runtimeRepairEvent    `json:"repair,omitempty"`
+	Advance          *runtimeAdvanceEvent   `json:"advance,omitempty"`
+	Handoff          *RuntimeHandoff        `json:"handoff,omitempty"`
+	Grant            *runtimeGrantEvent     `json:"grant,omitempty"`
 }
 
 // runtimeGrantEvent is the persisted per-change edit-authority grant (#2540
@@ -782,6 +817,37 @@ type runtimeRescopeEvent struct {
 	// predecessor FinishCandidateTree (#4195 R3/R4-002); present only when
 	// IntendedUntracked is (a declared selection legitimately widens it).
 	SuccessorCandidateDigest string `json:"successor_candidate_digest,omitempty"`
+}
+
+type runtimeSupersedeEvent struct {
+	PreviousObjectiveID        string                   `json:"previous_objective_id"`
+	PreviousGeneration         int                      `json:"previous_generation"`
+	PreviousMaxAttempts        int                      `json:"previous_max_attempts"`
+	PreviousMaxChangedLines    int                      `json:"previous_max_changed_lines"`
+	SupersedeCandidateIdentity string                   `json:"supersede_candidate_identity"`
+	SupersedeCandidateTree     string                   `json:"supersede_candidate_tree"`
+	ObjectiveID                string                   `json:"objective_id"`
+	ObjectiveGeneration        int                      `json:"objective_generation"`
+	WorkUnit                   string                   `json:"work_unit"`
+	EvidenceGoal               string                   `json:"evidence_goal"`
+	MaxAttempts                int                      `json:"max_attempts"`
+	MaxChangedLines            int                      `json:"max_changed_lines"`
+	Reason                     string                   `json:"reason"`
+	Actor                      string                   `json:"actor"`
+	Relation                   RuntimeObjectiveRelation `json:"relation,omitempty"`
+	IntendedUntracked          *[]string                `json:"intended_untracked,omitempty"`
+	DeclaredUntrackedInventory string                   `json:"declared_untracked_inventory,omitempty"`
+	SuccessorCandidateDigest   string                   `json:"successor_candidate_digest,omitempty"`
+}
+
+func runtimeRescopeAsSupersede(e *runtimeRescopeEvent) *runtimeSupersedeEvent {
+	return &runtimeSupersedeEvent{PreviousObjectiveID: e.PreviousObjectiveID, PreviousGeneration: e.PreviousGeneration, PreviousMaxAttempts: e.PreviousMaxAttempts, PreviousMaxChangedLines: e.PreviousMaxChangedLines, SupersedeCandidateIdentity: e.RescopeCandidateIdentity, SupersedeCandidateTree: e.RescopeCandidateTree, ObjectiveID: e.ObjectiveID, ObjectiveGeneration: e.ObjectiveGeneration, WorkUnit: e.WorkUnit, EvidenceGoal: e.EvidenceGoal, MaxAttempts: e.MaxAttempts, MaxChangedLines: e.MaxChangedLines, Reason: e.Reason, Actor: e.Actor, Relation: e.Relation, IntendedUntracked: e.IntendedUntracked, DeclaredUntrackedInventory: e.DeclaredUntrackedInventory, SuccessorCandidateDigest: e.SuccessorCandidateDigest}
+}
+func runtimeSupersedeAsRescope(e *runtimeSupersedeEvent) *runtimeRescopeEvent {
+	return &runtimeRescopeEvent{PreviousObjectiveID: e.PreviousObjectiveID, PreviousGeneration: e.PreviousGeneration, PreviousMaxAttempts: e.PreviousMaxAttempts, PreviousMaxChangedLines: e.PreviousMaxChangedLines, RescopeCandidateIdentity: e.SupersedeCandidateIdentity, RescopeCandidateTree: e.SupersedeCandidateTree, ObjectiveID: e.ObjectiveID, ObjectiveGeneration: e.ObjectiveGeneration, WorkUnit: e.WorkUnit, EvidenceGoal: e.EvidenceGoal, MaxAttempts: e.MaxAttempts, MaxChangedLines: e.MaxChangedLines, Reason: e.Reason, Actor: e.Actor, Relation: e.Relation, IntendedUntracked: e.IntendedUntracked, DeclaredUntrackedInventory: e.DeclaredUntrackedInventory, SuccessorCandidateDigest: e.SuccessorCandidateDigest}
+}
+func runtimeRescopeAsSupersedeStatus(r *RuntimeRescope) *RuntimeSupersede {
+	return &RuntimeSupersede{Revision: r.Revision, PreviousObjectiveID: r.PreviousObjectiveID, PreviousGeneration: r.PreviousGeneration, SupersedeCandidateIdentity: r.RescopeCandidateIdentity, SupersedeCandidateTree: r.RescopeCandidateTree, ObjectiveID: r.ObjectiveID, WorkUnit: r.WorkUnit, EvidenceGoal: r.EvidenceGoal, MaxAttempts: r.MaxAttempts, MaxChangedLines: r.MaxChangedLines, Reason: r.Reason, Actor: r.Actor, Relation: r.Relation, IntendedUntracked: r.IntendedUntracked}
 }
 
 type runtimeRepairEvent struct {
@@ -1178,7 +1244,7 @@ func (store RuntimeStore) Finish(ctx context.Context, request FinishAttemptReque
 		// can be environmental) and its evidence is the correction's own new
 		// failure, not proof the named failure was repaired.
 		if evidenceRemediation && request.Outcome == AttemptPassed {
-			evidenceOnly := runtimeEvidenceOnlyRetryAuthorized(status.LastReset, status.LastRescope, chainFailedAttempt, snapshot.CandidateTree)
+			evidenceOnly := runtimeEvidenceOnlyRetryAuthorized(status.LastReset, status.LastRescope, status.LastSupersede, chainFailedAttempt, snapshot.CandidateTree)
 			// #3073: "changed" is judged against the failed evidence's candidate
 			// snapshot, not the attempt's begin snapshot. A correction applied
 			// between the audited reset and the acquire lives inside the begin
@@ -1474,6 +1540,10 @@ func (store RuntimeStore) runtimeRescopeWidenedRefusal(status RuntimeStatus, fla
 // The refusal names the exact runnable range instead, which is never empty:
 // rescope is only structurally reachable while the predecessor still has
 // budget left, so `carried < allowed` always holds here.
+func runtimeSupersedeExhaustedRefusal(flag string, requested, carried int) error {
+	return fmt.Errorf("%w: received %s %d, but supersede preserves cumulative charges, so the successor needs %s greater than carried %d", ErrRuntimeSupersedeExhausted, flag, requested, flag, carried)
+}
+
 func (store RuntimeStore) runtimeRescopeExhaustedRefusal(flag string, requested, carried, allowed int) error {
 	return fmt.Errorf(
 		"%w: received %s %d, and rescope carries the cumulative charges forward unchanged, so this successor would open already exhausted -- its status would advertise begin while every acquire is refused budget-exhausted, and no later rescope could widen it. A runnable successor needs %s greater than the carried %d and at most %d, the current objective's ceiling",
@@ -1597,7 +1667,7 @@ func runtimeMissingWorktreeInterruptedRecord(status RuntimeStatus, active Runtim
 // reset is refused for lack of drift. The plain "begin against the scope"
 // branch survives only as the fail-closed default for a candidate-capture
 // failure, where neither reset nor rescope can be verified admissible.
-func (store RuntimeStore) runtimeObjectiveChangeRefusal(ctx context.Context, status RuntimeStatus) error {
+func (store RuntimeStore) runtimeObjectiveChangeRefusal(ctx context.Context, status RuntimeStatus, requests ...BeginAttemptRequest) error {
 	// The sentinel stays in the %w position in every branch: callers that
 	// route on errors.Is must keep working no matter which exit is named.
 	if store.runtimeObjectiveResetAdmissible(ctx, status) {
@@ -1607,10 +1677,7 @@ func (store RuntimeStore) runtimeObjectiveChangeRefusal(ctx context.Context, sta
 	}
 	if store.runtimeObjectiveRescopeAdmissible(ctx, status) {
 		objective := status.Objective
-		return fmt.Errorf(
-			"%w: this objective's candidate has not drifted, so resetting it is refused as an elective budget reset, but a maintainer may authorize a narrower successor scope instead — `gentle-ai sdd-attempt rescope --cwd %s --change %q --expected-revision %q --request-id \"<unique-request-id>\" --work-unit \"<narrower-work-unit>\" --evidence-goal \"<narrower-evidence-goal>\" --max-attempts \"<n, at most %d>\" --max-changed-lines \"<n, at most %d>\" --reason \"<why-the-objective-is-narrowing>\" --actor \"<actor>\"`; rescope carries cumulative_attempts and cumulative_changed_lines forward unchanged and refuses any max_attempts or max_changed_lines above the current objective's %d and %d",
-			ErrRuntimeObjectiveChange, pathquote.Quote(store.Workspace), store.Change, status.Revision,
-			objective.MaxAttempts, objective.MaxChangedLines, objective.MaxAttempts, objective.MaxChangedLines)
+		return fmt.Errorf("%w: maintainer choice is required: use `gentle-ai sdd-attempt rescope --cwd %s --change %q --expected-revision %q --request-id \"<unique-request-id>\" --work-unit \"<narrower-work-unit>\" --evidence-goal \"<narrower-evidence-goal>\" --max-attempts \"<n, at most %d>\" --max-changed-lines \"<n, at most %d>\" --reason \"<why-the-objective-is-narrowing>\" --actor \"<actor>\"` only for a genuinely narrower successor, or `gentle-ai sdd-attempt supersede --cwd %s --change %q --expected-revision %q --request-id \"<unique-request-id>\" --work-unit \"<distinct-successor-work-unit>\" --evidence-goal \"<distinct-successor-evidence-goal>\" --max-attempts <count> --max-changed-lines <count> --reason \"<why-distinct>\" --actor \"<actor>\"` for distinct/non-narrowing work; both preserve cumulative and lifetime charges", ErrRuntimeObjectiveChange, pathquote.Quote(store.Workspace), store.Change, status.Revision, objective.MaxAttempts, objective.MaxChangedLines, pathquote.Quote(store.Workspace), store.Change, status.Revision)
 	}
 	objective := status.Objective
 	if objective == nil {
@@ -1827,11 +1894,32 @@ func runtimeObjectiveRescopeStructurallyPermitted(status RuntimeStatus) bool {
 // fallback as attempt-count laundering, and an unzeroed carry-forward is the
 // mechanism that keeps rescope from being that same defect under a new name.
 func (store RuntimeStore) Rescope(ctx context.Context, request RescopeObjectiveRequest) (RuntimeStatus, error) {
-	request, err := normalizeRescopeObjectiveRequest(request)
+	return store.rescope(ctx, request, false)
+}
+func (store RuntimeStore) Supersede(ctx context.Context, request SupersedeObjectiveRequest) (RuntimeStatus, error) {
+	r, err := normalizeSupersedeObjectiveRequest(request)
 	if err != nil {
 		return RuntimeStatus{}, err
 	}
-	digest := runtimeValueHash("gentle-ai.sdd-runtime-rescope-request/v1", request)
+	return store.rescope(ctx, r, true)
+}
+func (store RuntimeStore) rescope(ctx context.Context, request RescopeObjectiveRequest, supersede bool) (RuntimeStatus, error) {
+	operation := "rescope"
+	if supersede {
+		operation = "supersede"
+	}
+	if !supersede {
+		var err error
+		request, err = normalizeRescopeObjectiveRequest(request)
+		if err != nil {
+			return RuntimeStatus{}, err
+		}
+	}
+	digestSchema := "gentle-ai.sdd-runtime-rescope-request/v1"
+	if supersede {
+		digestSchema = "gentle-ai.sdd-runtime-supersede-request/v1"
+	}
+	digest := runtimeValueHash(digestSchema, request)
 	return store.mutate(ctx, request.ExpectedRevision, request.RequestID, digest, func(replay runtimeReplay) (runtimeRecord, error) {
 		status := replay.Status
 		if status.ActiveAttempt != nil {
@@ -1847,6 +1935,9 @@ func (store RuntimeStore) Rescope(ctx context.Context, request RescopeObjectiveR
 			return runtimeRecord{}, ErrRuntimeObjectiveDone
 		}
 		if !runtimeObjectiveRescopeStructurallyPermitted(status) {
+			if supersede {
+				return runtimeRecord{}, ErrRuntimeSupersedeNotAllowed
+			}
 			return runtimeRecord{}, ErrRuntimeRescopeNotAllowed
 		}
 		last := status.Attempts[len(status.Attempts)-1]
@@ -1856,23 +1947,23 @@ func (store RuntimeStore) Rescope(ctx context.Context, request RescopeObjectiveR
 		// one selection rather than two.
 		intended, err := runtimeReplayedIntendedUntracked(ctx, store.Repo, last.IntendedUntracked)
 		if err != nil {
-			return runtimeRecord{}, fmt.Errorf("capture SDD runtime candidate to check rescope drift eligibility: %w", err)
+			return runtimeRecord{}, fmt.Errorf("capture SDD runtime candidate to check %s drift eligibility: %w", operation, err)
 		}
 		drift, driftErr := captureRuntimeTerminalCandidate(ctx, store, last.BeginCandidateTree, intended)
 		if driftErr != nil {
-			return runtimeRecord{}, fmt.Errorf("capture SDD runtime candidate to check rescope drift eligibility: %w", driftErr)
+			return runtimeRecord{}, fmt.Errorf("capture SDD runtime candidate to check %s drift eligibility: %w", operation, driftErr)
 		}
 		if drift.Identity != last.FinishCandidateIdentity || drift.CandidateTree != last.FinishCandidateTree {
-			// A drifted candidate is reset's shape, not rescope's -- naming
-			// that distinction is runtimeObjectiveChangeRefusal's job, not a
-			// bare mutation refusal, so Rescope itself stays fail-closed here.
+			if supersede {
+				return runtimeRecord{}, ErrRuntimeSupersedeNotAllowed
+			}
 			return runtimeRecord{}, ErrRuntimeRescopeNotAllowed
 		}
-		if request.MaxChangedLines > objective.MaxChangedLines {
+		if !supersede && request.MaxChangedLines > objective.MaxChangedLines {
 			return runtimeRecord{}, store.runtimeRescopeWidenedRefusal(
 				status, "--max-changed-lines", request.MaxChangedLines, objective.MaxChangedLines)
 		}
-		if request.MaxAttempts > objective.MaxAttempts {
+		if !supersede && request.MaxAttempts > objective.MaxAttempts {
 			return runtimeRecord{}, store.runtimeRescopeWidenedRefusal(
 				status, "--max-attempts", request.MaxAttempts, objective.MaxAttempts,
 			)
@@ -1880,12 +1971,16 @@ func (store RuntimeStore) Rescope(ctx context.Context, request RescopeObjectiveR
 		// #2804: the carried charges bind at admission. A ceiling they
 		// already meet would commit a successor with no runnable ordinal.
 		if request.MaxAttempts <= status.CumulativeAttempts {
-			return runtimeRecord{}, store.runtimeRescopeExhaustedRefusal(
-				"--max-attempts", request.MaxAttempts, status.CumulativeAttempts, objective.MaxAttempts)
+			if supersede {
+				return runtimeRecord{}, runtimeSupersedeExhaustedRefusal("--max-attempts", request.MaxAttempts, status.CumulativeAttempts)
+			}
+			return runtimeRecord{}, store.runtimeRescopeExhaustedRefusal("--max-attempts", request.MaxAttempts, status.CumulativeAttempts, objective.MaxAttempts)
 		}
 		if request.MaxChangedLines <= status.CumulativeChangedLines {
-			return runtimeRecord{}, store.runtimeRescopeExhaustedRefusal(
-				"--max-changed-lines", request.MaxChangedLines, status.CumulativeChangedLines, objective.MaxChangedLines)
+			if supersede {
+				return runtimeRecord{}, runtimeSupersedeExhaustedRefusal("--max-changed-lines", request.MaxChangedLines, status.CumulativeChangedLines)
+			}
+			return runtimeRecord{}, store.runtimeRescopeExhaustedRefusal("--max-changed-lines", request.MaxChangedLines, status.CumulativeChangedLines, objective.MaxChangedLines)
 		}
 		// #4195: a maintainer may declare a fresh successor selection instead
 		// of replaying the predecessor's recorded one. It is validated
@@ -1901,11 +1996,11 @@ func (store RuntimeStore) Rescope(ctx context.Context, request RescopeObjectiveR
 			selection, validateErr := (reviewtransaction.SnapshotBuilder{Repo: store.Repo}).
 				ValidateIntendedUntrackedSelection(ctx, request.ExpectedUntrackedInventory, *request.IntendedUntracked)
 			if validateErr != nil {
-				return runtimeRecord{}, fmt.Errorf("%w: %v; rerun `gentle-ai review status --next-transition` for the current inventory, then rerun `gentle-ai sdd-attempt rescope`", ErrRuntimeUndeclaredUntracked, validateErr)
+				return runtimeRecord{}, fmt.Errorf("%w: %v; rerun `gentle-ai review status --next-transition` for the current inventory, then rerun `gentle-ai sdd-attempt %s`", ErrRuntimeUndeclaredUntracked, validateErr, operation)
 			}
 			for _, path := range intended {
 				if !slices.Contains(selection, path) {
-					return runtimeRecord{}, fmt.Errorf("%w: this objective's terminal candidate already includes %q, and rescope cannot take it back out; rerun `gentle-ai sdd-attempt rescope` with --intended-untracked=%s included", ErrRuntimeUndeclaredUntracked, path, path)
+					return runtimeRecord{}, fmt.Errorf("%w: this objective's terminal candidate already includes %q, and %s cannot take it back out; rerun `gentle-ai sdd-attempt %s` with --intended-untracked=%s included", ErrRuntimeUndeclaredUntracked, path, operation, operation, path)
 				}
 			}
 			successorIntended, declaredInventory = selection, request.ExpectedUntrackedInventory
@@ -1932,15 +2027,18 @@ func (store RuntimeStore) Rescope(ctx context.Context, request RescopeObjectiveR
 		if request.IntendedUntracked != nil {
 			successorDrift, err = captureRuntimeTerminalCandidate(ctx, store, last.BeginCandidateTree, successorIntended)
 			if err != nil {
-				return runtimeRecord{}, fmt.Errorf("capture SDD runtime candidate to check rescope drift eligibility: %w", err)
+				return runtimeRecord{}, fmt.Errorf("capture SDD runtime candidate to check %s drift eligibility: %w", operation, err)
 			}
 		}
 		runtimeRescopeBeforeSecondCaptureHook()
 		fresh, err := captureRuntimeCandidate(ctx, store.Repo, successorIntended)
 		if err != nil {
-			return runtimeRecord{}, fmt.Errorf("capture SDD runtime candidate at objective rescope: %w", err)
+			return runtimeRecord{}, fmt.Errorf("capture SDD runtime candidate at objective %s: %w", operation, err)
 		}
 		if fresh.CandidateTree != successorDrift.CandidateTree {
+			if supersede {
+				return runtimeRecord{}, ErrRuntimeSupersedeNotAllowed
+			}
 			return runtimeRecord{}, ErrRuntimeRescopeNotAllowed
 		}
 		generation := status.ObjectiveGeneration + 1
@@ -1961,7 +2059,11 @@ func (store RuntimeStore) Rescope(ctx context.Context, request RescopeObjectiveR
 			event.SuccessorCandidateDigest = runtimeRescopeSuccessorCandidateDigest(
 				last.FinishCandidateTree, declared, declaredInventory, fresh.Identity, fresh.CandidateTree)
 		}
-		return runtimeRecord{Operation: runtimeOperationRescope, Rescope: event}, nil
+		record := runtimeRecord{Operation: runtimeOperationRescope, Rescope: event}
+		if supersede {
+			record.Operation, record.Rescope, record.Supersede = runtimeOperationSupersede, nil, runtimeRescopeAsSupersede(event)
+		}
+		return record, nil
 	})
 }
 
@@ -2382,9 +2484,16 @@ func applyRuntimeRecordLocked(store RuntimeStore, replay *runtimeReplay, revisio
 		}
 
 	case runtimeOperationRescope:
-		if err := applyRuntimeRescopeEvent(replay, revision, record); err != nil {
+		if err := applyRuntimeRescopeEvent(replay, revision, record, false); err != nil {
 			return err
 		}
+	case runtimeOperationSupersede:
+		copy := record
+		copy.Rescope, copy.Supersede = runtimeSupersedeAsRescope(record.Supersede), nil
+		if err := applyRuntimeRescopeEvent(replay, revision, copy, true); err != nil {
+			return err
+		}
+		replay.Status.LastSupersede, replay.Status.LastRescope = runtimeRescopeAsSupersedeStatus(replay.Status.LastRescope), nil
 	case runtimeOperationRepairConsecutiveRescope:
 		if err := applyRuntimeConsecutiveRescopeRepairEvent(store, replay, revision, record); err != nil {
 			return err
@@ -2513,7 +2622,7 @@ func applyRuntimeHandoffEvent(replay *runtimeReplay, event *RuntimeHandoff) erro
 // REPLAYED objective -- the one authority-verified transitions actually
 // produced -- so `event.MaxAttempts > objective.MaxAttempts` cannot be
 // fooled by a forged event.PreviousMaxAttempts.
-func applyRuntimeRescopeEvent(replay *runtimeReplay, revision string, record runtimeRecord) error {
+func applyRuntimeRescopeEvent(replay *runtimeReplay, revision string, record runtimeRecord, supersede bool) error {
 	event := record.Rescope
 	objective := replay.Status.Objective
 	if replay.Status.ActiveAttempt != nil || objective == nil || !runtimeObjectiveRescopeStructurallyPermitted(replay.Status) {
@@ -2524,7 +2633,7 @@ func applyRuntimeRescopeEvent(replay *runtimeReplay, revision string, record run
 	// PreviousMax* claim: a record cannot launder a widen by simply lying
 	// about what the previous ceiling was, because this comparison never
 	// reads event.PreviousMax* at all.
-	if event.MaxAttempts > objective.MaxAttempts || event.MaxChangedLines > objective.MaxChangedLines {
+	if !supersede && (event.MaxAttempts > objective.MaxAttempts || event.MaxChangedLines > objective.MaxChangedLines) {
 		return rejectRuntimeRecord("objective_rescope_widens_current")
 	}
 	if event.PreviousObjectiveID != objective.ID || event.PreviousGeneration != objective.Generation ||
@@ -2719,7 +2828,7 @@ func applyRuntimeFinishEvent(replay *runtimeReplay, event *runtimeFinishEvent, u
 		// #2621 lockstep twin: an audited reset or rescope that terminated the
 		// failing objective against these exact bytes authorizes one evidence-only
 		// retry, so a replayed correction may leave the candidate unchanged.
-		evidenceOnly := runtimeEvidenceOnlyRetryAuthorized(replay.Status.LastReset, replay.Status.LastRescope, chainFailedAttempt, event.FinishCandidateTree)
+		evidenceOnly := runtimeEvidenceOnlyRetryAuthorized(replay.Status.LastReset, replay.Status.LastRescope, replay.Status.LastSupersede, chainFailedAttempt, event.FinishCandidateTree)
 		// #3073 lockstep twin: replay decides the exact write-guard predicate;
 		// the helper falls back to the begin comparison only for a legacy
 		// failed record that carries no finish snapshot.
@@ -2936,14 +3045,14 @@ func validateRuntimeRecordShape(record runtimeRecord) error {
 	}
 	switch record.Operation {
 	case runtimeOperationBegin:
-		if record.Begin == nil || record.Finish != nil || record.Reset != nil || record.Rescope != nil || record.Advance != nil || record.Handoff != nil || record.Grant != nil {
+		if record.Begin == nil || record.Finish != nil || record.Reset != nil || record.Rescope != nil || record.Supersede != nil || record.Advance != nil || record.Handoff != nil || record.Grant != nil {
 			return rejectRuntimeRecord("invalid_begin_shape")
 		}
 		if err := validateRuntimeBeginEvent(record); err != nil {
 			return err
 		}
 	case runtimeOperationAdvance:
-		if record.Begin == nil || record.Advance == nil || record.Finish != nil || record.Reset != nil || record.Rescope != nil || record.Handoff != nil || record.Grant != nil {
+		if record.Begin == nil || record.Advance == nil || record.Finish != nil || record.Reset != nil || record.Rescope != nil || record.Supersede != nil || record.Handoff != nil || record.Grant != nil {
 			return rejectRuntimeRecord("invalid_objective_advance_shape")
 		}
 		advance := record.Advance
@@ -2957,7 +3066,7 @@ func validateRuntimeRecordShape(record runtimeRecord) error {
 			return err
 		}
 	case runtimeOperationFinish:
-		if record.Finish == nil || record.Begin != nil || record.Reset != nil || record.Rescope != nil || record.Advance != nil || record.Handoff != nil || record.Grant != nil {
+		if record.Finish == nil || record.Begin != nil || record.Reset != nil || record.Rescope != nil || record.Supersede != nil || record.Advance != nil || record.Handoff != nil || record.Grant != nil {
 			return rejectRuntimeRecord("invalid_finish_shape")
 		}
 		event := record.Finish
@@ -2989,7 +3098,7 @@ func validateRuntimeRecordShape(record runtimeRecord) error {
 			return rejectRuntimeRecord("finish_request_digest_match")
 		}
 	case runtimeOperationHandoff:
-		if record.Handoff == nil || record.Begin != nil || record.Finish != nil || record.Reset != nil || record.Rescope != nil || record.Advance != nil || record.Grant != nil {
+		if record.Handoff == nil || record.Begin != nil || record.Finish != nil || record.Reset != nil || record.Rescope != nil || record.Supersede != nil || record.Advance != nil || record.Grant != nil {
 			return rejectRuntimeRecord("invalid_handoff_shape")
 		}
 		event := record.Handoff
@@ -3006,7 +3115,7 @@ func validateRuntimeRecordShape(record runtimeRecord) error {
 			return rejectRuntimeRecord("handoff_request_digest_match")
 		}
 	case runtimeOperationReset:
-		if record.Reset == nil || record.Begin != nil || record.Finish != nil || record.Rescope != nil || record.Advance != nil || record.Handoff != nil || record.Grant != nil {
+		if record.Reset == nil || record.Begin != nil || record.Finish != nil || record.Rescope != nil || record.Supersede != nil || record.Advance != nil || record.Handoff != nil || record.Grant != nil {
 			return rejectRuntimeRecord("invalid_reset_shape")
 		}
 		event := record.Reset
@@ -3023,11 +3132,21 @@ func validateRuntimeRecordShape(record runtimeRecord) error {
 		if runtimeValueHash("gentle-ai.sdd-runtime-reset-request/v1", request) != record.RequestDigest {
 			return rejectRuntimeRecord("reset_request_digest_match")
 		}
-	case runtimeOperationRescope:
-		if record.Rescope == nil || record.Begin != nil || record.Finish != nil || record.Reset != nil || record.Advance != nil || record.Handoff != nil || record.Grant != nil {
-			return rejectRuntimeRecord("invalid_rescope_shape")
+	case runtimeOperationRescope, runtimeOperationSupersede:
+		shape := "rescope"
+		if record.Operation == runtimeOperationSupersede {
+			shape = "supersede"
+		}
+		if record.Operation == runtimeOperationSupersede && (record.Supersede == nil || record.Rescope != nil) {
+			return rejectRuntimeRecord("invalid_supersede_shape")
 		}
 		event := record.Rescope
+		if record.Operation == runtimeOperationSupersede {
+			event = runtimeSupersedeAsRescope(record.Supersede)
+		}
+		if event == nil || record.Begin != nil || record.Finish != nil || record.Reset != nil || record.Advance != nil || record.Handoff != nil || record.Grant != nil || (record.Operation == runtimeOperationRescope) != (record.Rescope != nil) || (record.Operation == runtimeOperationSupersede) != (record.Supersede != nil) {
+			return rejectRuntimeRecord("invalid_" + shape + "_shape")
+		}
 		if !runtimeRevisionPattern.MatchString(event.PreviousObjectiveID) || event.PreviousGeneration < 1 ||
 			event.PreviousMaxAttempts < 1 || event.PreviousMaxAttempts > maximumRuntimeAttemptLimit ||
 			event.PreviousMaxChangedLines < 1 || event.PreviousMaxChangedLines > maximumRuntimeChangedLines ||
@@ -3036,24 +3155,19 @@ func validateRuntimeRecordShape(record runtimeRecord) error {
 			validateRuntimeText(event.WorkUnit, 160) != nil || validateRuntimeText(event.EvidenceGoal, 240) != nil ||
 			event.MaxAttempts < 1 || event.MaxAttempts > maximumRuntimeAttemptLimit ||
 			event.MaxChangedLines < 1 || event.MaxChangedLines > maximumRuntimeChangedLines ||
-			// The shape-level narrowing check below defends against a record
-			// whose OWN fields are internally inconsistent; it is not the
-			// real narrowing guard. applyRuntimeRescopeEvent independently
-			// recomputes narrowing against the REPLAYED objective, which a
-			// forged PreviousMax* cannot fool (see its doc comment).
-			event.MaxAttempts > event.PreviousMaxAttempts || event.MaxChangedLines > event.PreviousMaxChangedLines ||
+			(record.Operation == runtimeOperationRescope && (event.MaxAttempts > event.PreviousMaxAttempts || event.MaxChangedLines > event.PreviousMaxChangedLines)) ||
 			validateRuntimeText(event.Reason, 500) != nil || validateRuntimeText(event.Actor, 128) != nil ||
 			!validRuntimeObjectiveRelation(event.Relation) ||
 			(event.IntendedUntracked == nil) != (event.DeclaredUntrackedInventory == "") ||
 			(event.DeclaredUntrackedInventory != "" && !runtimeRevisionPattern.MatchString(event.DeclaredUntrackedInventory)) ||
 			(event.IntendedUntracked == nil) != (event.SuccessorCandidateDigest == "") ||
 			(event.SuccessorCandidateDigest != "" && !runtimeRevisionPattern.MatchString(event.SuccessorCandidateDigest)) {
-			return rejectRuntimeRecord("invalid_rescope_event")
+			return rejectRuntimeRecord("invalid_" + shape + "_event")
 		}
 		if event.IntendedUntracked != nil {
 			canonical, canonicalErr := canonicalRuntimeIntendedUntracked(*event.IntendedUntracked)
 			if canonicalErr != nil || !slices.Equal(canonical, *event.IntendedUntracked) {
-				return rejectRuntimeRecord("invalid_rescope_intended_untracked_provenance")
+				return rejectRuntimeRecord("invalid_" + shape + "_intended_untracked_provenance")
 			}
 		}
 		request := RescopeObjectiveRequest{
@@ -3070,11 +3184,15 @@ func validateRuntimeRecordShape(record runtimeRecord) error {
 			request.IntendedUntracked = event.IntendedUntracked
 			request.ExpectedUntrackedInventory = event.DeclaredUntrackedInventory
 		}
-		if runtimeValueHash("gentle-ai.sdd-runtime-rescope-request/v1", request) != record.RequestDigest {
-			return rejectRuntimeRecord("rescope_request_digest_match")
+		digestSchema := "gentle-ai.sdd-runtime-rescope-request/v1"
+		if record.Operation == runtimeOperationSupersede {
+			digestSchema = "gentle-ai.sdd-runtime-supersede-request/v1"
+		}
+		if runtimeValueHash(digestSchema, request) != record.RequestDigest {
+			return rejectRuntimeRecord(shape + "_request_digest_match")
 		}
 	case runtimeOperationRepairConsecutiveRescope:
-		if record.Repair == nil || record.Begin != nil || record.Finish != nil || record.Reset != nil || record.Rescope != nil || record.Advance != nil || record.Handoff != nil || record.Grant != nil {
+		if record.Repair == nil || record.Begin != nil || record.Finish != nil || record.Reset != nil || record.Rescope != nil || record.Supersede != nil || record.Advance != nil || record.Handoff != nil || record.Grant != nil {
 			return rejectRuntimeRecord("invalid_consecutive_rescope_repair")
 		}
 		event := record.Repair
@@ -3087,7 +3205,7 @@ func validateRuntimeRecordShape(record runtimeRecord) error {
 			return rejectRuntimeRecord("consecutive_rescope_repair_request")
 		}
 	case runtimeOperationGrant:
-		if record.Grant == nil || record.Begin != nil || record.Finish != nil || record.Reset != nil || record.Rescope != nil || record.Advance != nil || record.Handoff != nil {
+		if record.Grant == nil || record.Begin != nil || record.Finish != nil || record.Reset != nil || record.Rescope != nil || record.Supersede != nil || record.Advance != nil || record.Handoff != nil {
 			return rejectRuntimeRecord("invalid_grant_shape")
 		}
 		event := record.Grant
@@ -3416,6 +3534,15 @@ func normalizeRescopeObjectiveRequest(request RescopeObjectiveRequest) (RescopeO
 	return request, nil
 }
 
+func normalizeSupersedeObjectiveRequest(request SupersedeObjectiveRequest) (RescopeObjectiveRequest, error) {
+	r := RescopeObjectiveRequest{ExpectedRevision: request.ExpectedRevision, RequestID: request.RequestID, WorkUnit: request.WorkUnit, EvidenceGoal: request.EvidenceGoal, MaxAttempts: request.MaxAttempts, MaxChangedLines: request.MaxChangedLines, Reason: request.Reason, Actor: request.Actor, Relation: request.Relation, IntendedUntracked: request.IntendedUntracked, ExpectedUntrackedInventory: request.ExpectedUntrackedInventory}
+	r, err := normalizeRescopeObjectiveRequest(r)
+	if err != nil {
+		return RescopeObjectiveRequest{}, errors.New(strings.ReplaceAll(err.Error(), "rescope", "supersede"))
+	}
+	return r, nil
+}
+
 func validateRuntimeText(value string, maximum int) error {
 	if value == "" || len(value) > maximum || strings.TrimSpace(value) != value || strings.ContainsAny(value, "\r\n\x00") {
 		return errors.New("value must be non-empty, trimmed, single-line, and bounded")
@@ -3710,7 +3837,7 @@ func runtimeFailedAttemptInObjectiveLineage(status RuntimeStatus, failed Runtime
 // be disabled with no binding, the chain must still hold the failed evidence
 // being repaired, and the corrected evidence must be fresh and distinct. No
 // approval is fabricated -- one that a human already gave is honored.
-func runtimeEvidenceOnlyRetryAuthorized(reset *RuntimeReset, rescope *RuntimeRescope, failed RuntimeAttempt, candidateTree string) bool {
+func runtimeEvidenceOnlyRetryAuthorized(reset *RuntimeReset, rescope *RuntimeRescope, supersede *RuntimeSupersede, failed RuntimeAttempt, candidateTree string) bool {
 	if candidateTree == "" {
 		return false
 	}
@@ -3719,9 +3846,10 @@ func runtimeEvidenceOnlyRetryAuthorized(reset *RuntimeReset, rescope *RuntimeRes
 		reset.ResetCandidateTree == candidateTree {
 		return true
 	}
-	return rescope != nil && rescope.Actor != "" && rescope.Reason != "" &&
-		rescope.PreviousObjectiveID == failed.ObjectiveID && rescope.PreviousGeneration == failed.ObjectiveGeneration &&
-		rescope.RescopeCandidateTree == candidateTree
+	if rescope != nil && rescope.Actor != "" && rescope.Reason != "" && rescope.PreviousObjectiveID == failed.ObjectiveID && rescope.PreviousGeneration == failed.ObjectiveGeneration && rescope.RescopeCandidateTree == candidateTree {
+		return true
+	}
+	return supersede != nil && supersede.Actor != "" && supersede.Reason != "" && supersede.PreviousObjectiveID == failed.ObjectiveID && supersede.PreviousGeneration == failed.ObjectiveGeneration && supersede.SupersedeCandidateTree == candidateTree
 }
 
 // runtimeRemediationCandidateUnchanged judges whether a settling unmanaged

--- a/internal/sddstatus/runtime_objective_relation_test.go
+++ b/internal/sddstatus/runtime_objective_relation_test.go
@@ -2,6 +2,7 @@ package sddstatus
 
 import (
 	"context"
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
@@ -171,6 +172,67 @@ func TestResetDefaultRelationStillInheritsTheObligation(t *testing.T) {
 // a fresh store to force a full from-genesis replay). A legacy reset must
 // replay exactly as RuntimeObjectiveRelationRemediation: the successor still
 // inherits the chain's unremediated failure.
+func TestSupersedeClosesDistinctZeroDriftRemediationWithoutFalseNarrowing(t *testing.T) {
+	ctx := context.Background()
+	repo := initRuntimeLedgerRepo(t)
+	store := mustRuntimeStore(t, repo, "supersede-4024")
+	started, err := store.Begin(ctx, BeginAttemptRequest{RequestID: "a-begin", WorkUnit: "verify-a", EvidenceGoal: "verify A", MaxAttempts: 2, MaxChangedLines: 40})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, e := store.Supersede(ctx, SupersedeObjectiveRequest{ExpectedRevision: started.Revision, RequestID: "active", WorkUnit: "b", EvidenceGoal: "b", MaxAttempts: 3, MaxChangedLines: 80, Reason: "x", Actor: "x"}); !errors.Is(e, ErrRuntimeAttemptActive) {
+		t.Fatalf("active supersede = %v", e)
+	}
+	failedEvidence := runtimeTestHash('a')
+	failed, err := store.Finish(ctx, FinishAttemptRequest{ExpectedRevision: started.Revision, RequestID: "a-finish", Outcome: AttemptFailed, EvidenceRevision: failedEvidence, Diagnosis: "A found a distinct remediation", HarnessDisposition: HarnessReused, CleanupEvidence: "unchanged", ProcessEvidence: "none"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.Begin(ctx, BeginAttemptRequest{ExpectedRevision: failed.Revision, RequestID: "changed-acquire", WorkUnit: "remediate-b", EvidenceGoal: "repair distinct B", MaxAttempts: 2, MaxChangedLines: 40}); !errors.Is(err, ErrRuntimeObjectiveChange) || !strings.Contains(err.Error(), "sdd-attempt supersede") || !strings.Contains(err.Error(), "sdd-attempt rescope") {
+		t.Fatalf("changed objective route = %v", err)
+	}
+	request := SupersedeObjectiveRequest{ExpectedRevision: failed.Revision, RequestID: "supersede-a-b", WorkUnit: "remediate-b", EvidenceGoal: "repair distinct B", MaxAttempts: 3, MaxChangedLines: 80, Reason: "maintainer authorized distinct remediation", Actor: "maintainer"}
+	superseded, err := store.Supersede(ctx, request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if superseded.LastSupersede == nil || superseded.Objective.WorkUnit != "remediate-b" || superseded.CumulativeAttempts != 1 || superseded.LifetimeAttempts != 1 {
+		t.Fatalf("supersede = %#v", superseded)
+	}
+	replayed, err := store.Supersede(ctx, request)
+	if err != nil || replayed.Revision != superseded.Revision {
+		t.Fatalf("replay = %#v, %v", replayed, err)
+	}
+	_, err = store.Supersede(ctx, SupersedeObjectiveRequest{ExpectedRevision: failed.Revision, RequestID: "supersede-other", WorkUnit: "x", EvidenceGoal: "x", MaxAttempts: 1, MaxChangedLines: 1, Reason: "x", Actor: "x"})
+	if !errors.Is(err, ErrRuntimeRevisionConflict) {
+		t.Fatalf("CAS = %v", err)
+	}
+	acquired, err := store.Acquire(ctx, CompactAcquireRequest{BeginAttemptRequest: BeginAttemptRequest{RequestID: "b-acquire", WorkUnit: "remediate-b", EvidenceGoal: "repair distinct B", MaxAttempts: 3, MaxChangedLines: 80}})
+	if err != nil || acquired.SettleObligation == "" {
+		t.Fatalf("remediation inheritance = %#v, %v", acquired, err)
+	}
+}
+func TestSupersedeIndependentSuppressesFailedEvidence(t *testing.T) {
+	ctx, repo := context.Background(), initRuntimeLedgerRepo(t)
+	store := mustRuntimeStore(t, repo, "supersede-independent")
+	started, err := store.Begin(ctx, BeginAttemptRequest{RequestID: "a", WorkUnit: "verify", EvidenceGoal: "verify", MaxAttempts: 2, MaxChangedLines: 40})
+	if err != nil {
+		t.Fatal(err)
+	}
+	failed, err := store.Finish(ctx, FinishAttemptRequest{ExpectedRevision: started.Revision, RequestID: "af", Outcome: AttemptFailed, EvidenceRevision: runtimeTestHash('b'), Diagnosis: "distinct prerequisite", HarnessDisposition: HarnessReused, CleanupEvidence: "unchanged", ProcessEvidence: "none"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = store.Supersede(ctx, SupersedeObjectiveRequest{ExpectedRevision: failed.Revision, RequestID: "ab", WorkUnit: "prerequisite", EvidenceGoal: "independent", MaxAttempts: 3, MaxChangedLines: 80, Reason: "independent prerequisite", Actor: "maintainer", Relation: RuntimeObjectiveRelationIndependent})
+	if err != nil {
+		t.Fatal(err)
+	}
+	result, err := store.Acquire(ctx, CompactAcquireRequest{BeginAttemptRequest: BeginAttemptRequest{RequestID: "b", WorkUnit: "prerequisite", EvidenceGoal: "independent", MaxAttempts: 3, MaxChangedLines: 80}})
+	if err != nil || result.SettleObligation != "" || result.SuppressedObligation == nil || result.SuppressedObligation.Reason != "declared_independent" {
+		t.Fatalf("independent successor = %#v, %v", result, err)
+	}
+}
+
 func TestLegacyResetReplaysAsRemediation(t *testing.T) {
 	ctx := context.Background()
 	repo := initRuntimeLedgerRepo(t)

--- a/internal/sddstatus/runtime_objective_relation_test.go
+++ b/internal/sddstatus/runtime_objective_relation_test.go
@@ -172,6 +172,106 @@ func TestResetDefaultRelationStillInheritsTheObligation(t *testing.T) {
 // a fresh store to force a full from-genesis replay). A legacy reset must
 // replay exactly as RuntimeObjectiveRelationRemediation: the successor still
 // inherits the chain's unremediated failure.
+func TestSupersedeRequiresDistinctCausalScope(t *testing.T) {
+	for _, test := range []struct {
+		name, workUnit, evidenceGoal string
+		wantErr                      bool
+	}{
+		{"same scope", "verify-a", "verify A", true},
+		{"work-unit-only", "verify-b", "verify A", false},
+		{"evidence-goal-only", "verify-a", "verify B", false},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			ctx := context.Background()
+			repo := initRuntimeLedgerRepo(t)
+			store := mustRuntimeStore(t, repo, "supersede-scope-"+test.name)
+			started, err := store.Begin(ctx, BeginAttemptRequest{RequestID: "begin", WorkUnit: "verify-a", EvidenceGoal: "verify A", MaxAttempts: 2, MaxChangedLines: 40})
+			if err != nil {
+				t.Fatal(err)
+			}
+			failed, err := store.Finish(ctx, FinishAttemptRequest{ExpectedRevision: started.Revision, RequestID: "finish", Outcome: AttemptFailed, EvidenceRevision: runtimeTestHash('a'), Diagnosis: "failed", HarnessDisposition: HarnessReused, CleanupEvidence: "unchanged", ProcessEvidence: "none"})
+			if err != nil {
+				t.Fatal(err)
+			}
+			status, err := store.Supersede(ctx, SupersedeObjectiveRequest{ExpectedRevision: failed.Revision, RequestID: "supersede", WorkUnit: test.workUnit, EvidenceGoal: test.evidenceGoal, MaxAttempts: 3, MaxChangedLines: 80, Reason: "distinct successor", Actor: "maintainer"})
+			if test.wantErr {
+				if !errors.Is(err, ErrRuntimeSupersedeNotAllowed) {
+					t.Fatalf("same-scope supersede = %v", err)
+				}
+				unchanged, statusErr := store.Status()
+				if statusErr != nil || unchanged.Revision != failed.Revision || countRuntimeRecords(t, store.Dir) != 2 {
+					t.Fatalf("same-scope supersede mutated ledger: status=%#v err=%v", unchanged, statusErr)
+				}
+				return
+			}
+			if err != nil || status.Objective.WorkUnit != test.workUnit || status.Objective.EvidenceGoal != test.evidenceGoal {
+				t.Fatalf("distinct supersede = %#v, %v", status, err)
+			}
+		})
+	}
+}
+
+func TestSupersedeSameScopePreservesCompleteObjectiveRefusal(t *testing.T) {
+	ctx, repo := context.Background(), initRuntimeLedgerRepo(t)
+	store := mustRuntimeStore(t, repo, "supersede-complete-precedence")
+	started, err := store.Begin(ctx, BeginAttemptRequest{RequestID: "begin", WorkUnit: "verify-a", EvidenceGoal: "verify A", MaxAttempts: 1, MaxChangedLines: 40})
+	if err != nil {
+		t.Fatal(err)
+	}
+	complete, err := store.Finish(ctx, FinishAttemptRequest{ExpectedRevision: started.Revision, RequestID: "finish", Outcome: AttemptPassed, EvidenceRevision: runtimeTestHash('c'), Diagnosis: "passed", HarnessDisposition: HarnessReused, CleanupEvidence: "unchanged", ProcessEvidence: "none"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = store.Supersede(ctx, SupersedeObjectiveRequest{ExpectedRevision: complete.Revision, RequestID: "supersede", WorkUnit: "verify-a", EvidenceGoal: "verify A", MaxAttempts: 3, MaxChangedLines: 80, Reason: "same scope", Actor: "maintainer"})
+	if !errors.Is(err, ErrRuntimeObjectiveDone) {
+		t.Fatalf("complete same-scope supersede = %v, want ErrRuntimeObjectiveDone", err)
+	}
+}
+
+func TestSupersedeReplayRejectsSameCausalScope(t *testing.T) {
+	ctx, repo := context.Background(), initRuntimeLedgerRepo(t)
+	store := mustRuntimeStore(t, repo, "supersede-same-scope-replay")
+	started, err := store.Begin(ctx, BeginAttemptRequest{RequestID: "begin", WorkUnit: "verify-a", EvidenceGoal: "verify A", MaxAttempts: 2, MaxChangedLines: 40})
+	if err != nil {
+		t.Fatal(err)
+	}
+	failed, err := store.Finish(ctx, FinishAttemptRequest{ExpectedRevision: started.Revision, RequestID: "finish", Outcome: AttemptFailed, EvidenceRevision: runtimeTestHash('a'), Diagnosis: "failed", HarnessDisposition: HarnessReused, CleanupEvidence: "unchanged", ProcessEvidence: "none"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	objective, last := failed.Objective, failed.Attempts[len(failed.Attempts)-1]
+	fresh, err := captureRuntimeCandidate(ctx, repo, []string{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	request := SupersedeObjectiveRequest{ExpectedRevision: failed.Revision, RequestID: "forged", WorkUnit: objective.WorkUnit, EvidenceGoal: objective.EvidenceGoal, MaxAttempts: 3, MaxChangedLines: 80, Reason: "forged budget bypass", Actor: "attacker"}
+	normalized, err := normalizeSupersedeObjectiveRequest(request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	event := &runtimeSupersedeEvent{PreviousObjectiveID: objective.ID, PreviousGeneration: objective.Generation, PreviousMaxAttempts: objective.MaxAttempts, PreviousMaxChangedLines: objective.MaxChangedLines, SupersedeCandidateIdentity: fresh.Identity, SupersedeCandidateTree: last.FinishCandidateTree, ObjectiveID: runtimeObjectiveID(store.Change, request.WorkUnit, request.EvidenceGoal, fresh.Identity, failed.ObjectiveGeneration+1), ObjectiveGeneration: failed.ObjectiveGeneration + 1, WorkUnit: request.WorkUnit, EvidenceGoal: request.EvidenceGoal, MaxAttempts: request.MaxAttempts, MaxChangedLines: request.MaxChangedLines, Reason: request.Reason, Actor: request.Actor}
+	record := runtimeRecord{Schema: runtimeRecordSchema, Change: store.Change, PreviousRevision: failed.Revision, Operation: runtimeOperationSupersede, RequestID: request.RequestID, RequestDigest: runtimeValueHash("gentle-ai.sdd-runtime-supersede-request/v1", normalized), Supersede: event}
+	if err := validateRuntimeRecordShape(record); err != nil {
+		t.Fatalf("same-scope record failed shape validation: %v", err)
+	}
+	revision, payload, err := runtimeRecordRevision(record)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := store.ensureDirectories(); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.publishRecord(revision, payload); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.publishHead(revision); err != nil {
+		t.Fatal(err)
+	}
+	if _, err = store.Status(); err == nil || !strings.Contains(err.Error(), "objective_supersede_same_scope") {
+		t.Fatalf("replay of forged same-scope supersede = %v", err)
+	}
+}
+
 func TestSupersedeClosesDistinctZeroDriftRemediationWithoutFalseNarrowing(t *testing.T) {
 	ctx := context.Background()
 	repo := initRuntimeLedgerRepo(t)


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #4024

---

## 🏷️ PR Type

- [x] `type:bug` — Bug fix (non-breaking change that fixes an issue)
- [ ] `type:feature` — New feature (non-breaking change that adds functionality)
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring (no functional changes)
- [ ] `type:chore` — Build, CI, or tooling changes
- [ ] `type:breaking-change` — Breaking change (fix or feature that changes existing behavior)

---

## 📝 Summary

Adds an explicit, maintainer-authorized `sdd-attempt supersede` transition for terminal zero-drift objectives when the successor is causally distinct rather than a narrower rescope.

This closes the residual dead end reported after the original #4024 fix: historical failed evidence and consumed budgets remain preserved without forcing the operator to falsely describe distinct remediation work as scope narrowing.

---

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/sddstatus/runtime_ledger.go` | Adds distinct supersede authority, persisted audit records, replay validation, accounting preservation, and relation semantics. |
| `internal/sddstatus/runtime_admission.go` | Gives changed-objective callers a truthful rescope-versus-supersede continuation and preserves successor untracked selection. |
| `internal/cli/sdd_attempt.go` | Exposes the `supersede` operation and its complete help/flag contract. |
| `internal/sddstatus/runtime_objective_relation_test.go` | Covers the residual reproduction, relation behavior, replay, CAS, and negative controls. |
| `internal/cli/sdd_attempt_test.go` | Covers CLI routing and help contracts. |

---

## 🤖 AI Assistance

- [ ] **None** — No material AI assistance was used.
- [x] **Material assistance used** — Complete all applicable declaration fields below.

**Tool/model (if known):** el Gentleman/Pi coding-agent harness with delegated exploration, implementation, and independent verification agents.

**Material scope:** Root-cause analysis, implementation, tests, review corrections, and PR preparation under human direction.

**Verification performed:** Independent diff review, focused and package-level Go tests, formatting checks, baseline comparison, and a real built-CLI lifecycle harness.

---

## 🧪 Test Plan

**Focused and affected packages — pass**
```bash
go test ./internal/sddstatus ./internal/cli -count=1
```

**Go Format — pass**
```bash
go run ./internal/gofmtcheck
```

**Full unit suite — two pre-existing failures**
```bash
go test ./...
```

The suite fails only in `internal/releaseprovenancecmd` because temporary `manifest.json` provenance input is missing. The same two failures reproduce on a clean detached `origin/main` worktree at `539a7313`.

**E2E Tests**
```bash
cd e2e && ./docker-test.sh
```

Passed locally with Docker 29.7.2 and Buildx 0.37.0: all 3/3 Docker targets passed.

**Benchmark / runtime validation**

A real candidate binary was built and run against a temporary Git repository. The black-box lifecycle verified failed zero-drift objective → truthful dual continuation → audited supersede → successor acquire with preserved obligation. It also verified equal/lower budgets, immutable evidence/accounting, distinct `last_supersede` serialization, and active-attempt refusal. All temporary state was removed.

- [ ] Unit tests pass (`go test ./...`)
- [x] Go format passes (`go run ./internal/gofmtcheck`)
- [x] E2E tests pass (`cd e2e && ./docker-test.sh`)
- [x] Manually tested locally

---

## 🤖 Automated Checks

| Check | Status | Description |
|-------|--------|-------------|
| Check PR Cognitive Load | ✅ | 510 changed lines; maintainer-approved `size:exception` covers the required review correction and current-main compatibility fix. |
| Check Issue Reference | ✅ | Links approved issue #4024. |
| Check Issue Has `status:approved` | ✅ | Confirmed before implementation. |
| Check PR Has `type:*` Label | ⏳ | Requires repository label capability after creation. |
| Unit Tests | ⚠️ | Affected packages pass; two baseline release-provenance failures remain. |
| Go Format | ✅ | Passed. |
| E2E Tests | ✅ | Passed locally, 3/3 Docker targets. |

---

## ✅ Contributor Checklist

- [x] PR is linked to an issue with `status:approved`
- [x] Maintainer-applied `size:exception` documents the required review correction integrated into this PR
- [ ] I have added the appropriate `type:*` label to this PR
- [ ] Unit tests pass (`go test ./...`)
- [x] Go format passes (`go run ./internal/gofmtcheck`)
- [x] E2E tests pass (`cd e2e && ./docker-test.sh`)
- [x] Benchmark validation completed, or this change is not applicable to the benchmark (explain why in the Test Plan).
- [x] I have updated documentation if necessary
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] I understand, reviewed, and take responsibility for the complete submission
- [x] I selected exactly one AI-assistance option and, if material assistance was used, completed all applicable declaration fields
- [x] My commits do not include `Co-Authored-By` trailers

---

## 💬 Notes for Reviewers

Please focus on the distinction between audited narrowing (`rescope`) and audited replacement (`supersede`), especially immutable replay shape, failed-evidence inheritance, cumulative-budget preservation, and the dual continuation returned when causal intent cannot be inferred from numeric budgets.

For the production admission guards changed here, the legitimate population is a terminal failed/interrupted objective with zero candidate drift and a distinct successor request. Active, complete, decision-required, drifted, exhausted, stale, or malformed inputs remain refused.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `supersede` operation for replacing eligible terminal objectives with distinct successor objectives.
  * Successors can specify metadata, limits, objective relationships, and optional untracked-file selections.
  * Superseding preserves cumulative charges and supports independent successors that suppress failed evidence.
  * Added CLI help, validation, and routing for supersede-specific options.

* **Bug Fixes**
  * Improved handling of intended untracked-file selections when objectives are superseded.
  * Added safeguards preventing supersedes during active attempts or when objective limits and state make the operation invalid.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Maintainer Correction

The review found a high-severity same-scope budget-laundering path. This PR now also:

- rejects supersede when both `WorkUnit` and `EvidenceGoal` are unchanged;
- independently rejects the same forged shape during replay;
- preserves complete-objective refusal precedence;
- passes `LastSupersede` through compact admission after updating onto current `main`;
- includes regression coverage for same-scope refusal, either-field changes, forged replay, and error precedence.

The final diff is 510 changed lines. The maintainer-approved `size:exception` keeps the correction with the authority transition it secures; splitting it would leave the parent mergeable with a known integrity defect.
