### PR TITLE
fix(review): expose admitted results before authority burn

### DIFF
--- a/bench/journeys_atomic_review.go
+++ b/bench/journeys_atomic_review.go
@@ -110,7 +110,7 @@ func captureAtomicBurnReviewerSlots(r *journeyRun) error {
 	if err != nil {
 		return err
 	}
-	return captureAtomicReviewerSlots(r, lineage, false)
+	return captureAtomicReviewerSlotsWithTerminalVerifier(r, lineage, false, requireAtomicLastCaptureReviewerResults)
 }
 
 func requirePendingApproval(lineage string) func(*Sandbox, Observation) error {
@@ -197,13 +197,13 @@ func requireExplicitAtomicFourLensStatusFor(r *journeyRun, lineage string) error
 func atomicReviewJourneys() []Journey {
 	return []Journey{{
 		ID:     "j111-approved-transaction-burns-and-shipped-gates-are-unmanaged",
-		Title:  "#3797: selectorless STATUS renders a printed START, the last lens emits acknowledgement, and repeat START follows the exact burn",
-		Source: "#3797: selectorless STATUS owns compact binding; terminal approval awaits exact acknowledgement, leaves no receipt or sidecar, and delivery gates remain informational",
+		Title:  "#3797/#4453: selectorless STATUS renders a printed START, and the last lens exposes every canonical reviewer result before acknowledgement",
+		Source: "#3797 compact binding and #4453 terminal readback expose the complete admitted selected-lens results before exact acknowledgement; delivery gates remain informational",
 		Steps: []Step{
 			{Name: "fixture: repository", Fixture: baseRepo},
 			{Name: "fixture: high-risk candidate", Fixture: stageAtomicHighRiskCorrectionCandidate},
 			{Name: "selectorless STATUS renders and executes the initial printed START", Requires: atomicReviewStatusCapability, Composite: startAtomicBurnFromSelectorlessStatus},
-			{Name: "capture every exact four-lens result; the last capture emits acknowledgement before the exact burn", Requires: captureResultCapability, Composite: captureAtomicBurnReviewerSlots},
+			{Name: "capture every exact four-lens result; the last response exposes canonical results before acknowledgement", Requires: captureResultCapability, Composite: captureAtomicBurnReviewerSlots},
 			{Name: "the exact acknowledgement leaves no reusable authority, receipt, or evidence", Requires: statusCapability, Composite: func(r *journeyRun) error {
 				return requireAtomicLineageAcknowledged(r, r.sandbox.Lineage)
 			}},

--- a/bench/journeys_wave3.go
+++ b/bench/journeys_wave3.go
@@ -233,6 +233,12 @@ func requireExplicitAtomicFourLensStatus(r *journeyRun) error {
 }
 
 func captureAtomicReviewerSlots(r *journeyRun, lineageID string, includeCorrectableFinding bool) error {
+	return captureAtomicReviewerSlotsWithTerminalVerifier(r, lineageID, includeCorrectableFinding, nil)
+}
+
+func captureAtomicReviewerSlotsWithTerminalVerifier(r *journeyRun, lineageID string, includeCorrectableFinding bool, verifyTerminal func(Observation, []string) error) error {
+	capturedLenses := make([]string, 0, 4)
+	var terminal Observation
 	for capture := 0; capture < 4; capture++ {
 		status, err := readAtomicReviewStatus(r, lineageID)
 		if err != nil {
@@ -261,6 +267,7 @@ func captureAtomicReviewerSlots(r *journeyRun, lineageID string, includeCorrecta
 		if lineage != lineageID || target == "" || revision == "" || lens == "" || order == "" {
 			return fmt.Errorf("atomic capture %d binding = %+v", capture, input)
 		}
+		capturedLenses = append(capturedLenses, lens)
 
 		payload, err := synthesizeReviewerResult(input.ArtifactSubject.SubjectHash, status.paths())
 		if err != nil {
@@ -292,6 +299,43 @@ func captureAtomicReviewerSlots(r *journeyRun, lineageID string, includeCorrecta
 		}, true)
 		if observation.ExitCode != 0 {
 			return fmt.Errorf("capture atomic reviewer slot %d: %s", capture, firstLine(observation.Stderr))
+		}
+		terminal = observation
+	}
+	if verifyTerminal != nil {
+		return verifyTerminal(terminal, capturedLenses)
+	}
+	return nil
+}
+
+// requireAtomicLastCaptureReviewerResults proves #4453 at the driven boundary:
+// the final capture exposes every canonical admitted lens result before its
+// acknowledgement can burn the approved authority.
+func requireAtomicLastCaptureReviewerResults(observation Observation, lenses []string) error {
+	var closure struct {
+		Schema          string          `json:"schema"`
+		State           string          `json:"state"`
+		Acknowledgement json.RawMessage `json:"acknowledgement"`
+		ReviewerResults []struct {
+			Lens       string            `json:"lens"`
+			Findings   []json.RawMessage `json:"findings"`
+			Evidence   []string          `json:"evidence"`
+			ResultHash string            `json:"result_hash"`
+		} `json:"reviewer_results"`
+	}
+	if err := json.Unmarshal([]byte(observation.Stdout), &closure); err != nil {
+		return fmt.Errorf("decode final reviewer capture closure: %w", err)
+	}
+	expectedLenses := []string{"review-risk", "review-resilience", "review-readability", "review-reliability"}
+	if closure.Schema != "gentle-ai.review-last-event-closure/v1" || closure.State != "approved" || len(closure.Acknowledgement) == 0 ||
+		len(lenses) != len(expectedLenses) || len(closure.ReviewerResults) != len(expectedLenses) {
+		return fmt.Errorf("final reviewer capture closure = %+v, want approved acknowledgement with every canonical selected-lens result", closure)
+	}
+	for order, result := range closure.ReviewerResults {
+		if lenses[order] != expectedLenses[order] || result.Lens != expectedLenses[order] || len(result.Findings) != 0 || len(result.Evidence) != 1 ||
+			result.Evidence[0] != "inspected the complete frozen candidate scope named by the capture binding" ||
+			!strings.HasPrefix(result.ResultHash, "sha256:") || len(result.ResultHash) != len("sha256:")+64 {
+			return fmt.Errorf("final reviewer result %d = %+v, want the canonical selected-lens readback", order, result)
 		}
 	}
 	return nil

--- a/contracts/review-integration/v2/schemas/last-event-closure.schema.json
+++ b/contracts/review-integration/v2/schemas/last-event-closure.schema.json
@@ -29,8 +29,13 @@
     },
     {
       "if": {"properties": {"state": {"const": "approved"}}, "required": ["state"]},
-      "then": {"required": ["acknowledgement"]},
+      "then": {"required": ["acknowledgement", "reviewer_results"]},
       "else": {"not": {"required": ["acknowledgement"]}}
+    },
+    {
+      "if": {"properties": {"state": {"const": "approved"}}, "required": ["state"]},
+      "then": {},
+      "else": {"not": {"required": ["reviewer_results"]}}
     },
     {"if": {"properties": {"state": {"const": "escalated"}}, "required": ["state"]}, "then": {"required": ["escalation"]}, "else": {"not": {"required": ["escalation"]}}}
   ],
@@ -45,6 +50,38 @@
     "action": {"type": "string", "minLength": 1},
     "status_continuation": {"$ref": "transition-execution.schema.json#/$defs/last_event_status_execution"},
     "acknowledgement": {"$ref": "transition-execution.schema.json#/$defs/approved_acknowledgement_execution"},
+    "reviewer_results": {
+      "type": "array",
+      "minItems": 0,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["lens", "findings", "evidence", "result_hash"],
+        "properties": {
+          "lens": {"type": "string", "minLength": 1},
+          "findings": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": ["id", "lens", "location", "severity", "claim", "proof_refs"],
+              "properties": {
+                "id": {"type": "string", "minLength": 1},
+                "lens": {"type": "string", "minLength": 1},
+                "location": {"type": "string", "minLength": 1},
+                "severity": {"type": "string", "enum": ["BLOCKER", "CRITICAL", "WARNING", "SUGGESTION"]},
+                "claim": {"type": "string", "minLength": 1},
+                "proof_refs": {"type": "array", "minItems": 1, "items": {"type": "string", "minLength": 1}},
+                "evidence_class": {"type": "string", "enum": ["deterministic", "inferential", "insufficient"]},
+                "causal_disposition": {"type": "string", "enum": ["introduced", "behavior-activated", "worsened", "pre-existing", "base-only", "unknown"]}
+              }
+            }
+          },
+          "evidence": {"type": "array", "items": {"type": "string", "minLength": 1}},
+          "result_hash": {"type": "string", "pattern": "^sha256:[0-9a-f]{64}$"}
+        }
+      }
+    },
     "store_revision": {"type": "string", "pattern": "^sha256:[0-9a-f]{64}$"},
     "escalation": {
       "type": "object",

--- a/internal/cli/review_last_event_closure.go
+++ b/internal/cli/review_last_event_closure.go
@@ -24,6 +24,7 @@ type reviewLastEventClosureResult struct {
 	TargetedValidatorEvidence *reviewtransaction.CompactTargetedValidatorEvidence `json:"targeted_validator_evidence,omitempty"`
 	Escalation                *reviewtransaction.CompactEscalationEvidence        `json:"escalation,omitempty"`
 	AdvisoryFindings          *reviewtransaction.AdvisoryFindingSet               `json:"advisory_findings,omitempty"`
+	ReviewerResults           *[]reviewtransaction.LensResult                     `json:"reviewer_results,omitempty"`
 	StatusContinuation        *ReviewTransitionExecution                          `json:"status_continuation,omitempty"`
 	Acknowledgement           *ReviewTransitionExecution                          `json:"acknowledgement,omitempty"`
 	StoreRevision             string                                              `json:"store_revision"`
@@ -136,7 +137,13 @@ func closeCorrectionOnCapturedValidator(
 	}
 	switch state.State {
 	case reviewtransaction.StateApproved:
+		view, err := state.CompactReviewView()
+		if err != nil {
+			return nil, fmt.Errorf("derive approved reviewer results for terminal validator closure: %w", err)
+		}
+		reviewerResults := append([]reviewtransaction.LensResult(nil), view.LensResults...)
 		result.Action = reviewApprovedLastEventAcknowledgementAction
+		result.ReviewerResults = &reviewerResults
 		result.Acknowledgement = reviewApprovedAcknowledgementTransition(repo, acknowledgement)
 		telemetryRecordReviewOutcome("approved")
 	case reviewtransaction.StateEscalated:
@@ -280,8 +287,10 @@ func closeReviewOnLastCapturedLens(
 	}
 	switch state.State {
 	case reviewtransaction.StateApproved:
+		reviewerResults := append([]reviewtransaction.LensResult(nil), view.LensResults...)
 		result.Action = reviewApprovedLastEventAcknowledgementAction
 		result.AdvisoryFindings = reviewtransaction.AdvisoryFindingSetFor(state)
+		result.ReviewerResults = &reviewerResults
 		result.Acknowledgement = reviewApprovedAcknowledgementTransition(repo, acknowledgement)
 		telemetryRecordReviewOutcome("approved")
 	case reviewtransaction.StateCorrectionRequired:

--- a/internal/cli/review_last_event_closure_test.go
+++ b/internal/cli/review_last_event_closure_test.go
@@ -220,14 +220,28 @@ func TestLastReviewerCaptureReturnsAdvisoriesBeforeBurn(t *testing.T) {
 
 	var terminal struct {
 		State            reviewtransaction.State               `json:"state"`
+		ReviewerResults  []reviewtransaction.LensResult        `json:"reviewer_results"`
 		AdvisoryFindings *reviewtransaction.AdvisoryFindingSet `json:"advisory_findings"`
 	}
 	if err := json.Unmarshal(terminalOutput.Bytes(), &terminal); err != nil {
 		t.Fatal(err)
 	}
-	if terminal.State != reviewtransaction.StateApproved || terminal.AdvisoryFindings == nil ||
-		len(terminal.AdvisoryFindings.Findings) != 1 || terminal.AdvisoryFindings.Findings[0].ID != "R3-W01" {
-		t.Fatalf("last capture advisories = %#v, want the admitted warning before burn", terminal)
+	if terminal.State != reviewtransaction.StateApproved || len(terminal.ReviewerResults) != len(started.SelectedLenses) {
+		t.Fatalf("last capture reviewer results = %#v, want every admitted selected lens before burn", terminal.ReviewerResults)
+	}
+	for order, result := range terminal.ReviewerResults {
+		if result.Lens != started.SelectedLenses[order] || len(result.Evidence) != 1 ||
+			result.Evidence[0] != "inspected the complete frozen candidate scope named by the capture binding" ||
+			!strings.HasPrefix(result.ResultHash, "sha256:") || len(result.ResultHash) != len("sha256:")+64 {
+			t.Fatalf("last capture reviewer result %d = %#v, want the canonical admitted result", order, result)
+		}
+	}
+	warning := terminal.ReviewerResults[len(terminal.ReviewerResults)-1].Findings
+	if len(warning) != 1 || !reflect.DeepEqual(warning[0], reviewtransaction.Finding{
+		ID: "R3-W01", Lens: "reliability", Location: "internal/auth/session.go:4", Severity: "WARNING",
+		Claim: "the token check could be easier to read", ProofRefs: []string{"the exact changed line was inspected"},
+	}) || terminal.AdvisoryFindings == nil || len(terminal.AdvisoryFindings.Findings) != 1 || terminal.AdvisoryFindings.Findings[0].ID != "R3-W01" {
+		t.Fatalf("last capture reviewer readback = %#v, want the admitted warning narrative and advisory before burn", terminal)
 	}
 	assertApprovedCompactAuthorityBurned(t, store, started.LineageID)
 }
@@ -253,15 +267,16 @@ func TestLastReviewerCaptureOpensBoundedCorrectionForSevereFinding(t *testing.T)
 	}}, &correctionOutput)
 
 	var correction struct {
-		Operation string                  `json:"operation"`
-		State     reviewtransaction.State `json:"state"`
-		Action    string                  `json:"action"`
+		Operation       string                  `json:"operation"`
+		State           reviewtransaction.State `json:"state"`
+		Action          string                  `json:"action"`
+		ReviewerResults json.RawMessage         `json:"reviewer_results"`
 	}
 	if err := json.Unmarshal(correctionOutput.Bytes(), &correction); err != nil {
 		t.Fatal(err)
 	}
 	if correction.Operation != "review/capture-result" || correction.State != reviewtransaction.StateCorrectionRequired ||
-		!strings.Contains(correction.Action, "bounded correction") {
+		len(correction.ReviewerResults) != 0 || !strings.Contains(correction.Action, "bounded correction") {
 		t.Fatalf("last capture correction result = %#v", correction)
 	}
 	record, err := store.Load()
@@ -467,7 +482,8 @@ func TestCompiledTargetedValidatorCaptureClosesOnItsTerminalEvent(t *testing.T) 
 	var terminal reviewLastEventClosureResult
 	decodeStrictReviewJSON(t, output.Bytes(), &terminal)
 	if terminal.Operation != "review/capture-validation" || terminal.State != reviewtransaction.StateApproved ||
-		terminal.Action != reviewApprovedLastEventAcknowledgementAction || terminal.Acknowledgement == nil {
+		terminal.Action != reviewApprovedLastEventAcknowledgementAction || terminal.Acknowledgement == nil ||
+		terminal.ReviewerResults == nil || len(*terminal.ReviewerResults) != 1 {
 		t.Fatalf("compiled validator terminal closure = %#v", terminal)
 	}
 	assertApprovedCompactAuthorityBurned(t, store, lineage)
@@ -857,16 +873,17 @@ func TestTargetedValidatorCaptureEscalatesRejectedCorrectionWithoutFinalize(t *t
 		t.Fatalf("capture rejected targeted validator: %v\n%s", err, terminalOutput.String())
 	}
 	var terminal struct {
-		Operation string                  `json:"operation"`
-		State     reviewtransaction.State `json:"state"`
-		Action    string                  `json:"action"`
-		Evidence  json.RawMessage         `json:"targeted_validator_evidence"`
+		Operation       string                  `json:"operation"`
+		State           reviewtransaction.State `json:"state"`
+		Action          string                  `json:"action"`
+		Evidence        json.RawMessage         `json:"targeted_validator_evidence"`
+		ReviewerResults json.RawMessage         `json:"reviewer_results"`
 	}
 	if err := json.Unmarshal(terminalOutput.Bytes(), &terminal); err != nil {
 		t.Fatal(err)
 	}
 	if terminal.Operation != "review/capture-validation" || terminal.State != reviewtransaction.StateEscalated ||
-		!strings.Contains(terminal.Action, "rejected") || len(terminal.Evidence) == 0 {
+		len(terminal.ReviewerResults) != 0 || !strings.Contains(terminal.Action, "rejected") || len(terminal.Evidence) == 0 {
 		t.Fatalf("rejected validator terminal result = %#v", terminal)
 	}
 	after, err := store.Load()

--- a/internal/cli/review_provider_artifact_contract_test.go
+++ b/internal/cli/review_provider_artifact_contract_test.go
@@ -203,10 +203,10 @@ func TestReviewProviderArtifactConformanceSchemasArePinned(t *testing.T) {
 	root := filepath.Join("..", "..", "contracts", "review-integration", "v2")
 	want := map[string]string{
 		"schemas/gate-result.schema.json": "afe5e2a030fae9949305811bcac0a6dbc8b4f28802fa61d1e31e58e895f9fcae",
-		// issue #4226: last-event-closure documents the CompactEscalationEvidence
-		// contract (cause, finding_ids, refuter_outcomes) for terminal escalation.
+		// issues #4226/#4453: last-event-closure documents terminal escalation
+		// and exposes complete admitted reviewer results before acknowledgement.
 		// Deliberate, not drift.
-		"schemas/last-event-closure.schema.json": "1c720e2bf6e5363fd6138a4da8cd5f65c55bf7bad5ab863838f9d43b8294f8a1",
+		"schemas/last-event-closure.schema.json": "08a94def144d70c0c1e84b73a1a245cd36bc73dc1ade4aa733b42097b05593eb",
 		// issue #3894: start/v4 publishes the reviewing status continuation, so
 		// transition-execution gains the start_status_execution definition it
 		// references. Deliberate, not drift.

--- a/internal/cli/review_published_schema_conformance_test.go
+++ b/internal/cli/review_published_schema_conformance_test.go
@@ -104,6 +104,19 @@ func TestPublishedLastEventClosureSchemaAcceptsApprovedTerminalCapture(t *testin
 	schema := compileWholePublishedReviewSchema(t, "v2", "last-event-closure.schema.json")
 	validatePublishedReviewSchema(t, schema, output.Bytes())
 	closure := decodeJSONObjectCopy(t, output.Bytes())
+	if results, found := closure["reviewer_results"].([]any); !found || len(results) != len(started.SelectedLenses) {
+		t.Fatalf("approved last-event closure reviewer_results = %#v, want every selected lens", closure["reviewer_results"])
+	}
+	closure["reviewer_results"] = []any{}
+	if err := schema.Validate(closure); err != nil {
+		t.Fatalf("published last-event closure schema rejected an approved zero-lens readback: %v", err)
+	}
+	closure = decodeJSONObjectCopy(t, output.Bytes())
+	delete(closure, "reviewer_results")
+	if err := schema.Validate(closure); err == nil {
+		t.Fatal("published last-event closure schema accepted approved output without reviewer_results")
+	}
+	closure = decodeJSONObjectCopy(t, output.Bytes())
 	closure["escalation"] = map[string]any{"cause": "unresolved_severe_findings", "finding_ids": []any{}}
 	if err := schema.Validate(closure); err == nil {
 		t.Fatal("published last-event closure schema accepted escalation on approved state")
@@ -143,9 +156,14 @@ func TestPublishedLastEventClosureSchemaRejectsNonStatusCorrectionContinuation(t
 	if !ok || closure["state"] != string(reviewtransaction.StateCorrectionRequired) {
 		t.Fatalf("real correction closure = %#v", closure)
 	}
+	closure["reviewer_results"] = []any{}
+	schema := compileWholePublishedReviewSchema(t, "v2", "last-event-closure.schema.json")
+	if err := schema.Validate(closure); err == nil {
+		t.Fatal("published last-event closure schema accepted reviewer_results on correction-required state")
+	}
+	delete(closure, "reviewer_results")
 	continuation["operation"] = "review.start"
 
-	schema := compileWholePublishedReviewSchema(t, "v2", "last-event-closure.schema.json")
 	if err := schema.Validate(closure); err == nil {
 		t.Fatalf("published last-event closure schema accepted non-STATUS correction continuation: %#v", closure)
 	}

--- a/internal/cli/review_transition_schema_drift_test.go
+++ b/internal/cli/review_transition_schema_drift_test.go
@@ -91,6 +91,20 @@ func TestV2TransitionSchemasStayLocalSharedAndPackaged(t *testing.T) {
 	if got := reviewSchemaRef(t, closureProperties["acknowledgement"], "last-event acknowledgement"); got != reviewV2AcknowledgementRef {
 		t.Fatalf("last-event acknowledgement ref = %q, want %q", got, reviewV2AcknowledgementRef)
 	}
+	reviewerResults := reviewSchemaObject(t, closureProperties["reviewer_results"], "last-event reviewer results")
+	if reviewerResults["type"] != "array" || reviewerResults["minItems"] != float64(0) {
+		t.Fatalf("last-event reviewer_results = %#v, want an empty-capable canonical array", reviewerResults)
+	}
+	reviewerResultItems := reviewSchemaObject(t, reviewerResults["items"], "last-event reviewer result items")
+	if reviewerResultItems["additionalProperties"] != false || !reflect.DeepEqual(schemaStringArray(t, reviewerResultItems["required"]), []string{"lens", "findings", "evidence", "result_hash"}) {
+		t.Fatalf("last-event reviewer result item = %#v, want the strict canonical shape", reviewerResultItems)
+	}
+	reviewerResultProperties := reviewSchemaObject(t, reviewerResultItems["properties"], "last-event reviewer result properties")
+	findingItems := reviewSchemaObject(t, reviewSchemaObject(t, reviewerResultProperties["findings"], "last-event reviewer findings")["items"], "last-event reviewer finding items")
+	findingProperties := reviewSchemaObject(t, findingItems["properties"], "last-event reviewer finding properties")
+	if dispositions := schemaStringArray(t, reviewSchemaObject(t, findingProperties["causal_disposition"], "last-event causal disposition")["enum"]); !reflect.DeepEqual(dispositions, []string{"introduced", "behavior-activated", "worsened", "pre-existing", "base-only", "unknown"}) {
+		t.Fatalf("last-event causal dispositions = %v, want canonical wire spellings", dispositions)
+	}
 
 	for _, name := range []string{"start.schema.json", "start-v4.schema.json", "status-v5.schema.json"} {
 		defs := reviewSchemaObject(t, documents[name]["$defs"], name+" $defs")


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #4453

---

## 🏷️ PR Type

- [x] `type:bug` — Bug fix (non-breaking change that fixes an issue)
- [ ] `type:feature` — New feature (non-breaking change that adds functionality)
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring (no functional changes)
- [ ] `type:chore` — Build, CI, or tooling changes
- [ ] `type:breaking-change` — Breaking change

---

## 📝 Summary

Expose every complete canonical reviewer result in approved last-event closures before the exact acknowledgement burns review authority. The existing advisory summary, approval transition, burn, and ordinary delivery semantics remain unchanged.

---

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/cli/review_last_event_closure.go` | Adds approved-only `reviewer_results` from already-admitted canonical state. |
| `contracts/review-integration/v2/schemas/last-event-closure.schema.json` | Publishes the strict full-result shape and canonical causal-disposition spellings. |
| `internal/cli/*test.go` | Covers approved readback, non-approved omission, schema conformance, drift, and digest pinning. |
| `bench/journeys_atomic_review.go`, `bench/journeys_wave3.go` | Makes j111 verify all four canonical results before acknowledgement. |

---

## 🤖 AI Assistance

- [ ] **None** — No material AI assistance was used.
- [x] **Material assistance used** — Complete all applicable declaration fields below.

**Tool/model (if known):** Pi coding agent; model managed by the host.

**Material scope:** Root-cause exploration, TDD implementation, schema/tests, driven journey, and verification orchestration.

**Verification performed:** Genuine RED with production/schema restored from HEAD; focused and full uncached Go tests; schema checks; deadcode ratchet; driven j111; Docker E2E on Ubuntu, Arch, and Fedora; native RDD reliability review and targeted correction validation.

---

## 🧪 Test Plan

- [x] `go test ./... -count=1`
- [x] `go run ./internal/gofmtcheck`
- [x] `./scripts/deadcode-ratchet.sh`
- [x] `cd bench && go vet ./... && go test ./... -count=1`
- [x] Built the benchmark harness and product binary, then ran `j111-approved-transaction-burns-and-shipped-gates-are-unmanaged`: **1 completed, 0 unsupported, 0 failed**
- [x] `cd e2e && ./docker-test.sh`: **3/3 platforms passed**
- [x] Manually verified the approved closure includes ordered findings, narratives, evidence, and result hashes before acknowledgement

---

## 🤖 Automated Checks

| Check | Status | Description |
|-------|--------|-------------|
| Check PR Cognitive Load | ⏳ | 183 changed lines; within the 400-line limit |
| Check Issue Reference | ⏳ | Closes #4453 |
| Check Issue Has `status:approved` | ⏳ | Approved before implementation |
| Check PR Has `type:*` Label | ⏳ | `type:bug` requested below |
| Unit Tests | ⏳ | Full uncached suite passed locally |
| Go Format | ⏳ | Passed locally |
| E2E Tests | ⏳ | 3/3 Docker platforms passed locally |

---

## ✅ Contributor Checklist

- [x] PR is linked to an issue with `status:approved`
- [x] PR stays within 400 changedeming lines
- [ ] API read-back confirms exactly one appropriate `type:*` label on this PR
- [x] Unit tests pass
- [x] Go format passes
- [x] E2E tests pass
- [x] Benchmark validation completed in driven mode
- [x] The published schema is the documentation update for this wire contract
- [x] Commit follows Conventional Commits
- [x] I understand, reviewed, and take responsibility for the complete submission
- [x] Exactly one AI-assistance option is selected with material scope and verification
- [x] Commit has no `Co-Authored-By` trailer

---

## 💬 Notes for Reviewers

The fix adds no state, verb, storage, export route, or post-burn authority. It exposes the already-derived canonical `CompactReviewView.LensResults` only on approved terminal closure paths. Correction-required and escalated closures continue to omit the field.

Native RDD review caught and corrected underscore/hyphen drift in the causal-disposition schema before approval.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Approved review closures now include complete results for each reviewer lens before acknowledgement.
  - Reviewer results include findings, evidence, and verification hashes for clearer terminal review outcomes.
  - Terminal closure validation now confirms reviewer lenses, ordering, findings, evidence, and result integrity.

- **Bug Fixes**
  - Corrected and escalated closures no longer include approved-only reviewer results.
  - Updated atomic review flows to expose the final reviewer results before the burn is acknowledged.

- **Tests**
  - Expanded coverage for approved, correction-required, and escalated closure scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->