### PR TITLE
feat(telemetry): attribute runtime usage to named subagents across pi, opencode, claude-code and codex

### DIFF
--- a/contracts/telemetry/runtime/v1/schemas/aggregate.schema.json
+++ b/contracts/telemetry/runtime/v1/schemas/aggregate.schema.json
@@ -49,7 +49,7 @@
       "properties": {
         "reasoning_tokens": {"$ref": "#/$defs/token"},
         "total_tokens": {"$ref": "#/$defs/token"},
-        "agent_class": {"enum": ["orchestrator", "worker", "explore", "verify", "unknown", "sdd-init", "sdd-explore", "sdd-research", "sdd-propose", "sdd-spec", "sdd-design", "sdd-tasks", "sdd-apply", "sdd-verify", "sdd-archive", "sdd-onboard", "jd-judge-a", "jd-judge-b", "jd-fix-agent", "review-risk", "review-readability", "review-reliability", "review-resilience", "review-refuter", "review-validator"]},
+        "agent_class": {"enum": ["orchestrator", "worker", "explore", "verify", "unknown", "sdd-init", "sdd-explore", "sdd-research", "sdd-propose", "sdd-spec", "sdd-design", "sdd-tasks", "sdd-apply", "sdd-verify", "sdd-archive", "sdd-onboard", "sdd-status", "sdd-sync", "jd-judge-a", "jd-judge-b", "jd-fix-agent", "review-risk", "review-readability", "review-reliability", "review-resilience", "review-refuter", "review-validator"]},
         "error_category": {"enum": ["none", "unknown", "auth", "output_length", "aborted", "api", "rate_limit", "server"]},
         "duration": {"$ref": "#/$defs/duration"},
         "model": {"$ref": "#/$defs/model"},

--- a/contracts/telemetry/runtime/v1/schemas/aggregate.schema.json
+++ b/contracts/telemetry/runtime/v1/schemas/aggregate.schema.json
@@ -49,7 +49,7 @@
       "properties": {
         "reasoning_tokens": {"$ref": "#/$defs/token"},
         "total_tokens": {"$ref": "#/$defs/token"},
-        "agent_class": {"enum": ["orchestrator", "worker", "explore", "verify", "unknown", "sdd-apply", "sdd-archive", "sdd-design", "sdd-explore", "sdd-init", "sdd-onboard", "sdd-proposal", "sdd-research", "sdd-spec", "sdd-status", "sdd-sync", "sdd-tasks", "sdd-verify", "review-readability", "review-reliability", "review-resilience", "review-risk", "jd-fix-agent", "jd-judge-a", "jd-judge-b"]},
+        "agent_class": {"enum": ["orchestrator", "worker", "explore", "verify", "unknown", "sdd-init", "sdd-explore", "sdd-research", "sdd-propose", "sdd-spec", "sdd-design", "sdd-tasks", "sdd-apply", "sdd-verify", "sdd-archive", "sdd-onboard", "jd-judge-a", "jd-judge-b", "jd-fix-agent", "review-risk", "review-readability", "review-reliability", "review-resilience", "review-refuter", "review-validator"]},
         "error_category": {"enum": ["none", "unknown", "auth", "output_length", "aborted", "api", "rate_limit", "server"]},
         "duration": {"$ref": "#/$defs/duration"},
         "model": {"$ref": "#/$defs/model"},

--- a/deploy/telemetry/grafana/dashboards/gentle-ai-usage.json
+++ b/deploy/telemetry/grafana/dashboards/gentle-ai-usage.json
@@ -16,8 +16,8 @@
   "refresh": "1m",
   "panels": [
     {
-      "id": 100,
-      "title": "Adoption",
+      "id": 550,
+      "title": "Active users",
       "type": "row",
       "collapsed": false,
       "panels": [],
@@ -29,13 +29,222 @@
       }
     },
     {
+      "id": 551,
+      "title": "Active users, last 24h",
+      "description": "Installs that opened a Gentle AI session in the last 24 hours; each install reports at most once per day, so shorter windows undercount.",
+      "type": "stat",
+      "gridPos": {
+        "x": 0,
+        "y": 1,
+        "w": 6,
+        "h": 4
+      },
+      "datasource": {
+        "type": "frser-sqlite-datasource",
+        "uid": "gentle-telemetry-sqlite"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "queryType": "table",
+          "queryText": "SELECT COUNT(DISTINCT install_id) AS \"Active users\" FROM events WHERE received_at >= (CAST(strftime('%s', 'now') AS INTEGER) - 86400) * 1000000000 AND received_at <= CAST(strftime('%s', 'now') AS INTEGER) * 1000000000 HAVING COUNT(*) > 0",
+          "rawQueryText": "SELECT COUNT(DISTINCT install_id) AS \"Active users\" FROM events WHERE received_at >= (CAST(strftime('%s', 'now') AS INTEGER) - 86400) * 1000000000 AND received_at <= CAST(strftime('%s', 'now') AS INTEGER) * 1000000000 HAVING COUNT(*) > 0"
+        }
+      ],
+      "options": {
+        "orientation": "horizontal",
+        "textMode": "value",
+        "colorMode": "value",
+        "graphMode": "none",
+        "reduceOptions": {
+          "values": false,
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": ""
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "locale",
+          "min": 0,
+          "decimals": 0,
+          "color": {
+            "mode": "fixed",
+            "fixedColor": "#73BF69"
+          }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "id": 552,
+      "title": "Active users, last 6h",
+      "description": "Distinct installs seen in the last six hours provide a directional view of recent tool use.",
+      "type": "stat",
+      "gridPos": {
+        "x": 6,
+        "y": 1,
+        "w": 6,
+        "h": 4
+      },
+      "datasource": {
+        "type": "frser-sqlite-datasource",
+        "uid": "gentle-telemetry-sqlite"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "queryType": "table",
+          "queryText": "SELECT COUNT(DISTINCT install_id) AS \"Active users\" FROM events WHERE received_at >= (CAST(strftime('%s', 'now') AS INTEGER) - 21600) * 1000000000 AND received_at <= CAST(strftime('%s', 'now') AS INTEGER) * 1000000000 HAVING COUNT(*) > 0",
+          "rawQueryText": "SELECT COUNT(DISTINCT install_id) AS \"Active users\" FROM events WHERE received_at >= (CAST(strftime('%s', 'now') AS INTEGER) - 21600) * 1000000000 AND received_at <= CAST(strftime('%s', 'now') AS INTEGER) * 1000000000 HAVING COUNT(*) > 0"
+        }
+      ],
+      "options": {
+        "orientation": "horizontal",
+        "textMode": "value",
+        "colorMode": "value",
+        "graphMode": "none",
+        "reduceOptions": {
+          "values": false,
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": ""
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "locale",
+          "min": 0,
+          "decimals": 0,
+          "color": {
+            "mode": "fixed",
+            "fixedColor": "#73BF69"
+          }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "id": 553,
+      "title": "Active users, last 1h",
+      "description": "Distinct installs seen in the last hour provide a directional view of immediate tool use.",
+      "type": "stat",
+      "gridPos": {
+        "x": 12,
+        "y": 1,
+        "w": 6,
+        "h": 4
+      },
+      "datasource": {
+        "type": "frser-sqlite-datasource",
+        "uid": "gentle-telemetry-sqlite"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "queryType": "table",
+          "queryText": "SELECT COUNT(DISTINCT install_id) AS \"Active users\" FROM events WHERE received_at >= (CAST(strftime('%s', 'now') AS INTEGER) - 3600) * 1000000000 AND received_at <= CAST(strftime('%s', 'now') AS INTEGER) * 1000000000 HAVING COUNT(*) > 0",
+          "rawQueryText": "SELECT COUNT(DISTINCT install_id) AS \"Active users\" FROM events WHERE received_at >= (CAST(strftime('%s', 'now') AS INTEGER) - 3600) * 1000000000 AND received_at <= CAST(strftime('%s', 'now') AS INTEGER) * 1000000000 HAVING COUNT(*) > 0"
+        }
+      ],
+      "options": {
+        "orientation": "horizontal",
+        "textMode": "value",
+        "colorMode": "value",
+        "graphMode": "none",
+        "reduceOptions": {
+          "values": false,
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": ""
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "locale",
+          "min": 0,
+          "decimals": 0,
+          "color": {
+            "mode": "fixed",
+            "fixedColor": "#73BF69"
+          }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "id": 554,
+      "title": "Active users, last 15 min",
+      "description": "Distinct installs seen in the last 15 minutes provide a directional view of live tool use.",
+      "type": "stat",
+      "gridPos": {
+        "x": 18,
+        "y": 1,
+        "w": 6,
+        "h": 4
+      },
+      "datasource": {
+        "type": "frser-sqlite-datasource",
+        "uid": "gentle-telemetry-sqlite"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "queryType": "table",
+          "queryText": "SELECT COUNT(DISTINCT install_id) AS \"Active users\" FROM events WHERE received_at >= (CAST(strftime('%s', 'now') AS INTEGER) - 900) * 1000000000 AND received_at <= CAST(strftime('%s', 'now') AS INTEGER) * 1000000000 HAVING COUNT(*) > 0",
+          "rawQueryText": "SELECT COUNT(DISTINCT install_id) AS \"Active users\" FROM events WHERE received_at >= (CAST(strftime('%s', 'now') AS INTEGER) - 900) * 1000000000 AND received_at <= CAST(strftime('%s', 'now') AS INTEGER) * 1000000000 HAVING COUNT(*) > 0"
+        }
+      ],
+      "options": {
+        "orientation": "horizontal",
+        "textMode": "value",
+        "colorMode": "value",
+        "graphMode": "none",
+        "reduceOptions": {
+          "values": false,
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": ""
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "locale",
+          "min": 0,
+          "decimals": 0,
+          "color": {
+            "mode": "fixed",
+            "fixedColor": "#73BF69"
+          }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "id": 100,
+      "title": "Adoption",
+      "type": "row",
+      "collapsed": false,
+      "panels": [],
+      "gridPos": {
+        "x": 0,
+        "y": 5,
+        "w": 24,
+        "h": 1
+      }
+    },
+    {
       "id": 101,
       "title": "Unique installs all-time",
       "description": "All installations ever observed, counted once regardless of the selected time range.",
       "type": "stat",
       "gridPos": {
         "x": 0,
-        "y": 1,
+        "y": 6,
         "w": 6,
         "h": 4
       },
@@ -84,7 +293,7 @@
       "type": "stat",
       "gridPos": {
         "x": 6,
-        "y": 1,
+        "y": 6,
         "w": 6,
         "h": 4
       },
@@ -133,7 +342,7 @@
       "type": "stat",
       "gridPos": {
         "x": 12,
-        "y": 1,
+        "y": 6,
         "w": 6,
         "h": 4
       },
@@ -182,7 +391,7 @@
       "type": "stat",
       "gridPos": {
         "x": 18,
-        "y": 1,
+        "y": 6,
         "w": 6,
         "h": 4
       },
@@ -231,7 +440,7 @@
       "type": "stat",
       "gridPos": {
         "x": 0,
-        "y": 5,
+        "y": 10,
         "w": 6,
         "h": 4
       },
@@ -280,7 +489,7 @@
       "type": "stat",
       "gridPos": {
         "x": 6,
-        "y": 5,
+        "y": 10,
         "w": 6,
         "h": 4
       },
@@ -329,7 +538,7 @@
       "type": "stat",
       "gridPos": {
         "x": 12,
-        "y": 5,
+        "y": 10,
         "w": 6,
         "h": 4
       },
@@ -378,7 +587,7 @@
       "type": "stat",
       "gridPos": {
         "x": 18,
-        "y": 5,
+        "y": 10,
         "w": 6,
         "h": 4
       },
@@ -428,7 +637,7 @@
       "panels": [],
       "gridPos": {
         "x": 0,
-        "y": 9,
+        "y": 14,
         "w": 24,
         "h": 1
       }
@@ -440,7 +649,7 @@
       "type": "timeseries",
       "gridPos": {
         "x": 0,
-        "y": 10,
+        "y": 15,
         "w": 8,
         "h": 8
       },
@@ -486,7 +695,7 @@
       "type": "timeseries",
       "gridPos": {
         "x": 8,
-        "y": 10,
+        "y": 15,
         "w": 8,
         "h": 8
       },
@@ -532,7 +741,7 @@
       "type": "timeseries",
       "gridPos": {
         "x": 16,
-        "y": 10,
+        "y": 15,
         "w": 8,
         "h": 8
       },
@@ -579,7 +788,7 @@
       "panels": [],
       "gridPos": {
         "x": 0,
-        "y": 18,
+        "y": 23,
         "w": 24,
         "h": 1
       }
@@ -591,7 +800,7 @@
       "type": "barchart",
       "gridPos": {
         "x": 0,
-        "y": 19,
+        "y": 24,
         "w": 6,
         "h": 8
       },
@@ -635,7 +844,7 @@
       "type": "barchart",
       "gridPos": {
         "x": 6,
-        "y": 19,
+        "y": 24,
         "w": 6,
         "h": 8
       },
@@ -679,7 +888,7 @@
       "type": "barchart",
       "gridPos": {
         "x": 12,
-        "y": 19,
+        "y": 24,
         "w": 6,
         "h": 8
       },
@@ -723,7 +932,7 @@
       "type": "barchart",
       "gridPos": {
         "x": 18,
-        "y": 19,
+        "y": 24,
         "w": 6,
         "h": 8
       },
@@ -768,9 +977,397 @@
       "panels": [],
       "gridPos": {
         "x": 0,
-        "y": 27,
+        "y": 32,
         "w": 24,
         "h": 1
+      }
+    },
+    {
+      "id": 600,
+      "title": "Live activity",
+      "type": "row",
+      "collapsed": false,
+      "panels": [],
+      "gridPos": {
+        "x": 0,
+        "y": 33,
+        "w": 24,
+        "h": 1
+      }
+    },
+    {
+      "id": 601,
+      "title": "Deliveries, last 15 min",
+      "description": "This anonymous activity counts agent responses, not people, and shows telemetry deliveries received in the last 15 minutes.",
+      "type": "stat",
+      "gridPos": {
+        "x": 0,
+        "y": 34,
+        "w": 6,
+        "h": 4
+      },
+      "datasource": {
+        "type": "frser-sqlite-datasource",
+        "uid": "gentle-telemetry-sqlite"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "queryType": "table",
+          "queryText": "SELECT COUNT(DISTINCT d.delivery_id) AS Deliveries FROM runtime_deliveries d WHERE d.received_at >= (CAST(strftime('%s', 'now') AS INTEGER) - 900) * 1000000000 AND d.received_at <= CAST(strftime('%s', 'now') AS INTEGER) * 1000000000 HAVING COUNT(*) > 0",
+          "rawQueryText": "SELECT COUNT(DISTINCT d.delivery_id) AS Deliveries FROM runtime_deliveries d WHERE d.received_at >= (CAST(strftime('%s', 'now') AS INTEGER) - 900) * 1000000000 AND d.received_at <= CAST(strftime('%s', 'now') AS INTEGER) * 1000000000 HAVING COUNT(*) > 0"
+        }
+      ],
+      "options": {
+        "orientation": "horizontal",
+        "textMode": "value",
+        "colorMode": "value",
+        "graphMode": "none",
+        "reduceOptions": {
+          "values": false,
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": ""
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "locale",
+          "min": 0,
+          "decimals": 0,
+          "color": {
+            "mode": "fixed",
+            "fixedColor": "#73BF69"
+          }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "id": 602,
+      "title": "Responses, last 15 min",
+      "description": "This anonymous activity counts agent responses, not people, received in the last 15 minutes.",
+      "type": "stat",
+      "gridPos": {
+        "x": 6,
+        "y": 34,
+        "w": 6,
+        "h": 4
+      },
+      "datasource": {
+        "type": "frser-sqlite-datasource",
+        "uid": "gentle-telemetry-sqlite"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "queryType": "table",
+          "queryText": "SELECT SUM(CASE WHEN json_type(r.row_json, '$.responses') = 'integer' THEN json_extract(r.row_json, '$.responses') ELSE 0 END) AS Responses FROM runtime_rows r JOIN runtime_deliveries d ON d.delivery_id = r.delivery_id WHERE d.received_at >= (CAST(strftime('%s', 'now') AS INTEGER) - 900) * 1000000000 AND d.received_at <= CAST(strftime('%s', 'now') AS INTEGER) * 1000000000 HAVING COUNT(*) > 0",
+          "rawQueryText": "SELECT SUM(CASE WHEN json_type(r.row_json, '$.responses') = 'integer' THEN json_extract(r.row_json, '$.responses') ELSE 0 END) AS Responses FROM runtime_rows r JOIN runtime_deliveries d ON d.delivery_id = r.delivery_id WHERE d.received_at >= (CAST(strftime('%s', 'now') AS INTEGER) - 900) * 1000000000 AND d.received_at <= CAST(strftime('%s', 'now') AS INTEGER) * 1000000000 HAVING COUNT(*) > 0"
+        }
+      ],
+      "options": {
+        "orientation": "horizontal",
+        "textMode": "value",
+        "colorMode": "value",
+        "graphMode": "none",
+        "reduceOptions": {
+          "values": false,
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": ""
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "locale",
+          "min": 0,
+          "decimals": 0,
+          "color": {
+            "mode": "fixed",
+            "fixedColor": "#73BF69"
+          }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "id": 603,
+      "title": "Tokens processed, last 15 min",
+      "description": "This anonymous activity counts agent responses, not people, and totals their derived token volume over the last 15 minutes.",
+      "type": "stat",
+      "gridPos": {
+        "x": 12,
+        "y": 34,
+        "w": 6,
+        "h": 4
+      },
+      "datasource": {
+        "type": "frser-sqlite-datasource",
+        "uid": "gentle-telemetry-sqlite"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "queryType": "table",
+          "queryText": "SELECT SUM((CASE WHEN json_extract(r.row_json, '$.input_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.input_tokens.sum'), 0) ELSE 0 END + CASE WHEN json_extract(r.row_json, '$.output_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.output_tokens.sum'), 0) ELSE 0 END + CASE WHEN json_extract(r.row_json, '$.cache_read_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.cache_read_tokens.sum'), 0) ELSE 0 END + CASE WHEN json_extract(r.row_json, '$.cache_creation_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.cache_creation_tokens.sum'), 0) ELSE 0 END + CASE WHEN json_extract(r.row_json, '$.reasoning_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.reasoning_tokens.sum'), 0) ELSE 0 END)) AS \"Tokens processed\" FROM runtime_rows r JOIN runtime_deliveries d ON d.delivery_id = r.delivery_id WHERE d.received_at >= (CAST(strftime('%s', 'now') AS INTEGER) - 900) * 1000000000 AND d.received_at <= CAST(strftime('%s', 'now') AS INTEGER) * 1000000000 HAVING COUNT(*) > 0",
+          "rawQueryText": "SELECT SUM((CASE WHEN json_extract(r.row_json, '$.input_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.input_tokens.sum'), 0) ELSE 0 END + CASE WHEN json_extract(r.row_json, '$.output_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.output_tokens.sum'), 0) ELSE 0 END + CASE WHEN json_extract(r.row_json, '$.cache_read_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.cache_read_tokens.sum'), 0) ELSE 0 END + CASE WHEN json_extract(r.row_json, '$.cache_creation_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.cache_creation_tokens.sum'), 0) ELSE 0 END + CASE WHEN json_extract(r.row_json, '$.reasoning_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.reasoning_tokens.sum'), 0) ELSE 0 END)) AS \"Tokens processed\" FROM runtime_rows r JOIN runtime_deliveries d ON d.delivery_id = r.delivery_id WHERE d.received_at >= (CAST(strftime('%s', 'now') AS INTEGER) - 900) * 1000000000 AND d.received_at <= CAST(strftime('%s', 'now') AS INTEGER) * 1000000000 HAVING COUNT(*) > 0"
+        }
+      ],
+      "options": {
+        "orientation": "horizontal",
+        "textMode": "value",
+        "colorMode": "value",
+        "graphMode": "none",
+        "reduceOptions": {
+          "values": false,
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": ""
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "locale",
+          "min": 0,
+          "decimals": 0,
+          "color": {
+            "mode": "fixed",
+            "fixedColor": "#73BF69"
+          }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "id": 604,
+      "title": "Hosts active, last 15 min",
+      "description": "This anonymous activity counts agent responses, not people, and shows distinct reporting host types over the last 15 minutes.",
+      "type": "stat",
+      "gridPos": {
+        "x": 18,
+        "y": 34,
+        "w": 6,
+        "h": 4
+      },
+      "datasource": {
+        "type": "frser-sqlite-datasource",
+        "uid": "gentle-telemetry-sqlite"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "queryType": "table",
+          "queryText": "SELECT COUNT(DISTINCT COALESCE(NULLIF(json_extract(d.canonical_payload, '$.host'), ''), 'unknown')) AS \"Hosts active\" FROM runtime_deliveries d WHERE d.received_at >= (CAST(strftime('%s', 'now') AS INTEGER) - 900) * 1000000000 AND d.received_at <= CAST(strftime('%s', 'now') AS INTEGER) * 1000000000 HAVING COUNT(*) > 0",
+          "rawQueryText": "SELECT COUNT(DISTINCT COALESCE(NULLIF(json_extract(d.canonical_payload, '$.host'), ''), 'unknown')) AS \"Hosts active\" FROM runtime_deliveries d WHERE d.received_at >= (CAST(strftime('%s', 'now') AS INTEGER) - 900) * 1000000000 AND d.received_at <= CAST(strftime('%s', 'now') AS INTEGER) * 1000000000 HAVING COUNT(*) > 0"
+        }
+      ],
+      "options": {
+        "orientation": "horizontal",
+        "textMode": "value",
+        "colorMode": "value",
+        "graphMode": "none",
+        "reduceOptions": {
+          "values": false,
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": ""
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "locale",
+          "min": 0,
+          "decimals": 0,
+          "color": {
+            "mode": "fixed",
+            "fixedColor": "#73BF69"
+          }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "id": 605,
+      "title": "Responses per minute by host (last 3h)",
+      "description": "This anonymous activity counts agent responses, not people, and shows their per-minute host distribution over the last three hours.",
+      "type": "timeseries",
+      "timeFrom": "3h",
+      "gridPos": {
+        "x": 0,
+        "y": 38,
+        "w": 12,
+        "h": 8
+      },
+      "datasource": {
+        "type": "frser-sqlite-datasource",
+        "uid": "gentle-telemetry-sqlite"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "queryType": "table",
+          "queryText": "SELECT CAST(strftime('%s', strftime('%Y-%m-%d %H:%M:00', d.received_at / 1000000000, 'unixepoch')) AS INTEGER) AS time, SUM(CASE WHEN COALESCE(NULLIF(json_extract(d.canonical_payload, '$.host'), ''), 'unknown') = 'pi' THEN CASE WHEN json_type(r.row_json, '$.responses') = 'integer' THEN json_extract(r.row_json, '$.responses') ELSE 0 END ELSE 0 END) AS pi, SUM(CASE WHEN COALESCE(NULLIF(json_extract(d.canonical_payload, '$.host'), ''), 'unknown') = 'opencode' THEN CASE WHEN json_type(r.row_json, '$.responses') = 'integer' THEN json_extract(r.row_json, '$.responses') ELSE 0 END ELSE 0 END) AS opencode, SUM(CASE WHEN COALESCE(NULLIF(json_extract(d.canonical_payload, '$.host'), ''), 'unknown') = 'claude-code' THEN CASE WHEN json_type(r.row_json, '$.responses') = 'integer' THEN json_extract(r.row_json, '$.responses') ELSE 0 END ELSE 0 END) AS \"claude-code\", SUM(CASE WHEN COALESCE(NULLIF(json_extract(d.canonical_payload, '$.host'), ''), 'unknown') = 'codex' THEN CASE WHEN json_type(r.row_json, '$.responses') = 'integer' THEN json_extract(r.row_json, '$.responses') ELSE 0 END ELSE 0 END) AS codex FROM runtime_rows r JOIN runtime_deliveries d ON d.delivery_id = r.delivery_id WHERE d.received_at >= (CAST(strftime('%s', 'now') AS INTEGER) - 10800) * 1000000000 AND d.received_at <= CAST(strftime('%s', 'now') AS INTEGER) * 1000000000 GROUP BY time ORDER BY time ASC",
+          "rawQueryText": "SELECT CAST(strftime('%s', strftime('%Y-%m-%d %H:%M:00', d.received_at / 1000000000, 'unixepoch')) AS INTEGER) AS time, SUM(CASE WHEN COALESCE(NULLIF(json_extract(d.canonical_payload, '$.host'), ''), 'unknown') = 'pi' THEN CASE WHEN json_type(r.row_json, '$.responses') = 'integer' THEN json_extract(r.row_json, '$.responses') ELSE 0 END ELSE 0 END) AS pi, SUM(CASE WHEN COALESCE(NULLIF(json_extract(d.canonical_payload, '$.host'), ''), 'unknown') = 'opencode' THEN CASE WHEN json_type(r.row_json, '$.responses') = 'integer' THEN json_extract(r.row_json, '$.responses') ELSE 0 END ELSE 0 END) AS opencode, SUM(CASE WHEN COALESCE(NULLIF(json_extract(d.canonical_payload, '$.host'), ''), 'unknown') = 'claude-code' THEN CASE WHEN json_type(r.row_json, '$.responses') = 'integer' THEN json_extract(r.row_json, '$.responses') ELSE 0 END ELSE 0 END) AS \"claude-code\", SUM(CASE WHEN COALESCE(NULLIF(json_extract(d.canonical_payload, '$.host'), ''), 'unknown') = 'codex' THEN CASE WHEN json_type(r.row_json, '$.responses') = 'integer' THEN json_extract(r.row_json, '$.responses') ELSE 0 END ELSE 0 END) AS codex FROM runtime_rows r JOIN runtime_deliveries d ON d.delivery_id = r.delivery_id WHERE d.received_at >= (CAST(strftime('%s', 'now') AS INTEGER) - 10800) * 1000000000 AND d.received_at <= CAST(strftime('%s', 'now') AS INTEGER) * 1000000000 GROUP BY time ORDER BY time ASC",
+          "timeColumns": [
+            "time"
+          ]
+        }
+      ],
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "min": 0,
+          "decimals": 0,
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 25,
+            "lineWidth": 2,
+            "showPoints": "never",
+            "stacking": {
+              "mode": "normal",
+              "group": "A"
+            }
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "pi"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "mode": "fixed",
+                  "fixedColor": "#73BF69"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "opencode"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "mode": "fixed",
+                  "fixedColor": "#5794F2"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "claude-code"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "mode": "fixed",
+                  "fixedColor": "#FF9830"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "codex"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "mode": "fixed",
+                  "fixedColor": "#B877D9"
+                }
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "id": 606,
+      "title": "Tokens processed per minute (last 3h)",
+      "description": "This anonymous activity counts agent responses, not people, and shows their derived token volume per minute over the last three hours.",
+      "type": "timeseries",
+      "timeFrom": "3h",
+      "gridPos": {
+        "x": 12,
+        "y": 38,
+        "w": 12,
+        "h": 8
+      },
+      "datasource": {
+        "type": "frser-sqlite-datasource",
+        "uid": "gentle-telemetry-sqlite"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "queryType": "table",
+          "queryText": "SELECT CAST(strftime('%s', strftime('%Y-%m-%d %H:%M:00', d.received_at / 1000000000, 'unixepoch')) AS INTEGER) AS time, SUM((CASE WHEN json_extract(r.row_json, '$.input_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.input_tokens.sum'), 0) ELSE 0 END + CASE WHEN json_extract(r.row_json, '$.output_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.output_tokens.sum'), 0) ELSE 0 END + CASE WHEN json_extract(r.row_json, '$.cache_read_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.cache_read_tokens.sum'), 0) ELSE 0 END + CASE WHEN json_extract(r.row_json, '$.cache_creation_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.cache_creation_tokens.sum'), 0) ELSE 0 END + CASE WHEN json_extract(r.row_json, '$.reasoning_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.reasoning_tokens.sum'), 0) ELSE 0 END)) AS \"Tokens processed\" FROM runtime_rows r JOIN runtime_deliveries d ON d.delivery_id = r.delivery_id WHERE d.received_at >= (CAST(strftime('%s', 'now') AS INTEGER) - 10800) * 1000000000 AND d.received_at <= CAST(strftime('%s', 'now') AS INTEGER) * 1000000000 GROUP BY time ORDER BY time ASC",
+          "rawQueryText": "SELECT CAST(strftime('%s', strftime('%Y-%m-%d %H:%M:00', d.received_at / 1000000000, 'unixepoch')) AS INTEGER) AS time, SUM((CASE WHEN json_extract(r.row_json, '$.input_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.input_tokens.sum'), 0) ELSE 0 END + CASE WHEN json_extract(r.row_json, '$.output_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.output_tokens.sum'), 0) ELSE 0 END + CASE WHEN json_extract(r.row_json, '$.cache_read_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.cache_read_tokens.sum'), 0) ELSE 0 END + CASE WHEN json_extract(r.row_json, '$.cache_creation_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.cache_creation_tokens.sum'), 0) ELSE 0 END + CASE WHEN json_extract(r.row_json, '$.reasoning_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.reasoning_tokens.sum'), 0) ELSE 0 END)) AS \"Tokens processed\" FROM runtime_rows r JOIN runtime_deliveries d ON d.delivery_id = r.delivery_id WHERE d.received_at >= (CAST(strftime('%s', 'now') AS INTEGER) - 10800) * 1000000000 AND d.received_at <= CAST(strftime('%s', 'now') AS INTEGER) * 1000000000 GROUP BY time ORDER BY time ASC",
+          "timeColumns": [
+            "time"
+          ]
+        }
+      ],
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "min": 0,
+          "decimals": 0,
+          "color": {
+            "mode": "fixed",
+            "fixedColor": "#8AB8A8"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 25,
+            "lineWidth": 2,
+            "showPoints": "never",
+            "stacking": {
+              "mode": "none",
+              "group": "A"
+            }
+          }
+        },
+        "overrides": []
       }
     },
     {
@@ -780,7 +1377,7 @@
       "type": "stat",
       "gridPos": {
         "x": 0,
-        "y": 28,
+        "y": 46,
         "w": 6,
         "h": 4
       },
@@ -829,7 +1426,7 @@
       "type": "stat",
       "gridPos": {
         "x": 6,
-        "y": 28,
+        "y": 46,
         "w": 6,
         "h": 4
       },
@@ -878,7 +1475,7 @@
       "type": "stat",
       "gridPos": {
         "x": 12,
-        "y": 28,
+        "y": 46,
         "w": 6,
         "h": 4
       },
@@ -927,7 +1524,7 @@
       "type": "stat",
       "gridPos": {
         "x": 18,
-        "y": 28,
+        "y": 46,
         "w": 6,
         "h": 4
       },
@@ -970,15 +1567,321 @@
       }
     },
     {
+      "id": 500,
+      "title": "Subagents",
+      "type": "row",
+      "collapsed": false,
+      "panels": [],
+      "gridPos": {
+        "x": 0,
+        "y": 50,
+        "w": 24,
+        "h": 1
+      }
+    },
+    {
+      "id": 501,
+      "title": "Subagent coverage",
+      "description": "Share of observations attributed to a named subagent.",
+      "type": "stat",
+      "gridPos": {
+        "x": 0,
+        "y": 51,
+        "w": 6,
+        "h": 4
+      },
+      "datasource": {
+        "type": "frser-sqlite-datasource",
+        "uid": "gentle-telemetry-sqlite"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "queryType": "table",
+          "queryText": "SELECT 100.0 * SUM(CASE WHEN COALESCE(NULLIF(json_extract(r.row_json, '$.agent_class'), ''), 'unknown') NOT IN ('orchestrator', 'unknown') THEN 1 ELSE 0 END) / NULLIF(COUNT(*), 0) AS \"Subagent coverage\" FROM runtime_rows r JOIN runtime_deliveries d ON d.delivery_id = r.delivery_id WHERE d.received_at >= ${__from} * 1000000 AND d.received_at <= ${__to} * 1000000 HAVING COUNT(*) > 0",
+          "rawQueryText": "SELECT 100.0 * SUM(CASE WHEN COALESCE(NULLIF(json_extract(r.row_json, '$.agent_class'), ''), 'unknown') NOT IN ('orchestrator', 'unknown') THEN 1 ELSE 0 END) / NULLIF(COUNT(*), 0) AS \"Subagent coverage\" FROM runtime_rows r JOIN runtime_deliveries d ON d.delivery_id = r.delivery_id WHERE d.received_at >= ${__from} * 1000000 AND d.received_at <= ${__to} * 1000000 HAVING COUNT(*) > 0"
+        }
+      ],
+      "options": {
+        "orientation": "horizontal",
+        "textMode": "value",
+        "colorMode": "value",
+        "graphMode": "none",
+        "reduceOptions": {
+          "values": false,
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": ""
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percent",
+          "min": 0,
+          "decimals": 0,
+          "color": {
+            "mode": "fixed",
+            "fixedColor": "#8AB8A8"
+          }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "id": 502,
+      "title": "Responses by subagent",
+      "description": "Observed responses and launches show which named subagents ran most often.",
+      "type": "barchart",
+      "gridPos": {
+        "x": 6,
+        "y": 51,
+        "w": 9,
+        "h": 7
+      },
+      "datasource": {
+        "type": "frser-sqlite-datasource",
+        "uid": "gentle-telemetry-sqlite"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "queryType": "table",
+          "queryText": "SELECT CAST(COALESCE(NULLIF(json_extract(r.row_json, '$.agent_class'), ''), 'unknown') AS TEXT) AS Subagent, SUM((COALESCE(CASE WHEN json_type(r.row_json, '$.responses') = 'integer' THEN json_extract(r.row_json, '$.responses') END, 0) + COALESCE(CASE WHEN json_type(r.row_json, '$.launches') = 'integer' THEN json_extract(r.row_json, '$.launches') END, 0))) AS \"Responses\" FROM runtime_rows r JOIN runtime_deliveries d ON d.delivery_id = r.delivery_id WHERE d.received_at >= ${__from} * 1000000 AND d.received_at <= ${__to} * 1000000 AND COALESCE(NULLIF(json_extract(r.row_json, '$.agent_class'), ''), 'unknown') NOT IN ('orchestrator', 'unknown') GROUP BY Subagent HAVING COUNT(*) > 0 ORDER BY \"Responses\" DESC, Subagent ASC LIMIT 1000",
+          "rawQueryText": "SELECT CAST(COALESCE(NULLIF(json_extract(r.row_json, '$.agent_class'), ''), 'unknown') AS TEXT) AS Subagent, SUM((COALESCE(CASE WHEN json_type(r.row_json, '$.responses') = 'integer' THEN json_extract(r.row_json, '$.responses') END, 0) + COALESCE(CASE WHEN json_type(r.row_json, '$.launches') = 'integer' THEN json_extract(r.row_json, '$.launches') END, 0))) AS \"Responses\" FROM runtime_rows r JOIN runtime_deliveries d ON d.delivery_id = r.delivery_id WHERE d.received_at >= ${__from} * 1000000 AND d.received_at <= ${__to} * 1000000 AND COALESCE(NULLIF(json_extract(r.row_json, '$.agent_class'), ''), 'unknown') NOT IN ('orchestrator', 'unknown') GROUP BY Subagent HAVING COUNT(*) > 0 ORDER BY \"Responses\" DESC, Subagent ASC LIMIT 1000"
+        }
+      ],
+      "options": {
+        "orientation": "horizontal",
+        "xField": "Subagent",
+        "showValue": "always",
+        "legend": {
+          "showLegend": false
+        },
+        "barWidth": 0.6,
+        "groupWidth": 0.7
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "min": 0,
+          "decimals": 0,
+          "color": {
+            "mode": "fixed",
+            "fixedColor": "#8AB8A8"
+          }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "id": 503,
+      "title": "Tokens processed by subagent",
+      "description": "Derived token volume shows which named subagents handled the most model work.",
+      "type": "barchart",
+      "gridPos": {
+        "x": 15,
+        "y": 51,
+        "w": 9,
+        "h": 7
+      },
+      "datasource": {
+        "type": "frser-sqlite-datasource",
+        "uid": "gentle-telemetry-sqlite"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "queryType": "table",
+          "queryText": "SELECT CAST(COALESCE(NULLIF(json_extract(r.row_json, '$.agent_class'), ''), 'unknown') AS TEXT) AS Subagent, SUM((CASE WHEN json_extract(r.row_json, '$.input_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.input_tokens.sum'), 0) ELSE 0 END + CASE WHEN json_extract(r.row_json, '$.output_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.output_tokens.sum'), 0) ELSE 0 END + CASE WHEN json_extract(r.row_json, '$.cache_read_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.cache_read_tokens.sum'), 0) ELSE 0 END + CASE WHEN json_extract(r.row_json, '$.cache_creation_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.cache_creation_tokens.sum'), 0) ELSE 0 END + CASE WHEN json_extract(r.row_json, '$.reasoning_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.reasoning_tokens.sum'), 0) ELSE 0 END)) AS \"Tokens processed\" FROM runtime_rows r JOIN runtime_deliveries d ON d.delivery_id = r.delivery_id WHERE d.received_at >= ${__from} * 1000000 AND d.received_at <= ${__to} * 1000000 AND COALESCE(NULLIF(json_extract(r.row_json, '$.agent_class'), ''), 'unknown') NOT IN ('orchestrator', 'unknown') GROUP BY Subagent HAVING COUNT(*) > 0 ORDER BY \"Tokens processed\" DESC, Subagent ASC LIMIT 1000",
+          "rawQueryText": "SELECT CAST(COALESCE(NULLIF(json_extract(r.row_json, '$.agent_class'), ''), 'unknown') AS TEXT) AS Subagent, SUM((CASE WHEN json_extract(r.row_json, '$.input_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.input_tokens.sum'), 0) ELSE 0 END + CASE WHEN json_extract(r.row_json, '$.output_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.output_tokens.sum'), 0) ELSE 0 END + CASE WHEN json_extract(r.row_json, '$.cache_read_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.cache_read_tokens.sum'), 0) ELSE 0 END + CASE WHEN json_extract(r.row_json, '$.cache_creation_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.cache_creation_tokens.sum'), 0) ELSE 0 END + CASE WHEN json_extract(r.row_json, '$.reasoning_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.reasoning_tokens.sum'), 0) ELSE 0 END)) AS \"Tokens processed\" FROM runtime_rows r JOIN runtime_deliveries d ON d.delivery_id = r.delivery_id WHERE d.received_at >= ${__from} * 1000000 AND d.received_at <= ${__to} * 1000000 AND COALESCE(NULLIF(json_extract(r.row_json, '$.agent_class'), ''), 'unknown') NOT IN ('orchestrator', 'unknown') GROUP BY Subagent HAVING COUNT(*) > 0 ORDER BY \"Tokens processed\" DESC, Subagent ASC LIMIT 1000"
+        }
+      ],
+      "options": {
+        "orientation": "horizontal",
+        "xField": "Subagent",
+        "showValue": "always",
+        "legend": {
+          "showLegend": false
+        },
+        "barWidth": 0.6,
+        "groupWidth": 0.7
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "min": 0,
+          "decimals": 0,
+          "color": {
+            "mode": "fixed",
+            "fixedColor": "#8AB8A8"
+          }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "id": 504,
+      "title": "Subagent model and effort selection",
+      "description": "Shows which named subagent ran on which model and effort, together with launches, responses, and token volume.",
+      "type": "table",
+      "gridPos": {
+        "x": 0,
+        "y": 58,
+        "w": 24,
+        "h": 9
+      },
+      "datasource": {
+        "type": "frser-sqlite-datasource",
+        "uid": "gentle-telemetry-sqlite"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "queryType": "table",
+          "queryText": "SELECT CAST(COALESCE(NULLIF(json_extract(d.canonical_payload, '$.host'), ''), 'unknown') AS TEXT) AS Host, CAST(COALESCE(NULLIF(json_extract(r.row_json, '$.agent_class'), ''), 'unknown') AS TEXT) AS Subagent, COALESCE(NULLIF(json_extract(r.row_json, '$.model.provider'), ''), 'unknown') || '/' || COALESCE(NULLIF(json_extract(r.row_json, '$.model.id'), ''), 'unknown') AS \"Provider/model\", COALESCE(NULLIF(json_extract(r.row_json, '$.model_evidence'), ''), 'unknown') AS Evidence, COALESCE(NULLIF(json_extract(r.row_json, '$.selected_effort'), ''), 'unknown') AS \"Selected effort\", COALESCE(NULLIF(json_extract(r.row_json, '$.effective_effort'), ''), 'unknown') AS \"Effective effort\", SUM(CASE WHEN json_type(r.row_json, '$.launches') = 'integer' THEN json_extract(r.row_json, '$.launches') ELSE 0 END) AS Launches, SUM(CASE WHEN json_type(r.row_json, '$.responses') = 'integer' THEN json_extract(r.row_json, '$.responses') ELSE 0 END) AS Responses, SUM((CASE WHEN json_extract(r.row_json, '$.input_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.input_tokens.sum'), 0) ELSE 0 END + CASE WHEN json_extract(r.row_json, '$.output_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.output_tokens.sum'), 0) ELSE 0 END + CASE WHEN json_extract(r.row_json, '$.cache_read_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.cache_read_tokens.sum'), 0) ELSE 0 END + CASE WHEN json_extract(r.row_json, '$.cache_creation_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.cache_creation_tokens.sum'), 0) ELSE 0 END + CASE WHEN json_extract(r.row_json, '$.reasoning_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.reasoning_tokens.sum'), 0) ELSE 0 END)) AS \"Tokens processed\", ROUND(1.0 * SUM((CASE WHEN json_extract(r.row_json, '$.input_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.input_tokens.sum'), 0) ELSE 0 END + CASE WHEN json_extract(r.row_json, '$.output_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.output_tokens.sum'), 0) ELSE 0 END + CASE WHEN json_extract(r.row_json, '$.cache_read_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.cache_read_tokens.sum'), 0) ELSE 0 END + CASE WHEN json_extract(r.row_json, '$.cache_creation_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.cache_creation_tokens.sum'), 0) ELSE 0 END + CASE WHEN json_extract(r.row_json, '$.reasoning_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.reasoning_tokens.sum'), 0) ELSE 0 END)) / NULLIF(SUM(CASE WHEN json_type(r.row_json, '$.responses') = 'integer' THEN json_extract(r.row_json, '$.responses') ELSE 0 END), 0), 1) AS \"Avg tokens per response\" FROM runtime_rows r JOIN runtime_deliveries d ON d.delivery_id = r.delivery_id WHERE d.received_at >= ${__from} * 1000000 AND d.received_at <= ${__to} * 1000000 AND COALESCE(NULLIF(json_extract(r.row_json, '$.agent_class'), ''), 'unknown') NOT IN ('orchestrator', 'unknown') GROUP BY Host, Subagent, \"Provider/model\", Evidence, \"Selected effort\", \"Effective effort\" HAVING COUNT(*) > 0 ORDER BY Responses DESC, \"Tokens processed\" DESC, Subagent ASC LIMIT 1000",
+          "rawQueryText": "SELECT CAST(COALESCE(NULLIF(json_extract(d.canonical_payload, '$.host'), ''), 'unknown') AS TEXT) AS Host, CAST(COALESCE(NULLIF(json_extract(r.row_json, '$.agent_class'), ''), 'unknown') AS TEXT) AS Subagent, COALESCE(NULLIF(json_extract(r.row_json, '$.model.provider'), ''), 'unknown') || '/' || COALESCE(NULLIF(json_extract(r.row_json, '$.model.id'), ''), 'unknown') AS \"Provider/model\", COALESCE(NULLIF(json_extract(r.row_json, '$.model_evidence'), ''), 'unknown') AS Evidence, COALESCE(NULLIF(json_extract(r.row_json, '$.selected_effort'), ''), 'unknown') AS \"Selected effort\", COALESCE(NULLIF(json_extract(r.row_json, '$.effective_effort'), ''), 'unknown') AS \"Effective effort\", SUM(CASE WHEN json_type(r.row_json, '$.launches') = 'integer' THEN json_extract(r.row_json, '$.launches') ELSE 0 END) AS Launches, SUM(CASE WHEN json_type(r.row_json, '$.responses') = 'integer' THEN json_extract(r.row_json, '$.responses') ELSE 0 END) AS Responses, SUM((CASE WHEN json_extract(r.row_json, '$.input_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.input_tokens.sum'), 0) ELSE 0 END + CASE WHEN json_extract(r.row_json, '$.output_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.output_tokens.sum'), 0) ELSE 0 END + CASE WHEN json_extract(r.row_json, '$.cache_read_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.cache_read_tokens.sum'), 0) ELSE 0 END + CASE WHEN json_extract(r.row_json, '$.cache_creation_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.cache_creation_tokens.sum'), 0) ELSE 0 END + CASE WHEN json_extract(r.row_json, '$.reasoning_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.reasoning_tokens.sum'), 0) ELSE 0 END)) AS \"Tokens processed\", ROUND(1.0 * SUM((CASE WHEN json_extract(r.row_json, '$.input_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.input_tokens.sum'), 0) ELSE 0 END + CASE WHEN json_extract(r.row_json, '$.output_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.output_tokens.sum'), 0) ELSE 0 END + CASE WHEN json_extract(r.row_json, '$.cache_read_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.cache_read_tokens.sum'), 0) ELSE 0 END + CASE WHEN json_extract(r.row_json, '$.cache_creation_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.cache_creation_tokens.sum'), 0) ELSE 0 END + CASE WHEN json_extract(r.row_json, '$.reasoning_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.reasoning_tokens.sum'), 0) ELSE 0 END)) / NULLIF(SUM(CASE WHEN json_type(r.row_json, '$.responses') = 'integer' THEN json_extract(r.row_json, '$.responses') ELSE 0 END), 0), 1) AS \"Avg tokens per response\" FROM runtime_rows r JOIN runtime_deliveries d ON d.delivery_id = r.delivery_id WHERE d.received_at >= ${__from} * 1000000 AND d.received_at <= ${__to} * 1000000 AND COALESCE(NULLIF(json_extract(r.row_json, '$.agent_class'), ''), 'unknown') NOT IN ('orchestrator', 'unknown') GROUP BY Host, Subagent, \"Provider/model\", Evidence, \"Selected effort\", \"Effective effort\" HAVING COUNT(*) > 0 ORDER BY Responses DESC, \"Tokens processed\" DESC, Subagent ASC LIMIT 1000"
+        }
+      ],
+      "options": {
+        "showHeader": true,
+        "cellHeight": "sm",
+        "footer": {
+          "enablePagination": false
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "min": 0
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Avg tokens per response"
+            },
+            "properties": [
+              {
+                "id": "decimals",
+                "value": 1
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "id": 505,
+      "title": "Most popular models per subagent",
+      "description": "Ranks the community’s most observed models for each named subagent and shows the effort and hosts behind that usage.",
+      "type": "table",
+      "gridPos": {
+        "x": 0,
+        "y": 67,
+        "w": 24,
+        "h": 9
+      },
+      "datasource": {
+        "type": "frser-sqlite-datasource",
+        "uid": "gentle-telemetry-sqlite"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "queryType": "table",
+          "queryText": "WITH base AS (SELECT CAST(COALESCE(NULLIF(json_extract(r.row_json, '$.agent_class'), ''), 'unknown') AS TEXT) AS Subagent, CAST(COALESCE(NULLIF(json_extract(r.row_json, '$.model.provider'), ''), 'unknown') || '/' || COALESCE(NULLIF(json_extract(r.row_json, '$.model.id'), ''), 'unknown') AS TEXT) AS Model, CAST(COALESCE(NULLIF(json_extract(r.row_json, '$.selected_effort'), ''), 'unknown') AS TEXT) AS Effort, CAST(COALESCE(NULLIF(json_extract(d.canonical_payload, '$.host'), ''), 'unknown') AS TEXT) AS Host, (COALESCE(CASE WHEN json_type(r.row_json, '$.responses') = 'integer' THEN json_extract(r.row_json, '$.responses') END, 0) + COALESCE(CASE WHEN json_type(r.row_json, '$.launches') = 'integer' THEN json_extract(r.row_json, '$.launches') END, 0)) AS Observations FROM runtime_rows r JOIN runtime_deliveries d ON d.delivery_id = r.delivery_id WHERE d.received_at >= ${__from} * 1000000 AND d.received_at <= ${__to} * 1000000 AND COALESCE(NULLIF(json_extract(r.row_json, '$.agent_class'), ''), 'unknown') NOT IN ('orchestrator', 'unknown')), pair_totals AS (SELECT Subagent, Model, SUM(Observations) AS Observations, group_concat(DISTINCT Host) AS Hosts FROM base GROUP BY Subagent, Model), effort_totals AS (SELECT Subagent, Model, Effort, SUM(Observations) AS Observations FROM base GROUP BY Subagent, Model, Effort), effort_ranked AS (SELECT Subagent, Model, Effort, ROW_NUMBER() OVER (PARTITION BY Subagent, Model ORDER BY Observations DESC, Effort ASC) AS effort_rank FROM effort_totals), ranked AS (SELECT p.Subagent, p.Model, e.Effort, p.Observations, p.Hosts, ROW_NUMBER() OVER (PARTITION BY p.Subagent ORDER BY p.Observations DESC, p.Model ASC) AS Rank, SUM(p.Observations) OVER (PARTITION BY p.Subagent) AS subagent_observations FROM pair_totals p JOIN effort_ranked e ON e.Subagent = p.Subagent AND e.Model = p.Model AND e.effort_rank = 1) SELECT Subagent, Rank, Model AS \"Provider/model\", Effort AS \"Most common selected effort\", Observations, ROUND(100.0 * Observations / NULLIF(subagent_observations, 0), 1) AS \"Share of subagent (%)\", Hosts FROM ranked ORDER BY Subagent ASC, Rank ASC LIMIT 1000",
+          "rawQueryText": "WITH base AS (SELECT CAST(COALESCE(NULLIF(json_extract(r.row_json, '$.agent_class'), ''), 'unknown') AS TEXT) AS Subagent, CAST(COALESCE(NULLIF(json_extract(r.row_json, '$.model.provider'), ''), 'unknown') || '/' || COALESCE(NULLIF(json_extract(r.row_json, '$.model.id'), ''), 'unknown') AS TEXT) AS Model, CAST(COALESCE(NULLIF(json_extract(r.row_json, '$.selected_effort'), ''), 'unknown') AS TEXT) AS Effort, CAST(COALESCE(NULLIF(json_extract(d.canonical_payload, '$.host'), ''), 'unknown') AS TEXT) AS Host, (COALESCE(CASE WHEN json_type(r.row_json, '$.responses') = 'integer' THEN json_extract(r.row_json, '$.responses') END, 0) + COALESCE(CASE WHEN json_type(r.row_json, '$.launches') = 'integer' THEN json_extract(r.row_json, '$.launches') END, 0)) AS Observations FROM runtime_rows r JOIN runtime_deliveries d ON d.delivery_id = r.delivery_id WHERE d.received_at >= ${__from} * 1000000 AND d.received_at <= ${__to} * 1000000 AND COALESCE(NULLIF(json_extract(r.row_json, '$.agent_class'), ''), 'unknown') NOT IN ('orchestrator', 'unknown')), pair_totals AS (SELECT Subagent, Model, SUM(Observations) AS Observations, group_concat(DISTINCT Host) AS Hosts FROM base GROUP BY Subagent, Model), effort_totals AS (SELECT Subagent, Model, Effort, SUM(Observations) AS Observations FROM base GROUP BY Subagent, Model, Effort), effort_ranked AS (SELECT Subagent, Model, Effort, ROW_NUMBER() OVER (PARTITION BY Subagent, Model ORDER BY Observations DESC, Effort ASC) AS effort_rank FROM effort_totals), ranked AS (SELECT p.Subagent, p.Model, e.Effort, p.Observations, p.Hosts, ROW_NUMBER() OVER (PARTITION BY p.Subagent ORDER BY p.Observations DESC, p.Model ASC) AS Rank, SUM(p.Observations) OVER (PARTITION BY p.Subagent) AS subagent_observations FROM pair_totals p JOIN effort_ranked e ON e.Subagent = p.Subagent AND e.Model = p.Model AND e.effort_rank = 1) SELECT Subagent, Rank, Model AS \"Provider/model\", Effort AS \"Most common selected effort\", Observations, ROUND(100.0 * Observations / NULLIF(subagent_observations, 0), 1) AS \"Share of subagent (%)\", Hosts FROM ranked ORDER BY Subagent ASC, Rank ASC LIMIT 1000"
+        }
+      ],
+      "options": {
+        "showHeader": true,
+        "cellHeight": "sm",
+        "footer": {
+          "enablePagination": false
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "min": 0
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Share of subagent (%)"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "percent"
+              },
+              {
+                "id": "decimals",
+                "value": 1
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "id": 506,
+      "title": "Top model per subagent",
+      "description": "Highlights the most observed model for each named subagent across the selected time range.",
+      "type": "barchart",
+      "gridPos": {
+        "x": 0,
+        "y": 76,
+        "w": 24,
+        "h": 7
+      },
+      "datasource": {
+        "type": "frser-sqlite-datasource",
+        "uid": "gentle-telemetry-sqlite"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "queryType": "table",
+          "queryText": "WITH base AS (SELECT CAST(COALESCE(NULLIF(json_extract(r.row_json, '$.agent_class'), ''), 'unknown') AS TEXT) AS Subagent, CAST(COALESCE(NULLIF(json_extract(r.row_json, '$.model.provider'), ''), 'unknown') || '/' || COALESCE(NULLIF(json_extract(r.row_json, '$.model.id'), ''), 'unknown') AS TEXT) AS Model, CAST(COALESCE(NULLIF(json_extract(r.row_json, '$.selected_effort'), ''), 'unknown') AS TEXT) AS Effort, CAST(COALESCE(NULLIF(json_extract(d.canonical_payload, '$.host'), ''), 'unknown') AS TEXT) AS Host, (COALESCE(CASE WHEN json_type(r.row_json, '$.responses') = 'integer' THEN json_extract(r.row_json, '$.responses') END, 0) + COALESCE(CASE WHEN json_type(r.row_json, '$.launches') = 'integer' THEN json_extract(r.row_json, '$.launches') END, 0)) AS Observations FROM runtime_rows r JOIN runtime_deliveries d ON d.delivery_id = r.delivery_id WHERE d.received_at >= ${__from} * 1000000 AND d.received_at <= ${__to} * 1000000 AND COALESCE(NULLIF(json_extract(r.row_json, '$.agent_class'), ''), 'unknown') NOT IN ('orchestrator', 'unknown')), pair_totals AS (SELECT Subagent, Model, SUM(Observations) AS Observations, group_concat(DISTINCT Host) AS Hosts FROM base GROUP BY Subagent, Model), effort_totals AS (SELECT Subagent, Model, Effort, SUM(Observations) AS Observations FROM base GROUP BY Subagent, Model, Effort), effort_ranked AS (SELECT Subagent, Model, Effort, ROW_NUMBER() OVER (PARTITION BY Subagent, Model ORDER BY Observations DESC, Effort ASC) AS effort_rank FROM effort_totals), ranked AS (SELECT p.Subagent, p.Model, e.Effort, p.Observations, p.Hosts, ROW_NUMBER() OVER (PARTITION BY p.Subagent ORDER BY p.Observations DESC, p.Model ASC) AS Rank, SUM(p.Observations) OVER (PARTITION BY p.Subagent) AS subagent_observations FROM pair_totals p JOIN effort_ranked e ON e.Subagent = p.Subagent AND e.Model = p.Model AND e.effort_rank = 1) SELECT CAST(Subagent || ' · ' || Model AS TEXT) AS \"Subagent and model\", Observations FROM ranked WHERE Rank = 1 ORDER BY Observations DESC, Subagent ASC LIMIT 1000",
+          "rawQueryText": "WITH base AS (SELECT CAST(COALESCE(NULLIF(json_extract(r.row_json, '$.agent_class'), ''), 'unknown') AS TEXT) AS Subagent, CAST(COALESCE(NULLIF(json_extract(r.row_json, '$.model.provider'), ''), 'unknown') || '/' || COALESCE(NULLIF(json_extract(r.row_json, '$.model.id'), ''), 'unknown') AS TEXT) AS Model, CAST(COALESCE(NULLIF(json_extract(r.row_json, '$.selected_effort'), ''), 'unknown') AS TEXT) AS Effort, CAST(COALESCE(NULLIF(json_extract(d.canonical_payload, '$.host'), ''), 'unknown') AS TEXT) AS Host, (COALESCE(CASE WHEN json_type(r.row_json, '$.responses') = 'integer' THEN json_extract(r.row_json, '$.responses') END, 0) + COALESCE(CASE WHEN json_type(r.row_json, '$.launches') = 'integer' THEN json_extract(r.row_json, '$.launches') END, 0)) AS Observations FROM runtime_rows r JOIN runtime_deliveries d ON d.delivery_id = r.delivery_id WHERE d.received_at >= ${__from} * 1000000 AND d.received_at <= ${__to} * 1000000 AND COALESCE(NULLIF(json_extract(r.row_json, '$.agent_class'), ''), 'unknown') NOT IN ('orchestrator', 'unknown')), pair_totals AS (SELECT Subagent, Model, SUM(Observations) AS Observations, group_concat(DISTINCT Host) AS Hosts FROM base GROUP BY Subagent, Model), effort_totals AS (SELECT Subagent, Model, Effort, SUM(Observations) AS Observations FROM base GROUP BY Subagent, Model, Effort), effort_ranked AS (SELECT Subagent, Model, Effort, ROW_NUMBER() OVER (PARTITION BY Subagent, Model ORDER BY Observations DESC, Effort ASC) AS effort_rank FROM effort_totals), ranked AS (SELECT p.Subagent, p.Model, e.Effort, p.Observations, p.Hosts, ROW_NUMBER() OVER (PARTITION BY p.Subagent ORDER BY p.Observations DESC, p.Model ASC) AS Rank, SUM(p.Observations) OVER (PARTITION BY p.Subagent) AS subagent_observations FROM pair_totals p JOIN effort_ranked e ON e.Subagent = p.Subagent AND e.Model = p.Model AND e.effort_rank = 1) SELECT CAST(Subagent || ' · ' || Model AS TEXT) AS \"Subagent and model\", Observations FROM ranked WHERE Rank = 1 ORDER BY Observations DESC, Subagent ASC LIMIT 1000"
+        }
+      ],
+      "options": {
+        "orientation": "horizontal",
+        "xField": "Subagent and model",
+        "showValue": "always",
+        "legend": {
+          "showLegend": false
+        },
+        "barWidth": 0.6,
+        "groupWidth": 0.7
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "min": 0,
+          "decimals": 0,
+          "color": {
+            "mode": "fixed",
+            "fixedColor": "#8AB8A8"
+          }
+        },
+        "overrides": []
+      }
+    },
+    {
       "id": 409,
       "title": "Usage by host, subagent, model and effort",
       "description": "Answers which subagent used which model at which effort and how many tokens were processed.",
       "type": "table",
       "gridPos": {
         "x": 0,
-        "y": 32,
+        "y": 83,
         "w": 24,
-        "h": 14
+        "h": 9
       },
       "datasource": {
         "type": "frser-sqlite-datasource",
@@ -1075,7 +1978,7 @@
       "type": "barchart",
       "gridPos": {
         "x": 0,
-        "y": 46,
+        "y": 92,
         "w": 12,
         "h": 7
       },
@@ -1145,7 +2048,9 @@
         "showValue": "always",
         "legend": {
           "showLegend": false
-        }
+        },
+        "barWidth": 0.6,
+        "groupWidth": 0.7
       }
     },
     {
@@ -1155,7 +2060,7 @@
       "type": "barchart",
       "gridPos": {
         "x": 12,
-        "y": 46,
+        "y": 92,
         "w": 12,
         "h": 7
       },
@@ -1225,7 +2130,9 @@
         "showValue": "always",
         "legend": {
           "showLegend": false
-        }
+        },
+        "barWidth": 0.6,
+        "groupWidth": 0.7
       }
     },
     {
@@ -1235,9 +2142,9 @@
       "type": "table",
       "gridPos": {
         "x": 0,
-        "y": 53,
+        "y": 99,
         "w": 12,
-        "h": 10
+        "h": 9
       },
       "datasource": {
         "type": "frser-sqlite-datasource",
@@ -1334,9 +2241,9 @@
       "type": "table",
       "gridPos": {
         "x": 12,
-        "y": 53,
+        "y": 99,
         "w": 12,
-        "h": 10
+        "h": 9
       },
       "datasource": {
         "type": "frser-sqlite-datasource",
@@ -1433,9 +2340,9 @@
       "type": "timeseries",
       "gridPos": {
         "x": 0,
-        "y": 63,
+        "y": 108,
         "w": 12,
-        "h": 11
+        "h": 8
       },
       "datasource": {
         "type": "frser-sqlite-datasource",
@@ -1551,9 +2458,9 @@
       "type": "table",
       "gridPos": {
         "x": 12,
-        "y": 63,
+        "y": 108,
         "w": 12,
-        "h": 11
+        "h": 9
       },
       "datasource": {
         "type": "frser-sqlite-datasource",
@@ -1650,7 +2557,7 @@
       "type": "barchart",
       "gridPos": {
         "x": 0,
-        "y": 74,
+        "y": 117,
         "w": 12,
         "h": 7
       },
@@ -1739,7 +2646,9 @@
         "orientation": "horizontal",
         "legend": {
           "showLegend": false
-        }
+        },
+        "barWidth": 0.6,
+        "groupWidth": 0.7
       }
     },
     {
@@ -1749,9 +2658,9 @@
       "type": "table",
       "gridPos": {
         "x": 12,
-        "y": 74,
+        "y": 117,
         "w": 12,
-        "h": 7
+        "h": 9
       },
       "datasource": {
         "type": "frser-sqlite-datasource",

--- a/deploy/telemetry/grafana/dashboards/gentle-ai-usage.json
+++ b/deploy/telemetry/grafana/dashboards/gentle-ai-usage.json
@@ -53,15 +53,20 @@
       ],
       "fieldConfig": {
         "defaults": {
-          "unit": "short",
+          "unit": "locale",
           "min": 0,
-          "decimals": 0
+          "decimals": 0,
+          "color": {
+            "mode": "fixed",
+            "fixedColor": "#73BF69"
+          }
         },
         "overrides": []
       },
       "options": {
         "orientation": "horizontal",
-        "textMode": "value_and_name",
+        "textMode": "value",
+        "colorMode": "value",
         "graphMode": "none",
         "reduceOptions": {
           "values": false,
@@ -97,15 +102,20 @@
       ],
       "fieldConfig": {
         "defaults": {
-          "unit": "short",
+          "unit": "locale",
           "min": 0,
-          "decimals": 0
+          "decimals": 0,
+          "color": {
+            "mode": "fixed",
+            "fixedColor": "#73BF69"
+          }
         },
         "overrides": []
       },
       "options": {
         "orientation": "horizontal",
-        "textMode": "value_and_name",
+        "textMode": "value",
+        "colorMode": "value",
         "graphMode": "none",
         "reduceOptions": {
           "values": false,
@@ -141,15 +151,20 @@
       ],
       "fieldConfig": {
         "defaults": {
-          "unit": "short",
+          "unit": "locale",
           "min": 0,
-          "decimals": 0
+          "decimals": 0,
+          "color": {
+            "mode": "fixed",
+            "fixedColor": "#73BF69"
+          }
         },
         "overrides": []
       },
       "options": {
         "orientation": "horizontal",
-        "textMode": "value_and_name",
+        "textMode": "value",
+        "colorMode": "value",
         "graphMode": "none",
         "reduceOptions": {
           "values": false,
@@ -185,15 +200,20 @@
       ],
       "fieldConfig": {
         "defaults": {
-          "unit": "short",
+          "unit": "locale",
           "min": 0,
-          "decimals": 0
+          "decimals": 0,
+          "color": {
+            "mode": "fixed",
+            "fixedColor": "#73BF69"
+          }
         },
         "overrides": []
       },
       "options": {
         "orientation": "horizontal",
-        "textMode": "value_and_name",
+        "textMode": "value",
+        "colorMode": "value",
         "graphMode": "none",
         "reduceOptions": {
           "values": false,
@@ -229,15 +249,20 @@
       ],
       "fieldConfig": {
         "defaults": {
-          "unit": "short",
+          "unit": "locale",
           "min": 0,
-          "decimals": 0
+          "decimals": 0,
+          "color": {
+            "mode": "fixed",
+            "fixedColor": "#73BF69"
+          }
         },
         "overrides": []
       },
       "options": {
         "orientation": "horizontal",
-        "textMode": "value_and_name",
+        "textMode": "value",
+        "colorMode": "value",
         "graphMode": "none",
         "reduceOptions": {
           "values": false,
@@ -275,13 +300,18 @@
         "defaults": {
           "unit": "percent",
           "min": 0,
-          "decimals": 0
+          "decimals": 0,
+          "color": {
+            "mode": "fixed",
+            "fixedColor": "#73BF69"
+          }
         },
         "overrides": []
       },
       "options": {
         "orientation": "horizontal",
-        "textMode": "value_and_name",
+        "textMode": "value",
+        "colorMode": "value",
         "graphMode": "none",
         "reduceOptions": {
           "values": false,
@@ -317,15 +347,20 @@
       ],
       "fieldConfig": {
         "defaults": {
-          "unit": "short",
+          "unit": "locale",
           "min": 0,
-          "decimals": 0
+          "decimals": 0,
+          "color": {
+            "mode": "fixed",
+            "fixedColor": "#73BF69"
+          }
         },
         "overrides": []
       },
       "options": {
         "orientation": "horizontal",
-        "textMode": "value_and_name",
+        "textMode": "value",
+        "colorMode": "value",
         "graphMode": "none",
         "reduceOptions": {
           "values": false,
@@ -361,15 +396,20 @@
       ],
       "fieldConfig": {
         "defaults": {
-          "unit": "short",
+          "unit": "locale",
           "min": 0,
-          "decimals": 0
+          "decimals": 0,
+          "color": {
+            "mode": "fixed",
+            "fixedColor": "#73BF69"
+          }
         },
         "overrides": []
       },
       "options": {
         "orientation": "horizontal",
-        "textMode": "value_and_name",
+        "textMode": "value",
+        "colorMode": "value",
         "graphMode": "none",
         "reduceOptions": {
           "values": false,
@@ -571,12 +611,18 @@
         "defaults": {
           "unit": "short",
           "min": 0,
-          "decimals": 0
+          "decimals": 0,
+          "color": {
+            "mode": "fixed",
+            "fixedColor": "#8AB8A8"
+          }
         },
         "overrides": []
       },
       "options": {
         "orientation": "horizontal",
+        "xField": "Agent",
+        "showValue": "always",
         "legend": {
           "showLegend": false
         }
@@ -609,12 +655,18 @@
         "defaults": {
           "unit": "short",
           "min": 0,
-          "decimals": 0
+          "decimals": 0,
+          "color": {
+            "mode": "fixed",
+            "fixedColor": "#8AB8A8"
+          }
         },
         "overrides": []
       },
       "options": {
         "orientation": "horizontal",
+        "xField": "Component",
+        "showValue": "always",
         "legend": {
           "showLegend": false
         }
@@ -647,12 +699,18 @@
         "defaults": {
           "unit": "short",
           "min": 0,
-          "decimals": 0
+          "decimals": 0,
+          "color": {
+            "mode": "fixed",
+            "fixedColor": "#8AB8A8"
+          }
         },
         "overrides": []
       },
       "options": {
         "orientation": "horizontal",
+        "xField": "Platform",
+        "showValue": "always",
         "legend": {
           "showLegend": false
         }
@@ -677,20 +735,26 @@
         {
           "refId": "A",
           "queryType": "table",
-          "queryText": "SELECT key AS Version, SUM(value) AS Installs FROM rollups_daily WHERE metric = 'version' AND day = (SELECT MAX(day) FROM rollups_daily WHERE metric = 'version') GROUP BY key ORDER BY Installs DESC LIMIT 10",
-          "rawQueryText": "SELECT key AS Version, SUM(value) AS Installs FROM rollups_daily WHERE metric = 'version' AND day = (SELECT MAX(day) FROM rollups_daily WHERE metric = 'version') GROUP BY key ORDER BY Installs DESC LIMIT 10"
+          "queryText": "WITH normalized AS (SELECT CASE WHEN instr(key, '-') > 0 THEN substr(key, 1, instr(key, '-') - 1) || ' (main)' ELSE key END AS Version, value FROM rollups_daily WHERE metric = 'version' AND day = (SELECT MAX(day) FROM rollups_daily WHERE metric = 'version')) SELECT CAST(Version AS TEXT) AS Version, SUM(value) AS Installs FROM normalized GROUP BY Version ORDER BY Installs DESC LIMIT 10",
+          "rawQueryText": "WITH normalized AS (SELECT CASE WHEN instr(key, '-') > 0 THEN substr(key, 1, instr(key, '-') - 1) || ' (main)' ELSE key END AS Version, value FROM rollups_daily WHERE metric = 'version' AND day = (SELECT MAX(day) FROM rollups_daily WHERE metric = 'version')) SELECT CAST(Version AS TEXT) AS Version, SUM(value) AS Installs FROM normalized GROUP BY Version ORDER BY Installs DESC LIMIT 10"
         }
       ],
       "fieldConfig": {
         "defaults": {
           "unit": "short",
           "min": 0,
-          "decimals": 0
+          "decimals": 0,
+          "color": {
+            "mode": "fixed",
+            "fixedColor": "#8AB8A8"
+          }
         },
         "overrides": []
       },
       "options": {
         "orientation": "horizontal",
+        "xField": "Version",
+        "showValue": "always",
         "legend": {
           "showLegend": false
         }
@@ -734,76 +798,20 @@
       ],
       "fieldConfig": {
         "defaults": {
-          "unit": "short",
+          "unit": "locale",
           "min": 0,
-          "decimals": 0
-        },
-        "overrides": [
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "pi"
-            },
-            "properties": [
-              {
-                "id": "color",
-                "value": {
-                  "mode": "fixed",
-                  "fixedColor": "#73BF69"
-                }
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "opencode"
-            },
-            "properties": [
-              {
-                "id": "color",
-                "value": {
-                  "mode": "fixed",
-                  "fixedColor": "#5794F2"
-                }
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "claude-code"
-            },
-            "properties": [
-              {
-                "id": "color",
-                "value": {
-                  "mode": "fixed",
-                  "fixedColor": "#FF9830"
-                }
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "codex"
-            },
-            "properties": [
-              {
-                "id": "color",
-                "value": {
-                  "mode": "fixed",
-                  "fixedColor": "#B877D9"
-                }
-              }
-            ]
+          "decimals": 0,
+          "color": {
+            "mode": "fixed",
+            "fixedColor": "#73BF69"
           }
-        ]
+        },
+        "overrides": []
       },
       "options": {
         "orientation": "horizontal",
-        "textMode": "value_and_name",
+        "textMode": "value",
+        "colorMode": "value",
         "graphMode": "none",
         "reduceOptions": {
           "values": false,
@@ -839,76 +847,20 @@
       ],
       "fieldConfig": {
         "defaults": {
-          "unit": "short",
+          "unit": "locale",
           "min": 0,
-          "decimals": 0
-        },
-        "overrides": [
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "pi"
-            },
-            "properties": [
-              {
-                "id": "color",
-                "value": {
-                  "mode": "fixed",
-                  "fixedColor": "#73BF69"
-                }
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "opencode"
-            },
-            "properties": [
-              {
-                "id": "color",
-                "value": {
-                  "mode": "fixed",
-                  "fixedColor": "#5794F2"
-                }
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "claude-code"
-            },
-            "properties": [
-              {
-                "id": "color",
-                "value": {
-                  "mode": "fixed",
-                  "fixedColor": "#FF9830"
-                }
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "codex"
-            },
-            "properties": [
-              {
-                "id": "color",
-                "value": {
-                  "mode": "fixed",
-                  "fixedColor": "#B877D9"
-                }
-              }
-            ]
+          "decimals": 0,
+          "color": {
+            "mode": "fixed",
+            "fixedColor": "#73BF69"
           }
-        ]
+        },
+        "overrides": []
       },
       "options": {
         "orientation": "horizontal",
-        "textMode": "value_and_name",
+        "textMode": "value",
+        "colorMode": "value",
         "graphMode": "none",
         "reduceOptions": {
           "values": false,
@@ -944,76 +896,20 @@
       ],
       "fieldConfig": {
         "defaults": {
-          "unit": "short",
+          "unit": "locale",
           "min": 0,
-          "decimals": 0
-        },
-        "overrides": [
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "pi"
-            },
-            "properties": [
-              {
-                "id": "color",
-                "value": {
-                  "mode": "fixed",
-                  "fixedColor": "#73BF69"
-                }
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "opencode"
-            },
-            "properties": [
-              {
-                "id": "color",
-                "value": {
-                  "mode": "fixed",
-                  "fixedColor": "#5794F2"
-                }
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "claude-code"
-            },
-            "properties": [
-              {
-                "id": "color",
-                "value": {
-                  "mode": "fixed",
-                  "fixedColor": "#FF9830"
-                }
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "codex"
-            },
-            "properties": [
-              {
-                "id": "color",
-                "value": {
-                  "mode": "fixed",
-                  "fixedColor": "#B877D9"
-                }
-              }
-            ]
+          "decimals": 0,
+          "color": {
+            "mode": "fixed",
+            "fixedColor": "#73BF69"
           }
-        ]
+        },
+        "overrides": []
       },
       "options": {
         "orientation": "horizontal",
-        "textMode": "value_and_name",
+        "textMode": "value",
+        "colorMode": "value",
         "graphMode": "none",
         "reduceOptions": {
           "values": false,
@@ -1049,76 +945,20 @@
       ],
       "fieldConfig": {
         "defaults": {
-          "unit": "short",
+          "unit": "locale",
           "min": 0,
-          "decimals": 0
-        },
-        "overrides": [
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "pi"
-            },
-            "properties": [
-              {
-                "id": "color",
-                "value": {
-                  "mode": "fixed",
-                  "fixedColor": "#73BF69"
-                }
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "opencode"
-            },
-            "properties": [
-              {
-                "id": "color",
-                "value": {
-                  "mode": "fixed",
-                  "fixedColor": "#5794F2"
-                }
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "claude-code"
-            },
-            "properties": [
-              {
-                "id": "color",
-                "value": {
-                  "mode": "fixed",
-                  "fixedColor": "#FF9830"
-                }
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "codex"
-            },
-            "properties": [
-              {
-                "id": "color",
-                "value": {
-                  "mode": "fixed",
-                  "fixedColor": "#B877D9"
-                }
-              }
-            ]
+          "decimals": 0,
+          "color": {
+            "mode": "fixed",
+            "fixedColor": "#73BF69"
           }
-        ]
+        },
+        "overrides": []
       },
       "options": {
         "orientation": "horizontal",
-        "textMode": "value_and_name",
+        "textMode": "value",
+        "colorMode": "value",
         "graphMode": "none",
         "reduceOptions": {
           "values": false,
@@ -1130,407 +970,15 @@
       }
     },
     {
-      "id": 405,
-      "title": "Tokens processed by host",
-      "description": "Derived token volume compares runtime usage across supported agent hosts.",
-      "type": "barchart",
-      "gridPos": {
-        "x": 0,
-        "y": 32,
-        "w": 12,
-        "h": 7
-      },
-      "datasource": {
-        "type": "frser-sqlite-datasource",
-        "uid": "gentle-telemetry-sqlite"
-      },
-      "targets": [
-        {
-          "refId": "A",
-          "queryType": "table",
-          "queryText": "SELECT SUM(CASE WHEN COALESCE(NULLIF(json_extract(d.canonical_payload, '$.host'), ''), 'unknown') = 'pi' THEN (CASE WHEN json_extract(r.row_json, '$.input_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.input_tokens.sum'), 0) ELSE 0 END + CASE WHEN json_extract(r.row_json, '$.output_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.output_tokens.sum'), 0) ELSE 0 END + CASE WHEN json_extract(r.row_json, '$.cache_read_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.cache_read_tokens.sum'), 0) ELSE 0 END + CASE WHEN json_extract(r.row_json, '$.cache_creation_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.cache_creation_tokens.sum'), 0) ELSE 0 END + CASE WHEN json_extract(r.row_json, '$.reasoning_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.reasoning_tokens.sum'), 0) ELSE 0 END) ELSE 0 END) AS pi, SUM(CASE WHEN COALESCE(NULLIF(json_extract(d.canonical_payload, '$.host'), ''), 'unknown') = 'opencode' THEN (CASE WHEN json_extract(r.row_json, '$.input_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.input_tokens.sum'), 0) ELSE 0 END + CASE WHEN json_extract(r.row_json, '$.output_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.output_tokens.sum'), 0) ELSE 0 END + CASE WHEN json_extract(r.row_json, '$.cache_read_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.cache_read_tokens.sum'), 0) ELSE 0 END + CASE WHEN json_extract(r.row_json, '$.cache_creation_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.cache_creation_tokens.sum'), 0) ELSE 0 END + CASE WHEN json_extract(r.row_json, '$.reasoning_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.reasoning_tokens.sum'), 0) ELSE 0 END) ELSE 0 END) AS opencode, SUM(CASE WHEN COALESCE(NULLIF(json_extract(d.canonical_payload, '$.host'), ''), 'unknown') = 'claude-code' THEN (CASE WHEN json_extract(r.row_json, '$.input_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.input_tokens.sum'), 0) ELSE 0 END + CASE WHEN json_extract(r.row_json, '$.output_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.output_tokens.sum'), 0) ELSE 0 END + CASE WHEN json_extract(r.row_json, '$.cache_read_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.cache_read_tokens.sum'), 0) ELSE 0 END + CASE WHEN json_extract(r.row_json, '$.cache_creation_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.cache_creation_tokens.sum'), 0) ELSE 0 END + CASE WHEN json_extract(r.row_json, '$.reasoning_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.reasoning_tokens.sum'), 0) ELSE 0 END) ELSE 0 END) AS \"claude-code\", SUM(CASE WHEN COALESCE(NULLIF(json_extract(d.canonical_payload, '$.host'), ''), 'unknown') = 'codex' THEN (CASE WHEN json_extract(r.row_json, '$.input_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.input_tokens.sum'), 0) ELSE 0 END + CASE WHEN json_extract(r.row_json, '$.output_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.output_tokens.sum'), 0) ELSE 0 END + CASE WHEN json_extract(r.row_json, '$.cache_read_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.cache_read_tokens.sum'), 0) ELSE 0 END + CASE WHEN json_extract(r.row_json, '$.cache_creation_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.cache_creation_tokens.sum'), 0) ELSE 0 END + CASE WHEN json_extract(r.row_json, '$.reasoning_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.reasoning_tokens.sum'), 0) ELSE 0 END) ELSE 0 END) AS codex FROM runtime_rows r JOIN runtime_deliveries d ON d.delivery_id = r.delivery_id WHERE d.received_at >= ${__from} * 1000000 AND d.received_at <= ${__to} * 1000000 HAVING COUNT(*) > 0",
-          "rawQueryText": "SELECT SUM(CASE WHEN COALESCE(NULLIF(json_extract(d.canonical_payload, '$.host'), ''), 'unknown') = 'pi' THEN (CASE WHEN json_extract(r.row_json, '$.input_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.input_tokens.sum'), 0) ELSE 0 END + CASE WHEN json_extract(r.row_json, '$.output_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.output_tokens.sum'), 0) ELSE 0 END + CASE WHEN json_extract(r.row_json, '$.cache_read_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.cache_read_tokens.sum'), 0) ELSE 0 END + CASE WHEN json_extract(r.row_json, '$.cache_creation_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.cache_creation_tokens.sum'), 0) ELSE 0 END + CASE WHEN json_extract(r.row_json, '$.reasoning_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.reasoning_tokens.sum'), 0) ELSE 0 END) ELSE 0 END) AS pi, SUM(CASE WHEN COALESCE(NULLIF(json_extract(d.canonical_payload, '$.host'), ''), 'unknown') = 'opencode' THEN (CASE WHEN json_extract(r.row_json, '$.input_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.input_tokens.sum'), 0) ELSE 0 END + CASE WHEN json_extract(r.row_json, '$.output_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.output_tokens.sum'), 0) ELSE 0 END + CASE WHEN json_extract(r.row_json, '$.cache_read_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.cache_read_tokens.sum'), 0) ELSE 0 END + CASE WHEN json_extract(r.row_json, '$.cache_creation_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.cache_creation_tokens.sum'), 0) ELSE 0 END + CASE WHEN json_extract(r.row_json, '$.reasoning_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.reasoning_tokens.sum'), 0) ELSE 0 END) ELSE 0 END) AS opencode, SUM(CASE WHEN COALESCE(NULLIF(json_extract(d.canonical_payload, '$.host'), ''), 'unknown') = 'claude-code' THEN (CASE WHEN json_extract(r.row_json, '$.input_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.input_tokens.sum'), 0) ELSE 0 END + CASE WHEN json_extract(r.row_json, '$.output_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.output_tokens.sum'), 0) ELSE 0 END + CASE WHEN json_extract(r.row_json, '$.cache_read_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.cache_read_tokens.sum'), 0) ELSE 0 END + CASE WHEN json_extract(r.row_json, '$.cache_creation_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.cache_creation_tokens.sum'), 0) ELSE 0 END + CASE WHEN json_extract(r.row_json, '$.reasoning_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.reasoning_tokens.sum'), 0) ELSE 0 END) ELSE 0 END) AS \"claude-code\", SUM(CASE WHEN COALESCE(NULLIF(json_extract(d.canonical_payload, '$.host'), ''), 'unknown') = 'codex' THEN (CASE WHEN json_extract(r.row_json, '$.input_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.input_tokens.sum'), 0) ELSE 0 END + CASE WHEN json_extract(r.row_json, '$.output_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.output_tokens.sum'), 0) ELSE 0 END + CASE WHEN json_extract(r.row_json, '$.cache_read_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.cache_read_tokens.sum'), 0) ELSE 0 END + CASE WHEN json_extract(r.row_json, '$.cache_creation_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.cache_creation_tokens.sum'), 0) ELSE 0 END + CASE WHEN json_extract(r.row_json, '$.reasoning_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.reasoning_tokens.sum'), 0) ELSE 0 END) ELSE 0 END) AS codex FROM runtime_rows r JOIN runtime_deliveries d ON d.delivery_id = r.delivery_id WHERE d.received_at >= ${__from} * 1000000 AND d.received_at <= ${__to} * 1000000 HAVING COUNT(*) > 0"
-        }
-      ],
-      "fieldConfig": {
-        "defaults": {
-          "unit": "short",
-          "min": 0,
-          "decimals": 0
-        },
-        "overrides": [
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "pi"
-            },
-            "properties": [
-              {
-                "id": "color",
-                "value": {
-                  "mode": "fixed",
-                  "fixedColor": "#73BF69"
-                }
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "opencode"
-            },
-            "properties": [
-              {
-                "id": "color",
-                "value": {
-                  "mode": "fixed",
-                  "fixedColor": "#5794F2"
-                }
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "claude-code"
-            },
-            "properties": [
-              {
-                "id": "color",
-                "value": {
-                  "mode": "fixed",
-                  "fixedColor": "#FF9830"
-                }
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "codex"
-            },
-            "properties": [
-              {
-                "id": "color",
-                "value": {
-                  "mode": "fixed",
-                  "fixedColor": "#B877D9"
-                }
-              }
-            ]
-          }
-        ]
-      },
-      "options": {
-        "orientation": "horizontal",
-        "legend": {
-          "showLegend": false
-        }
-      }
-    },
-    {
-      "id": 406,
-      "title": "Responses by host",
-      "description": "Reported response occurrences compare activity across supported agent hosts.",
-      "type": "barchart",
-      "gridPos": {
-        "x": 12,
-        "y": 32,
-        "w": 12,
-        "h": 7
-      },
-      "datasource": {
-        "type": "frser-sqlite-datasource",
-        "uid": "gentle-telemetry-sqlite"
-      },
-      "targets": [
-        {
-          "refId": "A",
-          "queryType": "table",
-          "queryText": "SELECT SUM(CASE WHEN COALESCE(NULLIF(json_extract(d.canonical_payload, '$.host'), ''), 'unknown') = 'pi' THEN CASE WHEN json_type(r.row_json, '$.responses') = 'integer' THEN json_extract(r.row_json, '$.responses') ELSE 0 END ELSE 0 END) AS pi, SUM(CASE WHEN COALESCE(NULLIF(json_extract(d.canonical_payload, '$.host'), ''), 'unknown') = 'opencode' THEN CASE WHEN json_type(r.row_json, '$.responses') = 'integer' THEN json_extract(r.row_json, '$.responses') ELSE 0 END ELSE 0 END) AS opencode, SUM(CASE WHEN COALESCE(NULLIF(json_extract(d.canonical_payload, '$.host'), ''), 'unknown') = 'claude-code' THEN CASE WHEN json_type(r.row_json, '$.responses') = 'integer' THEN json_extract(r.row_json, '$.responses') ELSE 0 END ELSE 0 END) AS \"claude-code\", SUM(CASE WHEN COALESCE(NULLIF(json_extract(d.canonical_payload, '$.host'), ''), 'unknown') = 'codex' THEN CASE WHEN json_type(r.row_json, '$.responses') = 'integer' THEN json_extract(r.row_json, '$.responses') ELSE 0 END ELSE 0 END) AS codex FROM runtime_rows r JOIN runtime_deliveries d ON d.delivery_id = r.delivery_id WHERE d.received_at >= ${__from} * 1000000 AND d.received_at <= ${__to} * 1000000 HAVING COUNT(*) > 0",
-          "rawQueryText": "SELECT SUM(CASE WHEN COALESCE(NULLIF(json_extract(d.canonical_payload, '$.host'), ''), 'unknown') = 'pi' THEN CASE WHEN json_type(r.row_json, '$.responses') = 'integer' THEN json_extract(r.row_json, '$.responses') ELSE 0 END ELSE 0 END) AS pi, SUM(CASE WHEN COALESCE(NULLIF(json_extract(d.canonical_payload, '$.host'), ''), 'unknown') = 'opencode' THEN CASE WHEN json_type(r.row_json, '$.responses') = 'integer' THEN json_extract(r.row_json, '$.responses') ELSE 0 END ELSE 0 END) AS opencode, SUM(CASE WHEN COALESCE(NULLIF(json_extract(d.canonical_payload, '$.host'), ''), 'unknown') = 'claude-code' THEN CASE WHEN json_type(r.row_json, '$.responses') = 'integer' THEN json_extract(r.row_json, '$.responses') ELSE 0 END ELSE 0 END) AS \"claude-code\", SUM(CASE WHEN COALESCE(NULLIF(json_extract(d.canonical_payload, '$.host'), ''), 'unknown') = 'codex' THEN CASE WHEN json_type(r.row_json, '$.responses') = 'integer' THEN json_extract(r.row_json, '$.responses') ELSE 0 END ELSE 0 END) AS codex FROM runtime_rows r JOIN runtime_deliveries d ON d.delivery_id = r.delivery_id WHERE d.received_at >= ${__from} * 1000000 AND d.received_at <= ${__to} * 1000000 HAVING COUNT(*) > 0"
-        }
-      ],
-      "fieldConfig": {
-        "defaults": {
-          "unit": "short",
-          "min": 0,
-          "decimals": 0
-        },
-        "overrides": [
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "pi"
-            },
-            "properties": [
-              {
-                "id": "color",
-                "value": {
-                  "mode": "fixed",
-                  "fixedColor": "#73BF69"
-                }
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "opencode"
-            },
-            "properties": [
-              {
-                "id": "color",
-                "value": {
-                  "mode": "fixed",
-                  "fixedColor": "#5794F2"
-                }
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "claude-code"
-            },
-            "properties": [
-              {
-                "id": "color",
-                "value": {
-                  "mode": "fixed",
-                  "fixedColor": "#FF9830"
-                }
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "codex"
-            },
-            "properties": [
-              {
-                "id": "color",
-                "value": {
-                  "mode": "fixed",
-                  "fixedColor": "#B877D9"
-                }
-              }
-            ]
-          }
-        ]
-      },
-      "options": {
-        "orientation": "horizontal",
-        "legend": {
-          "showLegend": false
-        }
-      }
-    },
-    {
-      "id": 407,
-      "title": "Tokens by model",
-      "description": "Model-level usage keeps unknown and custom model evidence visible instead of hiding incomplete attribution.",
-      "type": "table",
-      "gridPos": {
-        "x": 0,
-        "y": 39,
-        "w": 12,
-        "h": 9
-      },
-      "datasource": {
-        "type": "frser-sqlite-datasource",
-        "uid": "gentle-telemetry-sqlite"
-      },
-      "targets": [
-        {
-          "refId": "A",
-          "queryType": "table",
-          "queryText": "SELECT COALESCE(NULLIF(json_extract(d.canonical_payload, '$.host'), ''), 'unknown') AS Host, COALESCE(NULLIF(json_extract(r.row_json, '$.model.provider'), ''), 'unknown') AS Provider, COALESCE(NULLIF(json_extract(r.row_json, '$.model.id'), ''), 'unknown') AS Model, COALESCE(NULLIF(json_extract(r.row_json, '$.model_evidence'), ''), 'unknown') AS Evidence, SUM(CASE WHEN json_type(r.row_json, '$.responses') = 'integer' THEN json_extract(r.row_json, '$.responses') ELSE 0 END) AS Responses, SUM((CASE WHEN json_extract(r.row_json, '$.input_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.input_tokens.sum'), 0) ELSE 0 END + CASE WHEN json_extract(r.row_json, '$.output_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.output_tokens.sum'), 0) ELSE 0 END + CASE WHEN json_extract(r.row_json, '$.cache_read_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.cache_read_tokens.sum'), 0) ELSE 0 END + CASE WHEN json_extract(r.row_json, '$.cache_creation_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.cache_creation_tokens.sum'), 0) ELSE 0 END + CASE WHEN json_extract(r.row_json, '$.reasoning_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.reasoning_tokens.sum'), 0) ELSE 0 END)) AS \"Tokens processed\", ROUND(1.0 * SUM((CASE WHEN json_extract(r.row_json, '$.input_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.input_tokens.sum'), 0) ELSE 0 END + CASE WHEN json_extract(r.row_json, '$.output_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.output_tokens.sum'), 0) ELSE 0 END + CASE WHEN json_extract(r.row_json, '$.cache_read_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.cache_read_tokens.sum'), 0) ELSE 0 END + CASE WHEN json_extract(r.row_json, '$.cache_creation_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.cache_creation_tokens.sum'), 0) ELSE 0 END + CASE WHEN json_extract(r.row_json, '$.reasoning_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.reasoning_tokens.sum'), 0) ELSE 0 END)) / NULLIF(SUM(CASE WHEN json_type(r.row_json, '$.responses') = 'integer' THEN json_extract(r.row_json, '$.responses') ELSE 0 END), 0), 1) AS \"Avg tokens per response\" FROM runtime_rows r JOIN runtime_deliveries d ON d.delivery_id = r.delivery_id WHERE d.received_at >= ${__from} * 1000000 AND d.received_at <= ${__to} * 1000000 GROUP BY Host, Provider, Model, Evidence ORDER BY \"Tokens processed\" DESC LIMIT 1000",
-          "rawQueryText": "SELECT COALESCE(NULLIF(json_extract(d.canonical_payload, '$.host'), ''), 'unknown') AS Host, COALESCE(NULLIF(json_extract(r.row_json, '$.model.provider'), ''), 'unknown') AS Provider, COALESCE(NULLIF(json_extract(r.row_json, '$.model.id'), ''), 'unknown') AS Model, COALESCE(NULLIF(json_extract(r.row_json, '$.model_evidence'), ''), 'unknown') AS Evidence, SUM(CASE WHEN json_type(r.row_json, '$.responses') = 'integer' THEN json_extract(r.row_json, '$.responses') ELSE 0 END) AS Responses, SUM((CASE WHEN json_extract(r.row_json, '$.input_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.input_tokens.sum'), 0) ELSE 0 END + CASE WHEN json_extract(r.row_json, '$.output_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.output_tokens.sum'), 0) ELSE 0 END + CASE WHEN json_extract(r.row_json, '$.cache_read_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.cache_read_tokens.sum'), 0) ELSE 0 END + CASE WHEN json_extract(r.row_json, '$.cache_creation_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.cache_creation_tokens.sum'), 0) ELSE 0 END + CASE WHEN json_extract(r.row_json, '$.reasoning_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.reasoning_tokens.sum'), 0) ELSE 0 END)) AS \"Tokens processed\", ROUND(1.0 * SUM((CASE WHEN json_extract(r.row_json, '$.input_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.input_tokens.sum'), 0) ELSE 0 END + CASE WHEN json_extract(r.row_json, '$.output_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.output_tokens.sum'), 0) ELSE 0 END + CASE WHEN json_extract(r.row_json, '$.cache_read_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.cache_read_tokens.sum'), 0) ELSE 0 END + CASE WHEN json_extract(r.row_json, '$.cache_creation_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.cache_creation_tokens.sum'), 0) ELSE 0 END + CASE WHEN json_extract(r.row_json, '$.reasoning_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.reasoning_tokens.sum'), 0) ELSE 0 END)) / NULLIF(SUM(CASE WHEN json_type(r.row_json, '$.responses') = 'integer' THEN json_extract(r.row_json, '$.responses') ELSE 0 END), 0), 1) AS \"Avg tokens per response\" FROM runtime_rows r JOIN runtime_deliveries d ON d.delivery_id = r.delivery_id WHERE d.received_at >= ${__from} * 1000000 AND d.received_at <= ${__to} * 1000000 GROUP BY Host, Provider, Model, Evidence ORDER BY \"Tokens processed\" DESC LIMIT 1000"
-        }
-      ],
-      "fieldConfig": {
-        "defaults": {
-          "unit": "short",
-          "min": 0
-        },
-        "overrides": [
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "pi"
-            },
-            "properties": [
-              {
-                "id": "color",
-                "value": {
-                  "mode": "fixed",
-                  "fixedColor": "#73BF69"
-                }
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "opencode"
-            },
-            "properties": [
-              {
-                "id": "color",
-                "value": {
-                  "mode": "fixed",
-                  "fixedColor": "#5794F2"
-                }
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "claude-code"
-            },
-            "properties": [
-              {
-                "id": "color",
-                "value": {
-                  "mode": "fixed",
-                  "fixedColor": "#FF9830"
-                }
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "codex"
-            },
-            "properties": [
-              {
-                "id": "color",
-                "value": {
-                  "mode": "fixed",
-                  "fixedColor": "#B877D9"
-                }
-              }
-            ]
-          }
-        ]
-      },
-      "options": {
-        "showHeader": true,
-        "cellHeight": "sm",
-        "enablePagination": true
-      }
-    },
-    {
-      "id": 408,
-      "title": "Responses and tokens by selected effort",
-      "description": "Selected reasoning effort shows how usage and token volume are distributed across requested effort levels.",
-      "type": "table",
-      "gridPos": {
-        "x": 12,
-        "y": 39,
-        "w": 12,
-        "h": 9
-      },
-      "datasource": {
-        "type": "frser-sqlite-datasource",
-        "uid": "gentle-telemetry-sqlite"
-      },
-      "targets": [
-        {
-          "refId": "A",
-          "queryType": "table",
-          "queryText": "SELECT COALESCE(NULLIF(json_extract(r.row_json, '$.selected_effort'), ''), 'unknown') AS \"Selected effort\", SUM(CASE WHEN json_type(r.row_json, '$.responses') = 'integer' THEN json_extract(r.row_json, '$.responses') ELSE 0 END) AS Responses, SUM((CASE WHEN json_extract(r.row_json, '$.input_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.input_tokens.sum'), 0) ELSE 0 END + CASE WHEN json_extract(r.row_json, '$.output_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.output_tokens.sum'), 0) ELSE 0 END + CASE WHEN json_extract(r.row_json, '$.cache_read_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.cache_read_tokens.sum'), 0) ELSE 0 END + CASE WHEN json_extract(r.row_json, '$.cache_creation_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.cache_creation_tokens.sum'), 0) ELSE 0 END + CASE WHEN json_extract(r.row_json, '$.reasoning_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.reasoning_tokens.sum'), 0) ELSE 0 END)) AS \"Tokens processed\", ROUND(1.0 * SUM((CASE WHEN json_extract(r.row_json, '$.input_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.input_tokens.sum'), 0) ELSE 0 END + CASE WHEN json_extract(r.row_json, '$.output_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.output_tokens.sum'), 0) ELSE 0 END + CASE WHEN json_extract(r.row_json, '$.cache_read_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.cache_read_tokens.sum'), 0) ELSE 0 END + CASE WHEN json_extract(r.row_json, '$.cache_creation_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.cache_creation_tokens.sum'), 0) ELSE 0 END + CASE WHEN json_extract(r.row_json, '$.reasoning_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.reasoning_tokens.sum'), 0) ELSE 0 END)) / NULLIF(SUM(CASE WHEN json_type(r.row_json, '$.responses') = 'integer' THEN json_extract(r.row_json, '$.responses') ELSE 0 END), 0), 1) AS \"Avg tokens per response\" FROM runtime_rows r JOIN runtime_deliveries d ON d.delivery_id = r.delivery_id WHERE d.received_at >= ${__from} * 1000000 AND d.received_at <= ${__to} * 1000000 GROUP BY \"Selected effort\" ORDER BY Responses DESC, \"Tokens processed\" DESC LIMIT 1000",
-          "rawQueryText": "SELECT COALESCE(NULLIF(json_extract(r.row_json, '$.selected_effort'), ''), 'unknown') AS \"Selected effort\", SUM(CASE WHEN json_type(r.row_json, '$.responses') = 'integer' THEN json_extract(r.row_json, '$.responses') ELSE 0 END) AS Responses, SUM((CASE WHEN json_extract(r.row_json, '$.input_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.input_tokens.sum'), 0) ELSE 0 END + CASE WHEN json_extract(r.row_json, '$.output_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.output_tokens.sum'), 0) ELSE 0 END + CASE WHEN json_extract(r.row_json, '$.cache_read_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.cache_read_tokens.sum'), 0) ELSE 0 END + CASE WHEN json_extract(r.row_json, '$.cache_creation_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.cache_creation_tokens.sum'), 0) ELSE 0 END + CASE WHEN json_extract(r.row_json, '$.reasoning_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.reasoning_tokens.sum'), 0) ELSE 0 END)) AS \"Tokens processed\", ROUND(1.0 * SUM((CASE WHEN json_extract(r.row_json, '$.input_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.input_tokens.sum'), 0) ELSE 0 END + CASE WHEN json_extract(r.row_json, '$.output_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.output_tokens.sum'), 0) ELSE 0 END + CASE WHEN json_extract(r.row_json, '$.cache_read_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.cache_read_tokens.sum'), 0) ELSE 0 END + CASE WHEN json_extract(r.row_json, '$.cache_creation_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.cache_creation_tokens.sum'), 0) ELSE 0 END + CASE WHEN json_extract(r.row_json, '$.reasoning_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.reasoning_tokens.sum'), 0) ELSE 0 END)) / NULLIF(SUM(CASE WHEN json_type(r.row_json, '$.responses') = 'integer' THEN json_extract(r.row_json, '$.responses') ELSE 0 END), 0), 1) AS \"Avg tokens per response\" FROM runtime_rows r JOIN runtime_deliveries d ON d.delivery_id = r.delivery_id WHERE d.received_at >= ${__from} * 1000000 AND d.received_at <= ${__to} * 1000000 GROUP BY \"Selected effort\" ORDER BY Responses DESC, \"Tokens processed\" DESC LIMIT 1000"
-        }
-      ],
-      "fieldConfig": {
-        "defaults": {
-          "unit": "short",
-          "min": 0
-        },
-        "overrides": [
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "pi"
-            },
-            "properties": [
-              {
-                "id": "color",
-                "value": {
-                  "mode": "fixed",
-                  "fixedColor": "#73BF69"
-                }
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "opencode"
-            },
-            "properties": [
-              {
-                "id": "color",
-                "value": {
-                  "mode": "fixed",
-                  "fixedColor": "#5794F2"
-                }
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "claude-code"
-            },
-            "properties": [
-              {
-                "id": "color",
-                "value": {
-                  "mode": "fixed",
-                  "fixedColor": "#FF9830"
-                }
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "codex"
-            },
-            "properties": [
-              {
-                "id": "color",
-                "value": {
-                  "mode": "fixed",
-                  "fixedColor": "#B877D9"
-                }
-              }
-            ]
-          }
-        ]
-      },
-      "options": {
-        "showHeader": true,
-        "cellHeight": "sm",
-        "enablePagination": true
-      }
-    },
-    {
       "id": 409,
       "title": "Usage by host, subagent, model and effort",
-      "description": "The most active host, subagent, model, and effort combinations reveal how customers put the product to work.",
+      "description": "Answers which subagent used which model at which effort and how many tokens were processed.",
       "type": "table",
       "gridPos": {
         "x": 0,
-        "y": 48,
+        "y": 32,
         "w": 24,
-        "h": 10
+        "h": 14
       },
       "datasource": {
         "type": "frser-sqlite-datasource",
@@ -1615,19 +1063,379 @@
       "options": {
         "showHeader": true,
         "cellHeight": "sm",
-        "enablePagination": true
+        "footer": {
+          "enablePagination": false
+        }
+      }
+    },
+    {
+      "id": 405,
+      "title": "Tokens processed by host",
+      "description": "Derived token volume compares runtime usage across supported agent hosts.",
+      "type": "barchart",
+      "gridPos": {
+        "x": 0,
+        "y": 46,
+        "w": 12,
+        "h": 7
+      },
+      "datasource": {
+        "type": "frser-sqlite-datasource",
+        "uid": "gentle-telemetry-sqlite"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "queryType": "table",
+          "queryText": "SELECT CAST(COALESCE(NULLIF(json_extract(d.canonical_payload, '$.host'), ''), 'unknown') AS TEXT) AS Host, SUM((CASE WHEN json_extract(r.row_json, '$.input_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.input_tokens.sum'), 0) ELSE 0 END + CASE WHEN json_extract(r.row_json, '$.output_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.output_tokens.sum'), 0) ELSE 0 END + CASE WHEN json_extract(r.row_json, '$.cache_read_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.cache_read_tokens.sum'), 0) ELSE 0 END + CASE WHEN json_extract(r.row_json, '$.cache_creation_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.cache_creation_tokens.sum'), 0) ELSE 0 END + CASE WHEN json_extract(r.row_json, '$.reasoning_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.reasoning_tokens.sum'), 0) ELSE 0 END)) AS \"Tokens processed\" FROM runtime_rows r JOIN runtime_deliveries d ON d.delivery_id = r.delivery_id WHERE d.received_at >= ${__from} * 1000000 AND d.received_at <= ${__to} * 1000000 GROUP BY Host HAVING COUNT(*) > 0 ORDER BY \"Tokens processed\" DESC LIMIT 1000",
+          "rawQueryText": "SELECT CAST(COALESCE(NULLIF(json_extract(d.canonical_payload, '$.host'), ''), 'unknown') AS TEXT) AS Host, SUM((CASE WHEN json_extract(r.row_json, '$.input_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.input_tokens.sum'), 0) ELSE 0 END + CASE WHEN json_extract(r.row_json, '$.output_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.output_tokens.sum'), 0) ELSE 0 END + CASE WHEN json_extract(r.row_json, '$.cache_read_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.cache_read_tokens.sum'), 0) ELSE 0 END + CASE WHEN json_extract(r.row_json, '$.cache_creation_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.cache_creation_tokens.sum'), 0) ELSE 0 END + CASE WHEN json_extract(r.row_json, '$.reasoning_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.reasoning_tokens.sum'), 0) ELSE 0 END)) AS \"Tokens processed\" FROM runtime_rows r JOIN runtime_deliveries d ON d.delivery_id = r.delivery_id WHERE d.received_at >= ${__from} * 1000000 AND d.received_at <= ${__to} * 1000000 GROUP BY Host HAVING COUNT(*) > 0 ORDER BY \"Tokens processed\" DESC LIMIT 1000"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "min": 0,
+          "decimals": 0
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Host"
+            },
+            "properties": [
+              {
+                "id": "mappings",
+                "value": [
+                  {
+                    "type": "value",
+                    "options": {
+                      "pi": {
+                        "color": "#73BF69",
+                        "index": 0,
+                        "text": "pi"
+                      },
+                      "opencode": {
+                        "color": "#5794F2",
+                        "index": 1,
+                        "text": "opencode"
+                      },
+                      "claude-code": {
+                        "color": "#FF9830",
+                        "index": 2,
+                        "text": "claude-code"
+                      },
+                      "codex": {
+                        "color": "#B877D9",
+                        "index": 3,
+                        "text": "codex"
+                      }
+                    }
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      "options": {
+        "orientation": "horizontal",
+        "xField": "Host",
+        "colorByField": "Host",
+        "showValue": "always",
+        "legend": {
+          "showLegend": false
+        }
+      }
+    },
+    {
+      "id": 406,
+      "title": "Responses by host",
+      "description": "Reported response occurrences compare activity across supported agent hosts.",
+      "type": "barchart",
+      "gridPos": {
+        "x": 12,
+        "y": 46,
+        "w": 12,
+        "h": 7
+      },
+      "datasource": {
+        "type": "frser-sqlite-datasource",
+        "uid": "gentle-telemetry-sqlite"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "queryType": "table",
+          "queryText": "SELECT CAST(COALESCE(NULLIF(json_extract(d.canonical_payload, '$.host'), ''), 'unknown') AS TEXT) AS Host, SUM(CASE WHEN json_type(r.row_json, '$.responses') = 'integer' THEN json_extract(r.row_json, '$.responses') ELSE 0 END) AS \"Responses\" FROM runtime_rows r JOIN runtime_deliveries d ON d.delivery_id = r.delivery_id WHERE d.received_at >= ${__from} * 1000000 AND d.received_at <= ${__to} * 1000000 GROUP BY Host HAVING COUNT(*) > 0 ORDER BY \"Responses\" DESC LIMIT 1000",
+          "rawQueryText": "SELECT CAST(COALESCE(NULLIF(json_extract(d.canonical_payload, '$.host'), ''), 'unknown') AS TEXT) AS Host, SUM(CASE WHEN json_type(r.row_json, '$.responses') = 'integer' THEN json_extract(r.row_json, '$.responses') ELSE 0 END) AS \"Responses\" FROM runtime_rows r JOIN runtime_deliveries d ON d.delivery_id = r.delivery_id WHERE d.received_at >= ${__from} * 1000000 AND d.received_at <= ${__to} * 1000000 GROUP BY Host HAVING COUNT(*) > 0 ORDER BY \"Responses\" DESC LIMIT 1000"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "min": 0,
+          "decimals": 0
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Host"
+            },
+            "properties": [
+              {
+                "id": "mappings",
+                "value": [
+                  {
+                    "type": "value",
+                    "options": {
+                      "pi": {
+                        "color": "#73BF69",
+                        "index": 0,
+                        "text": "pi"
+                      },
+                      "opencode": {
+                        "color": "#5794F2",
+                        "index": 1,
+                        "text": "opencode"
+                      },
+                      "claude-code": {
+                        "color": "#FF9830",
+                        "index": 2,
+                        "text": "claude-code"
+                      },
+                      "codex": {
+                        "color": "#B877D9",
+                        "index": 3,
+                        "text": "codex"
+                      }
+                    }
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      "options": {
+        "orientation": "horizontal",
+        "xField": "Host",
+        "colorByField": "Host",
+        "showValue": "always",
+        "legend": {
+          "showLegend": false
+        }
+      }
+    },
+    {
+      "id": 407,
+      "title": "Tokens by model",
+      "description": "Model-level usage keeps unknown and custom model evidence visible instead of hiding incomplete attribution.",
+      "type": "table",
+      "gridPos": {
+        "x": 0,
+        "y": 53,
+        "w": 12,
+        "h": 10
+      },
+      "datasource": {
+        "type": "frser-sqlite-datasource",
+        "uid": "gentle-telemetry-sqlite"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "queryType": "table",
+          "queryText": "SELECT COALESCE(NULLIF(json_extract(d.canonical_payload, '$.host'), ''), 'unknown') AS Host, COALESCE(NULLIF(json_extract(r.row_json, '$.model.provider'), ''), 'unknown') AS Provider, COALESCE(NULLIF(json_extract(r.row_json, '$.model.id'), ''), 'unknown') AS Model, COALESCE(NULLIF(json_extract(r.row_json, '$.model_evidence'), ''), 'unknown') AS Evidence, SUM(CASE WHEN json_type(r.row_json, '$.responses') = 'integer' THEN json_extract(r.row_json, '$.responses') ELSE 0 END) AS Responses, SUM((CASE WHEN json_extract(r.row_json, '$.input_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.input_tokens.sum'), 0) ELSE 0 END + CASE WHEN json_extract(r.row_json, '$.output_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.output_tokens.sum'), 0) ELSE 0 END + CASE WHEN json_extract(r.row_json, '$.cache_read_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.cache_read_tokens.sum'), 0) ELSE 0 END + CASE WHEN json_extract(r.row_json, '$.cache_creation_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.cache_creation_tokens.sum'), 0) ELSE 0 END + CASE WHEN json_extract(r.row_json, '$.reasoning_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.reasoning_tokens.sum'), 0) ELSE 0 END)) AS \"Tokens processed\", ROUND(1.0 * SUM((CASE WHEN json_extract(r.row_json, '$.input_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.input_tokens.sum'), 0) ELSE 0 END + CASE WHEN json_extract(r.row_json, '$.output_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.output_tokens.sum'), 0) ELSE 0 END + CASE WHEN json_extract(r.row_json, '$.cache_read_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.cache_read_tokens.sum'), 0) ELSE 0 END + CASE WHEN json_extract(r.row_json, '$.cache_creation_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.cache_creation_tokens.sum'), 0) ELSE 0 END + CASE WHEN json_extract(r.row_json, '$.reasoning_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.reasoning_tokens.sum'), 0) ELSE 0 END)) / NULLIF(SUM(CASE WHEN json_type(r.row_json, '$.responses') = 'integer' THEN json_extract(r.row_json, '$.responses') ELSE 0 END), 0), 1) AS \"Avg tokens per response\" FROM runtime_rows r JOIN runtime_deliveries d ON d.delivery_id = r.delivery_id WHERE d.received_at >= ${__from} * 1000000 AND d.received_at <= ${__to} * 1000000 GROUP BY Host, Provider, Model, Evidence ORDER BY \"Tokens processed\" DESC LIMIT 1000",
+          "rawQueryText": "SELECT COALESCE(NULLIF(json_extract(d.canonical_payload, '$.host'), ''), 'unknown') AS Host, COALESCE(NULLIF(json_extract(r.row_json, '$.model.provider'), ''), 'unknown') AS Provider, COALESCE(NULLIF(json_extract(r.row_json, '$.model.id'), ''), 'unknown') AS Model, COALESCE(NULLIF(json_extract(r.row_json, '$.model_evidence'), ''), 'unknown') AS Evidence, SUM(CASE WHEN json_type(r.row_json, '$.responses') = 'integer' THEN json_extract(r.row_json, '$.responses') ELSE 0 END) AS Responses, SUM((CASE WHEN json_extract(r.row_json, '$.input_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.input_tokens.sum'), 0) ELSE 0 END + CASE WHEN json_extract(r.row_json, '$.output_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.output_tokens.sum'), 0) ELSE 0 END + CASE WHEN json_extract(r.row_json, '$.cache_read_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.cache_read_tokens.sum'), 0) ELSE 0 END + CASE WHEN json_extract(r.row_json, '$.cache_creation_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.cache_creation_tokens.sum'), 0) ELSE 0 END + CASE WHEN json_extract(r.row_json, '$.reasoning_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.reasoning_tokens.sum'), 0) ELSE 0 END)) AS \"Tokens processed\", ROUND(1.0 * SUM((CASE WHEN json_extract(r.row_json, '$.input_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.input_tokens.sum'), 0) ELSE 0 END + CASE WHEN json_extract(r.row_json, '$.output_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.output_tokens.sum'), 0) ELSE 0 END + CASE WHEN json_extract(r.row_json, '$.cache_read_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.cache_read_tokens.sum'), 0) ELSE 0 END + CASE WHEN json_extract(r.row_json, '$.cache_creation_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.cache_creation_tokens.sum'), 0) ELSE 0 END + CASE WHEN json_extract(r.row_json, '$.reasoning_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.reasoning_tokens.sum'), 0) ELSE 0 END)) / NULLIF(SUM(CASE WHEN json_type(r.row_json, '$.responses') = 'integer' THEN json_extract(r.row_json, '$.responses') ELSE 0 END), 0), 1) AS \"Avg tokens per response\" FROM runtime_rows r JOIN runtime_deliveries d ON d.delivery_id = r.delivery_id WHERE d.received_at >= ${__from} * 1000000 AND d.received_at <= ${__to} * 1000000 GROUP BY Host, Provider, Model, Evidence ORDER BY \"Tokens processed\" DESC LIMIT 1000"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "min": 0
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "pi"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "mode": "fixed",
+                  "fixedColor": "#73BF69"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "opencode"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "mode": "fixed",
+                  "fixedColor": "#5794F2"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "claude-code"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "mode": "fixed",
+                  "fixedColor": "#FF9830"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "codex"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "mode": "fixed",
+                  "fixedColor": "#B877D9"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "options": {
+        "showHeader": true,
+        "cellHeight": "sm",
+        "footer": {
+          "enablePagination": false
+        }
+      }
+    },
+    {
+      "id": 408,
+      "title": "Responses and tokens by selected effort",
+      "description": "Selected reasoning effort shows how usage and token volume are distributed across requested effort levels.",
+      "type": "table",
+      "gridPos": {
+        "x": 12,
+        "y": 53,
+        "w": 12,
+        "h": 10
+      },
+      "datasource": {
+        "type": "frser-sqlite-datasource",
+        "uid": "gentle-telemetry-sqlite"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "queryType": "table",
+          "queryText": "SELECT COALESCE(NULLIF(json_extract(r.row_json, '$.selected_effort'), ''), 'unknown') AS \"Selected effort\", SUM(CASE WHEN json_type(r.row_json, '$.responses') = 'integer' THEN json_extract(r.row_json, '$.responses') ELSE 0 END) AS Responses, SUM((CASE WHEN json_extract(r.row_json, '$.input_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.input_tokens.sum'), 0) ELSE 0 END + CASE WHEN json_extract(r.row_json, '$.output_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.output_tokens.sum'), 0) ELSE 0 END + CASE WHEN json_extract(r.row_json, '$.cache_read_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.cache_read_tokens.sum'), 0) ELSE 0 END + CASE WHEN json_extract(r.row_json, '$.cache_creation_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.cache_creation_tokens.sum'), 0) ELSE 0 END + CASE WHEN json_extract(r.row_json, '$.reasoning_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.reasoning_tokens.sum'), 0) ELSE 0 END)) AS \"Tokens processed\", ROUND(1.0 * SUM((CASE WHEN json_extract(r.row_json, '$.input_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.input_tokens.sum'), 0) ELSE 0 END + CASE WHEN json_extract(r.row_json, '$.output_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.output_tokens.sum'), 0) ELSE 0 END + CASE WHEN json_extract(r.row_json, '$.cache_read_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.cache_read_tokens.sum'), 0) ELSE 0 END + CASE WHEN json_extract(r.row_json, '$.cache_creation_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.cache_creation_tokens.sum'), 0) ELSE 0 END + CASE WHEN json_extract(r.row_json, '$.reasoning_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.reasoning_tokens.sum'), 0) ELSE 0 END)) / NULLIF(SUM(CASE WHEN json_type(r.row_json, '$.responses') = 'integer' THEN json_extract(r.row_json, '$.responses') ELSE 0 END), 0), 1) AS \"Avg tokens per response\" FROM runtime_rows r JOIN runtime_deliveries d ON d.delivery_id = r.delivery_id WHERE d.received_at >= ${__from} * 1000000 AND d.received_at <= ${__to} * 1000000 GROUP BY \"Selected effort\" ORDER BY Responses DESC, \"Tokens processed\" DESC LIMIT 1000",
+          "rawQueryText": "SELECT COALESCE(NULLIF(json_extract(r.row_json, '$.selected_effort'), ''), 'unknown') AS \"Selected effort\", SUM(CASE WHEN json_type(r.row_json, '$.responses') = 'integer' THEN json_extract(r.row_json, '$.responses') ELSE 0 END) AS Responses, SUM((CASE WHEN json_extract(r.row_json, '$.input_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.input_tokens.sum'), 0) ELSE 0 END + CASE WHEN json_extract(r.row_json, '$.output_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.output_tokens.sum'), 0) ELSE 0 END + CASE WHEN json_extract(r.row_json, '$.cache_read_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.cache_read_tokens.sum'), 0) ELSE 0 END + CASE WHEN json_extract(r.row_json, '$.cache_creation_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.cache_creation_tokens.sum'), 0) ELSE 0 END + CASE WHEN json_extract(r.row_json, '$.reasoning_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.reasoning_tokens.sum'), 0) ELSE 0 END)) AS \"Tokens processed\", ROUND(1.0 * SUM((CASE WHEN json_extract(r.row_json, '$.input_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.input_tokens.sum'), 0) ELSE 0 END + CASE WHEN json_extract(r.row_json, '$.output_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.output_tokens.sum'), 0) ELSE 0 END + CASE WHEN json_extract(r.row_json, '$.cache_read_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.cache_read_tokens.sum'), 0) ELSE 0 END + CASE WHEN json_extract(r.row_json, '$.cache_creation_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.cache_creation_tokens.sum'), 0) ELSE 0 END + CASE WHEN json_extract(r.row_json, '$.reasoning_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.reasoning_tokens.sum'), 0) ELSE 0 END)) / NULLIF(SUM(CASE WHEN json_type(r.row_json, '$.responses') = 'integer' THEN json_extract(r.row_json, '$.responses') ELSE 0 END), 0), 1) AS \"Avg tokens per response\" FROM runtime_rows r JOIN runtime_deliveries d ON d.delivery_id = r.delivery_id WHERE d.received_at >= ${__from} * 1000000 AND d.received_at <= ${__to} * 1000000 GROUP BY \"Selected effort\" ORDER BY Responses DESC, \"Tokens processed\" DESC LIMIT 1000"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "min": 0
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "pi"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "mode": "fixed",
+                  "fixedColor": "#73BF69"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "opencode"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "mode": "fixed",
+                  "fixedColor": "#5794F2"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "claude-code"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "mode": "fixed",
+                  "fixedColor": "#FF9830"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "codex"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "mode": "fixed",
+                  "fixedColor": "#B877D9"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "options": {
+        "showHeader": true,
+        "cellHeight": "sm",
+        "footer": {
+          "enablePagination": false
+        }
       }
     },
     {
       "id": 410,
-      "title": "Tokens processed per hour by host",
-      "description": "Hourly derived token volume shows when and where runtime usage is happening.",
+      "title": "Tokens processed per hour by host (last 24h)",
+      "description": "Hourly derived token volume over the last 24 hours shows recent runtime activity by host.",
       "type": "timeseries",
       "gridPos": {
         "x": 0,
-        "y": 58,
+        "y": 63,
         "w": 12,
-        "h": 9
+        "h": 11
       },
       "datasource": {
         "type": "frser-sqlite-datasource",
@@ -1733,7 +1541,8 @@
           "mode": "multi",
           "sort": "desc"
         }
-      }
+      },
+      "timeFrom": "24h"
     },
     {
       "id": 411,
@@ -1742,9 +1551,9 @@
       "type": "table",
       "gridPos": {
         "x": 12,
-        "y": 58,
+        "y": 63,
         "w": 12,
-        "h": 9
+        "h": 11
       },
       "datasource": {
         "type": "frser-sqlite-datasource",
@@ -1829,7 +1638,9 @@
       "options": {
         "showHeader": true,
         "cellHeight": "sm",
-        "enablePagination": true
+        "footer": {
+          "enablePagination": false
+        }
       }
     },
     {
@@ -1839,7 +1650,7 @@
       "type": "barchart",
       "gridPos": {
         "x": 0,
-        "y": 67,
+        "y": 74,
         "w": 12,
         "h": 7
       },
@@ -1938,7 +1749,7 @@
       "type": "table",
       "gridPos": {
         "x": 12,
-        "y": 67,
+        "y": 74,
         "w": 12,
         "h": 7
       },
@@ -1994,7 +1805,9 @@
       "options": {
         "showHeader": true,
         "cellHeight": "sm",
-        "enablePagination": false
+        "footer": {
+          "enablePagination": false
+        }
       }
     }
   ]

--- a/deploy/telemetry/grafana/dashboards/gentle-ai-usage.json
+++ b/deploy/telemetry/grafana/dashboards/gentle-ai-usage.json
@@ -1933,9 +1933,9 @@
     },
     {
       "id": 413,
-      "title": "Measured request duration",
-      "description": "Average measured request duration provides a simple view of runtime responsiveness.",
-      "type": "stat",
+      "title": "Measured duration by kind",
+      "description": "Average measured duration and observation count by available timing kind show how responsive instrumented activity is.",
+      "type": "table",
       "gridPos": {
         "x": 12,
         "y": 67,
@@ -1950,13 +1950,13 @@
         {
           "refId": "A",
           "queryType": "table",
-          "queryText": "SELECT ROUND(SUM(CASE WHEN json_extract(r.row_json, '$.duration.kind') = 'request' AND json_type(r.row_json, '$.duration.measured_count') = 'integer' AND json_extract(r.row_json, '$.duration.measured_count') > 0 THEN json_extract(r.row_json, '$.duration.sum_ms') ELSE 0 END) / NULLIF(SUM(CASE WHEN json_extract(r.row_json, '$.duration.kind') = 'request' AND json_type(r.row_json, '$.duration.measured_count') = 'integer' THEN json_extract(r.row_json, '$.duration.measured_count') ELSE 0 END), 0), 1) AS \"Average request duration\" FROM runtime_rows r JOIN runtime_deliveries d ON d.delivery_id = r.delivery_id WHERE d.received_at >= ${__from} * 1000000 AND d.received_at <= ${__to} * 1000000 HAVING SUM(CASE WHEN json_extract(r.row_json, '$.duration.kind') = 'request' AND json_type(r.row_json, '$.duration.measured_count') = 'integer' THEN json_extract(r.row_json, '$.duration.measured_count') ELSE 0 END) > 0",
-          "rawQueryText": "SELECT ROUND(SUM(CASE WHEN json_extract(r.row_json, '$.duration.kind') = 'request' AND json_type(r.row_json, '$.duration.measured_count') = 'integer' AND json_extract(r.row_json, '$.duration.measured_count') > 0 THEN json_extract(r.row_json, '$.duration.sum_ms') ELSE 0 END) / NULLIF(SUM(CASE WHEN json_extract(r.row_json, '$.duration.kind') = 'request' AND json_type(r.row_json, '$.duration.measured_count') = 'integer' THEN json_extract(r.row_json, '$.duration.measured_count') ELSE 0 END), 0), 1) AS \"Average request duration\" FROM runtime_rows r JOIN runtime_deliveries d ON d.delivery_id = r.delivery_id WHERE d.received_at >= ${__from} * 1000000 AND d.received_at <= ${__to} * 1000000 HAVING SUM(CASE WHEN json_extract(r.row_json, '$.duration.kind') = 'request' AND json_type(r.row_json, '$.duration.measured_count') = 'integer' THEN json_extract(r.row_json, '$.duration.measured_count') ELSE 0 END) > 0"
+          "queryText": "SELECT json_extract(r.row_json, '$.duration.kind') AS Kind, SUM(json_extract(r.row_json, '$.duration.measured_count')) AS \"Measured count\", ROUND(SUM(json_extract(r.row_json, '$.duration.sum_ms')) / NULLIF(SUM(json_extract(r.row_json, '$.duration.measured_count')), 0), 1) AS \"Average ms\" FROM runtime_rows r JOIN runtime_deliveries d ON d.delivery_id = r.delivery_id WHERE d.received_at >= ${__from} * 1000000 AND d.received_at <= ${__to} * 1000000 AND json_extract(r.row_json, '$.duration.kind') <> 'unavailable' AND json_type(r.row_json, '$.duration.measured_count') = 'integer' AND json_extract(r.row_json, '$.duration.measured_count') > 0 AND json_type(r.row_json, '$.duration.sum_ms') IN ('integer', 'real') GROUP BY Kind HAVING SUM(json_extract(r.row_json, '$.duration.measured_count')) > 0 ORDER BY \"Measured count\" DESC, Kind ASC LIMIT 1000",
+          "rawQueryText": "SELECT json_extract(r.row_json, '$.duration.kind') AS Kind, SUM(json_extract(r.row_json, '$.duration.measured_count')) AS \"Measured count\", ROUND(SUM(json_extract(r.row_json, '$.duration.sum_ms')) / NULLIF(SUM(json_extract(r.row_json, '$.duration.measured_count')), 0), 1) AS \"Average ms\" FROM runtime_rows r JOIN runtime_deliveries d ON d.delivery_id = r.delivery_id WHERE d.received_at >= ${__from} * 1000000 AND d.received_at <= ${__to} * 1000000 AND json_extract(r.row_json, '$.duration.kind') <> 'unavailable' AND json_type(r.row_json, '$.duration.measured_count') = 'integer' AND json_extract(r.row_json, '$.duration.measured_count') > 0 AND json_type(r.row_json, '$.duration.sum_ms') IN ('integer', 'real') GROUP BY Kind HAVING SUM(json_extract(r.row_json, '$.duration.measured_count')) > 0 ORDER BY \"Measured count\" DESC, Kind ASC LIMIT 1000"
         }
       ],
       "fieldConfig": {
         "defaults": {
-          "unit": "ms",
+          "unit": "short",
           "min": 0,
           "decimals": 0
         },
@@ -1964,76 +1964,37 @@
           {
             "matcher": {
               "id": "byName",
-              "options": "pi"
+              "options": "Average ms"
             },
             "properties": [
               {
-                "id": "color",
-                "value": {
-                  "mode": "fixed",
-                  "fixedColor": "#73BF69"
-                }
+                "id": "unit",
+                "value": "ms"
+              },
+              {
+                "id": "decimals",
+                "value": 1
               }
             ]
           },
           {
             "matcher": {
               "id": "byName",
-              "options": "opencode"
+              "options": "Kind"
             },
             "properties": [
               {
-                "id": "color",
-                "value": {
-                  "mode": "fixed",
-                  "fixedColor": "#5794F2"
-                }
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "claude-code"
-            },
-            "properties": [
-              {
-                "id": "color",
-                "value": {
-                  "mode": "fixed",
-                  "fixedColor": "#FF9830"
-                }
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "codex"
-            },
-            "properties": [
-              {
-                "id": "color",
-                "value": {
-                  "mode": "fixed",
-                  "fixedColor": "#B877D9"
-                }
+                "id": "custom.width",
+                "value": 160
               }
             ]
           }
         ]
       },
       "options": {
-        "orientation": "horizontal",
-        "textMode": "value_and_name",
-        "graphMode": "none",
-        "reduceOptions": {
-          "values": false,
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": ""
-        }
+        "showHeader": true,
+        "cellHeight": "sm",
+        "enablePagination": false
       }
     }
   ]

--- a/deploy/telemetry/grafana/dashboards/gentle-ai-usage.json
+++ b/deploy/telemetry/grafana/dashboards/gentle-ai-usage.json
@@ -1,370 +1,2040 @@
 {
   "uid": "gentle-ai-usage",
   "title": "Gentle AI — Usage",
-  "tags": ["gentle-ai", "telemetry"],
-  "timezone": "utc",
+  "tags": [
+    "gentle-ai",
+    "telemetry"
+  ],
+  "timezone": "browser",
   "editable": false,
   "schemaVersion": 39,
   "version": 1,
-  "time": { "from": "now-90d", "to": "now" },
-  "refresh": "5m",
+  "time": {
+    "from": "now-7d",
+    "to": "now"
+  },
+  "refresh": "1m",
   "panels": [
     {
-      "id": 19, "title": "Runtime observations",
-      "type": "row", "collapsed": false, "panels": [],
-      "gridPos": { "x": 0, "y": 0, "w": 24, "h": 1 }
-    },
-    {
-      "id": 20, "title": "Runtime overview",
-      "description": "Retained runtime observations received within the dashboard time range (inclusive collector receipt time, not client activity time). Observations are not sessions, users or people. Occurrence sums include integer reports only; total tokens are explicitly reported, never inferred. Error observations exclude category none and include unknown. Missing values are not zero. No prompts, paths or identities.",
-      "type": "stat",
-      "gridPos": { "x": 0, "y": 1, "w": 24, "h": 5 },
-      "datasource": { "type": "frser-sqlite-datasource", "uid": "gentle-telemetry-sqlite" },
-      "targets": [{
-        "refId": "A", "queryType": "table",
-        "queryText": "SELECT COUNT(*) AS \"Received observations\", SUM(CASE WHEN json_type(r.row_json, '$.responses') = 'integer' THEN json_extract(r.row_json, '$.responses') END) AS \"Response occurrences\", SUM(CASE WHEN json_type(r.row_json, '$.launches') = 'integer' THEN json_extract(r.row_json, '$.launches') END) AS \"Launch occurrences\", SUM(CASE WHEN json_extract(r.row_json, '$.total_tokens.reported') > 0 THEN json_extract(r.row_json, '$.total_tokens.sum') END) AS \"Reported total tokens\", SUM(CASE WHEN json_extract(r.row_json, '$.error_category') <> 'none' THEN 1 ELSE 0 END) AS \"Error observations\" FROM runtime_rows r JOIN runtime_deliveries d ON d.delivery_id = r.delivery_id WHERE d.received_at >= ${__from} * 1000000 AND d.received_at <= ${__to} * 1000000 HAVING COUNT(*) > 0",
-        "rawQueryText": "SELECT COUNT(*) AS \"Received observations\", SUM(CASE WHEN json_type(r.row_json, '$.responses') = 'integer' THEN json_extract(r.row_json, '$.responses') END) AS \"Response occurrences\", SUM(CASE WHEN json_type(r.row_json, '$.launches') = 'integer' THEN json_extract(r.row_json, '$.launches') END) AS \"Launch occurrences\", SUM(CASE WHEN json_extract(r.row_json, '$.total_tokens.reported') > 0 THEN json_extract(r.row_json, '$.total_tokens.sum') END) AS \"Reported total tokens\", SUM(CASE WHEN json_extract(r.row_json, '$.error_category') <> 'none' THEN 1 ELSE 0 END) AS \"Error observations\" FROM runtime_rows r JOIN runtime_deliveries d ON d.delivery_id = r.delivery_id WHERE d.received_at >= ${__from} * 1000000 AND d.received_at <= ${__to} * 1000000 HAVING COUNT(*) > 0"
-      }],
-      "options": { "orientation": "horizontal", "textMode": "value_and_name", "graphMode": "none", "reduceOptions": { "values": false, "calcs": ["lastNotNull"], "fields": "" } },
-      "fieldConfig": { "defaults": { "min": 0, "noValue": "Not reported", "decimals": 0 }, "overrides": [] }
-    },
-    {
-      "id": 21, "title": "Reported tokens",
-      "description": "Reported token sums within inclusive collector receipt-time bounds. Model observation shows tool host · provider/model · model evidence; Effort shows selected → effective effort. Groups retain every underlying dimension. Each metric includes only its own reported values. Total is explicitly reported, never added from overlapping categories. — means not reported; it is not zero. Reported zero remains zero. Cache write displays cache creation tokens. See Token coverage for reported/unavailable/unsupported counts. At most 1000 combinations in label order.",
-      "type": "table",
-      "gridPos": { "x": 0, "y": 22, "w": 24, "h": 10 },
-      "datasource": { "type": "frser-sqlite-datasource", "uid": "gentle-telemetry-sqlite" },
-      "targets": [{
-        "refId": "A", "queryType": "table",
-        "queryText": "SELECT json_extract(d.canonical_payload, '$.host') || ' · ' || json_extract(r.row_json, '$.model.provider') || '/' || json_extract(r.row_json, '$.model.id') || ' · ' || json_extract(r.row_json, '$.model_evidence') AS \"Model observation\", json_extract(r.row_json, '$.selected_effort') || ' → ' || json_extract(r.row_json, '$.effective_effort') AS \"Selected → effective\", SUM(CASE WHEN json_extract(r.row_json, '$.input_tokens.reported') > 0 THEN json_extract(r.row_json, '$.input_tokens.sum') END) AS Input, SUM(CASE WHEN json_extract(r.row_json, '$.output_tokens.reported') > 0 THEN json_extract(r.row_json, '$.output_tokens.sum') END) AS Output, SUM(CASE WHEN json_extract(r.row_json, '$.cache_read_tokens.reported') > 0 THEN json_extract(r.row_json, '$.cache_read_tokens.sum') END) AS \"Cache read\", SUM(CASE WHEN json_extract(r.row_json, '$.cache_creation_tokens.reported') > 0 THEN json_extract(r.row_json, '$.cache_creation_tokens.sum') END) AS \"Cache creation\", SUM(CASE WHEN json_extract(r.row_json, '$.reasoning_tokens.reported') > 0 THEN json_extract(r.row_json, '$.reasoning_tokens.sum') END) AS Reasoning, SUM(CASE WHEN json_extract(r.row_json, '$.total_tokens.reported') > 0 THEN json_extract(r.row_json, '$.total_tokens.sum') END) AS Total FROM runtime_rows r JOIN runtime_deliveries d ON d.delivery_id = r.delivery_id WHERE d.received_at >= ${__from} * 1000000 AND d.received_at <= ${__to} * 1000000 GROUP BY json_extract(d.canonical_payload, '$.host'), json_extract(r.row_json, '$.model.provider'), json_extract(r.row_json, '$.model.id'), json_extract(r.row_json, '$.model_evidence'), json_extract(r.row_json, '$.selected_effort'), json_extract(r.row_json, '$.effective_effort') ORDER BY 1, 2 LIMIT 1000",
-        "rawQueryText": "SELECT json_extract(d.canonical_payload, '$.host') || ' · ' || json_extract(r.row_json, '$.model.provider') || '/' || json_extract(r.row_json, '$.model.id') || ' · ' || json_extract(r.row_json, '$.model_evidence') AS \"Model observation\", json_extract(r.row_json, '$.selected_effort') || ' → ' || json_extract(r.row_json, '$.effective_effort') AS \"Selected → effective\", SUM(CASE WHEN json_extract(r.row_json, '$.input_tokens.reported') > 0 THEN json_extract(r.row_json, '$.input_tokens.sum') END) AS Input, SUM(CASE WHEN json_extract(r.row_json, '$.output_tokens.reported') > 0 THEN json_extract(r.row_json, '$.output_tokens.sum') END) AS Output, SUM(CASE WHEN json_extract(r.row_json, '$.cache_read_tokens.reported') > 0 THEN json_extract(r.row_json, '$.cache_read_tokens.sum') END) AS \"Cache read\", SUM(CASE WHEN json_extract(r.row_json, '$.cache_creation_tokens.reported') > 0 THEN json_extract(r.row_json, '$.cache_creation_tokens.sum') END) AS \"Cache creation\", SUM(CASE WHEN json_extract(r.row_json, '$.reasoning_tokens.reported') > 0 THEN json_extract(r.row_json, '$.reasoning_tokens.sum') END) AS Reasoning, SUM(CASE WHEN json_extract(r.row_json, '$.total_tokens.reported') > 0 THEN json_extract(r.row_json, '$.total_tokens.sum') END) AS Total FROM runtime_rows r JOIN runtime_deliveries d ON d.delivery_id = r.delivery_id WHERE d.received_at >= ${__from} * 1000000 AND d.received_at <= ${__to} * 1000000 GROUP BY json_extract(d.canonical_payload, '$.host'), json_extract(r.row_json, '$.model.provider'), json_extract(r.row_json, '$.model.id'), json_extract(r.row_json, '$.model_evidence'), json_extract(r.row_json, '$.selected_effort'), json_extract(r.row_json, '$.effective_effort') ORDER BY 1, 2 LIMIT 1000"
-      }],
-      "options": { "showHeader": true, "cellHeight": "sm", "enablePagination": true },
-      "fieldConfig": { "defaults": { "min": 0, "decimals": 0, "noValue": "Not reported", "custom": { "minWidth": 80 } }, "overrides": [{ "matcher": { "id": "byName", "options": "Model observation" }, "properties": [{ "id": "custom.width", "value": 340 }] }, { "matcher": { "id": "byName", "options": "Selected → effective" }, "properties": [{ "id": "custom.width", "value": 180 }] }, { "matcher": { "id": "byRegexp", "options": "^(Input|Output|Cache read|Cache creation|Reasoning|Total)$" }, "properties": [{ "id": "mappings", "value": [{ "type": "special", "options": { "match": "null", "result": { "text": "—" } } }] }] }, { "matcher": { "id": "byName", "options": "Cache creation" }, "properties": [{ "id": "displayName", "value": "Cache write" }] }] }
-    },
-    {
-      "id": 22, "title": "Error observations",
-      "description": "Observation counts by bounded error category in the selected receipt-time range, not failed response counts or an error rate. Category none is excluded; unknown is retained without inferring a cause. No error text. At most 1000 groups in label order.",
-      "type": "barchart",
-      "gridPos": { "x": 0, "y": 40, "w": 12, "h": 7 },
-      "datasource": { "type": "frser-sqlite-datasource", "uid": "gentle-telemetry-sqlite" },
-      "targets": [{
-        "refId": "A", "queryType": "table",
-        "queryText": "SELECT json_extract(r.row_json, '$.error_category') AS Category, COUNT(*) AS Observations FROM runtime_rows r JOIN runtime_deliveries d ON d.delivery_id = r.delivery_id WHERE d.received_at >= ${__from} * 1000000 AND d.received_at <= ${__to} * 1000000 AND json_extract(r.row_json, '$.error_category') <> 'none' GROUP BY Category ORDER BY Category LIMIT 1000",
-        "rawQueryText": "SELECT json_extract(r.row_json, '$.error_category') AS Category, COUNT(*) AS Observations FROM runtime_rows r JOIN runtime_deliveries d ON d.delivery_id = r.delivery_id WHERE d.received_at >= ${__from} * 1000000 AND d.received_at <= ${__to} * 1000000 AND json_extract(r.row_json, '$.error_category') <> 'none' GROUP BY Category ORDER BY Category LIMIT 1000"
-      }],
-      "options": { "orientation": "horizontal", "legend": { "showLegend": false } },
-      "fieldConfig": { "defaults": { "min": 0, "decimals": 0 }, "overrides": [] }
-    },
-    {
-      "id": 10,
-      "title": "Installs today (UTC)",
-      "description": "Distinct install ids that sent an install event since 00:00 UTC today, read live from the events table (the rollup panels below lag one day).",
-      "type": "stat",
-      "gridPos": { "x": 0, "y": 48, "w": 4, "h": 8 },
-      "datasource": { "type": "frser-sqlite-datasource", "uid": "gentle-telemetry-sqlite" },
-      "targets": [
-        {
-          "refId": "A",
-          "queryType": "table",
-          "queryText": "SELECT COUNT(DISTINCT install_id) AS installs_today FROM events WHERE event = 'install' AND received_at >= CAST(strftime('%s', date('now')) AS INTEGER) * 1000000000",
-          "rawQueryText": "SELECT COUNT(DISTINCT install_id) AS installs_today FROM events WHERE event = 'install' AND received_at >= CAST(strftime('%s', date('now')) AS INTEGER) * 1000000000"
-        }
-      ],
-      "fieldConfig": { "defaults": { "unit": "none" }, "overrides": [] }
-    },
-    {
-      "id": 11,
-      "title": "Heartbeats today (UTC)",
-      "description": "Heartbeat events received since 00:00 UTC today: installs that were used again after their first report.",
-      "type": "stat",
-      "gridPos": { "x": 4, "y": 48, "w": 4, "h": 8 },
-      "datasource": { "type": "frser-sqlite-datasource", "uid": "gentle-telemetry-sqlite" },
-      "targets": [
-        {
-          "refId": "A",
-          "queryType": "table",
-          "queryText": "SELECT COUNT(*) AS heartbeats_today FROM events WHERE event = 'heartbeat' AND received_at >= CAST(strftime('%s', date('now')) AS INTEGER) * 1000000000",
-          "rawQueryText": "SELECT COUNT(*) AS heartbeats_today FROM events WHERE event = 'heartbeat' AND received_at >= CAST(strftime('%s', date('now')) AS INTEGER) * 1000000000"
-        }
-      ],
-      "fieldConfig": { "defaults": { "unit": "none" }, "overrides": [] }
-    },
-    {
-      "id": 12,
-      "title": "Platforms today",
-      "description": "Distinct installs seen today by operating system, live from the events table.",
-      "type": "bargauge",
-      "gridPos": { "x": 8, "y": 48, "w": 5, "h": 8 },
-      "datasource": { "type": "frser-sqlite-datasource", "uid": "gentle-telemetry-sqlite" },
-      "targets": [
-        {
-          "refId": "A",
-          "queryType": "table",
-          "queryText": "SELECT os, COUNT(DISTINCT install_id) AS installs FROM events WHERE received_at >= CAST(strftime('%s', date('now')) AS INTEGER) * 1000000000 GROUP BY os ORDER BY installs DESC",
-          "rawQueryText": "SELECT os, COUNT(DISTINCT install_id) AS installs FROM events WHERE received_at >= CAST(strftime('%s', date('now')) AS INTEGER) * 1000000000 GROUP BY os ORDER BY installs DESC"
-        }
-      ],
-      "options": { "orientation": "horizontal", "displayMode": "basic", "showUnfilled": true, "reduceOptions": { "values": true, "calcs": ["lastNotNull"], "fields": "" } },
-      "fieldConfig": { "defaults": { "min": 0 }, "overrides": [] }
-    },
-    {
-      "id": 13,
-      "title": "Installs per hour (last 48 h)",
-      "description": "New install events per UTC hour over the last 48 hours, live from the events table.",
-      "type": "timeseries",
-      "gridPos": { "x": 13, "y": 48, "w": 11, "h": 8 },
-      "datasource": { "type": "frser-sqlite-datasource", "uid": "gentle-telemetry-sqlite" },
-      "targets": [
-        {
-          "refId": "A",
-          "queryType": "table",
-          "queryText": "SELECT CAST(strftime('%s', strftime('%Y-%m-%d %H:00:00', received_at / 1000000000, 'unixepoch')) AS INTEGER) AS hour, COUNT(DISTINCT install_id) AS installs FROM events WHERE event = 'install' AND received_at >= (CAST(strftime('%s', 'now') AS INTEGER) - 172800) * 1000000000 GROUP BY hour ORDER BY hour ASC",
-          "rawQueryText": "SELECT CAST(strftime('%s', strftime('%Y-%m-%d %H:00:00', received_at / 1000000000, 'unixepoch')) AS INTEGER) AS hour, COUNT(DISTINCT install_id) AS installs FROM events WHERE event = 'install' AND received_at >= (CAST(strftime('%s', 'now') AS INTEGER) - 172800) * 1000000000 GROUP BY hour ORDER BY hour ASC",
-          "timeColumns": ["hour"]
-        }
-      ],
-      "fieldConfig": { "defaults": { "min": 0, "custom": { "drawStyle": "bars", "fillOpacity": 70, "lineWidth": 1, "showPoints": "never" } }, "overrides": [] }
-    },
-    {
-      "id": 1,
-      "title": "Unique installs per month (12 months)",
-      "description": "Distinct install ids active in each of the last 12 calendar months: live from the events table for the retention window, from rollups_daily.active_install beyond it. Matches GET /v1/summary's installs_per_month.",
-      "type": "barchart",
-      "gridPos": { "x": 0, "y": 56, "w": 12, "h": 8 },
-      "datasource": { "type": "frser-sqlite-datasource", "uid": "gentle-telemetry-sqlite" },
-      "targets": [
-        {
-          "refId": "A",
-          "queryType": "table",
-          "queryText": "SELECT month, COUNT(DISTINCT id) AS unique_installs FROM (SELECT substr(day,1,7) AS month, key AS id FROM rollups_daily WHERE metric = 'active_install' AND day < date('now', '-89 day') UNION SELECT strftime('%Y-%m', received_at / 1000000000, 'unixepoch') AS month, install_id AS id FROM events WHERE received_at >= CAST(strftime('%s', date('now', '-89 day')) AS INTEGER) * 1000000000) GROUP BY month ORDER BY month DESC LIMIT 12",
-          "rawQueryText": "SELECT month, COUNT(DISTINCT id) AS unique_installs FROM (SELECT substr(day,1,7) AS month, key AS id FROM rollups_daily WHERE metric = 'active_install' AND day < date('now', '-89 day') UNION SELECT strftime('%Y-%m', received_at / 1000000000, 'unixepoch') AS month, install_id AS id FROM events WHERE received_at >= CAST(strftime('%s', date('now', '-89 day')) AS INTEGER) * 1000000000) GROUP BY month ORDER BY month DESC LIMIT 12"
-        }
-      ],
-      "fieldConfig": { "defaults": {}, "overrides": [] }
-    },
-    {
-      "id": 2,
-      "title": "Weekly active installs (12 weeks)",
-      "description": "Distinct install ids active per week, from rollups_daily.active_install. Uses SQLite's strftime('%W') (Monday-based week-of-year); this can disagree with the API's ISO week numbering right at a year boundary, so treat this as a trend view rather than a byte-for-byte match to /v1/summary.",
-      "type": "barchart",
-      "gridPos": { "x": 12, "y": 56, "w": 12, "h": 8 },
-      "datasource": { "type": "frser-sqlite-datasource", "uid": "gentle-telemetry-sqlite" },
-      "targets": [
-        {
-          "refId": "A",
-          "queryType": "table",
-          "queryText": "SELECT strftime('%Y-W%W', received_at / 1000000000, 'unixepoch') AS week, COUNT(DISTINCT install_id) AS active_installs FROM events WHERE received_at >= (CAST(strftime('%s','now') AS INTEGER) - 7776000) * 1000000000 GROUP BY week ORDER BY week DESC LIMIT 12",
-          "rawQueryText": "SELECT strftime('%Y-W%W', received_at / 1000000000, 'unixepoch') AS week, COUNT(DISTINCT install_id) AS active_installs FROM events WHERE received_at >= (CAST(strftime('%s','now') AS INTEGER) - 7776000) * 1000000000 GROUP BY week ORDER BY week DESC LIMIT 12"
-        }
-      ],
-      "fieldConfig": { "defaults": {}, "overrides": [] }
-    },
-    {
-      "id": 3,
-      "title": "Agent distribution (trailing 30 days)",
-      "description": "Install-days per agent over the trailing 30 rolled-up days: an install active on 10 different days contributes 10, once per day it reported that agent. Not distinct installs. Matches GET /v1/summary's agent_distribution.",
-      "type": "bargauge",
-      "gridPos": { "x": 0, "y": 64, "w": 8, "h": 8 },
-      "datasource": { "type": "frser-sqlite-datasource", "uid": "gentle-telemetry-sqlite" },
-      "targets": [
-        {
-          "refId": "A",
-          "queryType": "table",
-          "queryText": "SELECT je.value AS agent, COUNT(DISTINCT e.install_id) AS installs FROM events e, json_each(e.agents_json) je WHERE e.received_at >= (CAST(strftime('%s','now') AS INTEGER) - 2592000) * 1000000000 GROUP BY agent ORDER BY installs DESC",
-          "rawQueryText": "SELECT je.value AS agent, COUNT(DISTINCT e.install_id) AS installs FROM events e, json_each(e.agents_json) je WHERE e.received_at >= (CAST(strftime('%s','now') AS INTEGER) - 2592000) * 1000000000 GROUP BY agent ORDER BY installs DESC"
-        }
-      ],
-      "options": { "orientation": "horizontal", "displayMode": "basic", "showUnfilled": true, "reduceOptions": { "values": true, "calcs": ["lastNotNull"], "fields": "" } },
-      "fieldConfig": { "defaults": { "min": 0 }, "overrides": [] }
-    },
-    {
-      "id": 4,
-      "title": "Component distribution (trailing 30 days)",
-      "description": "Install-days per component over the trailing 30 rolled-up days, same install-days semantics as agent distribution. Matches GET /v1/summary's component_distribution.",
-      "type": "bargauge",
-      "gridPos": { "x": 8, "y": 64, "w": 8, "h": 8 },
-      "datasource": { "type": "frser-sqlite-datasource", "uid": "gentle-telemetry-sqlite" },
-      "targets": [
-        {
-          "refId": "A",
-          "queryType": "table",
-          "queryText": "SELECT je.value AS component, COUNT(DISTINCT e.install_id) AS installs FROM events e, json_each(e.components_json) je WHERE e.received_at >= (CAST(strftime('%s','now') AS INTEGER) - 2592000) * 1000000000 GROUP BY component ORDER BY installs DESC",
-          "rawQueryText": "SELECT je.value AS component, COUNT(DISTINCT e.install_id) AS installs FROM events e, json_each(e.components_json) je WHERE e.received_at >= (CAST(strftime('%s','now') AS INTEGER) - 2592000) * 1000000000 GROUP BY component ORDER BY installs DESC"
-        }
-      ],
-      "options": { "orientation": "horizontal", "displayMode": "basic", "showUnfilled": true, "reduceOptions": { "values": true, "calcs": ["lastNotNull"], "fields": "" } },
-      "fieldConfig": { "defaults": { "min": 0 }, "overrides": [] }
-    },
-    {
-      "id": 5,
-      "title": "RDD enabled ratio (trailing 30 days)",
-      "description": "Share of install-days over the trailing 30 rolled-up days reporting rdd_enabled=true. Matches GET /v1/summary's rdd_enabled_ratio.",
-      "type": "stat",
-      "gridPos": { "x": 16, "y": 64, "w": 8, "h": 8 },
-      "datasource": { "type": "frser-sqlite-datasource", "uid": "gentle-telemetry-sqlite" },
-      "fieldConfig": { "defaults": { "unit": "percentunit", "min": 0, "max": 1 }, "overrides": [] },
-      "targets": [
-        {
-          "refId": "A",
-          "queryType": "table",
-          "queryText": "SELECT SUM(rdd) * 1.0 / NULLIF(COUNT(*), 0) AS rdd_enabled_ratio FROM (SELECT install_id, MAX(rdd_enabled) AS rdd FROM events WHERE received_at >= (CAST(strftime('%s','now') AS INTEGER) - 2592000) * 1000000000 GROUP BY install_id)",
-          "rawQueryText": "SELECT SUM(rdd) * 1.0 / NULLIF(COUNT(*), 0) AS rdd_enabled_ratio FROM (SELECT install_id, MAX(rdd_enabled) AS rdd FROM events WHERE received_at >= (CAST(strftime('%s','now') AS INTEGER) - 2592000) * 1000000000 GROUP BY install_id)"
-        }
-      ]
-    },
-    {
-      "id": 6,
-      "title": "Version distribution (trailing 30 days)",
-      "description": "Install-days per reported version over the trailing 30 rolled-up days. A useful proxy for upgrade lag. Matches GET /v1/summary's version_distribution.",
-      "type": "bargauge",
-      "gridPos": { "x": 0, "y": 72, "w": 12, "h": 8 },
-      "datasource": { "type": "frser-sqlite-datasource", "uid": "gentle-telemetry-sqlite" },
-      "targets": [
-        {
-          "refId": "A",
-          "queryType": "table",
-          "queryText": "SELECT version, COUNT(DISTINCT install_id) AS installs FROM events WHERE received_at >= (CAST(strftime('%s','now') AS INTEGER) - 2592000) * 1000000000 GROUP BY version ORDER BY installs DESC LIMIT 10",
-          "rawQueryText": "SELECT version, COUNT(DISTINCT install_id) AS installs FROM events WHERE received_at >= (CAST(strftime('%s','now') AS INTEGER) - 2592000) * 1000000000 GROUP BY version ORDER BY installs DESC LIMIT 10"
-        }
-      ],
-      "options": { "orientation": "horizontal", "displayMode": "basic", "showUnfilled": true, "reduceOptions": { "values": true, "calcs": ["lastNotNull"], "fields": "" } },
-      "fieldConfig": { "defaults": { "min": 0 }, "overrides": [] }
-    },
-    {
-      "id": 7,
-      "title": "Events per day",
-      "description": "Raw event volume (install + heartbeat), bounded by --retention-days: older raw rows are purged, so this panel only ever shows the retention window, unlike the rollup-backed panels above which cover full history.",
-      "type": "timeseries",
-      "gridPos": { "x": 12, "y": 72, "w": 12, "h": 8 },
-      "datasource": { "type": "frser-sqlite-datasource", "uid": "gentle-telemetry-sqlite" },
-      "targets": [
-        {
-          "refId": "A",
-          "timeColumns": ["day"],
-          "queryText": "SELECT CAST(strftime('%s', date(received_at / 1000000000, 'unixepoch')) AS INTEGER) AS day, COUNT(*) AS events FROM events GROUP BY day ORDER BY day ASC",
-          "rawQueryText": "SELECT CAST(strftime('%s', date(received_at / 1000000000, 'unixepoch')) AS INTEGER) AS day, COUNT(*) AS events FROM events GROUP BY day ORDER BY day ASC"
-        }
-      ],
-      "fieldConfig": { "defaults": { "min": 0, "custom": { "drawStyle": "bars", "fillOpacity": 70, "lineWidth": 1, "showPoints": "never" } }, "overrides": [] }
-    },
-    {
-      "id": 8,
-      "title": "npm downloads per day (gentle-pi, gentle-engram)",
-      "description": "Daily download counts from the npm registry's public API (api.npmjs.org) — a public count, not telemetry from any gentle-ai install. Matches GET /v1/summary's downloads.npm. The gentle_pi and gentle_engram columns mirror the collector's default --npm-package list; any other package it is configured to fetch lands in other_packages so nothing is silently dropped.",
-      "type": "timeseries",
-      "gridPos": { "x": 0, "y": 80, "w": 12, "h": 8 },
-      "datasource": { "type": "frser-sqlite-datasource", "uid": "gentle-telemetry-sqlite" },
-      "targets": [
-        {
-          "refId": "A",
-          "timeColumns": ["day"],
-          "queryText": "SELECT CAST(strftime('%s', day) AS INTEGER) AS day, SUM(CASE WHEN key = 'gentle-pi' THEN value ELSE 0 END) AS gentle_pi, SUM(CASE WHEN key = 'gentle-engram' THEN value ELSE 0 END) AS gentle_engram, SUM(CASE WHEN key NOT IN ('gentle-pi', 'gentle-engram') THEN value ELSE 0 END) AS other_packages FROM rollups_daily WHERE metric = 'npm_downloads_day' GROUP BY day ORDER BY day ASC",
-          "rawQueryText": "SELECT CAST(strftime('%s', day) AS INTEGER) AS day, SUM(CASE WHEN key = 'gentle-pi' THEN value ELSE 0 END) AS gentle_pi, SUM(CASE WHEN key = 'gentle-engram' THEN value ELSE 0 END) AS gentle_engram, SUM(CASE WHEN key NOT IN ('gentle-pi', 'gentle-engram') THEN value ELSE 0 END) AS other_packages FROM rollups_daily WHERE metric = 'npm_downloads_day' GROUP BY day ORDER BY day ASC"
-        }
-      ],
-      "fieldConfig": { "defaults": { "min": 0, "custom": { "drawStyle": "bars", "fillOpacity": 70, "lineWidth": 1, "showPoints": "never" } }, "overrides": [] }
-    },
-    {
-      "id": 9,
-      "title": "gentle-ai release downloads (cumulative per tag)",
-      "description": "Cumulative GitHub release asset download counts per tag, from the public GitHub API (api.github.com) — a public count, not telemetry from any gentle-ai install. Each bar is the latest known total for that tag, not a per-day delta. Matches GET /v1/summary's downloads.github.",
-      "type": "bargauge",
-      "gridPos": { "x": 12, "y": 80, "w": 12, "h": 8 },
-      "datasource": { "type": "frser-sqlite-datasource", "uid": "gentle-telemetry-sqlite" },
-      "targets": [
-        {
-          "refId": "A",
-          "queryType": "table",
-          "queryText": "SELECT r.key AS tag, r.value AS total_downloads FROM rollups_daily r INNER JOIN (SELECT key, MAX(day) AS max_day FROM rollups_daily WHERE metric = 'github_release_downloads_total' GROUP BY key) latest ON latest.key = r.key AND latest.max_day = r.day WHERE r.metric = 'github_release_downloads_total' ORDER BY total_downloads DESC",
-          "rawQueryText": "SELECT r.key AS tag, r.value AS total_downloads FROM rollups_daily r INNER JOIN (SELECT key, MAX(day) AS max_day FROM rollups_daily WHERE metric = 'github_release_downloads_total' GROUP BY key) latest ON latest.key = r.key AND latest.max_day = r.day WHERE r.metric = 'github_release_downloads_total' ORDER BY total_downloads DESC"
-        }
-      ],
-      "options": { "orientation": "horizontal", "displayMode": "basic", "showUnfilled": true, "reduceOptions": { "values": true, "calcs": ["lastNotNull"], "fields": "" } },
-      "fieldConfig": { "defaults": { "min": 0 }, "overrides": [] }
-    },
-    {
-      "id": 14,
-      "title": "Agents declared today",
-      "description": "Distinct installs seen today that declare each agent, live from the events table (json_each over agents_json). One install can declare several agents.",
-      "type": "bargauge",
-      "gridPos": { "x": 0, "y": 88, "w": 24, "h": 8 },
-      "datasource": { "type": "frser-sqlite-datasource", "uid": "gentle-telemetry-sqlite" },
-      "targets": [
-        {
-          "refId": "A",
-          "queryType": "table",
-          "queryText": "SELECT je.value AS agent, COUNT(DISTINCT e.install_id) AS installs FROM events e, json_each(e.agents_json) je WHERE e.event = 'install' AND e.received_at >= CAST(strftime('%s', date('now')) AS INTEGER) * 1000000000 GROUP BY agent ORDER BY installs DESC",
-          "rawQueryText": "SELECT je.value AS agent, COUNT(DISTINCT e.install_id) AS installs FROM events e, json_each(e.agents_json) je WHERE e.event = 'install' AND e.received_at >= CAST(strftime('%s', date('now')) AS INTEGER) * 1000000000 GROUP BY agent ORDER BY installs DESC"
-        }
-      ],
-      "options": { "orientation": "horizontal", "displayMode": "basic", "showUnfilled": true, "reduceOptions": { "values": true, "calcs": ["lastNotNull"], "fields": "" } },
-      "fieldConfig": { "defaults": { "min": 0 }, "overrides": [] }
-    },
-    {
-      "id": 15,
-      "title": "Responses by model",
-      "description": "Response occurrences in the selected receipt-time range, not client activity time. Response evidence identifies the model reported by a response; selected evidence is configuration only, not proof of execution. Public model and host labels only. At most 1000 groups in label order.",
-      "type": "barchart",
-      "gridPos": { "x": 0, "y": 6, "w": 24, "h": 8 },
-      "datasource": { "type": "frser-sqlite-datasource", "uid": "gentle-telemetry-sqlite" },
-      "targets": [{
-        "refId": "A", "queryType": "table",
-        "queryText": "SELECT json_extract(r.row_json, '$.model.provider') || '/' || json_extract(r.row_json, '$.model.id') || ' · ' || json_extract(r.row_json, '$.model_evidence') || ' · ' || json_extract(d.canonical_payload, '$.host') AS Model, SUM(json_extract(r.row_json, '$.responses')) AS Responses FROM runtime_rows r JOIN runtime_deliveries d ON d.delivery_id = r.delivery_id WHERE d.received_at >= ${__from} * 1000000 AND d.received_at <= ${__to} * 1000000 AND json_type(r.row_json, '$.responses') = 'integer' GROUP BY Model ORDER BY Model LIMIT 1000",
-        "rawQueryText": "SELECT json_extract(r.row_json, '$.model.provider') || '/' || json_extract(r.row_json, '$.model.id') || ' · ' || json_extract(r.row_json, '$.model_evidence') || ' · ' || json_extract(d.canonical_payload, '$.host') AS Model, SUM(json_extract(r.row_json, '$.responses')) AS Responses FROM runtime_rows r JOIN runtime_deliveries d ON d.delivery_id = r.delivery_id WHERE d.received_at >= ${__from} * 1000000 AND d.received_at <= ${__to} * 1000000 AND json_type(r.row_json, '$.responses') = 'integer' GROUP BY Model ORDER BY Model LIMIT 1000"
-      }],
-      "options": { "orientation": "horizontal", "xTickLabelMaxLength": 45, "legend": { "showLegend": false }, "tooltip": { "mode": "single" } },
-      "fieldConfig": { "defaults": { "min": 0, "noValue": "Not reported" }, "overrides": [] }
-    },
-    {
-      "id": 16, "title": "Usage by agent, model, and effort",
-      "description": "Integer occurrences from observations within inclusive collector receipt-time bounds; these are not sessions, users or people. Responses and launches are separate independent sums, including orchestrator responses and subagent launches. Labels show public agent class/kind, host · provider/model · model evidence, and selected → effective effort, grouped by every dimension. Response evidence identifies the model reported by a response. Selected evidence identifies the configured model, not proof that it ran. Effective effort is never inferred from selected effort. unknown is retained without identity inference. No custom or private names. — means not reported; it is not zero. Groups without either integer count are excluded. At most 1000 groups, ranked by total available occurrences only, then stable agent/model/effort labels; no combined metric is displayed.",
-      "type": "table",
-      "gridPos": { "x": 0, "y": 14, "w": 24, "h": 8 },
-      "datasource": { "type": "frser-sqlite-datasource", "uid": "gentle-telemetry-sqlite" },
-      "targets": [{
-        "refId": "A", "queryType": "table",
-        "queryText": "SELECT json_extract(r.row_json, '$.agent_class') || ' / ' || json_extract(r.row_json, '$.agent_kind') AS \"Agent observation\", json_extract(d.canonical_payload, '$.host') || ' · ' || json_extract(r.row_json, '$.model.provider') || '/' || json_extract(r.row_json, '$.model.id') || ' · ' || json_extract(r.row_json, '$.model_evidence') AS \"Model observation\", json_extract(r.row_json, '$.selected_effort') || ' → ' || json_extract(r.row_json, '$.effective_effort') AS \"Selected → effective\", SUM(CASE WHEN json_type(r.row_json, '$.responses') = 'integer' THEN json_extract(r.row_json, '$.responses') END) AS Responses, SUM(CASE WHEN json_type(r.row_json, '$.launches') = 'integer' THEN json_extract(r.row_json, '$.launches') END) AS Launches FROM runtime_rows r JOIN runtime_deliveries d ON d.delivery_id = r.delivery_id WHERE d.received_at >= ${__from} * 1000000 AND d.received_at <= ${__to} * 1000000 AND (json_type(r.row_json, '$.responses') = 'integer' OR json_type(r.row_json, '$.launches') = 'integer') GROUP BY json_extract(r.row_json, '$.agent_class'), json_extract(r.row_json, '$.agent_kind'), json_extract(d.canonical_payload, '$.host'), json_extract(r.row_json, '$.model.provider'), json_extract(r.row_json, '$.model.id'), json_extract(r.row_json, '$.model_evidence'), json_extract(r.row_json, '$.selected_effort'), json_extract(r.row_json, '$.effective_effort') ORDER BY COALESCE(Responses, 0) + COALESCE(Launches, 0) DESC, \"Agent observation\" ASC, \"Model observation\" ASC, \"Selected → effective\" ASC LIMIT 1000",
-        "rawQueryText": "SELECT json_extract(r.row_json, '$.agent_class') || ' / ' || json_extract(r.row_json, '$.agent_kind') AS \"Agent observation\", json_extract(d.canonical_payload, '$.host') || ' · ' || json_extract(r.row_json, '$.model.provider') || '/' || json_extract(r.row_json, '$.model.id') || ' · ' || json_extract(r.row_json, '$.model_evidence') AS \"Model observation\", json_extract(r.row_json, '$.selected_effort') || ' → ' || json_extract(r.row_json, '$.effective_effort') AS \"Selected → effective\", SUM(CASE WHEN json_type(r.row_json, '$.responses') = 'integer' THEN json_extract(r.row_json, '$.responses') END) AS Responses, SUM(CASE WHEN json_type(r.row_json, '$.launches') = 'integer' THEN json_extract(r.row_json, '$.launches') END) AS Launches FROM runtime_rows r JOIN runtime_deliveries d ON d.delivery_id = r.delivery_id WHERE d.received_at >= ${__from} * 1000000 AND d.received_at <= ${__to} * 1000000 AND (json_type(r.row_json, '$.responses') = 'integer' OR json_type(r.row_json, '$.launches') = 'integer') GROUP BY json_extract(r.row_json, '$.agent_class'), json_extract(r.row_json, '$.agent_kind'), json_extract(d.canonical_payload, '$.host'), json_extract(r.row_json, '$.model.provider'), json_extract(r.row_json, '$.model.id'), json_extract(r.row_json, '$.model_evidence'), json_extract(r.row_json, '$.selected_effort'), json_extract(r.row_json, '$.effective_effort') ORDER BY COALESCE(Responses, 0) + COALESCE(Launches, 0) DESC, \"Agent observation\" ASC, \"Model observation\" ASC, \"Selected → effective\" ASC LIMIT 1000"
-      }],
-      "options": { "cellHeight": "sm", "showHeader": true },
-      "fieldConfig": {
-        "defaults": { "min": 0, "decimals": 0, "custom": { "minWidth": 100 } },
-        "overrides": [
-          { "matcher": { "id": "byName", "options": "Agent observation" }, "properties": [{ "id": "custom.width", "value": 240 }] },
-          { "matcher": { "id": "byName", "options": "Model observation" }, "properties": [{ "id": "custom.width", "value": 360 }] },
-          { "matcher": { "id": "byName", "options": "Selected → effective" }, "properties": [{ "id": "custom.width", "value": 200 }] },
-          { "matcher": { "id": "byRegexp", "options": "^(Responses|Launches)$" }, "properties": [{ "id": "custom.width", "value": 120 }, { "id": "mappings", "value": [{ "type": "special", "options": { "match": "null", "result": { "text": "—" } } }] }] }
-        ]
+      "id": 100,
+      "title": "Adoption",
+      "type": "row",
+      "collapsed": false,
+      "panels": [],
+      "gridPos": {
+        "x": 0,
+        "y": 0,
+        "w": 24,
+        "h": 1
       }
     },
     {
-      "id": 17, "title": "Token coverage",
-      "description": "Exact reported, unavailable and unsupported observation counts for each token metric in the selected receipt-time range. Coverage is not a token sum. Reported zero is still reported; metrics are independent.",
-      "type": "table",
-      "gridPos": { "x": 0, "y": 32, "w": 24, "h": 8 },
-      "datasource": { "type": "frser-sqlite-datasource", "uid": "gentle-telemetry-sqlite" },
-      "targets": [{
-        "refId": "A", "queryType": "table",
-        "queryText": "SELECT CASE t.key WHEN 'input_tokens' THEN 'Input' WHEN 'output_tokens' THEN 'Output' WHEN 'cache_read_tokens' THEN 'Cache read' WHEN 'cache_creation_tokens' THEN 'Cache creation' WHEN 'reasoning_tokens' THEN 'Reasoning' WHEN 'total_tokens' THEN 'Total' END AS Metric, SUM(json_extract(t.value, '$.reported')) AS Reported, SUM(json_extract(t.value, '$.unavailable')) AS Unavailable, SUM(json_extract(t.value, '$.unsupported')) AS Unsupported FROM runtime_rows r JOIN runtime_deliveries d ON d.delivery_id = r.delivery_id JOIN json_each(r.row_json) t WHERE d.received_at >= ${__from} * 1000000 AND d.received_at <= ${__to} * 1000000 AND t.key IN ('input_tokens', 'output_tokens', 'cache_read_tokens', 'cache_creation_tokens', 'reasoning_tokens', 'total_tokens') GROUP BY t.key ORDER BY t.key LIMIT 1000",
-        "rawQueryText": "SELECT CASE t.key WHEN 'input_tokens' THEN 'Input' WHEN 'output_tokens' THEN 'Output' WHEN 'cache_read_tokens' THEN 'Cache read' WHEN 'cache_creation_tokens' THEN 'Cache creation' WHEN 'reasoning_tokens' THEN 'Reasoning' WHEN 'total_tokens' THEN 'Total' END AS Metric, SUM(json_extract(t.value, '$.reported')) AS Reported, SUM(json_extract(t.value, '$.unavailable')) AS Unavailable, SUM(json_extract(t.value, '$.unsupported')) AS Unsupported FROM runtime_rows r JOIN runtime_deliveries d ON d.delivery_id = r.delivery_id JOIN json_each(r.row_json) t WHERE d.received_at >= ${__from} * 1000000 AND d.received_at <= ${__to} * 1000000 AND t.key IN ('input_tokens', 'output_tokens', 'cache_read_tokens', 'cache_creation_tokens', 'reasoning_tokens', 'total_tokens') GROUP BY t.key ORDER BY t.key LIMIT 1000"
-      }],
-      "options": { "cellHeight": "sm", "showHeader": true },
-      "fieldConfig": { "defaults": { "custom": { "minWidth": 80 }, "noValue": "Not reported" }, "overrides": [] }
+      "id": 101,
+      "title": "Unique installs all-time",
+      "description": "All installations ever observed, counted once regardless of the selected time range.",
+      "type": "stat",
+      "gridPos": {
+        "x": 0,
+        "y": 1,
+        "w": 6,
+        "h": 4
+      },
+      "datasource": {
+        "type": "frser-sqlite-datasource",
+        "uid": "gentle-telemetry-sqlite"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "queryType": "table",
+          "queryText": "SELECT COUNT(DISTINCT install_id) AS \"Unique installs\" FROM events HAVING COUNT(*) > 0",
+          "rawQueryText": "SELECT COUNT(DISTINCT install_id) AS \"Unique installs\" FROM events HAVING COUNT(*) > 0"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "min": 0,
+          "decimals": 0
+        },
+        "overrides": []
+      },
+      "options": {
+        "orientation": "horizontal",
+        "textMode": "value_and_name",
+        "graphMode": "none",
+        "reduceOptions": {
+          "values": false,
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": ""
+        }
+      }
     },
     {
-      "id": 18, "title": "Measured duration",
-      "description": "Sum of measured milliseconds, separately for request and message timing in the selected receipt-time range. Not per-response latency. Unavailable timing is excluded, never shown as zero. No data means no measurements.",
+      "id": 102,
+      "title": "Active installs yesterday",
+      "description": "Installations active on the latest completed rollup day, which normally represents yesterday.",
+      "type": "stat",
+      "gridPos": {
+        "x": 6,
+        "y": 1,
+        "w": 6,
+        "h": 4
+      },
+      "datasource": {
+        "type": "frser-sqlite-datasource",
+        "uid": "gentle-telemetry-sqlite"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "queryType": "table",
+          "queryText": "SELECT COUNT(*) AS \"Active installs\" FROM rollups_daily WHERE metric = 'active_install' AND day = (SELECT MAX(day) FROM rollups_daily WHERE metric = 'active_install') HAVING COUNT(*) > 0",
+          "rawQueryText": "SELECT COUNT(*) AS \"Active installs\" FROM rollups_daily WHERE metric = 'active_install' AND day = (SELECT MAX(day) FROM rollups_daily WHERE metric = 'active_install') HAVING COUNT(*) > 0"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "min": 0,
+          "decimals": 0
+        },
+        "overrides": []
+      },
+      "options": {
+        "orientation": "horizontal",
+        "textMode": "value_and_name",
+        "graphMode": "none",
+        "reduceOptions": {
+          "values": false,
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": ""
+        }
+      }
+    },
+    {
+      "id": 103,
+      "title": "Active installs in range",
+      "description": "Distinct installations that reported activity during the selected time range.",
+      "type": "stat",
+      "gridPos": {
+        "x": 12,
+        "y": 1,
+        "w": 6,
+        "h": 4
+      },
+      "datasource": {
+        "type": "frser-sqlite-datasource",
+        "uid": "gentle-telemetry-sqlite"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "queryType": "table",
+          "queryText": "SELECT COUNT(DISTINCT install_id) AS \"Active installs\" FROM events WHERE received_at >= ${__from} * 1000000 AND received_at <= ${__to} * 1000000 HAVING COUNT(*) > 0",
+          "rawQueryText": "SELECT COUNT(DISTINCT install_id) AS \"Active installs\" FROM events WHERE received_at >= ${__from} * 1000000 AND received_at <= ${__to} * 1000000 HAVING COUNT(*) > 0"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "min": 0,
+          "decimals": 0
+        },
+        "overrides": []
+      },
+      "options": {
+        "orientation": "horizontal",
+        "textMode": "value_and_name",
+        "graphMode": "none",
+        "reduceOptions": {
+          "values": false,
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": ""
+        }
+      }
+    },
+    {
+      "id": 104,
+      "title": "New installs in range",
+      "description": "Distinct new installations first reported during the selected time range.",
+      "type": "stat",
+      "gridPos": {
+        "x": 18,
+        "y": 1,
+        "w": 6,
+        "h": 4
+      },
+      "datasource": {
+        "type": "frser-sqlite-datasource",
+        "uid": "gentle-telemetry-sqlite"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "queryType": "table",
+          "queryText": "SELECT COUNT(DISTINCT install_id) AS \"New installs\" FROM events WHERE event = 'install' AND received_at >= ${__from} * 1000000 AND received_at <= ${__to} * 1000000 HAVING COUNT(*) > 0",
+          "rawQueryText": "SELECT COUNT(DISTINCT install_id) AS \"New installs\" FROM events WHERE event = 'install' AND received_at >= ${__from} * 1000000 AND received_at <= ${__to} * 1000000 HAVING COUNT(*) > 0"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "min": 0,
+          "decimals": 0
+        },
+        "overrides": []
+      },
+      "options": {
+        "orientation": "horizontal",
+        "textMode": "value_and_name",
+        "graphMode": "none",
+        "reduceOptions": {
+          "values": false,
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": ""
+        }
+      }
+    },
+    {
+      "id": 105,
+      "title": "Heartbeats in range",
+      "description": "Repeat activity signals received during the selected time range.",
+      "type": "stat",
+      "gridPos": {
+        "x": 0,
+        "y": 5,
+        "w": 6,
+        "h": 4
+      },
+      "datasource": {
+        "type": "frser-sqlite-datasource",
+        "uid": "gentle-telemetry-sqlite"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "queryType": "table",
+          "queryText": "SELECT COUNT(*) AS Heartbeats FROM events WHERE event = 'heartbeat' AND received_at >= ${__from} * 1000000 AND received_at <= ${__to} * 1000000 HAVING COUNT(*) > 0",
+          "rawQueryText": "SELECT COUNT(*) AS Heartbeats FROM events WHERE event = 'heartbeat' AND received_at >= ${__from} * 1000000 AND received_at <= ${__to} * 1000000 HAVING COUNT(*) > 0"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "min": 0,
+          "decimals": 0
+        },
+        "overrides": []
+      },
+      "options": {
+        "orientation": "horizontal",
+        "textMode": "value_and_name",
+        "graphMode": "none",
+        "reduceOptions": {
+          "values": false,
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": ""
+        }
+      }
+    },
+    {
+      "id": 106,
+      "title": "RDD adoption %",
+      "description": "Share of installations on the latest completed rollup day that had receipt-driven development enabled.",
+      "type": "stat",
+      "gridPos": {
+        "x": 6,
+        "y": 5,
+        "w": 6,
+        "h": 4
+      },
+      "datasource": {
+        "type": "frser-sqlite-datasource",
+        "uid": "gentle-telemetry-sqlite"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "queryType": "table",
+          "queryText": "SELECT 100.0 * SUM(CASE WHEN key = 'true' THEN value ELSE 0 END) / NULLIF(SUM(CASE WHEN key IN ('true','false') THEN value ELSE 0 END), 0) AS \"RDD adoption\" FROM rollups_daily WHERE metric = 'rdd_enabled' AND day = (SELECT MAX(day) FROM rollups_daily WHERE metric = 'rdd_enabled') HAVING COUNT(*) > 0",
+          "rawQueryText": "SELECT 100.0 * SUM(CASE WHEN key = 'true' THEN value ELSE 0 END) / NULLIF(SUM(CASE WHEN key IN ('true','false') THEN value ELSE 0 END), 0) AS \"RDD adoption\" FROM rollups_daily WHERE metric = 'rdd_enabled' AND day = (SELECT MAX(day) FROM rollups_daily WHERE metric = 'rdd_enabled') HAVING COUNT(*) > 0"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percent",
+          "min": 0,
+          "decimals": 0
+        },
+        "overrides": []
+      },
+      "options": {
+        "orientation": "horizontal",
+        "textMode": "value_and_name",
+        "graphMode": "none",
+        "reduceOptions": {
+          "values": false,
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": ""
+        }
+      }
+    },
+    {
+      "id": 107,
+      "title": "npm downloads latest day",
+      "description": "Combined public npm downloads for Gentle Pi and Gentle Engram on the latest collected day.",
+      "type": "stat",
+      "gridPos": {
+        "x": 12,
+        "y": 5,
+        "w": 6,
+        "h": 4
+      },
+      "datasource": {
+        "type": "frser-sqlite-datasource",
+        "uid": "gentle-telemetry-sqlite"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "queryType": "table",
+          "queryText": "SELECT SUM(value) AS \"npm downloads\" FROM rollups_daily WHERE metric = 'npm_downloads_day' AND day = (SELECT MAX(day) FROM rollups_daily WHERE metric = 'npm_downloads_day') HAVING COUNT(*) > 0",
+          "rawQueryText": "SELECT SUM(value) AS \"npm downloads\" FROM rollups_daily WHERE metric = 'npm_downloads_day' AND day = (SELECT MAX(day) FROM rollups_daily WHERE metric = 'npm_downloads_day') HAVING COUNT(*) > 0"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "min": 0,
+          "decimals": 0
+        },
+        "overrides": []
+      },
+      "options": {
+        "orientation": "horizontal",
+        "textMode": "value_and_name",
+        "graphMode": "none",
+        "reduceOptions": {
+          "values": false,
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": ""
+        }
+      }
+    },
+    {
+      "id": 108,
+      "title": "GitHub release downloads",
+      "description": "Cumulative downloads across all release tags on the latest collected GitHub snapshot.",
+      "type": "stat",
+      "gridPos": {
+        "x": 18,
+        "y": 5,
+        "w": 6,
+        "h": 4
+      },
+      "datasource": {
+        "type": "frser-sqlite-datasource",
+        "uid": "gentle-telemetry-sqlite"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "queryType": "table",
+          "queryText": "SELECT SUM(value) AS \"Release downloads\" FROM rollups_daily WHERE metric = 'github_release_downloads_total' AND day = (SELECT MAX(day) FROM rollups_daily WHERE metric = 'github_release_downloads_total') HAVING COUNT(*) > 0",
+          "rawQueryText": "SELECT SUM(value) AS \"Release downloads\" FROM rollups_daily WHERE metric = 'github_release_downloads_total' AND day = (SELECT MAX(day) FROM rollups_daily WHERE metric = 'github_release_downloads_total') HAVING COUNT(*) > 0"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "min": 0,
+          "decimals": 0
+        },
+        "overrides": []
+      },
+      "options": {
+        "orientation": "horizontal",
+        "textMode": "value_and_name",
+        "graphMode": "none",
+        "reduceOptions": {
+          "values": false,
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": ""
+        }
+      }
+    },
+    {
+      "id": 200,
+      "title": "Growth",
+      "type": "row",
+      "collapsed": false,
+      "panels": [],
+      "gridPos": {
+        "x": 0,
+        "y": 9,
+        "w": 24,
+        "h": 1
+      }
+    },
+    {
+      "id": 201,
+      "title": "Daily active installs",
+      "description": "Distinct installations active on each day within the selected time range.",
+      "type": "timeseries",
+      "gridPos": {
+        "x": 0,
+        "y": 10,
+        "w": 8,
+        "h": 8
+      },
+      "datasource": {
+        "type": "frser-sqlite-datasource",
+        "uid": "gentle-telemetry-sqlite"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "queryType": "table",
+          "queryText": "SELECT CAST(strftime('%s', date(received_at / 1000000000, 'unixepoch')) AS INTEGER) AS time, COUNT(DISTINCT install_id) AS \"Active installs\" FROM events WHERE received_at >= ${__from} * 1000000 AND received_at <= ${__to} * 1000000 GROUP BY time ORDER BY time ASC",
+          "rawQueryText": "SELECT CAST(strftime('%s', date(received_at / 1000000000, 'unixepoch')) AS INTEGER) AS time, COUNT(DISTINCT install_id) AS \"Active installs\" FROM events WHERE received_at >= ${__from} * 1000000 AND received_at <= ${__to} * 1000000 GROUP BY time ORDER BY time ASC",
+          "timeColumns": [
+            "time"
+          ]
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "min": 0,
+          "decimals": 0
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      }
+    },
+    {
+      "id": 202,
+      "title": "Daily new installs",
+      "description": "Distinct new installations first reported on each day within the selected time range.",
+      "type": "timeseries",
+      "gridPos": {
+        "x": 8,
+        "y": 10,
+        "w": 8,
+        "h": 8
+      },
+      "datasource": {
+        "type": "frser-sqlite-datasource",
+        "uid": "gentle-telemetry-sqlite"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "queryType": "table",
+          "queryText": "SELECT CAST(strftime('%s', date(received_at / 1000000000, 'unixepoch')) AS INTEGER) AS time, COUNT(DISTINCT install_id) AS \"New installs\" FROM events WHERE event = 'install' AND received_at >= ${__from} * 1000000 AND received_at <= ${__to} * 1000000 GROUP BY time ORDER BY time ASC",
+          "rawQueryText": "SELECT CAST(strftime('%s', date(received_at / 1000000000, 'unixepoch')) AS INTEGER) AS time, COUNT(DISTINCT install_id) AS \"New installs\" FROM events WHERE event = 'install' AND received_at >= ${__from} * 1000000 AND received_at <= ${__to} * 1000000 GROUP BY time ORDER BY time ASC",
+          "timeColumns": [
+            "time"
+          ]
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "min": 0,
+          "decimals": 0
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      }
+    },
+    {
+      "id": 203,
+      "title": "Cumulative unique installs",
+      "description": "All-time unique installations accumulated by first-seen day and displayed across the selected time range.",
+      "type": "timeseries",
+      "gridPos": {
+        "x": 16,
+        "y": 10,
+        "w": 8,
+        "h": 8
+      },
+      "datasource": {
+        "type": "frser-sqlite-datasource",
+        "uid": "gentle-telemetry-sqlite"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "queryType": "table",
+          "queryText": "WITH first_seen AS (SELECT install_id, date(MIN(received_at) / 1000000000, 'unixepoch') AS day FROM events GROUP BY install_id), daily AS (SELECT day, COUNT(*) AS new_installs FROM first_seen GROUP BY day), cumulative AS (SELECT day, SUM(new_installs) OVER (ORDER BY day ROWS UNBOUNDED PRECEDING) AS installs FROM daily) SELECT CAST(strftime('%s', day) AS INTEGER) AS time, installs AS \"Cumulative installs\" FROM cumulative WHERE CAST(strftime('%s', day) AS INTEGER) * 1000 >= ${__from} AND CAST(strftime('%s', day) AS INTEGER) * 1000 <= ${__to} ORDER BY time ASC",
+          "rawQueryText": "WITH first_seen AS (SELECT install_id, date(MIN(received_at) / 1000000000, 'unixepoch') AS day FROM events GROUP BY install_id), daily AS (SELECT day, COUNT(*) AS new_installs FROM first_seen GROUP BY day), cumulative AS (SELECT day, SUM(new_installs) OVER (ORDER BY day ROWS UNBOUNDED PRECEDING) AS installs FROM daily) SELECT CAST(strftime('%s', day) AS INTEGER) AS time, installs AS \"Cumulative installs\" FROM cumulative WHERE CAST(strftime('%s', day) AS INTEGER) * 1000 >= ${__from} AND CAST(strftime('%s', day) AS INTEGER) * 1000 <= ${__to} ORDER BY time ASC",
+          "timeColumns": [
+            "time"
+          ]
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "min": 0,
+          "decimals": 0
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      }
+    },
+    {
+      "id": 300,
+      "title": "Where Gentle AI runs",
+      "type": "row",
+      "collapsed": false,
+      "panels": [],
+      "gridPos": {
+        "x": 0,
+        "y": 18,
+        "w": 24,
+        "h": 1
+      }
+    },
+    {
+      "id": 301,
+      "title": "Agent adoption",
+      "description": "Install counts by detected coding agent on the latest completed rollup day.",
       "type": "barchart",
-      "gridPos": { "x": 12, "y": 40, "w": 12, "h": 7 },
-      "datasource": { "type": "frser-sqlite-datasource", "uid": "gentle-telemetry-sqlite" },
-      "targets": [{
-        "refId": "A", "queryType": "table",
-        "queryText": "SELECT json_extract(r.row_json, '$.duration.kind') AS Timing, SUM(json_extract(r.row_json, '$.duration.sum_ms')) AS Milliseconds FROM runtime_rows r JOIN runtime_deliveries d ON d.delivery_id = r.delivery_id WHERE d.received_at >= ${__from} * 1000000 AND d.received_at <= ${__to} * 1000000 AND json_extract(r.row_json, '$.duration.measured_count') > 0 AND json_extract(r.row_json, '$.duration.kind') IN ('request', 'message') GROUP BY Timing ORDER BY Timing LIMIT 1000",
-        "rawQueryText": "SELECT json_extract(r.row_json, '$.duration.kind') AS Timing, SUM(json_extract(r.row_json, '$.duration.sum_ms')) AS Milliseconds FROM runtime_rows r JOIN runtime_deliveries d ON d.delivery_id = r.delivery_id WHERE d.received_at >= ${__from} * 1000000 AND d.received_at <= ${__to} * 1000000 AND json_extract(r.row_json, '$.duration.measured_count') > 0 AND json_extract(r.row_json, '$.duration.kind') IN ('request', 'message') GROUP BY Timing ORDER BY Timing LIMIT 1000"
-      }],
-      "options": { "orientation": "horizontal", "legend": { "showLegend": false } },
-      "fieldConfig": { "defaults": { "unit": "ms", "min": 0, "noValue": "No measurements" }, "overrides": [] }
+      "gridPos": {
+        "x": 0,
+        "y": 19,
+        "w": 6,
+        "h": 8
+      },
+      "datasource": {
+        "type": "frser-sqlite-datasource",
+        "uid": "gentle-telemetry-sqlite"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "queryType": "table",
+          "queryText": "SELECT key AS Agent, SUM(value) AS Installs FROM rollups_daily WHERE metric = 'agent' AND day = (SELECT MAX(day) FROM rollups_daily WHERE metric = 'agent') GROUP BY key ORDER BY Installs DESC LIMIT 1000",
+          "rawQueryText": "SELECT key AS Agent, SUM(value) AS Installs FROM rollups_daily WHERE metric = 'agent' AND day = (SELECT MAX(day) FROM rollups_daily WHERE metric = 'agent') GROUP BY key ORDER BY Installs DESC LIMIT 1000"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "min": 0,
+          "decimals": 0
+        },
+        "overrides": []
+      },
+      "options": {
+        "orientation": "horizontal",
+        "legend": {
+          "showLegend": false
+        }
+      }
+    },
+    {
+      "id": 302,
+      "title": "Component adoption",
+      "description": "Install counts by enabled Gentle AI component on the latest completed rollup day.",
+      "type": "barchart",
+      "gridPos": {
+        "x": 6,
+        "y": 19,
+        "w": 6,
+        "h": 8
+      },
+      "datasource": {
+        "type": "frser-sqlite-datasource",
+        "uid": "gentle-telemetry-sqlite"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "queryType": "table",
+          "queryText": "SELECT key AS Component, SUM(value) AS Installs FROM rollups_daily WHERE metric = 'component' AND day = (SELECT MAX(day) FROM rollups_daily WHERE metric = 'component') GROUP BY key ORDER BY Installs DESC LIMIT 1000",
+          "rawQueryText": "SELECT key AS Component, SUM(value) AS Installs FROM rollups_daily WHERE metric = 'component' AND day = (SELECT MAX(day) FROM rollups_daily WHERE metric = 'component') GROUP BY key ORDER BY Installs DESC LIMIT 1000"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "min": 0,
+          "decimals": 0
+        },
+        "overrides": []
+      },
+      "options": {
+        "orientation": "horizontal",
+        "legend": {
+          "showLegend": false
+        }
+      }
+    },
+    {
+      "id": 303,
+      "title": "OS and architecture",
+      "description": "Distinct installations by operating system and CPU architecture during the selected time range.",
+      "type": "barchart",
+      "gridPos": {
+        "x": 12,
+        "y": 19,
+        "w": 6,
+        "h": 8
+      },
+      "datasource": {
+        "type": "frser-sqlite-datasource",
+        "uid": "gentle-telemetry-sqlite"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "queryType": "table",
+          "queryText": "SELECT COALESCE(NULLIF(os, ''), 'unknown') || '/' || COALESCE(NULLIF(arch, ''), 'unknown') AS Platform, COUNT(DISTINCT install_id) AS Installs FROM events WHERE received_at >= ${__from} * 1000000 AND received_at <= ${__to} * 1000000 GROUP BY Platform ORDER BY Installs DESC LIMIT 1000",
+          "rawQueryText": "SELECT COALESCE(NULLIF(os, ''), 'unknown') || '/' || COALESCE(NULLIF(arch, ''), 'unknown') AS Platform, COUNT(DISTINCT install_id) AS Installs FROM events WHERE received_at >= ${__from} * 1000000 AND received_at <= ${__to} * 1000000 GROUP BY Platform ORDER BY Installs DESC LIMIT 1000"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "min": 0,
+          "decimals": 0
+        },
+        "overrides": []
+      },
+      "options": {
+        "orientation": "horizontal",
+        "legend": {
+          "showLegend": false
+        }
+      }
+    },
+    {
+      "id": 304,
+      "title": "Version adoption",
+      "description": "Top ten reported Gentle AI versions on the latest completed rollup day.",
+      "type": "barchart",
+      "gridPos": {
+        "x": 18,
+        "y": 19,
+        "w": 6,
+        "h": 8
+      },
+      "datasource": {
+        "type": "frser-sqlite-datasource",
+        "uid": "gentle-telemetry-sqlite"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "queryType": "table",
+          "queryText": "SELECT key AS Version, SUM(value) AS Installs FROM rollups_daily WHERE metric = 'version' AND day = (SELECT MAX(day) FROM rollups_daily WHERE metric = 'version') GROUP BY key ORDER BY Installs DESC LIMIT 10",
+          "rawQueryText": "SELECT key AS Version, SUM(value) AS Installs FROM rollups_daily WHERE metric = 'version' AND day = (SELECT MAX(day) FROM rollups_daily WHERE metric = 'version') GROUP BY key ORDER BY Installs DESC LIMIT 10"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "min": 0,
+          "decimals": 0
+        },
+        "overrides": []
+      },
+      "options": {
+        "orientation": "horizontal",
+        "legend": {
+          "showLegend": false
+        }
+      }
+    },
+    {
+      "id": 400,
+      "title": "Runtime usage",
+      "type": "row",
+      "collapsed": false,
+      "panels": [],
+      "gridPos": {
+        "x": 0,
+        "y": 27,
+        "w": 24,
+        "h": 1
+      }
+    },
+    {
+      "id": 401,
+      "title": "Tokens processed",
+      "description": "Derived token volume processed by instrumented agents during the selected time range.",
+      "type": "stat",
+      "gridPos": {
+        "x": 0,
+        "y": 28,
+        "w": 6,
+        "h": 4
+      },
+      "datasource": {
+        "type": "frser-sqlite-datasource",
+        "uid": "gentle-telemetry-sqlite"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "queryType": "table",
+          "queryText": "SELECT SUM((CASE WHEN json_extract(r.row_json, '$.input_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.input_tokens.sum'), 0) ELSE 0 END + CASE WHEN json_extract(r.row_json, '$.output_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.output_tokens.sum'), 0) ELSE 0 END + CASE WHEN json_extract(r.row_json, '$.cache_read_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.cache_read_tokens.sum'), 0) ELSE 0 END + CASE WHEN json_extract(r.row_json, '$.cache_creation_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.cache_creation_tokens.sum'), 0) ELSE 0 END + CASE WHEN json_extract(r.row_json, '$.reasoning_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.reasoning_tokens.sum'), 0) ELSE 0 END)) AS \"Tokens processed\" FROM runtime_rows r JOIN runtime_deliveries d ON d.delivery_id = r.delivery_id WHERE d.received_at >= ${__from} * 1000000 AND d.received_at <= ${__to} * 1000000 HAVING COUNT(*) > 0",
+          "rawQueryText": "SELECT SUM((CASE WHEN json_extract(r.row_json, '$.input_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.input_tokens.sum'), 0) ELSE 0 END + CASE WHEN json_extract(r.row_json, '$.output_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.output_tokens.sum'), 0) ELSE 0 END + CASE WHEN json_extract(r.row_json, '$.cache_read_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.cache_read_tokens.sum'), 0) ELSE 0 END + CASE WHEN json_extract(r.row_json, '$.cache_creation_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.cache_creation_tokens.sum'), 0) ELSE 0 END + CASE WHEN json_extract(r.row_json, '$.reasoning_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.reasoning_tokens.sum'), 0) ELSE 0 END)) AS \"Tokens processed\" FROM runtime_rows r JOIN runtime_deliveries d ON d.delivery_id = r.delivery_id WHERE d.received_at >= ${__from} * 1000000 AND d.received_at <= ${__to} * 1000000 HAVING COUNT(*) > 0"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "min": 0,
+          "decimals": 0
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "pi"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "mode": "fixed",
+                  "fixedColor": "#73BF69"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "opencode"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "mode": "fixed",
+                  "fixedColor": "#5794F2"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "claude-code"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "mode": "fixed",
+                  "fixedColor": "#FF9830"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "codex"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "mode": "fixed",
+                  "fixedColor": "#B877D9"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "options": {
+        "orientation": "horizontal",
+        "textMode": "value_and_name",
+        "graphMode": "none",
+        "reduceOptions": {
+          "values": false,
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": ""
+        }
+      }
+    },
+    {
+      "id": 402,
+      "title": "Responses",
+      "description": "Response occurrences reported by instrumented agents during the selected time range.",
+      "type": "stat",
+      "gridPos": {
+        "x": 6,
+        "y": 28,
+        "w": 6,
+        "h": 4
+      },
+      "datasource": {
+        "type": "frser-sqlite-datasource",
+        "uid": "gentle-telemetry-sqlite"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "queryType": "table",
+          "queryText": "SELECT SUM(CASE WHEN json_type(r.row_json, '$.responses') = 'integer' THEN json_extract(r.row_json, '$.responses') ELSE 0 END) AS Responses FROM runtime_rows r JOIN runtime_deliveries d ON d.delivery_id = r.delivery_id WHERE d.received_at >= ${__from} * 1000000 AND d.received_at <= ${__to} * 1000000 HAVING COUNT(*) > 0",
+          "rawQueryText": "SELECT SUM(CASE WHEN json_type(r.row_json, '$.responses') = 'integer' THEN json_extract(r.row_json, '$.responses') ELSE 0 END) AS Responses FROM runtime_rows r JOIN runtime_deliveries d ON d.delivery_id = r.delivery_id WHERE d.received_at >= ${__from} * 1000000 AND d.received_at <= ${__to} * 1000000 HAVING COUNT(*) > 0"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "min": 0,
+          "decimals": 0
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "pi"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "mode": "fixed",
+                  "fixedColor": "#73BF69"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "opencode"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "mode": "fixed",
+                  "fixedColor": "#5794F2"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "claude-code"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "mode": "fixed",
+                  "fixedColor": "#FF9830"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "codex"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "mode": "fixed",
+                  "fixedColor": "#B877D9"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "options": {
+        "orientation": "horizontal",
+        "textMode": "value_and_name",
+        "graphMode": "none",
+        "reduceOptions": {
+          "values": false,
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": ""
+        }
+      }
+    },
+    {
+      "id": 403,
+      "title": "Deliveries",
+      "description": "Telemetry deliveries received from instrumented agent hosts during the selected time range.",
+      "type": "stat",
+      "gridPos": {
+        "x": 12,
+        "y": 28,
+        "w": 6,
+        "h": 4
+      },
+      "datasource": {
+        "type": "frser-sqlite-datasource",
+        "uid": "gentle-telemetry-sqlite"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "queryType": "table",
+          "queryText": "SELECT COUNT(DISTINCT d.delivery_id) AS Deliveries FROM runtime_deliveries d JOIN runtime_rows r ON r.delivery_id = d.delivery_id WHERE d.received_at >= ${__from} * 1000000 AND d.received_at <= ${__to} * 1000000 HAVING COUNT(*) > 0",
+          "rawQueryText": "SELECT COUNT(DISTINCT d.delivery_id) AS Deliveries FROM runtime_deliveries d JOIN runtime_rows r ON r.delivery_id = d.delivery_id WHERE d.received_at >= ${__from} * 1000000 AND d.received_at <= ${__to} * 1000000 HAVING COUNT(*) > 0"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "min": 0,
+          "decimals": 0
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "pi"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "mode": "fixed",
+                  "fixedColor": "#73BF69"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "opencode"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "mode": "fixed",
+                  "fixedColor": "#5794F2"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "claude-code"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "mode": "fixed",
+                  "fixedColor": "#FF9830"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "codex"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "mode": "fixed",
+                  "fixedColor": "#B877D9"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "options": {
+        "orientation": "horizontal",
+        "textMode": "value_and_name",
+        "graphMode": "none",
+        "reduceOptions": {
+          "values": false,
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": ""
+        }
+      }
+    },
+    {
+      "id": 404,
+      "title": "Hosts reporting",
+      "description": "Distinct agent host types that reported runtime usage during the selected time range.",
+      "type": "stat",
+      "gridPos": {
+        "x": 18,
+        "y": 28,
+        "w": 6,
+        "h": 4
+      },
+      "datasource": {
+        "type": "frser-sqlite-datasource",
+        "uid": "gentle-telemetry-sqlite"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "queryType": "table",
+          "queryText": "SELECT COUNT(DISTINCT COALESCE(NULLIF(json_extract(d.canonical_payload, '$.host'), ''), 'unknown')) AS Hosts FROM runtime_deliveries d JOIN runtime_rows r ON r.delivery_id = d.delivery_id WHERE d.received_at >= ${__from} * 1000000 AND d.received_at <= ${__to} * 1000000 HAVING COUNT(*) > 0",
+          "rawQueryText": "SELECT COUNT(DISTINCT COALESCE(NULLIF(json_extract(d.canonical_payload, '$.host'), ''), 'unknown')) AS Hosts FROM runtime_deliveries d JOIN runtime_rows r ON r.delivery_id = d.delivery_id WHERE d.received_at >= ${__from} * 1000000 AND d.received_at <= ${__to} * 1000000 HAVING COUNT(*) > 0"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "min": 0,
+          "decimals": 0
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "pi"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "mode": "fixed",
+                  "fixedColor": "#73BF69"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "opencode"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "mode": "fixed",
+                  "fixedColor": "#5794F2"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "claude-code"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "mode": "fixed",
+                  "fixedColor": "#FF9830"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "codex"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "mode": "fixed",
+                  "fixedColor": "#B877D9"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "options": {
+        "orientation": "horizontal",
+        "textMode": "value_and_name",
+        "graphMode": "none",
+        "reduceOptions": {
+          "values": false,
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": ""
+        }
+      }
+    },
+    {
+      "id": 405,
+      "title": "Tokens processed by host",
+      "description": "Derived token volume compares runtime usage across supported agent hosts.",
+      "type": "barchart",
+      "gridPos": {
+        "x": 0,
+        "y": 32,
+        "w": 12,
+        "h": 7
+      },
+      "datasource": {
+        "type": "frser-sqlite-datasource",
+        "uid": "gentle-telemetry-sqlite"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "queryType": "table",
+          "queryText": "SELECT SUM(CASE WHEN COALESCE(NULLIF(json_extract(d.canonical_payload, '$.host'), ''), 'unknown') = 'pi' THEN (CASE WHEN json_extract(r.row_json, '$.input_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.input_tokens.sum'), 0) ELSE 0 END + CASE WHEN json_extract(r.row_json, '$.output_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.output_tokens.sum'), 0) ELSE 0 END + CASE WHEN json_extract(r.row_json, '$.cache_read_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.cache_read_tokens.sum'), 0) ELSE 0 END + CASE WHEN json_extract(r.row_json, '$.cache_creation_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.cache_creation_tokens.sum'), 0) ELSE 0 END + CASE WHEN json_extract(r.row_json, '$.reasoning_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.reasoning_tokens.sum'), 0) ELSE 0 END) ELSE 0 END) AS pi, SUM(CASE WHEN COALESCE(NULLIF(json_extract(d.canonical_payload, '$.host'), ''), 'unknown') = 'opencode' THEN (CASE WHEN json_extract(r.row_json, '$.input_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.input_tokens.sum'), 0) ELSE 0 END + CASE WHEN json_extract(r.row_json, '$.output_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.output_tokens.sum'), 0) ELSE 0 END + CASE WHEN json_extract(r.row_json, '$.cache_read_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.cache_read_tokens.sum'), 0) ELSE 0 END + CASE WHEN json_extract(r.row_json, '$.cache_creation_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.cache_creation_tokens.sum'), 0) ELSE 0 END + CASE WHEN json_extract(r.row_json, '$.reasoning_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.reasoning_tokens.sum'), 0) ELSE 0 END) ELSE 0 END) AS opencode, SUM(CASE WHEN COALESCE(NULLIF(json_extract(d.canonical_payload, '$.host'), ''), 'unknown') = 'claude-code' THEN (CASE WHEN json_extract(r.row_json, '$.input_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.input_tokens.sum'), 0) ELSE 0 END + CASE WHEN json_extract(r.row_json, '$.output_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.output_tokens.sum'), 0) ELSE 0 END + CASE WHEN json_extract(r.row_json, '$.cache_read_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.cache_read_tokens.sum'), 0) ELSE 0 END + CASE WHEN json_extract(r.row_json, '$.cache_creation_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.cache_creation_tokens.sum'), 0) ELSE 0 END + CASE WHEN json_extract(r.row_json, '$.reasoning_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.reasoning_tokens.sum'), 0) ELSE 0 END) ELSE 0 END) AS \"claude-code\", SUM(CASE WHEN COALESCE(NULLIF(json_extract(d.canonical_payload, '$.host'), ''), 'unknown') = 'codex' THEN (CASE WHEN json_extract(r.row_json, '$.input_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.input_tokens.sum'), 0) ELSE 0 END + CASE WHEN json_extract(r.row_json, '$.output_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.output_tokens.sum'), 0) ELSE 0 END + CASE WHEN json_extract(r.row_json, '$.cache_read_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.cache_read_tokens.sum'), 0) ELSE 0 END + CASE WHEN json_extract(r.row_json, '$.cache_creation_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.cache_creation_tokens.sum'), 0) ELSE 0 END + CASE WHEN json_extract(r.row_json, '$.reasoning_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.reasoning_tokens.sum'), 0) ELSE 0 END) ELSE 0 END) AS codex FROM runtime_rows r JOIN runtime_deliveries d ON d.delivery_id = r.delivery_id WHERE d.received_at >= ${__from} * 1000000 AND d.received_at <= ${__to} * 1000000 HAVING COUNT(*) > 0",
+          "rawQueryText": "SELECT SUM(CASE WHEN COALESCE(NULLIF(json_extract(d.canonical_payload, '$.host'), ''), 'unknown') = 'pi' THEN (CASE WHEN json_extract(r.row_json, '$.input_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.input_tokens.sum'), 0) ELSE 0 END + CASE WHEN json_extract(r.row_json, '$.output_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.output_tokens.sum'), 0) ELSE 0 END + CASE WHEN json_extract(r.row_json, '$.cache_read_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.cache_read_tokens.sum'), 0) ELSE 0 END + CASE WHEN json_extract(r.row_json, '$.cache_creation_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.cache_creation_tokens.sum'), 0) ELSE 0 END + CASE WHEN json_extract(r.row_json, '$.reasoning_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.reasoning_tokens.sum'), 0) ELSE 0 END) ELSE 0 END) AS pi, SUM(CASE WHEN COALESCE(NULLIF(json_extract(d.canonical_payload, '$.host'), ''), 'unknown') = 'opencode' THEN (CASE WHEN json_extract(r.row_json, '$.input_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.input_tokens.sum'), 0) ELSE 0 END + CASE WHEN json_extract(r.row_json, '$.output_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.output_tokens.sum'), 0) ELSE 0 END + CASE WHEN json_extract(r.row_json, '$.cache_read_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.cache_read_tokens.sum'), 0) ELSE 0 END + CASE WHEN json_extract(r.row_json, '$.cache_creation_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.cache_creation_tokens.sum'), 0) ELSE 0 END + CASE WHEN json_extract(r.row_json, '$.reasoning_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.reasoning_tokens.sum'), 0) ELSE 0 END) ELSE 0 END) AS opencode, SUM(CASE WHEN COALESCE(NULLIF(json_extract(d.canonical_payload, '$.host'), ''), 'unknown') = 'claude-code' THEN (CASE WHEN json_extract(r.row_json, '$.input_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.input_tokens.sum'), 0) ELSE 0 END + CASE WHEN json_extract(r.row_json, '$.output_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.output_tokens.sum'), 0) ELSE 0 END + CASE WHEN json_extract(r.row_json, '$.cache_read_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.cache_read_tokens.sum'), 0) ELSE 0 END + CASE WHEN json_extract(r.row_json, '$.cache_creation_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.cache_creation_tokens.sum'), 0) ELSE 0 END + CASE WHEN json_extract(r.row_json, '$.reasoning_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.reasoning_tokens.sum'), 0) ELSE 0 END) ELSE 0 END) AS \"claude-code\", SUM(CASE WHEN COALESCE(NULLIF(json_extract(d.canonical_payload, '$.host'), ''), 'unknown') = 'codex' THEN (CASE WHEN json_extract(r.row_json, '$.input_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.input_tokens.sum'), 0) ELSE 0 END + CASE WHEN json_extract(r.row_json, '$.output_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.output_tokens.sum'), 0) ELSE 0 END + CASE WHEN json_extract(r.row_json, '$.cache_read_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.cache_read_tokens.sum'), 0) ELSE 0 END + CASE WHEN json_extract(r.row_json, '$.cache_creation_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.cache_creation_tokens.sum'), 0) ELSE 0 END + CASE WHEN json_extract(r.row_json, '$.reasoning_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.reasoning_tokens.sum'), 0) ELSE 0 END) ELSE 0 END) AS codex FROM runtime_rows r JOIN runtime_deliveries d ON d.delivery_id = r.delivery_id WHERE d.received_at >= ${__from} * 1000000 AND d.received_at <= ${__to} * 1000000 HAVING COUNT(*) > 0"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "min": 0,
+          "decimals": 0
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "pi"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "mode": "fixed",
+                  "fixedColor": "#73BF69"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "opencode"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "mode": "fixed",
+                  "fixedColor": "#5794F2"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "claude-code"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "mode": "fixed",
+                  "fixedColor": "#FF9830"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "codex"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "mode": "fixed",
+                  "fixedColor": "#B877D9"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "options": {
+        "orientation": "horizontal",
+        "legend": {
+          "showLegend": false
+        }
+      }
+    },
+    {
+      "id": 406,
+      "title": "Responses by host",
+      "description": "Reported response occurrences compare activity across supported agent hosts.",
+      "type": "barchart",
+      "gridPos": {
+        "x": 12,
+        "y": 32,
+        "w": 12,
+        "h": 7
+      },
+      "datasource": {
+        "type": "frser-sqlite-datasource",
+        "uid": "gentle-telemetry-sqlite"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "queryType": "table",
+          "queryText": "SELECT SUM(CASE WHEN COALESCE(NULLIF(json_extract(d.canonical_payload, '$.host'), ''), 'unknown') = 'pi' THEN CASE WHEN json_type(r.row_json, '$.responses') = 'integer' THEN json_extract(r.row_json, '$.responses') ELSE 0 END ELSE 0 END) AS pi, SUM(CASE WHEN COALESCE(NULLIF(json_extract(d.canonical_payload, '$.host'), ''), 'unknown') = 'opencode' THEN CASE WHEN json_type(r.row_json, '$.responses') = 'integer' THEN json_extract(r.row_json, '$.responses') ELSE 0 END ELSE 0 END) AS opencode, SUM(CASE WHEN COALESCE(NULLIF(json_extract(d.canonical_payload, '$.host'), ''), 'unknown') = 'claude-code' THEN CASE WHEN json_type(r.row_json, '$.responses') = 'integer' THEN json_extract(r.row_json, '$.responses') ELSE 0 END ELSE 0 END) AS \"claude-code\", SUM(CASE WHEN COALESCE(NULLIF(json_extract(d.canonical_payload, '$.host'), ''), 'unknown') = 'codex' THEN CASE WHEN json_type(r.row_json, '$.responses') = 'integer' THEN json_extract(r.row_json, '$.responses') ELSE 0 END ELSE 0 END) AS codex FROM runtime_rows r JOIN runtime_deliveries d ON d.delivery_id = r.delivery_id WHERE d.received_at >= ${__from} * 1000000 AND d.received_at <= ${__to} * 1000000 HAVING COUNT(*) > 0",
+          "rawQueryText": "SELECT SUM(CASE WHEN COALESCE(NULLIF(json_extract(d.canonical_payload, '$.host'), ''), 'unknown') = 'pi' THEN CASE WHEN json_type(r.row_json, '$.responses') = 'integer' THEN json_extract(r.row_json, '$.responses') ELSE 0 END ELSE 0 END) AS pi, SUM(CASE WHEN COALESCE(NULLIF(json_extract(d.canonical_payload, '$.host'), ''), 'unknown') = 'opencode' THEN CASE WHEN json_type(r.row_json, '$.responses') = 'integer' THEN json_extract(r.row_json, '$.responses') ELSE 0 END ELSE 0 END) AS opencode, SUM(CASE WHEN COALESCE(NULLIF(json_extract(d.canonical_payload, '$.host'), ''), 'unknown') = 'claude-code' THEN CASE WHEN json_type(r.row_json, '$.responses') = 'integer' THEN json_extract(r.row_json, '$.responses') ELSE 0 END ELSE 0 END) AS \"claude-code\", SUM(CASE WHEN COALESCE(NULLIF(json_extract(d.canonical_payload, '$.host'), ''), 'unknown') = 'codex' THEN CASE WHEN json_type(r.row_json, '$.responses') = 'integer' THEN json_extract(r.row_json, '$.responses') ELSE 0 END ELSE 0 END) AS codex FROM runtime_rows r JOIN runtime_deliveries d ON d.delivery_id = r.delivery_id WHERE d.received_at >= ${__from} * 1000000 AND d.received_at <= ${__to} * 1000000 HAVING COUNT(*) > 0"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "min": 0,
+          "decimals": 0
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "pi"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "mode": "fixed",
+                  "fixedColor": "#73BF69"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "opencode"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "mode": "fixed",
+                  "fixedColor": "#5794F2"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "claude-code"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "mode": "fixed",
+                  "fixedColor": "#FF9830"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "codex"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "mode": "fixed",
+                  "fixedColor": "#B877D9"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "options": {
+        "orientation": "horizontal",
+        "legend": {
+          "showLegend": false
+        }
+      }
+    },
+    {
+      "id": 407,
+      "title": "Tokens by model",
+      "description": "Model-level usage keeps unknown and custom model evidence visible instead of hiding incomplete attribution.",
+      "type": "table",
+      "gridPos": {
+        "x": 0,
+        "y": 39,
+        "w": 12,
+        "h": 9
+      },
+      "datasource": {
+        "type": "frser-sqlite-datasource",
+        "uid": "gentle-telemetry-sqlite"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "queryType": "table",
+          "queryText": "SELECT COALESCE(NULLIF(json_extract(d.canonical_payload, '$.host'), ''), 'unknown') AS Host, COALESCE(NULLIF(json_extract(r.row_json, '$.model.provider'), ''), 'unknown') AS Provider, COALESCE(NULLIF(json_extract(r.row_json, '$.model.id'), ''), 'unknown') AS Model, COALESCE(NULLIF(json_extract(r.row_json, '$.model_evidence'), ''), 'unknown') AS Evidence, SUM(CASE WHEN json_type(r.row_json, '$.responses') = 'integer' THEN json_extract(r.row_json, '$.responses') ELSE 0 END) AS Responses, SUM((CASE WHEN json_extract(r.row_json, '$.input_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.input_tokens.sum'), 0) ELSE 0 END + CASE WHEN json_extract(r.row_json, '$.output_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.output_tokens.sum'), 0) ELSE 0 END + CASE WHEN json_extract(r.row_json, '$.cache_read_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.cache_read_tokens.sum'), 0) ELSE 0 END + CASE WHEN json_extract(r.row_json, '$.cache_creation_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.cache_creation_tokens.sum'), 0) ELSE 0 END + CASE WHEN json_extract(r.row_json, '$.reasoning_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.reasoning_tokens.sum'), 0) ELSE 0 END)) AS \"Tokens processed\", ROUND(1.0 * SUM((CASE WHEN json_extract(r.row_json, '$.input_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.input_tokens.sum'), 0) ELSE 0 END + CASE WHEN json_extract(r.row_json, '$.output_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.output_tokens.sum'), 0) ELSE 0 END + CASE WHEN json_extract(r.row_json, '$.cache_read_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.cache_read_tokens.sum'), 0) ELSE 0 END + CASE WHEN json_extract(r.row_json, '$.cache_creation_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.cache_creation_tokens.sum'), 0) ELSE 0 END + CASE WHEN json_extract(r.row_json, '$.reasoning_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.reasoning_tokens.sum'), 0) ELSE 0 END)) / NULLIF(SUM(CASE WHEN json_type(r.row_json, '$.responses') = 'integer' THEN json_extract(r.row_json, '$.responses') ELSE 0 END), 0), 1) AS \"Avg tokens per response\" FROM runtime_rows r JOIN runtime_deliveries d ON d.delivery_id = r.delivery_id WHERE d.received_at >= ${__from} * 1000000 AND d.received_at <= ${__to} * 1000000 GROUP BY Host, Provider, Model, Evidence ORDER BY \"Tokens processed\" DESC LIMIT 1000",
+          "rawQueryText": "SELECT COALESCE(NULLIF(json_extract(d.canonical_payload, '$.host'), ''), 'unknown') AS Host, COALESCE(NULLIF(json_extract(r.row_json, '$.model.provider'), ''), 'unknown') AS Provider, COALESCE(NULLIF(json_extract(r.row_json, '$.model.id'), ''), 'unknown') AS Model, COALESCE(NULLIF(json_extract(r.row_json, '$.model_evidence'), ''), 'unknown') AS Evidence, SUM(CASE WHEN json_type(r.row_json, '$.responses') = 'integer' THEN json_extract(r.row_json, '$.responses') ELSE 0 END) AS Responses, SUM((CASE WHEN json_extract(r.row_json, '$.input_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.input_tokens.sum'), 0) ELSE 0 END + CASE WHEN json_extract(r.row_json, '$.output_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.output_tokens.sum'), 0) ELSE 0 END + CASE WHEN json_extract(r.row_json, '$.cache_read_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.cache_read_tokens.sum'), 0) ELSE 0 END + CASE WHEN json_extract(r.row_json, '$.cache_creation_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.cache_creation_tokens.sum'), 0) ELSE 0 END + CASE WHEN json_extract(r.row_json, '$.reasoning_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.reasoning_tokens.sum'), 0) ELSE 0 END)) AS \"Tokens processed\", ROUND(1.0 * SUM((CASE WHEN json_extract(r.row_json, '$.input_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.input_tokens.sum'), 0) ELSE 0 END + CASE WHEN json_extract(r.row_json, '$.output_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.output_tokens.sum'), 0) ELSE 0 END + CASE WHEN json_extract(r.row_json, '$.cache_read_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.cache_read_tokens.sum'), 0) ELSE 0 END + CASE WHEN json_extract(r.row_json, '$.cache_creation_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.cache_creation_tokens.sum'), 0) ELSE 0 END + CASE WHEN json_extract(r.row_json, '$.reasoning_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.reasoning_tokens.sum'), 0) ELSE 0 END)) / NULLIF(SUM(CASE WHEN json_type(r.row_json, '$.responses') = 'integer' THEN json_extract(r.row_json, '$.responses') ELSE 0 END), 0), 1) AS \"Avg tokens per response\" FROM runtime_rows r JOIN runtime_deliveries d ON d.delivery_id = r.delivery_id WHERE d.received_at >= ${__from} * 1000000 AND d.received_at <= ${__to} * 1000000 GROUP BY Host, Provider, Model, Evidence ORDER BY \"Tokens processed\" DESC LIMIT 1000"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "min": 0
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "pi"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "mode": "fixed",
+                  "fixedColor": "#73BF69"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "opencode"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "mode": "fixed",
+                  "fixedColor": "#5794F2"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "claude-code"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "mode": "fixed",
+                  "fixedColor": "#FF9830"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "codex"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "mode": "fixed",
+                  "fixedColor": "#B877D9"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "options": {
+        "showHeader": true,
+        "cellHeight": "sm",
+        "enablePagination": true
+      }
+    },
+    {
+      "id": 408,
+      "title": "Responses and tokens by selected effort",
+      "description": "Selected reasoning effort shows how usage and token volume are distributed across requested effort levels.",
+      "type": "table",
+      "gridPos": {
+        "x": 12,
+        "y": 39,
+        "w": 12,
+        "h": 9
+      },
+      "datasource": {
+        "type": "frser-sqlite-datasource",
+        "uid": "gentle-telemetry-sqlite"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "queryType": "table",
+          "queryText": "SELECT COALESCE(NULLIF(json_extract(r.row_json, '$.selected_effort'), ''), 'unknown') AS \"Selected effort\", SUM(CASE WHEN json_type(r.row_json, '$.responses') = 'integer' THEN json_extract(r.row_json, '$.responses') ELSE 0 END) AS Responses, SUM((CASE WHEN json_extract(r.row_json, '$.input_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.input_tokens.sum'), 0) ELSE 0 END + CASE WHEN json_extract(r.row_json, '$.output_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.output_tokens.sum'), 0) ELSE 0 END + CASE WHEN json_extract(r.row_json, '$.cache_read_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.cache_read_tokens.sum'), 0) ELSE 0 END + CASE WHEN json_extract(r.row_json, '$.cache_creation_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.cache_creation_tokens.sum'), 0) ELSE 0 END + CASE WHEN json_extract(r.row_json, '$.reasoning_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.reasoning_tokens.sum'), 0) ELSE 0 END)) AS \"Tokens processed\", ROUND(1.0 * SUM((CASE WHEN json_extract(r.row_json, '$.input_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.input_tokens.sum'), 0) ELSE 0 END + CASE WHEN json_extract(r.row_json, '$.output_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.output_tokens.sum'), 0) ELSE 0 END + CASE WHEN json_extract(r.row_json, '$.cache_read_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.cache_read_tokens.sum'), 0) ELSE 0 END + CASE WHEN json_extract(r.row_json, '$.cache_creation_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.cache_creation_tokens.sum'), 0) ELSE 0 END + CASE WHEN json_extract(r.row_json, '$.reasoning_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.reasoning_tokens.sum'), 0) ELSE 0 END)) / NULLIF(SUM(CASE WHEN json_type(r.row_json, '$.responses') = 'integer' THEN json_extract(r.row_json, '$.responses') ELSE 0 END), 0), 1) AS \"Avg tokens per response\" FROM runtime_rows r JOIN runtime_deliveries d ON d.delivery_id = r.delivery_id WHERE d.received_at >= ${__from} * 1000000 AND d.received_at <= ${__to} * 1000000 GROUP BY \"Selected effort\" ORDER BY Responses DESC, \"Tokens processed\" DESC LIMIT 1000",
+          "rawQueryText": "SELECT COALESCE(NULLIF(json_extract(r.row_json, '$.selected_effort'), ''), 'unknown') AS \"Selected effort\", SUM(CASE WHEN json_type(r.row_json, '$.responses') = 'integer' THEN json_extract(r.row_json, '$.responses') ELSE 0 END) AS Responses, SUM((CASE WHEN json_extract(r.row_json, '$.input_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.input_tokens.sum'), 0) ELSE 0 END + CASE WHEN json_extract(r.row_json, '$.output_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.output_tokens.sum'), 0) ELSE 0 END + CASE WHEN json_extract(r.row_json, '$.cache_read_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.cache_read_tokens.sum'), 0) ELSE 0 END + CASE WHEN json_extract(r.row_json, '$.cache_creation_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.cache_creation_tokens.sum'), 0) ELSE 0 END + CASE WHEN json_extract(r.row_json, '$.reasoning_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.reasoning_tokens.sum'), 0) ELSE 0 END)) AS \"Tokens processed\", ROUND(1.0 * SUM((CASE WHEN json_extract(r.row_json, '$.input_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.input_tokens.sum'), 0) ELSE 0 END + CASE WHEN json_extract(r.row_json, '$.output_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.output_tokens.sum'), 0) ELSE 0 END + CASE WHEN json_extract(r.row_json, '$.cache_read_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.cache_read_tokens.sum'), 0) ELSE 0 END + CASE WHEN json_extract(r.row_json, '$.cache_creation_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.cache_creation_tokens.sum'), 0) ELSE 0 END + CASE WHEN json_extract(r.row_json, '$.reasoning_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.reasoning_tokens.sum'), 0) ELSE 0 END)) / NULLIF(SUM(CASE WHEN json_type(r.row_json, '$.responses') = 'integer' THEN json_extract(r.row_json, '$.responses') ELSE 0 END), 0), 1) AS \"Avg tokens per response\" FROM runtime_rows r JOIN runtime_deliveries d ON d.delivery_id = r.delivery_id WHERE d.received_at >= ${__from} * 1000000 AND d.received_at <= ${__to} * 1000000 GROUP BY \"Selected effort\" ORDER BY Responses DESC, \"Tokens processed\" DESC LIMIT 1000"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "min": 0
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "pi"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "mode": "fixed",
+                  "fixedColor": "#73BF69"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "opencode"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "mode": "fixed",
+                  "fixedColor": "#5794F2"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "claude-code"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "mode": "fixed",
+                  "fixedColor": "#FF9830"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "codex"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "mode": "fixed",
+                  "fixedColor": "#B877D9"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "options": {
+        "showHeader": true,
+        "cellHeight": "sm",
+        "enablePagination": true
+      }
+    },
+    {
+      "id": 409,
+      "title": "Usage by host, subagent, model and effort",
+      "description": "The most active host, subagent, model, and effort combinations reveal how customers put the product to work.",
+      "type": "table",
+      "gridPos": {
+        "x": 0,
+        "y": 48,
+        "w": 24,
+        "h": 10
+      },
+      "datasource": {
+        "type": "frser-sqlite-datasource",
+        "uid": "gentle-telemetry-sqlite"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "queryType": "table",
+          "queryText": "SELECT COALESCE(NULLIF(json_extract(d.canonical_payload, '$.host'), ''), 'unknown') AS Host, COALESCE(NULLIF(json_extract(r.row_json, '$.agent_kind'), ''), 'unknown') AS agent_kind, COALESCE(NULLIF(json_extract(r.row_json, '$.agent_class'), ''), 'unknown') AS agent_class, COALESCE(NULLIF(json_extract(r.row_json, '$.model.provider'), ''), 'unknown') || '/' || COALESCE(NULLIF(json_extract(r.row_json, '$.model.id'), ''), 'unknown') AS \"Provider/model\", COALESCE(NULLIF(json_extract(r.row_json, '$.selected_effort'), ''), 'unknown') AS selected_effort, COALESCE(NULLIF(json_extract(r.row_json, '$.effective_effort'), ''), 'unknown') AS effective_effort, SUM(CASE WHEN json_type(r.row_json, '$.launches') = 'integer' THEN json_extract(r.row_json, '$.launches') ELSE 0 END) AS Launches, SUM(CASE WHEN json_type(r.row_json, '$.responses') = 'integer' THEN json_extract(r.row_json, '$.responses') ELSE 0 END) AS Responses, SUM((CASE WHEN json_extract(r.row_json, '$.input_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.input_tokens.sum'), 0) ELSE 0 END + CASE WHEN json_extract(r.row_json, '$.output_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.output_tokens.sum'), 0) ELSE 0 END + CASE WHEN json_extract(r.row_json, '$.cache_read_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.cache_read_tokens.sum'), 0) ELSE 0 END + CASE WHEN json_extract(r.row_json, '$.cache_creation_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.cache_creation_tokens.sum'), 0) ELSE 0 END + CASE WHEN json_extract(r.row_json, '$.reasoning_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.reasoning_tokens.sum'), 0) ELSE 0 END)) AS \"Tokens processed\" FROM runtime_rows r JOIN runtime_deliveries d ON d.delivery_id = r.delivery_id WHERE d.received_at >= ${__from} * 1000000 AND d.received_at <= ${__to} * 1000000 GROUP BY Host, agent_kind, agent_class, \"Provider/model\", selected_effort, effective_effort ORDER BY Responses + Launches DESC LIMIT 1000",
+          "rawQueryText": "SELECT COALESCE(NULLIF(json_extract(d.canonical_payload, '$.host'), ''), 'unknown') AS Host, COALESCE(NULLIF(json_extract(r.row_json, '$.agent_kind'), ''), 'unknown') AS agent_kind, COALESCE(NULLIF(json_extract(r.row_json, '$.agent_class'), ''), 'unknown') AS agent_class, COALESCE(NULLIF(json_extract(r.row_json, '$.model.provider'), ''), 'unknown') || '/' || COALESCE(NULLIF(json_extract(r.row_json, '$.model.id'), ''), 'unknown') AS \"Provider/model\", COALESCE(NULLIF(json_extract(r.row_json, '$.selected_effort'), ''), 'unknown') AS selected_effort, COALESCE(NULLIF(json_extract(r.row_json, '$.effective_effort'), ''), 'unknown') AS effective_effort, SUM(CASE WHEN json_type(r.row_json, '$.launches') = 'integer' THEN json_extract(r.row_json, '$.launches') ELSE 0 END) AS Launches, SUM(CASE WHEN json_type(r.row_json, '$.responses') = 'integer' THEN json_extract(r.row_json, '$.responses') ELSE 0 END) AS Responses, SUM((CASE WHEN json_extract(r.row_json, '$.input_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.input_tokens.sum'), 0) ELSE 0 END + CASE WHEN json_extract(r.row_json, '$.output_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.output_tokens.sum'), 0) ELSE 0 END + CASE WHEN json_extract(r.row_json, '$.cache_read_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.cache_read_tokens.sum'), 0) ELSE 0 END + CASE WHEN json_extract(r.row_json, '$.cache_creation_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.cache_creation_tokens.sum'), 0) ELSE 0 END + CASE WHEN json_extract(r.row_json, '$.reasoning_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.reasoning_tokens.sum'), 0) ELSE 0 END)) AS \"Tokens processed\" FROM runtime_rows r JOIN runtime_deliveries d ON d.delivery_id = r.delivery_id WHERE d.received_at >= ${__from} * 1000000 AND d.received_at <= ${__to} * 1000000 GROUP BY Host, agent_kind, agent_class, \"Provider/model\", selected_effort, effective_effort ORDER BY Responses + Launches DESC LIMIT 1000"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "min": 0
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "pi"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "mode": "fixed",
+                  "fixedColor": "#73BF69"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "opencode"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "mode": "fixed",
+                  "fixedColor": "#5794F2"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "claude-code"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "mode": "fixed",
+                  "fixedColor": "#FF9830"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "codex"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "mode": "fixed",
+                  "fixedColor": "#B877D9"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "options": {
+        "showHeader": true,
+        "cellHeight": "sm",
+        "enablePagination": true
+      }
+    },
+    {
+      "id": 410,
+      "title": "Tokens processed per hour by host",
+      "description": "Hourly derived token volume shows when and where runtime usage is happening.",
+      "type": "timeseries",
+      "gridPos": {
+        "x": 0,
+        "y": 58,
+        "w": 12,
+        "h": 9
+      },
+      "datasource": {
+        "type": "frser-sqlite-datasource",
+        "uid": "gentle-telemetry-sqlite"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "queryType": "table",
+          "queryText": "SELECT CAST(strftime('%s', strftime('%Y-%m-%d %H:00:00', d.received_at / 1000000000, 'unixepoch')) AS INTEGER) AS time, SUM(CASE WHEN COALESCE(NULLIF(json_extract(d.canonical_payload, '$.host'), ''), 'unknown') = 'pi' THEN (CASE WHEN json_extract(r.row_json, '$.input_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.input_tokens.sum'), 0) ELSE 0 END + CASE WHEN json_extract(r.row_json, '$.output_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.output_tokens.sum'), 0) ELSE 0 END + CASE WHEN json_extract(r.row_json, '$.cache_read_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.cache_read_tokens.sum'), 0) ELSE 0 END + CASE WHEN json_extract(r.row_json, '$.cache_creation_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.cache_creation_tokens.sum'), 0) ELSE 0 END + CASE WHEN json_extract(r.row_json, '$.reasoning_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.reasoning_tokens.sum'), 0) ELSE 0 END) ELSE 0 END) AS pi, SUM(CASE WHEN COALESCE(NULLIF(json_extract(d.canonical_payload, '$.host'), ''), 'unknown') = 'opencode' THEN (CASE WHEN json_extract(r.row_json, '$.input_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.input_tokens.sum'), 0) ELSE 0 END + CASE WHEN json_extract(r.row_json, '$.output_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.output_tokens.sum'), 0) ELSE 0 END + CASE WHEN json_extract(r.row_json, '$.cache_read_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.cache_read_tokens.sum'), 0) ELSE 0 END + CASE WHEN json_extract(r.row_json, '$.cache_creation_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.cache_creation_tokens.sum'), 0) ELSE 0 END + CASE WHEN json_extract(r.row_json, '$.reasoning_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.reasoning_tokens.sum'), 0) ELSE 0 END) ELSE 0 END) AS opencode, SUM(CASE WHEN COALESCE(NULLIF(json_extract(d.canonical_payload, '$.host'), ''), 'unknown') = 'claude-code' THEN (CASE WHEN json_extract(r.row_json, '$.input_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.input_tokens.sum'), 0) ELSE 0 END + CASE WHEN json_extract(r.row_json, '$.output_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.output_tokens.sum'), 0) ELSE 0 END + CASE WHEN json_extract(r.row_json, '$.cache_read_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.cache_read_tokens.sum'), 0) ELSE 0 END + CASE WHEN json_extract(r.row_json, '$.cache_creation_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.cache_creation_tokens.sum'), 0) ELSE 0 END + CASE WHEN json_extract(r.row_json, '$.reasoning_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.reasoning_tokens.sum'), 0) ELSE 0 END) ELSE 0 END) AS \"claude-code\", SUM(CASE WHEN COALESCE(NULLIF(json_extract(d.canonical_payload, '$.host'), ''), 'unknown') = 'codex' THEN (CASE WHEN json_extract(r.row_json, '$.input_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.input_tokens.sum'), 0) ELSE 0 END + CASE WHEN json_extract(r.row_json, '$.output_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.output_tokens.sum'), 0) ELSE 0 END + CASE WHEN json_extract(r.row_json, '$.cache_read_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.cache_read_tokens.sum'), 0) ELSE 0 END + CASE WHEN json_extract(r.row_json, '$.cache_creation_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.cache_creation_tokens.sum'), 0) ELSE 0 END + CASE WHEN json_extract(r.row_json, '$.reasoning_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.reasoning_tokens.sum'), 0) ELSE 0 END) ELSE 0 END) AS codex FROM runtime_rows r JOIN runtime_deliveries d ON d.delivery_id = r.delivery_id WHERE d.received_at >= ${__from} * 1000000 AND d.received_at <= ${__to} * 1000000 GROUP BY time ORDER BY time ASC",
+          "rawQueryText": "SELECT CAST(strftime('%s', strftime('%Y-%m-%d %H:00:00', d.received_at / 1000000000, 'unixepoch')) AS INTEGER) AS time, SUM(CASE WHEN COALESCE(NULLIF(json_extract(d.canonical_payload, '$.host'), ''), 'unknown') = 'pi' THEN (CASE WHEN json_extract(r.row_json, '$.input_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.input_tokens.sum'), 0) ELSE 0 END + CASE WHEN json_extract(r.row_json, '$.output_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.output_tokens.sum'), 0) ELSE 0 END + CASE WHEN json_extract(r.row_json, '$.cache_read_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.cache_read_tokens.sum'), 0) ELSE 0 END + CASE WHEN json_extract(r.row_json, '$.cache_creation_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.cache_creation_tokens.sum'), 0) ELSE 0 END + CASE WHEN json_extract(r.row_json, '$.reasoning_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.reasoning_tokens.sum'), 0) ELSE 0 END) ELSE 0 END) AS pi, SUM(CASE WHEN COALESCE(NULLIF(json_extract(d.canonical_payload, '$.host'), ''), 'unknown') = 'opencode' THEN (CASE WHEN json_extract(r.row_json, '$.input_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.input_tokens.sum'), 0) ELSE 0 END + CASE WHEN json_extract(r.row_json, '$.output_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.output_tokens.sum'), 0) ELSE 0 END + CASE WHEN json_extract(r.row_json, '$.cache_read_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.cache_read_tokens.sum'), 0) ELSE 0 END + CASE WHEN json_extract(r.row_json, '$.cache_creation_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.cache_creation_tokens.sum'), 0) ELSE 0 END + CASE WHEN json_extract(r.row_json, '$.reasoning_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.reasoning_tokens.sum'), 0) ELSE 0 END) ELSE 0 END) AS opencode, SUM(CASE WHEN COALESCE(NULLIF(json_extract(d.canonical_payload, '$.host'), ''), 'unknown') = 'claude-code' THEN (CASE WHEN json_extract(r.row_json, '$.input_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.input_tokens.sum'), 0) ELSE 0 END + CASE WHEN json_extract(r.row_json, '$.output_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.output_tokens.sum'), 0) ELSE 0 END + CASE WHEN json_extract(r.row_json, '$.cache_read_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.cache_read_tokens.sum'), 0) ELSE 0 END + CASE WHEN json_extract(r.row_json, '$.cache_creation_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.cache_creation_tokens.sum'), 0) ELSE 0 END + CASE WHEN json_extract(r.row_json, '$.reasoning_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.reasoning_tokens.sum'), 0) ELSE 0 END) ELSE 0 END) AS \"claude-code\", SUM(CASE WHEN COALESCE(NULLIF(json_extract(d.canonical_payload, '$.host'), ''), 'unknown') = 'codex' THEN (CASE WHEN json_extract(r.row_json, '$.input_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.input_tokens.sum'), 0) ELSE 0 END + CASE WHEN json_extract(r.row_json, '$.output_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.output_tokens.sum'), 0) ELSE 0 END + CASE WHEN json_extract(r.row_json, '$.cache_read_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.cache_read_tokens.sum'), 0) ELSE 0 END + CASE WHEN json_extract(r.row_json, '$.cache_creation_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.cache_creation_tokens.sum'), 0) ELSE 0 END + CASE WHEN json_extract(r.row_json, '$.reasoning_tokens.reported') > 0 THEN COALESCE(json_extract(r.row_json, '$.reasoning_tokens.sum'), 0) ELSE 0 END) ELSE 0 END) AS codex FROM runtime_rows r JOIN runtime_deliveries d ON d.delivery_id = r.delivery_id WHERE d.received_at >= ${__from} * 1000000 AND d.received_at <= ${__to} * 1000000 GROUP BY time ORDER BY time ASC",
+          "timeColumns": [
+            "time"
+          ]
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "min": 0,
+          "decimals": 0,
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 25,
+            "lineWidth": 2,
+            "showPoints": "never",
+            "stacking": {
+              "mode": "normal",
+              "group": "A"
+            }
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "pi"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "mode": "fixed",
+                  "fixedColor": "#73BF69"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "opencode"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "mode": "fixed",
+                  "fixedColor": "#5794F2"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "claude-code"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "mode": "fixed",
+                  "fixedColor": "#FF9830"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "codex"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "mode": "fixed",
+                  "fixedColor": "#B877D9"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      }
+    },
+    {
+      "id": 411,
+      "title": "Token coverage per field",
+      "description": "Coverage makes the reporting quality of every token field transparent for each host.",
+      "type": "table",
+      "gridPos": {
+        "x": 12,
+        "y": 58,
+        "w": 12,
+        "h": 9
+      },
+      "datasource": {
+        "type": "frser-sqlite-datasource",
+        "uid": "gentle-telemetry-sqlite"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "queryType": "table",
+          "queryText": "SELECT * FROM (SELECT COALESCE(NULLIF(json_extract(d.canonical_payload, '$.host'), ''), 'unknown') AS Host, 'Input' AS Field, SUM(COALESCE(json_extract(r.row_json, '$.input_tokens.reported'), 0)) AS Reported, SUM(COALESCE(json_extract(r.row_json, '$.input_tokens.unavailable'), 0)) AS Unavailable, SUM(COALESCE(json_extract(r.row_json, '$.input_tokens.unsupported'), 0)) AS Unsupported, ROUND(100.0 * SUM(COALESCE(json_extract(r.row_json, '$.input_tokens.reported'), 0)) / NULLIF(SUM(COALESCE(json_extract(r.row_json, '$.input_tokens.reported'), 0) + COALESCE(json_extract(r.row_json, '$.input_tokens.unavailable'), 0) + COALESCE(json_extract(r.row_json, '$.input_tokens.unsupported'), 0)), 0), 1) AS \"Reported %\" FROM runtime_rows r JOIN runtime_deliveries d ON d.delivery_id = r.delivery_id WHERE d.received_at >= ${__from} * 1000000 AND d.received_at <= ${__to} * 1000000 GROUP BY Host UNION ALL SELECT COALESCE(NULLIF(json_extract(d.canonical_payload, '$.host'), ''), 'unknown') AS Host, 'Output' AS Field, SUM(COALESCE(json_extract(r.row_json, '$.output_tokens.reported'), 0)) AS Reported, SUM(COALESCE(json_extract(r.row_json, '$.output_tokens.unavailable'), 0)) AS Unavailable, SUM(COALESCE(json_extract(r.row_json, '$.output_tokens.unsupported'), 0)) AS Unsupported, ROUND(100.0 * SUM(COALESCE(json_extract(r.row_json, '$.output_tokens.reported'), 0)) / NULLIF(SUM(COALESCE(json_extract(r.row_json, '$.output_tokens.reported'), 0) + COALESCE(json_extract(r.row_json, '$.output_tokens.unavailable'), 0) + COALESCE(json_extract(r.row_json, '$.output_tokens.unsupported'), 0)), 0), 1) AS \"Reported %\" FROM runtime_rows r JOIN runtime_deliveries d ON d.delivery_id = r.delivery_id WHERE d.received_at >= ${__from} * 1000000 AND d.received_at <= ${__to} * 1000000 GROUP BY Host UNION ALL SELECT COALESCE(NULLIF(json_extract(d.canonical_payload, '$.host'), ''), 'unknown') AS Host, 'Cache read' AS Field, SUM(COALESCE(json_extract(r.row_json, '$.cache_read_tokens.reported'), 0)) AS Reported, SUM(COALESCE(json_extract(r.row_json, '$.cache_read_tokens.unavailable'), 0)) AS Unavailable, SUM(COALESCE(json_extract(r.row_json, '$.cache_read_tokens.unsupported'), 0)) AS Unsupported, ROUND(100.0 * SUM(COALESCE(json_extract(r.row_json, '$.cache_read_tokens.reported'), 0)) / NULLIF(SUM(COALESCE(json_extract(r.row_json, '$.cache_read_tokens.reported'), 0) + COALESCE(json_extract(r.row_json, '$.cache_read_tokens.unavailable'), 0) + COALESCE(json_extract(r.row_json, '$.cache_read_tokens.unsupported'), 0)), 0), 1) AS \"Reported %\" FROM runtime_rows r JOIN runtime_deliveries d ON d.delivery_id = r.delivery_id WHERE d.received_at >= ${__from} * 1000000 AND d.received_at <= ${__to} * 1000000 GROUP BY Host UNION ALL SELECT COALESCE(NULLIF(json_extract(d.canonical_payload, '$.host'), ''), 'unknown') AS Host, 'Cache creation' AS Field, SUM(COALESCE(json_extract(r.row_json, '$.cache_creation_tokens.reported'), 0)) AS Reported, SUM(COALESCE(json_extract(r.row_json, '$.cache_creation_tokens.unavailable'), 0)) AS Unavailable, SUM(COALESCE(json_extract(r.row_json, '$.cache_creation_tokens.unsupported'), 0)) AS Unsupported, ROUND(100.0 * SUM(COALESCE(json_extract(r.row_json, '$.cache_creation_tokens.reported'), 0)) / NULLIF(SUM(COALESCE(json_extract(r.row_json, '$.cache_creation_tokens.reported'), 0) + COALESCE(json_extract(r.row_json, '$.cache_creation_tokens.unavailable'), 0) + COALESCE(json_extract(r.row_json, '$.cache_creation_tokens.unsupported'), 0)), 0), 1) AS \"Reported %\" FROM runtime_rows r JOIN runtime_deliveries d ON d.delivery_id = r.delivery_id WHERE d.received_at >= ${__from} * 1000000 AND d.received_at <= ${__to} * 1000000 GROUP BY Host UNION ALL SELECT COALESCE(NULLIF(json_extract(d.canonical_payload, '$.host'), ''), 'unknown') AS Host, 'Reasoning' AS Field, SUM(COALESCE(json_extract(r.row_json, '$.reasoning_tokens.reported'), 0)) AS Reported, SUM(COALESCE(json_extract(r.row_json, '$.reasoning_tokens.unavailable'), 0)) AS Unavailable, SUM(COALESCE(json_extract(r.row_json, '$.reasoning_tokens.unsupported'), 0)) AS Unsupported, ROUND(100.0 * SUM(COALESCE(json_extract(r.row_json, '$.reasoning_tokens.reported'), 0)) / NULLIF(SUM(COALESCE(json_extract(r.row_json, '$.reasoning_tokens.reported'), 0) + COALESCE(json_extract(r.row_json, '$.reasoning_tokens.unavailable'), 0) + COALESCE(json_extract(r.row_json, '$.reasoning_tokens.unsupported'), 0)), 0), 1) AS \"Reported %\" FROM runtime_rows r JOIN runtime_deliveries d ON d.delivery_id = r.delivery_id WHERE d.received_at >= ${__from} * 1000000 AND d.received_at <= ${__to} * 1000000 GROUP BY Host UNION ALL SELECT COALESCE(NULLIF(json_extract(d.canonical_payload, '$.host'), ''), 'unknown') AS Host, 'Total reported' AS Field, SUM(COALESCE(json_extract(r.row_json, '$.total_tokens.reported'), 0)) AS Reported, SUM(COALESCE(json_extract(r.row_json, '$.total_tokens.unavailable'), 0)) AS Unavailable, SUM(COALESCE(json_extract(r.row_json, '$.total_tokens.unsupported'), 0)) AS Unsupported, ROUND(100.0 * SUM(COALESCE(json_extract(r.row_json, '$.total_tokens.reported'), 0)) / NULLIF(SUM(COALESCE(json_extract(r.row_json, '$.total_tokens.reported'), 0) + COALESCE(json_extract(r.row_json, '$.total_tokens.unavailable'), 0) + COALESCE(json_extract(r.row_json, '$.total_tokens.unsupported'), 0)), 0), 1) AS \"Reported %\" FROM runtime_rows r JOIN runtime_deliveries d ON d.delivery_id = r.delivery_id WHERE d.received_at >= ${__from} * 1000000 AND d.received_at <= ${__to} * 1000000 GROUP BY Host) ORDER BY Host, Field LIMIT 1000",
+          "rawQueryText": "SELECT * FROM (SELECT COALESCE(NULLIF(json_extract(d.canonical_payload, '$.host'), ''), 'unknown') AS Host, 'Input' AS Field, SUM(COALESCE(json_extract(r.row_json, '$.input_tokens.reported'), 0)) AS Reported, SUM(COALESCE(json_extract(r.row_json, '$.input_tokens.unavailable'), 0)) AS Unavailable, SUM(COALESCE(json_extract(r.row_json, '$.input_tokens.unsupported'), 0)) AS Unsupported, ROUND(100.0 * SUM(COALESCE(json_extract(r.row_json, '$.input_tokens.reported'), 0)) / NULLIF(SUM(COALESCE(json_extract(r.row_json, '$.input_tokens.reported'), 0) + COALESCE(json_extract(r.row_json, '$.input_tokens.unavailable'), 0) + COALESCE(json_extract(r.row_json, '$.input_tokens.unsupported'), 0)), 0), 1) AS \"Reported %\" FROM runtime_rows r JOIN runtime_deliveries d ON d.delivery_id = r.delivery_id WHERE d.received_at >= ${__from} * 1000000 AND d.received_at <= ${__to} * 1000000 GROUP BY Host UNION ALL SELECT COALESCE(NULLIF(json_extract(d.canonical_payload, '$.host'), ''), 'unknown') AS Host, 'Output' AS Field, SUM(COALESCE(json_extract(r.row_json, '$.output_tokens.reported'), 0)) AS Reported, SUM(COALESCE(json_extract(r.row_json, '$.output_tokens.unavailable'), 0)) AS Unavailable, SUM(COALESCE(json_extract(r.row_json, '$.output_tokens.unsupported'), 0)) AS Unsupported, ROUND(100.0 * SUM(COALESCE(json_extract(r.row_json, '$.output_tokens.reported'), 0)) / NULLIF(SUM(COALESCE(json_extract(r.row_json, '$.output_tokens.reported'), 0) + COALESCE(json_extract(r.row_json, '$.output_tokens.unavailable'), 0) + COALESCE(json_extract(r.row_json, '$.output_tokens.unsupported'), 0)), 0), 1) AS \"Reported %\" FROM runtime_rows r JOIN runtime_deliveries d ON d.delivery_id = r.delivery_id WHERE d.received_at >= ${__from} * 1000000 AND d.received_at <= ${__to} * 1000000 GROUP BY Host UNION ALL SELECT COALESCE(NULLIF(json_extract(d.canonical_payload, '$.host'), ''), 'unknown') AS Host, 'Cache read' AS Field, SUM(COALESCE(json_extract(r.row_json, '$.cache_read_tokens.reported'), 0)) AS Reported, SUM(COALESCE(json_extract(r.row_json, '$.cache_read_tokens.unavailable'), 0)) AS Unavailable, SUM(COALESCE(json_extract(r.row_json, '$.cache_read_tokens.unsupported'), 0)) AS Unsupported, ROUND(100.0 * SUM(COALESCE(json_extract(r.row_json, '$.cache_read_tokens.reported'), 0)) / NULLIF(SUM(COALESCE(json_extract(r.row_json, '$.cache_read_tokens.reported'), 0) + COALESCE(json_extract(r.row_json, '$.cache_read_tokens.unavailable'), 0) + COALESCE(json_extract(r.row_json, '$.cache_read_tokens.unsupported'), 0)), 0), 1) AS \"Reported %\" FROM runtime_rows r JOIN runtime_deliveries d ON d.delivery_id = r.delivery_id WHERE d.received_at >= ${__from} * 1000000 AND d.received_at <= ${__to} * 1000000 GROUP BY Host UNION ALL SELECT COALESCE(NULLIF(json_extract(d.canonical_payload, '$.host'), ''), 'unknown') AS Host, 'Cache creation' AS Field, SUM(COALESCE(json_extract(r.row_json, '$.cache_creation_tokens.reported'), 0)) AS Reported, SUM(COALESCE(json_extract(r.row_json, '$.cache_creation_tokens.unavailable'), 0)) AS Unavailable, SUM(COALESCE(json_extract(r.row_json, '$.cache_creation_tokens.unsupported'), 0)) AS Unsupported, ROUND(100.0 * SUM(COALESCE(json_extract(r.row_json, '$.cache_creation_tokens.reported'), 0)) / NULLIF(SUM(COALESCE(json_extract(r.row_json, '$.cache_creation_tokens.reported'), 0) + COALESCE(json_extract(r.row_json, '$.cache_creation_tokens.unavailable'), 0) + COALESCE(json_extract(r.row_json, '$.cache_creation_tokens.unsupported'), 0)), 0), 1) AS \"Reported %\" FROM runtime_rows r JOIN runtime_deliveries d ON d.delivery_id = r.delivery_id WHERE d.received_at >= ${__from} * 1000000 AND d.received_at <= ${__to} * 1000000 GROUP BY Host UNION ALL SELECT COALESCE(NULLIF(json_extract(d.canonical_payload, '$.host'), ''), 'unknown') AS Host, 'Reasoning' AS Field, SUM(COALESCE(json_extract(r.row_json, '$.reasoning_tokens.reported'), 0)) AS Reported, SUM(COALESCE(json_extract(r.row_json, '$.reasoning_tokens.unavailable'), 0)) AS Unavailable, SUM(COALESCE(json_extract(r.row_json, '$.reasoning_tokens.unsupported'), 0)) AS Unsupported, ROUND(100.0 * SUM(COALESCE(json_extract(r.row_json, '$.reasoning_tokens.reported'), 0)) / NULLIF(SUM(COALESCE(json_extract(r.row_json, '$.reasoning_tokens.reported'), 0) + COALESCE(json_extract(r.row_json, '$.reasoning_tokens.unavailable'), 0) + COALESCE(json_extract(r.row_json, '$.reasoning_tokens.unsupported'), 0)), 0), 1) AS \"Reported %\" FROM runtime_rows r JOIN runtime_deliveries d ON d.delivery_id = r.delivery_id WHERE d.received_at >= ${__from} * 1000000 AND d.received_at <= ${__to} * 1000000 GROUP BY Host UNION ALL SELECT COALESCE(NULLIF(json_extract(d.canonical_payload, '$.host'), ''), 'unknown') AS Host, 'Total reported' AS Field, SUM(COALESCE(json_extract(r.row_json, '$.total_tokens.reported'), 0)) AS Reported, SUM(COALESCE(json_extract(r.row_json, '$.total_tokens.unavailable'), 0)) AS Unavailable, SUM(COALESCE(json_extract(r.row_json, '$.total_tokens.unsupported'), 0)) AS Unsupported, ROUND(100.0 * SUM(COALESCE(json_extract(r.row_json, '$.total_tokens.reported'), 0)) / NULLIF(SUM(COALESCE(json_extract(r.row_json, '$.total_tokens.reported'), 0) + COALESCE(json_extract(r.row_json, '$.total_tokens.unavailable'), 0) + COALESCE(json_extract(r.row_json, '$.total_tokens.unsupported'), 0)), 0), 1) AS \"Reported %\" FROM runtime_rows r JOIN runtime_deliveries d ON d.delivery_id = r.delivery_id WHERE d.received_at >= ${__from} * 1000000 AND d.received_at <= ${__to} * 1000000 GROUP BY Host) ORDER BY Host, Field LIMIT 1000"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "min": 0
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "pi"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "mode": "fixed",
+                  "fixedColor": "#73BF69"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "opencode"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "mode": "fixed",
+                  "fixedColor": "#5794F2"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "claude-code"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "mode": "fixed",
+                  "fixedColor": "#FF9830"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "codex"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "mode": "fixed",
+                  "fixedColor": "#B877D9"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "options": {
+        "showHeader": true,
+        "cellHeight": "sm",
+        "enablePagination": true
+      }
+    },
+    {
+      "id": 412,
+      "title": "Error observations by category",
+      "description": "Categorized error observations surface reliability signals without exposing error text.",
+      "type": "barchart",
+      "gridPos": {
+        "x": 0,
+        "y": 67,
+        "w": 12,
+        "h": 7
+      },
+      "datasource": {
+        "type": "frser-sqlite-datasource",
+        "uid": "gentle-telemetry-sqlite"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "queryType": "table",
+          "queryText": "SELECT COALESCE(NULLIF(json_extract(r.row_json, '$.error_category'), ''), 'unknown') AS Category, COUNT(*) AS Observations FROM runtime_rows r JOIN runtime_deliveries d ON d.delivery_id = r.delivery_id WHERE d.received_at >= ${__from} * 1000000 AND d.received_at <= ${__to} * 1000000 AND COALESCE(NULLIF(json_extract(r.row_json, '$.error_category'), ''), 'unknown') <> 'none' GROUP BY Category ORDER BY Observations DESC LIMIT 1000",
+          "rawQueryText": "SELECT COALESCE(NULLIF(json_extract(r.row_json, '$.error_category'), ''), 'unknown') AS Category, COUNT(*) AS Observations FROM runtime_rows r JOIN runtime_deliveries d ON d.delivery_id = r.delivery_id WHERE d.received_at >= ${__from} * 1000000 AND d.received_at <= ${__to} * 1000000 AND COALESCE(NULLIF(json_extract(r.row_json, '$.error_category'), ''), 'unknown') <> 'none' GROUP BY Category ORDER BY Observations DESC LIMIT 1000"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "min": 0,
+          "decimals": 0
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "pi"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "mode": "fixed",
+                  "fixedColor": "#73BF69"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "opencode"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "mode": "fixed",
+                  "fixedColor": "#5794F2"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "claude-code"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "mode": "fixed",
+                  "fixedColor": "#FF9830"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "codex"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "mode": "fixed",
+                  "fixedColor": "#B877D9"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "options": {
+        "orientation": "horizontal",
+        "legend": {
+          "showLegend": false
+        }
+      }
+    },
+    {
+      "id": 413,
+      "title": "Measured request duration",
+      "description": "Average measured request duration provides a simple view of runtime responsiveness.",
+      "type": "stat",
+      "gridPos": {
+        "x": 12,
+        "y": 67,
+        "w": 12,
+        "h": 7
+      },
+      "datasource": {
+        "type": "frser-sqlite-datasource",
+        "uid": "gentle-telemetry-sqlite"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "queryType": "table",
+          "queryText": "SELECT ROUND(SUM(CASE WHEN json_extract(r.row_json, '$.duration.kind') = 'request' AND json_type(r.row_json, '$.duration.measured_count') = 'integer' AND json_extract(r.row_json, '$.duration.measured_count') > 0 THEN json_extract(r.row_json, '$.duration.sum_ms') ELSE 0 END) / NULLIF(SUM(CASE WHEN json_extract(r.row_json, '$.duration.kind') = 'request' AND json_type(r.row_json, '$.duration.measured_count') = 'integer' THEN json_extract(r.row_json, '$.duration.measured_count') ELSE 0 END), 0), 1) AS \"Average request duration\" FROM runtime_rows r JOIN runtime_deliveries d ON d.delivery_id = r.delivery_id WHERE d.received_at >= ${__from} * 1000000 AND d.received_at <= ${__to} * 1000000 HAVING SUM(CASE WHEN json_extract(r.row_json, '$.duration.kind') = 'request' AND json_type(r.row_json, '$.duration.measured_count') = 'integer' THEN json_extract(r.row_json, '$.duration.measured_count') ELSE 0 END) > 0",
+          "rawQueryText": "SELECT ROUND(SUM(CASE WHEN json_extract(r.row_json, '$.duration.kind') = 'request' AND json_type(r.row_json, '$.duration.measured_count') = 'integer' AND json_extract(r.row_json, '$.duration.measured_count') > 0 THEN json_extract(r.row_json, '$.duration.sum_ms') ELSE 0 END) / NULLIF(SUM(CASE WHEN json_extract(r.row_json, '$.duration.kind') = 'request' AND json_type(r.row_json, '$.duration.measured_count') = 'integer' THEN json_extract(r.row_json, '$.duration.measured_count') ELSE 0 END), 0), 1) AS \"Average request duration\" FROM runtime_rows r JOIN runtime_deliveries d ON d.delivery_id = r.delivery_id WHERE d.received_at >= ${__from} * 1000000 AND d.received_at <= ${__to} * 1000000 HAVING SUM(CASE WHEN json_extract(r.row_json, '$.duration.kind') = 'request' AND json_type(r.row_json, '$.duration.measured_count') = 'integer' THEN json_extract(r.row_json, '$.duration.measured_count') ELSE 0 END) > 0"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ms",
+          "min": 0,
+          "decimals": 0
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "pi"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "mode": "fixed",
+                  "fixedColor": "#73BF69"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "opencode"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "mode": "fixed",
+                  "fixedColor": "#5794F2"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "claude-code"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "mode": "fixed",
+                  "fixedColor": "#FF9830"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "codex"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "mode": "fixed",
+                  "fixedColor": "#B877D9"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "options": {
+        "orientation": "horizontal",
+        "textMode": "value_and_name",
+        "graphMode": "none",
+        "reduceOptions": {
+          "values": false,
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": ""
+        }
+      }
     }
   ]
 }

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -204,9 +204,11 @@ Install/sync still reconcile the dedicated `plugins/telemetry-runtime.ts` and
 independently of SDD and using the existing scope/XDG resolution. These are static
 installation assets, **not metric state**. Managed byte/hash/mode checks, guarded
 rollback, unowned/edited-file preservation, and validated-pair uninstall remain
-unchanged. Initial unreleased ownership accepts only the embedded asset; approving
-historical digests for a rollout is separate work. Disable leaves the plugin inert
-under existing policy; installation never reenrolls or changes exporter settings.
+unchanged. Each managed plugin asset change must append the immediately previous
+embedded asset digest to the explicit provenance allowlist so owned installs can
+upgrade without treating arbitrary self-consistent content as package provenance.
+Disable leaves the plugin inert under existing policy; installation never reenrolls
+or changes exporter settings.
 
 **Automatic sources:** Pi and OpenCode integrations provide one-shot runtime
 telemetry. Claude Code and Codex are unsupported: neither provides a supported

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -137,7 +137,7 @@ The CLI does not close caller-owned readers or shared `os.Stdin`. A timed-out re
 can leave **one process-scoped reader goroutine** until stdin completes or the
 standalone process exits. A buffered result prevents late completion from blocking;
 the deadline timer is canceled on return. This is not a daemon or retry mechanism.
-The library `SendRuntime`/`SendOpenCode` APIs still accept caller-owned readers:
+The library `SendRuntime`/`SendOpenCode`/`SendCodex` APIs still accept caller-owned readers:
 their context bounds HTTP, not arbitrary blocking `Read` implementations. Embedded
 callers must supply bounded input; only the CLI owns this pre-read deadline.
 
@@ -194,12 +194,57 @@ unchanged. Initial unreleased ownership accepts only the embedded asset; approvi
 historical digests for a rollout is separate work. Disable leaves the plugin inert
 under existing policy; installation never reenrolls or changes exporter settings.
 
-**Automatic sources:** Pi and OpenCode integrations provide one-shot runtime
-telemetry. Claude Code and Codex are unsupported: neither provides a supported
-direct hook supplying sanitized usage under the no-daemon/no-persistence
-constraint. Schema host values remain for compatibility, not as evidence of
-installed support. No installation, deployment, or external-network validation
-is implied here.
+## Automatic Codex collection
+
+Managed Codex `hooks.json` entries invoke
+`gentle-ai telemetry runtime codex --json` asynchronously for `SubagentStop` and
+`Stop`. These events and their input fields are documented by the
+[Codex hooks reference](https://developers.openai.com/codex/hooks). Runtime policy is
+checked before hook stdin, local state, or transcript data is read, again after
+stdin, and before the one-attempt sender. Disabled telemetry therefore leaves
+the installed hooks inert. The command writes no stdout because Codex validates
+JSON-looking output as a hook response even for asynchronous hooks.
+
+The hook input is limited to 16 KiB. Native code retains at most the final 256 KiB
+of `agent_transcript_path` for `SubagentStop`, or `transcript_path` for `Stop`;
+one look-behind byte determines whether the first retained line is complete.
+The final observed `turn_context` starts the eligible evidence segment. Its valid
+model and effort and that segment's latest valid `event_msg` `token_count`
+`last_token_usage` are used together. The public hook contract does not establish
+that hook `turn_id` has matching semantics in both parent and subagent transcripts,
+so sequence segmentation is the bounded fallback and private IDs stay memory-only.
+Codex documents `agent_type` as a subagent type or profile,
+but its [subagent documentation](https://developers.openai.com/codex/subagents)
+does not establish that `spawn_agent.task_name` becomes `agent_type`. Therefore
+only an exact `agent_type` already present in the runtime agent-class allowlist
+is classified as `built_in`; every other subagent is `custom` with class
+`unknown`. `Stop` is classified as the orchestrator. When response model evidence
+is missing, a valid persisted Gentle AI phase or orchestrator model assignment is
+used with `selected` evidence. Missing, malformed, or unreadable transcript/state
+data never fails the send and remains unavailable.
+
+| Codex `last_token_usage` field | Runtime field |
+| --- | --- |
+| `input_tokens` | `input_tokens` |
+| `cached_input_tokens` | `cache_read_tokens` |
+| `cache_write_input_tokens` | `cache_creation_tokens` |
+| `output_tokens` | `output_tokens` |
+| `reasoning_output_tokens` | `reasoning_tokens` |
+| `total_tokens` | `total_tokens` |
+
+No identifier, path, prompt, summary, assistant message, raw error, or rate-limit
+detail enters the runtime payload. Missing counters are unavailable rather than
+zero, totals are not inferred, duration is unavailable, and there is no daemon,
+queue, retry, telemetry persistence, or filesystem mutation. Codex explicitly
+notes that transcript format is not a stable hook interface, so this parser is a
+bounded best-effort compatibility layer and may lose coverage after Codex format
+changes.
+
+**Automatic sources:** Pi, OpenCode, and Codex integrations provide one-shot
+runtime telemetry. Claude Code remains unsupported under the current
+no-daemon/no-persistence constraint. Schema host values remain for compatibility,
+not as evidence of installed support. No installation, deployment, or
+external-network validation is implied here.
 
 ## Anonymous runtime collector and retention
 
@@ -310,7 +355,7 @@ installation, gentle-ai does exactly one thing: it prints this line to
 stderr, synchronously, in that same command —
 
 ```text
-Gentle AI sends anonymous usage metrics (version, OS, agents, counters) and may send anonymous runtime usage from supported Pi/OpenCode integrations (public model, effort, agent class, available token usage, timing, error categories); runtime usage is never stored locally; run gentle-ai telemetry disable to opt out.
+Gentle AI sends anonymous usage metrics (version, OS, agents, counters) and may send anonymous runtime usage from supported Pi/OpenCode/Codex integrations (public model, effort, agent class, available token usage, timing, error categories); runtime usage is never stored locally; run gentle-ai telemetry disable to opt out.
 ```
 
 — and stores a locally generated `install_id`. **Nothing is sent on that

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -190,7 +190,7 @@ agents map `explore` to the built-in `explore` class and `general` to the built-
 map to their built-in class. Other non-empty names map to `custom`/`unknown`;
 their raw names never leave native code. Missing names remain `unknown`/`unknown`.
 
-For the observed agent, native code reads the bounded local `opencode.json`
+For the observed agent, native code reads up to 1 MiB from the local `opencode.json`
 `agent.<name>.model` and `agent.<name>.variant` assignment. A valid contract effort
 becomes `selected_effort`; `effective_effort` remains `unavailable` because OpenCode
 does not report it. A response provider/model remains authoritative with

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -207,14 +207,14 @@ Names in Gentle AI's runtime agent-class registry become `built_in` observations
 all other names become `custom`/`unknown` without transmitting the name.
 
 For `SubagentStop`, the adapter reads at most the last 512 KiB of the matching
-agent transcript, from inside the user's home only. Usage is accepted only when
-the final non-empty JSONL record is a complete assistant record whose text matches
-the hook's memory-only `last_assistant_message`. Any later record, malformed or
-partial trailing record, or unmatched final record leaves the observation
-activity-only. Malformed lines before a valid final match do not invalidate it.
-The matched record supplies response model plus input, output, cache-read, and
-cache-creation tokens. Reasoning tokens are unsupported and total tokens are
-unavailable; neither is inferred.
+agent transcript, from inside the user's home only. It scans backward for the
+last complete assistant record carrying valid usage, skipping malformed,
+partial, and non-usage records. A memory-only `last_assistant_message` match is
+stronger correlation evidence, but a missing or different value does not discard
+usage because `agent_transcript_path` is scoped to that subagent run. The record
+supplies response model plus input, output, cache-read, and cache-creation tokens.
+Reasoning tokens are unsupported and total tokens are unavailable; neither is
+inferred.
 
 `Stop` always becomes an `orchestrator` activity-only launch-style observation.
 It does not read or attribute transcript usage or a response model: without a
@@ -227,12 +227,16 @@ The selected model is used only when no response model exists. The hook contract
 does not expose effective effort, duration, or an error shape: effective effort
 and duration remain unavailable, while successful `Stop`/`SubagentStop` events
 use error category `none` (API failures fire the separate `StopFailure` event).
-Unknown model IDs map to `custom`/`custom` under the public registry.
+Selected aliases map as `sonnet` to `claude-sonnet-5`, `opus` to
+`claude-opus-5`, and `haiku` to `claude-haiku-4-5`; `inherit`, `default`, and an
+empty selector remain unknown. Transcript release/revision suffixes are reduced
+by longest registered-ID prefix, so for example `claude-sonnet-5-20260501` maps
+to `claude-sonnet-5`. Other model IDs map to `custom`/`custom`.
 
-If a subagent transcript is missing, unreadable, malformed, uncorrelated, or lacks
-assistant usage, the completion records the same launch-style occurrence with
-unavailable token coverage rather than claiming a response. This preserves
-observed agent activity without fabricating response evidence. Transcript paths,
+If a subagent transcript is missing, unreadable, or has no valid assistant usage,
+the completion records the same launch-style occurrence with unavailable token
+coverage rather than claiming a response. This preserves observed agent activity
+without fabricating response evidence. Transcript paths,
 hook/session/agent IDs, cwd, prompts, messages, transcript content, and private
 agent names never enter the aggregate or logs. Symlinks resolving outside the
 user's home are refused.

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -194,12 +194,60 @@ unchanged. Initial unreleased ownership accepts only the embedded asset; approvi
 historical digests for a rollout is separate work. Disable leaves the plugin inert
 under existing policy; installation never reenrolls or changes exporter settings.
 
-**Automatic sources:** Pi and OpenCode integrations provide one-shot runtime
-telemetry. Claude Code and Codex are unsupported: neither provides a supported
-direct hook supplying sanitized usage under the no-daemon/no-persistence
-constraint. Schema host values remain for compatibility, not as evidence of
-installed support. No installation, deployment, or external-network validation
-is implied here.
+## Automatic Claude Code collection
+
+Claude Code installs asynchronous `Stop` and `SubagentStop` command hooks that
+invoke `gentle-ai telemetry runtime claude --json`. Each hook starts one one-shot
+process; native code checks the existing telemetry policy before reading stdin,
+uses the same 16 KiB/500 ms input bound, and sends at most once with no daemon,
+queue, persistence, retry, or filesystem mutation.
+
+For `SubagentStop`, the documented `agent_type` names the subagent frontmatter.
+Names in Gentle AI's runtime agent-class registry become `built_in` observations;
+all other names become `custom`/`unknown` without transmitting the name.
+
+For `SubagentStop`, the adapter reads at most the last 512 KiB of the matching
+agent transcript, from inside the user's home only. Usage is accepted only when
+the final non-empty JSONL record is a complete assistant record whose text matches
+the hook's memory-only `last_assistant_message`. Any later record, malformed or
+partial trailing record, or unmatched final record leaves the observation
+activity-only. Malformed lines before a valid final match do not invalidate it.
+The matched record supplies response model plus input, output, cache-read, and
+cache-creation tokens. Reasoning tokens are unsupported and total tokens are
+unavailable; neither is inferred.
+
+`Stop` always becomes an `orchestrator` activity-only launch-style observation.
+It does not read or attribute transcript usage or a response model: without a
+unique response identity or persistent replay state, a repeated final message
+could match an older record when the current transcript row has not been flushed.
+
+For a known named subagent, at most 64 KiB of
+`~/.claude/agents/<agent_type>.md` supplies selected model and selected effort.
+The selected model is used only when no response model exists. The hook contract
+does not expose effective effort, duration, or an error shape: effective effort
+and duration remain unavailable, while successful `Stop`/`SubagentStop` events
+use error category `none` (API failures fire the separate `StopFailure` event).
+Unknown model IDs map to `custom`/`custom` under the public registry.
+
+If a subagent transcript is missing, unreadable, malformed, uncorrelated, or lacks
+assistant usage, the completion records the same launch-style occurrence with
+unavailable token coverage rather than claiming a response. This preserves
+observed agent activity without fabricating response evidence. Transcript paths,
+hook/session/agent IDs, cwd, prompts, messages, transcript content, and private
+agent names never enter the aggregate or logs. Symlinks resolving outside the
+user's home are refused.
+
+Hook and subagent-field behavior follows the official
+[Claude Code hooks reference](https://code.claude.com/docs/en/hooks) and
+[subagent reference](https://code.claude.com/docs/en/sub-agents). Transcript JSONL
+`message.model` and `message.usage` shapes are observed implementation evidence,
+not documented compatibility guarantees in those references.
+
+**Automatic sources:** Pi, OpenCode, and Claude Code integrations provide one-shot
+runtime telemetry. Codex remains unsupported because its installed integration
+does not yet provide a supported direct producer under the no-daemon/no-persistence
+constraint. No installation, deployment, or external-network validation is
+implied here.
 
 ## Anonymous runtime collector and retention
 

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -95,7 +95,7 @@ cumulative snapshots. No parent-child links or source IDs exist.
 Canonical `agent_class` values are:
 
 - Fixed classes: `orchestrator`, `worker`, `explore`, `verify`, `unknown`
-- SDD agents: `sdd-init`, `sdd-explore`, `sdd-research`, `sdd-propose`, `sdd-spec`, `sdd-design`, `sdd-tasks`, `sdd-apply`, `sdd-verify`, `sdd-archive`, `sdd-onboard`
+- SDD agents: `sdd-init`, `sdd-explore`, `sdd-research`, `sdd-propose`, `sdd-spec`, `sdd-design`, `sdd-tasks`, `sdd-apply`, `sdd-verify`, `sdd-archive`, `sdd-onboard`, `sdd-status`, `sdd-sync`
 - Judgment Day agents: `jd-judge-a`, `jd-judge-b`, `jd-fix-agent`
 - Review agents: `review-risk`, `review-readability`, `review-reliability`, `review-resilience`, `review-refuter`, `review-validator`
 

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -83,12 +83,23 @@ cumulative snapshots. No parent-child links or source IDs exist.
 | `host` | `pi`, `opencode`, `claude-code`, or `codex`; never a hostname |
 | `model` | Registered public provider/model pair, otherwise the `unknown` or `custom` pair |
 | `model_evidence` | `selected`, `response`, or `unknown`; selected model is not proof of response model |
-| `agent_kind`, `agent_class` | Closed broad category and known package class, otherwise `unknown`; no private agent names |
+| `agent_kind`, `agent_class` | Closed broad category and known package class, otherwise `unknown`; no private agent names. See the canonical vocabulary below. |
 | `selected_effort`, `effective_effort` | Independent source evidence; never infer one from the other |
 | `launches`, `responses` | Source-observed event occurrence counts, `null` if unobserved, or `"unsupported"`; not sessions, successes, or reconstructed composition |
 | Six token fields | Independent `{reported, unavailable, unsupported, sum}` coverage objects |
 | `duration` | Typed source-reported request or message elapsed time, never inferred latency |
 | `error_category` | `none`, `unknown`, `auth`, `output_length`, `aborted`, `api`, `rate_limit`, or `server`; never error text |
+
+### Agent class vocabulary
+
+Canonical `agent_class` values are:
+
+- Fixed classes: `orchestrator`, `worker`, `explore`, `verify`, `unknown`
+- SDD agents: `sdd-init`, `sdd-explore`, `sdd-research`, `sdd-propose`, `sdd-spec`, `sdd-design`, `sdd-tasks`, `sdd-apply`, `sdd-verify`, `sdd-archive`, `sdd-onboard`
+- Judgment Day agents: `jd-judge-a`, `jd-judge-b`, `jd-fix-agent`
+- Review agents: `review-risk`, `review-readability`, `review-reliability`, `review-resilience`, `review-refuter`, `review-validator`
+
+The collector accepts deprecated `sdd-proposal` from older registry-1 clients and normalizes it to `sdd-propose` before storage.
 
 Occurrence counts remain because they describe the event's observed coverage, not
 session reconstruction. Token coverage does not derive from these counts. A

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -162,16 +162,17 @@ and asynchronously. Native code checks policy, normalizes one bounded source
 observation, then uses the same one-attempt sender. Example stdin:
 
 ```json
-{"schema":"gentle-ai.telemetry-opencode/v1","info":{"role":"assistant","time":{"created":1,"completed":3},"providerID":"anthropic","modelID":"claude-opus-5"}}
+{"schema":"gentle-ai.telemetry-opencode/v1","info":{"role":"assistant","time":{"created":1,"completed":3},"providerID":"anthropic","modelID":"claude-opus-5","agent":"sdd-apply"}}
 ```
 
 Only completed non-summary assistant `message.updated` events qualify. Source
 compatibility is pinned to [plugin 1.18.30](https://unpkg.com/@opencode-ai/plugin@1.18.30/dist/index.d.ts)
 and its [V1 SDK](https://unpkg.com/@opencode-ai/sdk@1.18.30/dist/gen/types.gen.d.ts),
 not V2; this is not an installed-runtime smoke test. Source timestamps become
-message elapsed time and do not leave native code. Unknown provider/model names
-become `custom`; error names/status become closed categories. Prompts, parts, paths,
-raw error text, tools, and source/session/task IDs never enter the envelope.
+message elapsed time and do not leave native code. The source `mode` is forwarded
+as `agent` only when it is 1-64 printable ASCII characters. Unknown provider/model
+names become `custom`; error names/status become closed categories. Prompts, parts,
+paths, raw error text, tools, and source/session/task IDs never enter the envelope.
 
 The hook does not read message/session IDs, reconstruct sessions, dedupe across
 events, or retain failed payloads. Each event gets at most one native process.
@@ -182,8 +183,21 @@ Disposal terminates active children. Repeated source events can be counted again
 this intentionally makes no exactly-once coverage claim.
 
 Missing/default-zero source tokens remain unavailable; available reasoning is
-preserved, and total tokens are not inferred. OpenCode agent class and selected/
-effective effort remain unknown/unavailable without source evidence.
+preserved, and total tokens are not inferred. Native `build` and `plan`, plus
+`gentle-orchestrator`, map to the orchestrator class. OpenCode's managed fallback
+agents map `explore` to the built-in `explore` class and `general` to the built-in
+`worker` class. Agent names in the runtime contract's named Gentle AI allowlist
+map to their built-in class. Other non-empty names map to `custom`/`unknown`;
+their raw names never leave native code. Missing names remain `unknown`/`unknown`.
+
+For the observed agent, native code reads the bounded local `opencode.json`
+`agent.<name>.model` and `agent.<name>.variant` assignment. A valid contract effort
+becomes `selected_effort`; `effective_effort` remains `unavailable` because OpenCode
+does not report it. A response provider/model remains authoritative with
+`model_evidence: response`; the assigned model is used with
+`model_evidence: selected` only when the response omits provider/model. Missing,
+oversized, or invalid configuration falls back to unavailable/unknown attribution
+and never blocks the send.
 
 Install/sync still reconcile the dedicated `plugins/telemetry-runtime.ts` and
 `.gentle-ai-telemetry-runtime.json` ownership manifest for selected OpenCode,

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -205,23 +205,30 @@ stdin, and before the one-attempt sender. Disabled telemetry therefore leaves
 the installed hooks inert. The command writes no stdout because Codex validates
 JSON-looking output as a hook response even for asynchronous hooks.
 
-The hook input is limited to 16 KiB. Native code retains at most the final 256 KiB
-of `agent_transcript_path` for `SubagentStop`, or `transcript_path` for `Stop`;
-one look-behind byte determines whether the first retained line is complete.
+The hook input is limited to 16 KiB. For `SubagentStop`, native code separately
+reads at most the first 64 KiB of `agent_transcript_path` for attribution. Only
+the first `session_meta` record is eligible: the basename of
+`source.subagent.thread_spawn.agent_path` is normalized from Codex's underscored
+task name to the hyphenated runtime class, then checked against the exact Go
+allowlist. A directly allowlisted hook `agent_type` takes precedence; every
+unrecognized result remains `custom`/`unknown`. The nickname, IDs, and source
+path are discarded in memory and never enter telemetry.
+
+Native code also retains at most the final 256 KiB of `agent_transcript_path`
+for `SubagentStop`, or `transcript_path` for `Stop`; one look-behind byte
+determines whether the first retained line is complete.
 The final observed `turn_context` starts the eligible evidence segment. Its valid
 model and effort and that segment's latest valid `event_msg` `token_count`
 `last_token_usage` are used together. The public hook contract does not establish
 that hook `turn_id` has matching semantics in both parent and subagent transcripts,
 so sequence segmentation is the bounded fallback and private IDs stay memory-only.
-Codex documents `agent_type` as a subagent type or profile,
-but its [subagent documentation](https://developers.openai.com/codex/subagents)
-does not establish that `spawn_agent.task_name` becomes `agent_type`. Therefore
-only an exact `agent_type` already present in the runtime agent-class allowlist
-is classified as `built_in`; every other subagent is `custom` with class
-`unknown`. `Stop` is classified as the orchestrator. When response model evidence
-is missing, a valid persisted Gentle AI phase or orchestrator model assignment is
-used with `selected` evidence. Missing, malformed, or unreadable transcript/state
-data never fails the send and remains unavailable.
+Codex's [subagent documentation](https://developers.openai.com/codex/subagents)
+describes subagent configuration. `Stop` is classified as the orchestrator.
+When response model evidence is missing, a valid persisted Gentle AI phase or
+orchestrator model assignment is used with `selected` evidence. The transcript
+`effort` or nested `collaboration_mode.settings.reasoning_effort` is effective
+evidence only and never becomes `selected_effort`. Missing, malformed, or
+unreadable transcript/state data never fails the send and remains unavailable.
 
 | Codex `last_token_usage` field | Runtime field |
 | --- | --- |

--- a/internal/assets/assets_test.go
+++ b/internal/assets/assets_test.go
@@ -45,7 +45,7 @@ const { default: plugin } = await import("./plugin.mts")
 for (const key of ["DO_NOT_TRACK","GENTLE_AI_TELEMETRY","CI","GITHUB_ACTIONS"]) delete process.env[key]
 const hooks = await plugin({})
 const tick = async () => { await new Promise(resolve => setImmediate(resolve)) }
-const info = { role:"assistant", time:{created:1,completed:2}, providerID:"anthropic", modelID:"claude-opus-5", mode:"PRIVATE_MODE", path:{cwd:"PRIVATE_PATH"}, parts:["PRIVATE_PROMPT"], error:{name:"APIError",data:{statusCode:429,message:"PRIVATE_ERROR"}} }
+const info = { role:"assistant", time:{created:1,completed:2}, providerID:"anthropic", modelID:"claude-opus-5", mode:"sdd-apply", path:{cwd:"PRIVATE_PATH"}, parts:["PRIVATE_PROMPT"], error:{name:"APIError",data:{statusCode:429,message:"PRIVATE_ERROR"}} }
 // No source identifiers are necessary or read, even locally.
 Object.defineProperty(info,"id",{get(){throw new Error("source id read")}})
 Object.defineProperty(info,"sessionID",{get(){throw new Error("session id read")}})
@@ -65,21 +65,26 @@ assert(!calls[0].body.includes("PRIVATE"))
 const envelope=JSON.parse(calls[0].body)
 assert.deepEqual(Object.keys(envelope).sort(),["info","schema"])
 assert.equal(envelope.schema,"gentle-ai.telemetry-opencode/v1")
+assert.equal(envelope.info.agent,"sdd-apply")
 assert.equal(envelope.info.tokens,undefined)
 held.shift()(new Error("PRIVATE_NATIVE_ERROR"),"")
 await tick();await tick();assert.equal(calls.length,1) // failure never retries
 await event(info);assert.equal(calls.length,2) // a new event is a new attempt
 held.shift()(null,JSON.stringify({schema:"gentle-ai.telemetry-runtime-send/v1",decision:"discarded"}))
 await tick();assert.equal(calls.length,2) // discarded metrics stay discarded
+await event({...info,mode:"x".repeat(65)});assert.equal(calls.length,3)
+assert.equal(JSON.parse(calls[2].body).info.agent,undefined);held.shift()(null,"")
+await event({...info,mode:"bad\nagent"});assert.equal(calls.length,4)
+assert.equal(JSON.parse(calls[3].body).info.agent,undefined);held.shift()(null,"")
 // No backlog: saturation discards new events rather than scheduling work.
 for(let i=0;i<100;i++) await event(info)
-assert.equal(held.length,32);assert.equal(calls.length,34)
+assert.equal(held.length,32);assert.equal(calls.length,36)
 for(const cb of held.splice(0))cb(new Error("timeout"),"")
-await tick();assert.equal(calls.length,34)
-await event({...info,modelID:"x".repeat(16385)});assert.equal(calls.length,34)
-await event(info);assert.equal(calls.length,35)
-await hooks.dispose();assert.equal(calls[34].killed,true)
-await event(info);await tick();assert.equal(calls.length,35)
+await tick();assert.equal(calls.length,36)
+await event({...info,modelID:"x".repeat(16385)});assert.equal(calls.length,36)
+await event(info);assert.equal(calls.length,37)
+await hooks.dispose();assert.equal(calls[36].killed,true)
+await event(info);await tick();assert.equal(calls.length,37)
 console.log("ok")
 `
 	output, log := runOpenCodeTransportPluginHarness(t, map[string]string{"plugin.mts": string(source)}, harness, "#!/bin/sh\nexit 99\n")

--- a/internal/assets/opencode/plugins/telemetry-runtime.ts
+++ b/internal/assets/opencode/plugins/telemetry-runtime.ts
@@ -27,6 +27,8 @@ const telemetryRuntime: Plugin = async () => {
       try {
         const tokens = info.tokens
         const error = info.error
+        const agent = typeof info.mode === "string" && info.mode.length > 0 && info.mode.length <= 64
+          && /^[\x20-\x7e]+$/.test(info.mode) ? info.mode : undefined
         const knownErrors = ["ProviderAuthError", "UnknownError", "MessageOutputLengthError", "MessageAbortedError", "APIError"]
         const body = JSON.stringify({
           schema: "gentle-ai.telemetry-opencode/v1",
@@ -35,6 +37,7 @@ const telemetryRuntime: Plugin = async () => {
             time: { created: info.time.created, completed: info.time.completed },
             providerID: info.providerID,
             modelID: info.modelID,
+            agent,
             tokens: tokens && {
               input: tokens.input, output: tokens.output, reasoning: tokens.reasoning,
               cache: tokens.cache && { read: tokens.cache.read, write: tokens.cache.write },

--- a/internal/cli/telemetry_runtime.go
+++ b/internal/cli/telemetry_runtime.go
@@ -63,6 +63,7 @@ func readRuntimeJSONValue(input io.Reader) ([]byte, error) {
 	decoder := json.NewDecoder(io.LimitReader(input, telemetry.RuntimeMaxBytes+1))
 	var value json.RawMessage
 	if err := decoder.Decode(&value); err != nil || decoder.InputOffset() > telemetry.RuntimeMaxBytes || len(value) > telemetry.RuntimeMaxBytes {
+		// refusal:by-design world-action: the host hook wrote malformed or oversized stdin; only the host process can emit one complete JSON object within the bound, no gentle-ai command repairs its stream
 		return nil, errors.New("invalid bounded runtime hook input")
 	}
 	return value, nil

--- a/internal/cli/telemetry_runtime.go
+++ b/internal/cli/telemetry_runtime.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"io"
 	"net/http"
@@ -13,23 +14,41 @@ import (
 	"github.com/gentleman-programming/gentle-ai/v2/internal/telemetry"
 )
 
-// Tests inject transport and the stdin deadline. Native execution never spawns
-// another sender. The 500 ms input budget precedes the 3-second HTTP budget.
+// Tests inject transport and stdin deadlines. Direct send/OpenCode input keeps
+// its 500 ms EOF budget. Hook runtimes allow 3 seconds for delayed hook delivery
+// but return as soon as one complete JSON value arrives; the sender's separate
+// 3-second HTTP budget starts afterward.
 var runtimeHTTPClient = func() *http.Client { return nil }
 var runtimeStdinTimeout = 500 * time.Millisecond
+var runtimeHookStdinTimeout = 3 * time.Second
+
+func runtimeStdinConfig(verb string) (time.Duration, bool) {
+	if verb == "claude" || verb == "codex" {
+		return runtimeHookStdinTimeout, true
+	}
+	return runtimeStdinTimeout, false
+}
 
 // readRuntimeStdin is CLI/process scoped, not a library reader API. We do not own
-// arbitrary caller readers (including shared os.Stdin), so never close them. On
-// timeout at most this one reader goroutine can remain until process exit. Its
-// buffered result cannot block a late completion, and its byte limit bounds data.
-func readRuntimeStdin(ctx context.Context, input io.Reader) ([]byte, bool) {
+// arbitrary caller readers (including shared os.Stdin), so never close them.
+// Hook readers stop after the first complete JSON value and ignore trailing
+// bytes, because hook hosts can keep stdin open. On timeout at most this one
+// reader goroutine can remain until process exit. Its buffered result cannot
+// block a late completion, and every mode has a strict byte limit.
+func readRuntimeStdin(ctx context.Context, input io.Reader, firstJSONValue bool) ([]byte, bool) {
 	type result struct {
 		data []byte
 		err  error
 	}
 	done := make(chan result, 1)
 	go func() {
-		data, err := io.ReadAll(io.LimitReader(input, telemetry.RuntimeMaxBytes+1))
+		var data []byte
+		var err error
+		if firstJSONValue {
+			data, err = readRuntimeJSONValue(input)
+		} else {
+			data, err = io.ReadAll(io.LimitReader(input, telemetry.RuntimeMaxBytes+1))
+		}
 		done <- result{data, err}
 	}()
 	select {
@@ -38,6 +57,15 @@ func readRuntimeStdin(ctx context.Context, input io.Reader) ([]byte, bool) {
 	case got := <-done:
 		return got.data, ctx.Err() == nil && got.err == nil && len(got.data) <= telemetry.RuntimeMaxBytes
 	}
+}
+
+func readRuntimeJSONValue(input io.Reader) ([]byte, error) {
+	decoder := json.NewDecoder(io.LimitReader(input, telemetry.RuntimeMaxBytes+1))
+	var value json.RawMessage
+	if err := decoder.Decode(&value); err != nil || decoder.InputOffset() > telemetry.RuntimeMaxBytes || len(value) > telemetry.RuntimeMaxBytes {
+		return nil, errors.New("invalid bounded runtime hook input")
+	}
+	return value, nil
 }
 
 func runTelemetryRuntime(args []string, stdout io.Writer) error {
@@ -58,8 +86,9 @@ func runTelemetryRuntimeInput(args []string, stdout io.Writer, input io.Reader) 
 			// library rechecks fresh policy after this read and immediately before HTTP.
 			policy, err := telemetry.LoadPolicyState(home)
 			if err == nil && policy.NoticeShown && telemetry.Decide(os.Getenv, policy).Enabled {
-				ctx, cancel := context.WithTimeout(context.Background(), runtimeStdinTimeout)
-				data, ok := readRuntimeStdin(ctx, input)
+				timeout, firstJSONValue := runtimeStdinConfig(args[0])
+				ctx, cancel := context.WithTimeout(context.Background(), timeout)
+				data, ok := readRuntimeStdin(ctx, input, firstJSONValue)
 				cancel()
 				decision = "discarded"
 				if ok {

--- a/internal/cli/telemetry_runtime.go
+++ b/internal/cli/telemetry_runtime.go
@@ -45,8 +45,8 @@ func runTelemetryRuntime(args []string, stdout io.Writer) error {
 }
 
 func runTelemetryRuntimeInput(args []string, stdout io.Writer, input io.Reader) error {
-	if len(args) != 2 || (args[0] != "send" && args[0] != "opencode") || args[1] != "--json" {
-		return errors.New("usage: gentle-ai telemetry runtime <send|opencode> --json (bounded aggregate on stdin)")
+	if len(args) != 2 || (args[0] != "send" && args[0] != "opencode" && args[0] != "codex") || args[1] != "--json" {
+		return errors.New("usage: gentle-ai telemetry runtime <send|opencode|codex> --json (bounded event on stdin)")
 	}
 	decision := "disabled"
 	if telemetry.Decide(os.Getenv, telemetry.State{Enabled: true}).Enabled {
@@ -65,12 +65,19 @@ func runTelemetryRuntimeInput(args []string, stdout io.Writer, input io.Reader) 
 				if ok {
 					if args[0] == "opencode" {
 						decision = telemetryruntime.SendOpenCode(context.Background(), home, os.Getenv, bytes.NewReader(data), runtimeHTTPClient())
+					} else if args[0] == "codex" {
+						decision = telemetryruntime.SendCodex(context.Background(), home, os.Getenv, bytes.NewReader(data), runtimeHTTPClient())
 					} else {
 						decision = telemetry.SendRuntime(context.Background(), home, os.Getenv, bytes.NewReader(data), runtimeHTTPClient())
 					}
 				}
 			}
 		}
+	}
+	// Codex validates JSON-looking hook stdout as hook output even for async
+	// commands. Runtime telemetry has no Codex hook response, so stay silent.
+	if args[0] == "codex" {
+		return nil
 	}
 	return encodeReviewJSON(stdout, struct {
 		Schema   string `json:"schema"`

--- a/internal/cli/telemetry_runtime.go
+++ b/internal/cli/telemetry_runtime.go
@@ -45,8 +45,8 @@ func runTelemetryRuntime(args []string, stdout io.Writer) error {
 }
 
 func runTelemetryRuntimeInput(args []string, stdout io.Writer, input io.Reader) error {
-	if len(args) != 2 || (args[0] != "send" && args[0] != "opencode") || args[1] != "--json" {
-		return errors.New("usage: gentle-ai telemetry runtime <send|opencode> --json (bounded aggregate on stdin)")
+	if len(args) != 2 || (args[0] != "send" && args[0] != "opencode" && args[0] != "claude") || args[1] != "--json" {
+		return errors.New("usage: gentle-ai telemetry runtime <send|opencode|claude> --json (bounded aggregate or hook on stdin)")
 	}
 	decision := "disabled"
 	if telemetry.Decide(os.Getenv, telemetry.State{Enabled: true}).Enabled {
@@ -65,6 +65,8 @@ func runTelemetryRuntimeInput(args []string, stdout io.Writer, input io.Reader) 
 				if ok {
 					if args[0] == "opencode" {
 						decision = telemetryruntime.SendOpenCode(context.Background(), home, os.Getenv, bytes.NewReader(data), runtimeHTTPClient())
+					} else if args[0] == "claude" {
+						decision = telemetryruntime.SendClaude(context.Background(), home, os.Getenv, bytes.NewReader(data), runtimeHTTPClient())
 					} else {
 						decision = telemetry.SendRuntime(context.Background(), home, os.Getenv, bytes.NewReader(data), runtimeHTTPClient())
 					}

--- a/internal/cli/telemetry_runtime_claude_test.go
+++ b/internal/cli/telemetry_runtime_claude_test.go
@@ -28,10 +28,10 @@ func TestTelemetryRuntimeClaudeDirectSend(t *testing.T) {
 	if err := os.MkdirAll(filepath.Dir(agent), 0o700); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.WriteFile(transcript, []byte(`{"type":"assistant","message":{"model":"claude-opus-5","content":"PRIVATE_MESSAGE","usage":{"input_tokens":1,"output_tokens":2,"cache_read_input_tokens":3,"cache_creation_input_tokens":4}}}`+"\n"), 0o600); err != nil {
+	if err := os.WriteFile(transcript, []byte(`{"type":"assistant","message":{"model":"claude-opus-5-1","content":"PRIVATE_MESSAGE","usage":{"input_tokens":1,"output_tokens":2,"cache_read_input_tokens":3,"cache_creation_input_tokens":4}}}`+"\n"), 0o600); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.WriteFile(agent, []byte("---\nname: sdd-apply\nmodel: claude-haiku-4-5\neffort: high\n---\nPRIVATE_PROMPT"), 0o600); err != nil {
+	if err := os.WriteFile(agent, []byte("---\nname: sdd-apply\nmodel: sonnet\neffort: high\n---\nPRIVATE_PROMPT"), 0o600); err != nil {
 		t.Fatal(err)
 	}
 	before := runtimeCLIDisk(t, home)
@@ -42,7 +42,7 @@ func TestTelemetryRuntimeClaudeDirectSend(t *testing.T) {
 			requests++
 			body, _ := io.ReadAll(r.Body)
 			event, err := telemetry.ParseRuntimeEvent(body)
-			if err != nil || event.Host != "claude-code" || event.Rows[0].AgentClass != "sdd-apply" || event.Rows[0].Model.ID != "claude-opus-5" || event.Rows[0].SelectedEffort != "high" || bytes.Contains(body, []byte("PRIVATE")) {
+			if err != nil || event.Host != "claude-code" || event.Rows[0].AgentClass != "sdd-apply" || event.Rows[0].Model.ID != "claude-opus-5" || event.Rows[0].ModelEvidence != "response" || event.Rows[0].SelectedEffort != "high" || string(event.Rows[0].Responses) != "1" || bytes.Contains(body, []byte("PRIVATE")) {
 				t.Error("incorrect or unsafe event", err, string(body))
 			}
 			return &http.Response{StatusCode: http.StatusOK, Header: make(http.Header), Body: io.NopCloser(strings.NewReader(`{"schema":"gentle-ai.telemetry-runtime-delivery/v1","decision":"stored"}`))}, nil
@@ -50,7 +50,7 @@ func TestTelemetryRuntimeClaudeDirectSend(t *testing.T) {
 	}
 	t.Cleanup(func() { runtimeHTTPClient = oldClient })
 	t.Setenv(telemetry.EndpointEnvVar, "https://telemetry.invalid")
-	input := `{"session_id":"PRIVATE_SESSION","transcript_path":"PRIVATE_MAIN","cwd":"PRIVATE_CWD","permission_mode":"default","hook_event_name":"SubagentStop","stop_hook_active":false,"agent_id":"PRIVATE_ID","agent_type":"sdd-apply","agent_transcript_path":` + strconvQuote(transcript) + `,"last_assistant_message":"PRIVATE_MESSAGE"}`
+	input := `{"session_id":"PRIVATE_SESSION","transcript_path":"PRIVATE_MAIN","cwd":"PRIVATE_CWD","permission_mode":"default","hook_event_name":"SubagentStop","stop_hook_active":false,"agent_id":"PRIVATE_ID","agent_type":"sdd-apply","agent_transcript_path":` + strconvQuote(transcript) + `,"last_assistant_message":"DIFFERENT_PRIVATE_MESSAGE"}`
 	var out bytes.Buffer
 	if err := runTelemetryRuntimeInput([]string{"claude", "--json"}, &out, strings.NewReader(input)); err != nil || !strings.Contains(out.String(), `"stored"`) || requests != 1 {
 		t.Fatal(out.String(), err, requests)

--- a/internal/cli/telemetry_runtime_claude_test.go
+++ b/internal/cli/telemetry_runtime_claude_test.go
@@ -1,0 +1,100 @@
+package cli
+
+import (
+	"bytes"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gentleman-programming/gentle-ai/v2/internal/telemetry"
+)
+
+type claudeRoundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f claudeRoundTripFunc) RoundTrip(r *http.Request) (*http.Response, error) { return f(r) }
+
+func TestTelemetryRuntimeClaudeDirectSend(t *testing.T) {
+	home := runtimeCLIHome(t)
+	transcript := filepath.Join(home, ".claude", "projects", "agent.jsonl")
+	agent := filepath.Join(home, ".claude", "agents", "sdd-apply.md")
+	if err := os.MkdirAll(filepath.Dir(transcript), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Dir(agent), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(transcript, []byte(`{"type":"assistant","message":{"model":"claude-opus-5","content":"PRIVATE_MESSAGE","usage":{"input_tokens":1,"output_tokens":2,"cache_read_input_tokens":3,"cache_creation_input_tokens":4}}}`+"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(agent, []byte("---\nname: sdd-apply\nmodel: claude-haiku-4-5\neffort: high\n---\nPRIVATE_PROMPT"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	before := runtimeCLIDisk(t, home)
+	requests := 0
+	oldClient := runtimeHTTPClient
+	runtimeHTTPClient = func() *http.Client {
+		return &http.Client{Transport: claudeRoundTripFunc(func(r *http.Request) (*http.Response, error) {
+			requests++
+			body, _ := io.ReadAll(r.Body)
+			event, err := telemetry.ParseRuntimeEvent(body)
+			if err != nil || event.Host != "claude-code" || event.Rows[0].AgentClass != "sdd-apply" || event.Rows[0].Model.ID != "claude-opus-5" || event.Rows[0].SelectedEffort != "high" || bytes.Contains(body, []byte("PRIVATE")) {
+				t.Error("incorrect or unsafe event", err, string(body))
+			}
+			return &http.Response{StatusCode: http.StatusOK, Header: make(http.Header), Body: io.NopCloser(strings.NewReader(`{"schema":"gentle-ai.telemetry-runtime-delivery/v1","decision":"stored"}`))}, nil
+		})}
+	}
+	t.Cleanup(func() { runtimeHTTPClient = oldClient })
+	t.Setenv(telemetry.EndpointEnvVar, "https://telemetry.invalid")
+	input := `{"session_id":"PRIVATE_SESSION","transcript_path":"PRIVATE_MAIN","cwd":"PRIVATE_CWD","permission_mode":"default","hook_event_name":"SubagentStop","stop_hook_active":false,"agent_id":"PRIVATE_ID","agent_type":"sdd-apply","agent_transcript_path":` + strconvQuote(transcript) + `,"last_assistant_message":"PRIVATE_MESSAGE"}`
+	var out bytes.Buffer
+	if err := runTelemetryRuntimeInput([]string{"claude", "--json"}, &out, strings.NewReader(input)); err != nil || !strings.Contains(out.String(), `"stored"`) || requests != 1 {
+		t.Fatal(out.String(), err, requests)
+	}
+	if !reflect.DeepEqual(before, runtimeCLIDisk(t, home)) {
+		t.Fatal("Claude adapter mutated the filesystem")
+	}
+}
+
+type blockingClaudeReader struct{ release <-chan struct{} }
+
+func (r blockingClaudeReader) Read([]byte) (int, error) { <-r.release; return 0, io.EOF }
+
+func TestTelemetryRuntimeClaudeStdinBounds(t *testing.T) {
+	runtimeCLIHome(t)
+	for _, input := range []io.Reader{strings.NewReader(strings.Repeat("x", telemetry.RuntimeMaxBytes+1))} {
+		var out bytes.Buffer
+		if err := runTelemetryRuntimeInput([]string{"claude", "--json"}, &out, input); err != nil || !strings.Contains(out.String(), `"discarded"`) {
+			t.Fatal(out.String(), err)
+		}
+	}
+	release := make(chan struct{})
+	old := runtimeStdinTimeout
+	runtimeStdinTimeout = time.Millisecond
+	t.Cleanup(func() { runtimeStdinTimeout = old; close(release) })
+	var out bytes.Buffer
+	if err := runTelemetryRuntimeInput([]string{"claude", "--json"}, &out, blockingClaudeReader{release}); err != nil || !strings.Contains(out.String(), `"discarded"`) {
+		t.Fatal(out.String(), err)
+	}
+}
+
+func TestTelemetryRuntimeClaudeIgnoredAndPolicyBeforeRead(t *testing.T) {
+	home := runtimeCLIHome(t)
+	var out bytes.Buffer
+	if err := runTelemetryRuntimeInput([]string{"claude", "--json"}, &out, strings.NewReader(`{"hook_event_name":"PreToolUse"}`)); err != nil || !strings.Contains(out.String(), `"ignored"`) {
+		t.Fatal(out.String(), err)
+	}
+	if err := telemetry.Save(home, telemetry.State{InstallID: "local", Enabled: false, NoticeShown: true}); err != nil {
+		t.Fatal(err)
+	}
+	out.Reset()
+	if err := runTelemetryRuntimeInput([]string{"claude", "--json"}, &out, noOpenCodeRead{t}); err != nil || !strings.Contains(out.String(), `"disabled"`) {
+		t.Fatal(out.String(), err)
+	}
+}
+
+func strconvQuote(s string) string { return `"` + strings.ReplaceAll(s, `\`, `\\`) + `"` }

--- a/internal/cli/telemetry_runtime_codex_test.go
+++ b/internal/cli/telemetry_runtime_codex_test.go
@@ -1,0 +1,81 @@
+package cli
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/gentleman-programming/gentle-ai/v2/internal/state"
+	"github.com/gentleman-programming/gentle-ai/v2/internal/telemetry"
+)
+
+func TestTelemetryRuntimeCodexDirectSend(t *testing.T) {
+	home := runtimeCLIHome(t)
+	if err := state.Write(home, state.InstallState{
+		CodexModelAssignments:      map[string]string{"sdd-apply": "medium"},
+		CodexPhaseModelAssignments: map[string]string{"sdd-apply": "gpt-5.6-terra"},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	transcript := filepath.Join(t.TempDir(), "rollout.jsonl")
+	if err := os.WriteFile(transcript, []byte(`{"type":"turn_context","payload":{"model":"gpt-5.6-sol","effort":"high"}}
+{"type":"event_msg","payload":{"type":"token_count","info":{"last_token_usage":{"input_tokens":3,"output_tokens":2,"total_tokens":5}}}}
+`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	hook, _ := json.Marshal(map[string]any{
+		"session_id": "PRIVATE_SESSION", "transcript_path": "PRIVATE_PARENT", "cwd": "PRIVATE_CWD",
+		"hook_event_name": "SubagentStop", "model": "gpt-5.6-sol", "permission_mode": "default", "turn_id": "PRIVATE_TURN",
+		"agent_id": "PRIVATE_AGENT", "agent_type": "sdd-apply", "agent_transcript_path": transcript,
+		"stop_hook_active": false, "last_assistant_message": "PRIVATE_MESSAGE",
+	})
+	requests := 0
+	oldClient := runtimeHTTPClient
+	runtimeHTTPClient = func() *http.Client {
+		return &http.Client{Transport: codexCLIRoundTrip(func(r *http.Request) (*http.Response, error) {
+			requests++
+			body, _ := io.ReadAll(r.Body)
+			event, err := telemetry.ParseRuntimeEvent(body)
+			if err != nil || event.Host != "codex" || event.Rows[0].AgentClass != "sdd-apply" || event.Rows[0].Model.ID != "gpt-5.6-sol" {
+				t.Fatalf("event=%+v err=%v", event, err)
+			}
+			if bytes.Contains(body, []byte("PRIVATE")) || bytes.Contains(body, []byte(transcript)) {
+				t.Fatalf("private data leaked: %s", body)
+			}
+			return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(`{"schema":"gentle-ai.telemetry-runtime-delivery/v1","decision":"stored"}`))}, nil
+		})}
+	}
+	t.Cleanup(func() { runtimeHTTPClient = oldClient })
+	t.Setenv(telemetry.EndpointEnvVar, "https://telemetry.example.invalid")
+	before := runtimeCLIDisk(t, home)
+	var out bytes.Buffer
+	if err := runTelemetryRuntimeInput([]string{"codex", "--json"}, &out, bytes.NewReader(hook)); err != nil || out.Len() != 0 || requests != 1 {
+		t.Fatalf("out=%s requests=%d err=%v", out.String(), requests, err)
+	}
+	if after := runtimeCLIDisk(t, home); !equalCodexCLIDisk(before, after) {
+		t.Fatal("Codex runtime command mutated disk")
+	}
+}
+
+type codexCLIRoundTrip func(*http.Request) (*http.Response, error)
+
+func (f codexCLIRoundTrip) RoundTrip(request *http.Request) (*http.Response, error) {
+	return f(request)
+}
+
+func equalCodexCLIDisk(a, b map[string]string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for key, value := range a {
+		if b[key] != value {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/cli/telemetry_runtime_codex_test.go
+++ b/internal/cli/telemetry_runtime_codex_test.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/gentleman-programming/gentle-ai/v2/internal/state"
 	"github.com/gentleman-programming/gentle-ai/v2/internal/telemetry"
@@ -59,6 +60,52 @@ func TestTelemetryRuntimeCodexDirectSend(t *testing.T) {
 	}
 	if after := runtimeCLIDisk(t, home); !equalCodexCLIDisk(before, after) {
 		t.Fatal("Codex runtime command mutated disk")
+	}
+}
+
+func TestTelemetryRuntimeCodexProcessesHeldOpenHookStdin(t *testing.T) {
+	home := runtimeCLIHome(t)
+	hook, _ := json.Marshal(map[string]any{
+		"session_id": "PRIVATE_SESSION", "transcript_path": nil, "cwd": "PRIVATE_CWD",
+		"hook_event_name": "Stop", "model": "gpt-5.6-sol", "permission_mode": "default", "turn_id": "PRIVATE_TURN",
+		"stop_hook_active": false, "last_assistant_message": nil,
+	})
+	requests := 0
+	oldClient := runtimeHTTPClient
+	runtimeHTTPClient = func() *http.Client {
+		return &http.Client{Transport: codexCLIRoundTrip(func(*http.Request) (*http.Response, error) {
+			requests++
+			return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(`{"schema":"gentle-ai.telemetry-runtime-delivery/v1","decision":"stored"}`))}, nil
+		})}
+	}
+	t.Cleanup(func() { runtimeHTTPClient = oldClient })
+	t.Setenv(telemetry.EndpointEnvVar, "https://telemetry.example.invalid")
+	old, oldHook := runtimeStdinTimeout, runtimeHookStdinTimeout
+	runtimeStdinTimeout = 10 * time.Millisecond
+	runtimeHookStdinTimeout = 100 * time.Millisecond
+	t.Cleanup(func() {
+		runtimeStdinTimeout = old
+		runtimeHookStdinTimeout = oldHook
+	})
+	r, w := io.Pipe()
+	defer r.Close()
+	defer w.Close()
+	done := make(chan error, 1)
+	var out bytes.Buffer
+	go func() { done <- runTelemetryRuntimeInput([]string{"codex", "--json"}, &out, r) }()
+	if _, err := w.Write(hook); err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case err := <-done:
+		if err != nil || requests != 1 || out.Len() != 0 {
+			t.Fatalf("err=%v requests=%d out=%q", err, requests, out.String())
+		}
+	case <-time.After(time.Second):
+		t.Fatal("Codex hook waited for stdin EOF")
+	}
+	if entries, err := os.ReadDir(home); err != nil || len(entries) == 0 {
+		t.Fatalf("test home unavailable: entries=%d err=%v", len(entries), err)
 	}
 }
 

--- a/internal/cli/telemetry_runtime_opencode_test.go
+++ b/internal/cli/telemetry_runtime_opencode_test.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"path/filepath"
 	"reflect"
 	"strings"
 	"testing"
@@ -16,6 +17,12 @@ import (
 const completedOpenCodeEnvelope = `{"schema":"gentle-ai.telemetry-opencode/v1","info":{"role":"assistant","time":{"created":1,"completed":3},"providerID":"PRIVATE_PROVIDER","modelID":"PRIVATE_MODEL"}}`
 
 type noOpenCodeRead struct{ t *testing.T }
+
+type openCodeRoundTripFunc func(*http.Request) (*http.Response, error)
+
+func (fn openCodeRoundTripFunc) RoundTrip(request *http.Request) (*http.Response, error) {
+	return fn(request)
+}
 
 func (r noOpenCodeRead) Read([]byte) (int, error) {
 	r.t.Fatal("read event without permission")
@@ -56,6 +63,77 @@ func TestTelemetryRuntimeOpenCodeDirectSend(t *testing.T) {
 		if requests != i+1 || !reflect.DeepEqual(before, runtimeCLIDisk(t, home)) {
 			t.Fatal("extra attempt or disk mutation")
 		}
+	}
+}
+
+func TestTelemetryRuntimeOpenCodeUsesAgentAssignment(t *testing.T) {
+	for _, tt := range []struct {
+		name         string
+		agent        string
+		provider     string
+		model        string
+		config       string
+		wantModel    telemetry.RuntimeModel
+		wantEvidence string
+		wantKind     string
+		wantClass    string
+		wantEffort   string
+	}{
+		{
+			name: "response model wins while selected effort is retained", agent: "sdd-apply", provider: "openai", model: "gpt-5.4",
+			config:    `{"agent":{"sdd-apply":{"model":"openai/gpt-5.6","variant":"high"}}}`,
+			wantModel: telemetry.RuntimeModel{Provider: "openai", ID: "gpt-5.4"}, wantEvidence: "response", wantKind: "built_in", wantClass: "sdd-apply", wantEffort: "high",
+		},
+		{
+			name: "selected model fills absent response model", agent: "gentle-orchestrator",
+			config:    `{"agent":{"gentle-orchestrator":{"model":"anthropic/claude-opus-5","variant":"xhigh"}}}`,
+			wantModel: telemetry.RuntimeModel{Provider: "anthropic", ID: "claude-opus-5"}, wantEvidence: "selected", wantKind: "orchestrator", wantClass: "orchestrator", wantEffort: "xhigh",
+		},
+		{
+			name: "custom agent name stays private and invalid effort falls back", agent: "private-team-agent",
+			config:    `{"agent":{"private-team-agent":{"model":"openai/gpt-5.4","variant":"turbo"}}}`,
+			wantModel: telemetry.RuntimeModel{Provider: "openai", ID: "gpt-5.4"}, wantEvidence: "selected", wantKind: "custom", wantClass: "unknown", wantEffort: "unavailable",
+		},
+		{
+			name: "oversized config fails open to unavailable attribution", agent: "sdd-apply",
+			config:    strings.Repeat(" ", 65537),
+			wantModel: telemetry.RuntimeModel{Provider: "unknown", ID: "unknown"}, wantEvidence: "unknown", wantKind: "built_in", wantClass: "sdd-apply", wantEffort: "unavailable",
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			runtimeCLIHome(t)
+			configPath := filepath.Join(os.Getenv("XDG_CONFIG_HOME"), "opencode", "opencode.json")
+			if err := os.MkdirAll(filepath.Dir(configPath), 0o700); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.WriteFile(configPath, []byte(tt.config), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			previousClient := runtimeHTTPClient
+			t.Cleanup(func() { runtimeHTTPClient = previousClient })
+			runtimeHTTPClient = func() *http.Client {
+				return &http.Client{Transport: openCodeRoundTripFunc(func(r *http.Request) (*http.Response, error) {
+					body, _ := io.ReadAll(r.Body)
+					event, err := telemetry.ParseRuntimeEvent(body)
+					if err != nil {
+						t.Fatal(err)
+					}
+					row := event.Rows[0]
+					if row.Model != tt.wantModel || row.ModelEvidence != tt.wantEvidence || row.AgentKind != tt.wantKind || row.AgentClass != tt.wantClass || row.SelectedEffort != tt.wantEffort || row.EffectiveEffort != "unavailable" {
+						t.Fatalf("row = %+v", row)
+					}
+					if bytes.Contains(body, []byte(tt.agent)) && tt.wantClass == "unknown" {
+						t.Fatal("custom agent name leaked")
+					}
+					return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(`{"schema":"gentle-ai.telemetry-runtime-delivery/v1","decision":"stored"}`)), Header: make(http.Header)}, nil
+				})}
+			}
+			input := `{"schema":"gentle-ai.telemetry-opencode/v1","info":{"role":"assistant","time":{"created":1,"completed":3},"providerID":"` + tt.provider + `","modelID":"` + tt.model + `","agent":"` + tt.agent + `"}}`
+			var out bytes.Buffer
+			if err := runTelemetryRuntimeInput([]string{"opencode", "--json"}, &out, strings.NewReader(input)); err != nil || !strings.Contains(out.String(), `"stored"`) {
+				t.Fatalf("send = %q, %v", out.String(), err)
+			}
+		})
 	}
 }
 
@@ -114,6 +192,8 @@ func TestTelemetryRuntimeOpenCodeRejectsUnsafeEnvelope(t *testing.T) {
 		strings.Replace(completedOpenCodeEnvelope, `"created":1,`, "", 1),
 		strings.Replace(completedOpenCodeEnvelope, `"role":"assistant"`, `"role":"assistant","tokens":{"input":"2"}`, 1),
 		strings.Replace(completedOpenCodeEnvelope, `"role":"assistant"`, `"role":"assistant","id":"PRIVATE_SOURCE_ID"`, 1),
+		strings.Replace(completedOpenCodeEnvelope, `"role":"assistant"`, `"role":"assistant","agent":"`+strings.Repeat("x", 65)+`"`, 1),
+		strings.Replace(completedOpenCodeEnvelope, `"role":"assistant"`, `"role":"assistant","agent":"bad\nagent"`, 1),
 		strings.Replace(completedOpenCodeEnvelope, `"info":`, `"batch_id":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","info":`, 1),
 		completedOpenCodeEnvelope + `{}`, strings.Repeat("x", 16385),
 	} {

--- a/internal/cli/telemetry_runtime_test.go
+++ b/internal/cli/telemetry_runtime_test.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -31,11 +32,11 @@ func TestTelemetryRuntimeStdinDeadline(t *testing.T) {
 	old := runtimeStdinTimeout
 	runtimeStdinTimeout = 20 * time.Millisecond
 	t.Cleanup(func() { runtimeStdinTimeout = old })
-	for _, route := range []string{"send", "opencode"} {
+	for _, route := range []string{"send", "opencode", "codex"} {
 		t.Run(route, func(t *testing.T) {
 			home := runtimeCLIHome(t)
 			before := runtimeCLIDisk(t, home)
-			runtimeCLIServer(t, func(w http.ResponseWriter, r *http.Request) { t.Error("timed-out stdin made HTTP request") })
+			runtimeCLINoRequest(t, "timed-out stdin made HTTP request")
 			release, finished := make(chan struct{}), make(chan struct{})
 			done := make(chan struct{})
 			var out bytes.Buffer
@@ -56,7 +57,7 @@ func TestTelemetryRuntimeStdinDeadline(t *testing.T) {
 			close(release)
 			<-finished
 			<-done
-			if runErr != nil || !strings.Contains(out.String(), `"discarded"`) {
+			if runErr != nil || (route == "codex" && out.Len() != 0) || (route != "codex" && !strings.Contains(out.String(), `"discarded"`)) {
 				t.Fatal("unexpected timeout decision", out.String(), runErr)
 			}
 			if !reflect.DeepEqual(before, runtimeCLIDisk(t, home)) {
@@ -81,10 +82,10 @@ func (r runtimeSignalInput) Read(p []byte) (int, error) {
 }
 
 func TestTelemetryRuntimePolicyRevokedDuringStdin(t *testing.T) {
-	for _, route := range []string{"send", "opencode"} {
+	for _, route := range []string{"send", "opencode", "codex"} {
 		t.Run(route, func(t *testing.T) {
 			home := runtimeCLIHome(t)
-			runtimeCLIServer(t, func(w http.ResponseWriter, r *http.Request) { t.Error("revoked input sent HTTP") })
+			runtimeCLINoRequest(t, "revoked input sent HTTP")
 			r, w := io.Pipe()
 			defer r.Close()
 			defer w.Close()
@@ -109,7 +110,7 @@ func TestTelemetryRuntimePolicyRevokedDuringStdin(t *testing.T) {
 			}
 			_ = w.Close()
 			<-done
-			if runErr != nil || !strings.Contains(out.String(), `"disabled"`) {
+			if runErr != nil || (route == "codex" && out.Len() != 0) || (route != "codex" && !strings.Contains(out.String(), `"disabled"`)) {
 				t.Fatal("policy revocation ignored", out.String(), runErr)
 			}
 			if !reflect.DeepEqual(revoked, runtimeCLIDisk(t, home)) {
@@ -195,6 +196,18 @@ func runtimeCLIServer(t *testing.T, handler http.HandlerFunc) *httptest.Server {
 	t.Cleanup(func() { runtimeHTTPClient = old })
 	t.Setenv(telemetry.EndpointEnvVar, server.URL)
 	return server
+}
+
+func runtimeCLINoRequest(t *testing.T, message string) {
+	t.Helper()
+	old := runtimeHTTPClient
+	runtimeHTTPClient = func() *http.Client {
+		return &http.Client{Transport: codexCLIRoundTrip(func(*http.Request) (*http.Response, error) {
+			t.Error(message)
+			return nil, errors.New("unexpected request")
+		})}
+	}
+	t.Cleanup(func() { runtimeHTTPClient = old })
 }
 
 func TestTelemetryRuntimeStdin(t *testing.T) {

--- a/internal/cli/telemetry_runtime_test.go
+++ b/internal/cli/telemetry_runtime_test.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"errors"
 	"io"
@@ -30,8 +31,13 @@ func (r runtimeHeldInput) Read([]byte) (int, error) {
 
 func TestTelemetryRuntimeStdinDeadline(t *testing.T) {
 	old := runtimeStdinTimeout
+	oldHook := runtimeHookStdinTimeout
 	runtimeStdinTimeout = 20 * time.Millisecond
-	t.Cleanup(func() { runtimeStdinTimeout = old })
+	runtimeHookStdinTimeout = 20 * time.Millisecond
+	t.Cleanup(func() {
+		runtimeStdinTimeout = old
+		runtimeHookStdinTimeout = oldHook
+	})
 	for _, route := range []string{"send", "opencode", "codex"} {
 		t.Run(route, func(t *testing.T) {
 			home := runtimeCLIHome(t)
@@ -62,6 +68,134 @@ func TestTelemetryRuntimeStdinDeadline(t *testing.T) {
 			}
 			if !reflect.DeepEqual(before, runtimeCLIDisk(t, home)) {
 				t.Fatal("timed-out stdin wrote artifacts")
+			}
+		})
+	}
+}
+
+func TestRuntimeStdinBudgetsByVerb(t *testing.T) {
+	for _, tt := range []struct {
+		verb     string
+		want     time.Duration
+		wantJSON bool
+	}{
+		{"send", 500 * time.Millisecond, false},
+		{"opencode", 500 * time.Millisecond, false},
+		{"claude", 3 * time.Second, true},
+		{"codex", 3 * time.Second, true},
+	} {
+		t.Run(tt.verb, func(t *testing.T) {
+			got, gotJSON := runtimeStdinConfig(tt.verb)
+			if got != tt.want || gotJSON != tt.wantJSON {
+				t.Fatalf("timeout=%s json=%t", got, gotJSON)
+			}
+		})
+	}
+}
+
+func TestRuntimeHookStdinCompletesWithoutEOF(t *testing.T) {
+	for _, verb := range []string{"claude", "codex"} {
+		t.Run(verb, func(t *testing.T) {
+			r, w := io.Pipe()
+			defer r.Close()
+			defer w.Close()
+			ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+			defer cancel()
+			type result struct {
+				data []byte
+				ok   bool
+			}
+			done := make(chan result, 1)
+			go func() {
+				_, jsonValue := runtimeStdinConfig(verb)
+				data, ok := readRuntimeStdin(ctx, r, jsonValue)
+				done <- result{data, ok}
+			}()
+			payload := []byte(`{"message":"escaped \" brace } stays inside","nested":{"ok":true}}`)
+			if _, err := w.Write(payload); err != nil {
+				t.Fatal(err)
+			}
+			got := <-done
+			if !got.ok || !bytes.Equal(got.data, payload) {
+				t.Fatalf("data=%q ok=%t", got.data, got.ok)
+			}
+		})
+	}
+}
+
+func TestRuntimeHookStdinAcceptsDelayedPayloadWithinHookBudget(t *testing.T) {
+	old, oldHook := runtimeStdinTimeout, runtimeHookStdinTimeout
+	runtimeStdinTimeout = 10 * time.Millisecond
+	runtimeHookStdinTimeout = 100 * time.Millisecond
+	t.Cleanup(func() {
+		runtimeStdinTimeout = old
+		runtimeHookStdinTimeout = oldHook
+	})
+	for _, verb := range []string{"claude", "codex"} {
+		t.Run(verb, func(t *testing.T) {
+			r, w := io.Pipe()
+			defer r.Close()
+			defer w.Close()
+			go func() {
+				// Scaled timing: this arrives after the direct-input budget but
+				// comfortably within the hook budget, without a real one-second wait.
+				time.Sleep(30 * time.Millisecond)
+				_, _ = io.WriteString(w, `{"late":true}`)
+			}()
+			timeout, jsonValue := runtimeStdinConfig(verb)
+			ctx, cancel := context.WithTimeout(context.Background(), timeout)
+			defer cancel()
+			data, ok := readRuntimeStdin(ctx, r, jsonValue)
+			if !ok || string(data) != `{"late":true}` {
+				t.Fatalf("data=%q ok=%t", data, ok)
+			}
+		})
+	}
+}
+
+func TestRuntimeHookStdinTimeoutAndBounds(t *testing.T) {
+	t.Run("no payload", func(t *testing.T) {
+		r, w := io.Pipe()
+		defer r.Close()
+		defer w.Close()
+		ctx, cancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
+		defer cancel()
+		if data, ok := readRuntimeStdin(ctx, r, true); ok || data != nil {
+			t.Fatalf("data=%q ok=%t", data, ok)
+		}
+	})
+	t.Run("oversized first value", func(t *testing.T) {
+		input := `{"value":"` + strings.Repeat("x", telemetry.RuntimeMaxBytes) + `"}`
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+		defer cancel()
+		if data, ok := readRuntimeStdin(ctx, strings.NewReader(input), true); ok || data != nil {
+			t.Fatalf("len=%d ok=%t", len(data), ok)
+		}
+	})
+	t.Run("trailing bytes ignored", func(t *testing.T) {
+		first := `{"first":true}`
+		input := first + strings.Repeat("PRIVATE_TRAILING", telemetry.RuntimeMaxBytes)
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+		defer cancel()
+		data, ok := readRuntimeStdin(ctx, strings.NewReader(input), true)
+		if !ok || string(data) != first || bytes.Contains(data, []byte("PRIVATE")) {
+			t.Fatalf("data=%q ok=%t", data, ok)
+		}
+	})
+}
+
+func TestRuntimeDirectStdinStillRequiresEOF(t *testing.T) {
+	for _, verb := range []string{"send", "opencode"} {
+		t.Run(verb, func(t *testing.T) {
+			r, w := io.Pipe()
+			defer r.Close()
+			defer w.Close()
+			go func() { _, _ = io.WriteString(w, `{"complete":true}`) }()
+			ctx, cancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
+			defer cancel()
+			_, jsonValue := runtimeStdinConfig(verb)
+			if data, ok := readRuntimeStdin(ctx, r, jsonValue); ok || data != nil {
+				t.Fatalf("data=%q ok=%t", data, ok)
 			}
 		})
 	}

--- a/internal/components/sdd/inject.go
+++ b/internal/components/sdd/inject.go
@@ -1815,10 +1815,6 @@ func ensureCodexSkillRegistryHook(hooksPath string) (bool, error) {
 	}
 
 	const command = `gentle-ai skill-registry refresh --quiet --no-gitignore --cwd "$PWD" || true`
-	if claudeHookExists(root, command) {
-		return false, nil
-	}
-
 	hooksRaw, hasHooks := root["hooks"]
 	hooksMap, _ := hooksRaw.(map[string]any)
 	if hasHooks && hooksMap == nil {
@@ -1828,23 +1824,54 @@ func ensureCodexSkillRegistryHook(hooksPath string) (bool, error) {
 		hooksMap = map[string]any{}
 	}
 
-	sessionRaw, hasSessionStart := hooksMap["SessionStart"]
-	sessionStart, _ := sessionRaw.([]any)
-	if hasSessionStart && sessionStart == nil {
-		return false, fmt.Errorf("Codex hooks %q has unsupported hooks.SessionStart shape: want array", hooksPath)
-	}
-	sessionStart = append(sessionStart, map[string]any{
-		"matcher": "startup|resume|clear|compact",
-		"hooks": []any{
-			map[string]any{
-				"type":          "command",
-				"command":       command,
-				"timeout":       30,
-				"statusMessage": "Refreshing skill registry",
+	changed := false
+	if !hookCommandExists(hooksMap, "SessionStart", command) {
+		sessionRaw, hasSessionStart := hooksMap["SessionStart"]
+		sessionStart, _ := sessionRaw.([]any)
+		if hasSessionStart && sessionStart == nil {
+			return false, fmt.Errorf("Codex hooks %q has unsupported hooks.SessionStart shape: want array", hooksPath)
+		}
+		sessionStart = append(sessionStart, map[string]any{
+			"matcher": "startup|resume|clear|compact",
+			"hooks": []any{
+				map[string]any{
+					"type":          "command",
+					"command":       command,
+					"timeout":       30,
+					"statusMessage": "Refreshing skill registry",
+				},
 			},
-		},
-	})
-	hooksMap["SessionStart"] = sessionStart
+		})
+		hooksMap["SessionStart"] = sessionStart
+		changed = true
+	}
+
+	const telemetryCommand = `gentle-ai telemetry runtime codex --json`
+	for _, event := range []string{"SubagentStop", "Stop"} {
+		if hookCommandExists(hooksMap, event, telemetryCommand) {
+			continue
+		}
+		raw, exists := hooksMap[event]
+		entries, _ := raw.([]any)
+		if exists && entries == nil {
+			return false, fmt.Errorf("Codex hooks %q has unsupported hooks.%s shape: want array", hooksPath, event)
+		}
+		entries = append(entries, map[string]any{
+			"hooks": []any{
+				map[string]any{
+					"type":    "command",
+					"command": telemetryCommand,
+					"async":   true,
+					"timeout": 4,
+				},
+			},
+		})
+		hooksMap[event] = entries
+		changed = true
+	}
+	if !changed {
+		return false, nil
+	}
 	root["hooks"] = hooksMap
 
 	out, err := json.MarshalIndent(root, "", "  ")
@@ -1860,6 +1887,21 @@ func ensureCodexSkillRegistryHook(hooksPath string) (bool, error) {
 		return false, err
 	}
 	return wr.Changed, nil
+}
+
+func hookCommandExists(hooksMap map[string]any, event, command string) bool {
+	entries, _ := hooksMap[event].([]any)
+	for _, entry := range entries {
+		entryMap, _ := entry.(map[string]any)
+		hooks, _ := entryMap["hooks"].([]any)
+		for _, hook := range hooks {
+			hookMap, _ := hook.(map[string]any)
+			if hookMap["command"] == command {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 func ensureClaudeSkillRegistryHook(settingsPath string) (bool, error) {

--- a/internal/components/sdd/inject.go
+++ b/internal/components/sdd/inject.go
@@ -1801,7 +1801,11 @@ func installSkillRegistryAutomation(homeDir string, adapter agents.Adapter) (Inj
 	if err != nil {
 		return InjectionResult{}, fmt.Errorf("install Claude review stop-hook: %w", err)
 	}
-	return InjectionResult{Changed: changed || stopHookChanged, Files: []string{settingsPath}}, nil
+	telemetryHookChanged, err := ensureClaudeTelemetryHooks(settingsPath)
+	if err != nil {
+		return InjectionResult{}, fmt.Errorf("install Claude runtime telemetry hooks: %w", err)
+	}
+	return InjectionResult{Changed: changed || stopHookChanged || telemetryHookChanged, Files: []string{settingsPath}}, nil
 }
 
 func ensureCodexSkillRegistryHook(hooksPath string) (bool, error) {
@@ -2010,12 +2014,61 @@ func appendClaudeReviewStopHookEntry(hooksMap map[string]any, hookKey, settingsP
 	return true, nil
 }
 
+// ensureClaudeTelemetryHooks installs one asynchronous, one-shot command for
+// both main-agent and subagent completions. Native policy checks run before the
+// hook payload or any transcript is read, so installation itself never enrolls
+// telemetry and disabled installations remain inert.
+func ensureClaudeTelemetryHooks(settingsPath string) (bool, error) {
+	root := map[string]any{}
+	if data, err := os.ReadFile(settingsPath); err == nil && len(strings.TrimSpace(string(data))) > 0 {
+		if err := json.Unmarshal(data, &root); err != nil {
+			return false, fmt.Errorf("parse Claude settings %q: %w", settingsPath, err)
+		}
+	} else if err != nil && !os.IsNotExist(err) {
+		return false, err
+	}
+	hooksRaw, hasHooks := root["hooks"]
+	hooksMap, _ := hooksRaw.(map[string]any)
+	if hasHooks && hooksMap == nil {
+		return false, fmt.Errorf("Claude settings %q has unsupported hooks shape: want object", settingsPath)
+	}
+	if hooksMap == nil {
+		hooksMap = map[string]any{}
+	}
+	const command = "gentle-ai telemetry runtime claude --json"
+	changed := false
+	for _, hookKey := range []string{"SubagentStop", "Stop"} {
+		added, err := appendClaudeReviewStopHookEntry(hooksMap, hookKey, settingsPath, command, map[string]any{
+			"matcher": "",
+			"hooks":   []any{map[string]any{"type": "command", "command": command, "async": true, "timeout": 5}},
+		})
+		if err != nil {
+			return false, err
+		}
+		changed = changed || added
+	}
+	if !changed {
+		return false, nil
+	}
+	root["hooks"] = hooksMap
+	out, err := json.MarshalIndent(root, "", "  ")
+	if err != nil {
+		return false, err
+	}
+	out = append(out, '\n')
+	wr, err := filemerge.WriteFileAtomic(settingsPath, out, 0o644)
+	if err != nil {
+		return false, err
+	}
+	return wr.Changed, nil
+}
+
 func claudeHookExists(root map[string]any, command string) bool {
 	hooksMap, ok := root["hooks"].(map[string]any)
 	if !ok {
 		return false
 	}
-	for _, key := range []string{"UserPromptSubmit", "SessionStart", "Stop"} {
+	for _, key := range []string{"UserPromptSubmit", "SessionStart", "Stop", "SubagentStop"} {
 		hookEntries, ok := hooksMap[key].([]any)
 		if !ok {
 			continue

--- a/internal/components/sdd/inject_test.go
+++ b/internal/components/sdd/inject_test.go
@@ -7697,6 +7697,33 @@ func TestEnsureClaudeReviewStopHookAppendsIdempotently(t *testing.T) {
 	}
 }
 
+func TestEnsureClaudeTelemetryHooksAppendsIdempotently(t *testing.T) {
+	home := t.TempDir()
+	settingsPath := filepath.Join(home, ".claude", "settings.json")
+	if err := os.MkdirAll(filepath.Dir(settingsPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(settingsPath, []byte(`{"hooks":{"Stop":[{"matcher":"","hooks":[{"type":"command","command":"echo keep"}]}]}}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	changed, err := ensureClaudeTelemetryHooks(settingsPath)
+	if err != nil || !changed {
+		t.Fatal(changed, err)
+	}
+	changed, err = ensureClaudeTelemetryHooks(settingsPath)
+	if err != nil || changed {
+		t.Fatal(changed, err)
+	}
+	data, err := os.ReadFile(settingsPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	text := string(data)
+	if strings.Count(text, "gentle-ai telemetry runtime claude --json") != 2 || strings.Count(text, `"async": true`) != 2 || !strings.Contains(text, "echo keep") {
+		t.Fatalf("hooks not merged idempotently:\n%s", text)
+	}
+}
+
 func TestEnsureClaudeReviewStopHookRejectsUnexpectedHookSchema(t *testing.T) {
 	home := t.TempDir()
 	settingsPath := filepath.Join(home, ".claude", "settings.json")

--- a/internal/components/sdd/inject_test.go
+++ b/internal/components/sdd/inject_test.go
@@ -7796,6 +7796,15 @@ func TestEnsureCodexSkillRegistryHookWritesSessionStartHookIdempotently(t *testi
 	if strings.Count(text, "gentle-ai skill-registry refresh") != 1 {
 		t.Fatalf("hook command count mismatch:\n%s", text)
 	}
+	if strings.Count(text, "gentle-ai telemetry runtime codex --json") != 2 {
+		t.Fatalf("Codex telemetry hook must cover SubagentStop and Stop exactly once:\n%s", text)
+	}
+	if strings.Count(text, `"async": true`) != 2 {
+		t.Fatalf("Codex telemetry hooks must be asynchronous:\n%s", text)
+	}
+	if !strings.Contains(text, `"SubagentStop"`) || !strings.Contains(text, `"Stop"`) {
+		t.Fatalf("Codex telemetry hook events missing:\n%s", text)
+	}
 	if !strings.Contains(text, `"SessionStart"`) {
 		t.Fatalf("Codex hook should use SessionStart, got:\n%s", text)
 	}
@@ -7968,6 +7977,9 @@ func TestInject_CodexInstallsSkillRegistryHook(t *testing.T) {
 	}
 	if !strings.Contains(string(data), "gentle-ai skill-registry refresh") {
 		t.Fatalf("Codex hooks.json missing skill-registry refresh:\n%s", data)
+	}
+	if strings.Count(string(data), "gentle-ai telemetry runtime codex --json") != 2 {
+		t.Fatalf("Codex hooks.json missing telemetry Stop hooks:\n%s", data)
 	}
 }
 

--- a/internal/components/telemetryruntime/claude.go
+++ b/internal/components/telemetryruntime/claude.go
@@ -1,0 +1,106 @@
+package telemetryruntime
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/gentleman-programming/gentle-ai/v2/internal/telemetry"
+)
+
+// SendClaude handles one Claude Code hook in memory and sends at most once.
+// Source paths and file contents never enter the aggregate or an error message.
+func SendClaude(ctx context.Context, home string, getenv func(string) string, input io.Reader, client *http.Client) string {
+	if !allowed(home, getenv) {
+		return "disabled"
+	}
+	hook, err := telemetry.ParseClaudeHook(input)
+	if err != nil {
+		return "discarded"
+	}
+	if hook.HookEventName != "Stop" && hook.HookEventName != "SubagentStop" {
+		return "ignored"
+	}
+	if !allowed(home, getenv) {
+		return "disabled"
+	}
+	var usage telemetry.ClaudeUsage
+	var definition []byte
+	if hook.HookEventName == "SubagentStop" {
+		if tail, firstPartial, err := readClaudeFile(home, hook.AgentTranscriptPath, telemetry.ClaudeTranscriptMaxBytes, true); err == nil {
+			usage, _ = telemetry.ParseClaudeTranscriptTail(tail, firstPartial, hook.LastAssistantDigest)
+		}
+		if telemetry.ClaudeNamedAgent(hook.AgentType) {
+			definition, _, _ = readClaudeFile(home, filepath.Join(home, ".claude", "agents", hook.AgentType+".md"), telemetry.ClaudeAgentMaxBytes, false)
+		}
+	}
+	if !allowed(home, getenv) {
+		return "disabled"
+	}
+	observation := telemetry.NormalizeClaude(hook, usage, definition)
+	if observation == nil {
+		return "ignored"
+	}
+	batch, err := json.Marshal(telemetry.RuntimeBatch{Schema: telemetry.RuntimeSchema, Registry: json.RawMessage("1"), Host: "claude-code", Rows: []telemetry.RuntimeRow{observation.Row}})
+	if err != nil || len(batch) > telemetry.RuntimeMaxBytes {
+		return "discarded"
+	}
+	return telemetry.SendRuntime(ctx, home, getenv, bytes.NewReader(batch), client)
+}
+
+func readClaudeFile(home, source string, limit int, tail bool) ([]byte, bool, error) {
+	if strings.HasPrefix(source, "~/") {
+		source = filepath.Join(home, strings.TrimPrefix(source, "~/"))
+	}
+	homeAbs, err := filepath.Abs(home)
+	if err != nil {
+		return nil, false, err
+	}
+	sourceAbs, err := filepath.Abs(source)
+	if err != nil || !withinClaudeHome(homeAbs, sourceAbs) {
+		return nil, false, os.ErrPermission
+	}
+	homeReal, err := filepath.EvalSymlinks(homeAbs)
+	if err != nil {
+		return nil, false, err
+	}
+	real, err := filepath.EvalSymlinks(sourceAbs)
+	if err != nil || !withinClaudeHome(homeReal, real) {
+		return nil, false, os.ErrPermission
+	}
+	info, err := os.Stat(real)
+	if err != nil || !info.Mode().IsRegular() {
+		return nil, false, os.ErrInvalid
+	}
+	f, err := os.Open(real)
+	if err != nil {
+		return nil, false, err
+	}
+	defer f.Close()
+	firstPartial := false
+	if tail && info.Size() > int64(limit) {
+		if _, err := f.Seek(-int64(limit)-1, io.SeekEnd); err != nil {
+			return nil, false, err
+		}
+		boundary := make([]byte, 1)
+		if _, err := io.ReadFull(f, boundary); err != nil {
+			return nil, false, err
+		}
+		firstPartial = boundary[0] != '\n'
+	}
+	data, err := io.ReadAll(io.LimitReader(f, int64(limit)+1))
+	if err != nil || len(data) > limit {
+		return nil, false, os.ErrInvalid
+	}
+	return data, firstPartial, nil
+}
+
+func withinClaudeHome(home, candidate string) bool {
+	rel, err := filepath.Rel(home, candidate)
+	return err == nil && rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator)) && !filepath.IsAbs(rel)
+}

--- a/internal/components/telemetryruntime/claude_test.go
+++ b/internal/components/telemetryruntime/claude_test.go
@@ -1,0 +1,68 @@
+package telemetryruntime
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/gentleman-programming/gentle-ai/v2/internal/telemetry"
+)
+
+func TestReadClaudeFileReturnsOnlyBoundedTail(t *testing.T) {
+	home := t.TempDir()
+	path := filepath.Join(home, ".claude", "projects", "transcript.jsonl")
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	recent := []byte(`{"type":"assistant","message":{"model":"claude-opus-5","content":"MATCH","usage":{"input_tokens":21,"output_tokens":22,"cache_read_input_tokens":23,"cache_creation_input_tokens":24}}}` + "\n")
+	body := append(bytes.Repeat([]byte("x"), telemetry.ClaudeTranscriptMaxBytes+100), '\n')
+	body = append(body, recent...)
+	if err := os.WriteFile(path, body, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	tail, truncated, err := readClaudeFile(home, path, telemetry.ClaudeTranscriptMaxBytes, true)
+	if err != nil || !truncated || len(tail) > telemetry.ClaudeTranscriptMaxBytes {
+		t.Fatal(len(tail), truncated, err)
+	}
+	usage, ok := telemetry.ParseClaudeTranscriptTail(tail, truncated, sha256.Sum256([]byte("MATCH")))
+	if !ok || string(usage.Input) != "21" {
+		t.Fatalf("tail usage: %+v %v", usage, ok)
+	}
+}
+
+func TestReadClaudeFileExactNewlineBoundaryKeepsFirstRecord(t *testing.T) {
+	home := t.TempDir()
+	path := filepath.Join(home, "transcript.jsonl")
+	line := []byte(`{"type":"assistant","message":{"model":"claude-opus-5","content":"MATCH","usage":{"input_tokens":41}}}` + "\n")
+	tail := append(append([]byte(nil), line...), bytes.Repeat([]byte{'\n'}, telemetry.ClaudeTranscriptMaxBytes-len(line))...)
+	body := append(append([]byte("old"), '\n'), tail...)
+	if err := os.WriteFile(path, body, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	tail, firstPartial, err := readClaudeFile(home, path, telemetry.ClaudeTranscriptMaxBytes, true)
+	if err != nil || firstPartial {
+		t.Fatalf("boundary misclassified: %v partial=%v", err, firstPartial)
+	}
+	usage, ok := telemetry.ParseClaudeTranscriptTail(tail, firstPartial, sha256.Sum256([]byte("MATCH")))
+	if !ok || string(usage.Input) != "41" {
+		t.Fatalf("boundary record lost: %+v %v", usage, ok)
+	}
+}
+
+func TestReadClaudeFileRefusesOutsideHomeSymlink(t *testing.T) {
+	home := t.TempDir()
+	outside := t.TempDir()
+	target := filepath.Join(outside, "transcript.jsonl")
+	if err := os.WriteFile(target, []byte("private"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	link := filepath.Join(home, "transcript.jsonl")
+	if err := os.Symlink(target, link); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := readClaudeFile(home, link, telemetry.ClaudeTranscriptMaxBytes, true); err == nil {
+		t.Fatal("followed symlink outside home")
+	}
+}

--- a/internal/components/telemetryruntime/codex.go
+++ b/internal/components/telemetryruntime/codex.go
@@ -14,6 +14,7 @@ import (
 )
 
 const codexStateMaxBytes = 65536
+const codexTranscriptHeadMaxBytes = telemetry.CodexTranscriptHeadMaxBytes
 
 // SendCodex performs one policy-gated, memory-only normalization and send.
 // It never retries, persists source data, or logs hook fields and paths.
@@ -43,6 +44,12 @@ func sendCodex(ctx context.Context, home string, getenv func(string) string, inp
 	if source == nil {
 		return "ignored", nil
 	}
+	if source.Event == "SubagentStop" {
+		head, _ := readCodexTranscriptHead(source.TranscriptPath)
+		if resolved, resolveErr := telemetry.ResolveCodexAgentType(*source, bytes.NewReader(head)); resolveErr == nil {
+			source = &resolved
+		}
+	}
 	assignment := readCodexAssignment(home, *source)
 	transcript, _ := readCodexTranscriptTail(source.TranscriptPath)
 	if !allowed(home, getenv) {
@@ -59,6 +66,26 @@ func sendCodex(ctx context.Context, home string, getenv func(string) string, inp
 		return "", errEnvelope
 	}
 	return telemetry.SendRuntime(ctx, home, getenv, bytes.NewReader(batch), client), nil
+}
+
+func readCodexTranscriptHead(path string) ([]byte, error) {
+	if path == "" {
+		return nil, nil
+	}
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+	info, err := f.Stat()
+	if err != nil || !info.Mode().IsRegular() {
+		return nil, errEnvelope
+	}
+	data, err := io.ReadAll(io.LimitReader(f, codexTranscriptHeadMaxBytes))
+	if err != nil {
+		return nil, errEnvelope
+	}
+	return data, nil
 }
 
 func readCodexTranscriptTail(path string) ([]byte, error) {

--- a/internal/components/telemetryruntime/codex.go
+++ b/internal/components/telemetryruntime/codex.go
@@ -1,0 +1,161 @@
+package telemetryruntime
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"os"
+
+	"github.com/gentleman-programming/gentle-ai/v2/internal/model"
+	"github.com/gentleman-programming/gentle-ai/v2/internal/state"
+	"github.com/gentleman-programming/gentle-ai/v2/internal/telemetry"
+)
+
+const codexStateMaxBytes = 65536
+
+// SendCodex performs one policy-gated, memory-only normalization and send.
+// It never retries, persists source data, or logs hook fields and paths.
+func SendCodex(ctx context.Context, home string, getenv func(string) string, input io.Reader, client *http.Client) string {
+	decision, err := sendCodex(ctx, home, getenv, input, client)
+	if err != nil {
+		return "discarded"
+	}
+	return decision
+}
+
+func sendCodex(ctx context.Context, home string, getenv func(string) string, input io.Reader, client *http.Client) (string, error) {
+	if !allowed(home, getenv) {
+		return "disabled", nil
+	}
+	data, err := io.ReadAll(io.LimitReader(input, telemetry.CodexMaxBytes+1))
+	if !allowed(home, getenv) {
+		return "disabled", nil
+	}
+	if err != nil || len(data) > telemetry.CodexMaxBytes {
+		return "", errEnvelope
+	}
+	source, err := telemetry.DecodeCodexHook(bytes.NewReader(data))
+	if err != nil {
+		return "", errEnvelope
+	}
+	if source == nil {
+		return "ignored", nil
+	}
+	assignment := readCodexAssignment(home, *source)
+	transcript, _ := readCodexTranscriptTail(source.TranscriptPath)
+	if !allowed(home, getenv) {
+		return "disabled", nil
+	}
+	observation, err := telemetry.NormalizeCodex(*source, bytes.NewReader(transcript), assignment)
+	if err != nil || observation == nil {
+		return "", errEnvelope
+	}
+	batch, err := json.Marshal(telemetry.RuntimeBatch{
+		Schema: telemetry.RuntimeSchema, Registry: json.RawMessage("1"), Host: "codex", Rows: []telemetry.RuntimeRow{observation.Row},
+	})
+	if err != nil || len(batch) > telemetry.RuntimeMaxBytes {
+		return "", errEnvelope
+	}
+	return telemetry.SendRuntime(ctx, home, getenv, bytes.NewReader(batch), client), nil
+}
+
+func readCodexTranscriptTail(path string) ([]byte, error) {
+	if path == "" {
+		return nil, nil
+	}
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+	info, err := f.Stat()
+	if err != nil || !info.Mode().IsRegular() {
+		return nil, errEnvelope
+	}
+	start := int64(0)
+	if info.Size() > telemetry.CodexTranscriptMaxBytes {
+		start = info.Size() - telemetry.CodexTranscriptMaxBytes
+	}
+	readStart := start
+	readLimit := int64(telemetry.CodexTranscriptMaxBytes + 1)
+	if start > 0 {
+		readStart--
+		readLimit++
+	}
+	if _, err := f.Seek(readStart, io.SeekStart); err != nil {
+		return nil, err
+	}
+	data, err := io.ReadAll(io.LimitReader(f, readLimit))
+	if err != nil {
+		return nil, errEnvelope
+	}
+	if start > 0 {
+		if len(data) == 0 || len(data) > telemetry.CodexTranscriptMaxBytes+1 {
+			return nil, errEnvelope
+		}
+		lookBehind := data[0]
+		data = data[1:]
+		if lookBehind != '\n' {
+			newline := bytes.IndexByte(data, '\n')
+			if newline < 0 {
+				return nil, nil
+			}
+			data = data[newline+1:]
+		}
+	} else if len(data) > telemetry.CodexTranscriptMaxBytes {
+		return nil, errEnvelope
+	}
+	return data, nil
+}
+
+func readCodexAssignment(home string, source telemetry.CodexHook) telemetry.CodexAssignment {
+	f, err := os.Open(state.Path(home))
+	if err != nil {
+		return telemetry.CodexAssignment{}
+	}
+	defer f.Close()
+	data, err := io.ReadAll(io.LimitReader(f, codexStateMaxBytes+1))
+	if err != nil || len(data) > codexStateMaxBytes {
+		return telemetry.CodexAssignment{}
+	}
+	var persisted struct {
+		CodexModelAssignments       map[string]string                       `json:"codexModelAssignments"`
+		CodexOrchestratorAssignment *state.CodexOrchestratorAssignmentState `json:"codexOrchestratorAssignment"`
+		CodexCarrilModels           map[string]string                       `json:"codexCarrilModelAssignments"`
+		CodexPhaseModels            map[string]string                       `json:"codexPhaseModelAssignments"`
+	}
+	if json.Unmarshal(data, &persisted) != nil {
+		return telemetry.CodexAssignment{}
+	}
+	if source.Event == "Stop" {
+		if persisted.CodexOrchestratorAssignment == nil {
+			return telemetry.CodexAssignment{}
+		}
+		return telemetry.CodexAssignment{Model: persisted.CodexOrchestratorAssignment.Model, Effort: persisted.CodexOrchestratorAssignment.Effort}
+	}
+	if source.AgentType == "" {
+		return telemetry.CodexAssignment{}
+	}
+	assignment := telemetry.CodexAssignment{
+		Model:  persisted.CodexPhaseModels[source.AgentType],
+		Effort: persisted.CodexModelAssignments[source.AgentType],
+	}
+	if assignment.Model != "" {
+		return assignment
+	}
+	for _, tier := range model.CodexTierGroups() {
+		for _, phase := range tier.Phases {
+			if phase != source.AgentType {
+				continue
+			}
+			assignment.Model = persisted.CodexCarrilModels[tier.Profile]
+			if assignment.Model == "" {
+				assignment.Model = tier.Model
+			}
+			return assignment
+		}
+	}
+	return assignment
+}

--- a/internal/components/telemetryruntime/codex_test.go
+++ b/internal/components/telemetryruntime/codex_test.go
@@ -16,6 +16,11 @@ import (
 	"github.com/gentleman-programming/gentle-ai/v2/internal/telemetry"
 )
 
+const codexRealBridgeTranscriptFixture = `{"timestamp":"PRIVATE_TIME","type":"session_meta","payload":{"id":"PRIVATE_SESSION","source":{"subagent":{"thread_spawn":{"parent_thread_id":"PRIVATE_PARENT","depth":1,"agent_nickname":"PRIVATE_NICKNAME","agent_path":"/root/sdd_explore"}}}}}
+{"timestamp":"PRIVATE_TIME","type":"turn_context","payload":{"turn_id":"PRIVATE_TURN","model":"gpt-5.6-sol","effort":"medium","collaboration_mode":{"settings":{"reasoning_effort":"medium"}}}}
+{"timestamp":"PRIVATE_TIME","type":"event_msg","payload":{"type":"token_count","info":{"last_token_usage":{"input_tokens":120,"cached_input_tokens":20,"cache_write_input_tokens":4,"output_tokens":30,"reasoning_output_tokens":10,"total_tokens":164}}}}
+`
+
 func codexBridgeHome(t *testing.T, enabled bool) string {
 	t.Helper()
 	home := t.TempDir()
@@ -28,10 +33,14 @@ func codexBridgeHome(t *testing.T, enabled bool) string {
 }
 
 func codexBridgeHook(path string) string {
+	return codexBridgeHookForAgent(path, "sdd-apply")
+}
+
+func codexBridgeHookForAgent(path, agentType string) string {
 	encoded, _ := json.Marshal(map[string]any{
 		"session_id": "PRIVATE_SESSION", "transcript_path": "PRIVATE_PARENT", "cwd": "PRIVATE_CWD",
 		"hook_event_name": "SubagentStop", "model": "gpt-5.6-sol", "permission_mode": "default", "turn_id": "PRIVATE_TURN",
-		"agent_id": "PRIVATE_AGENT", "agent_type": "sdd-apply", "agent_transcript_path": path,
+		"agent_id": "PRIVATE_AGENT", "agent_type": agentType, "agent_transcript_path": path,
 		"stop_hook_active": false, "last_assistant_message": "PRIVATE_MESSAGE",
 	})
 	return string(encoded)
@@ -93,6 +102,50 @@ func TestSendCodexPolicyNormalizeAndSendOnce(t *testing.T) {
 	}
 	if !reflect.DeepEqual(before, codexBridgeDisk(t, home)) {
 		t.Fatal("Codex bridge mutated disk")
+	}
+}
+
+func TestSendCodexDerivesTaskNameAndAssignmentFromTranscriptHead(t *testing.T) {
+	home := codexBridgeHome(t, true)
+	if err := state.Write(home, state.InstallState{
+		CodexModelAssignments:      map[string]string{"sdd-explore": "xhigh"},
+		CodexPhaseModelAssignments: map[string]string{"sdd-explore": "gpt-5.4"},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	transcript := filepath.Join(t.TempDir(), "rollout.jsonl")
+	if err := os.WriteFile(transcript, []byte(codexRealBridgeTranscriptFixture), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	client := &http.Client{Transport: codexRoundTrip(func(r *http.Request) (*http.Response, error) {
+		body, _ := io.ReadAll(r.Body)
+		event, err := telemetry.ParseRuntimeEvent(body)
+		if err != nil {
+			t.Fatal(err)
+		}
+		row := event.Rows[0]
+		if row.AgentKind != "built_in" || row.AgentClass != "sdd-explore" || row.Model != (telemetry.RuntimeModel{Provider: "openai-codex", ID: "gpt-5.6-sol"}) || row.ModelEvidence != "response" || row.SelectedEffort != "xhigh" || row.EffectiveEffort != "medium" {
+			t.Fatalf("row=%+v", row)
+		}
+		for name, got := range map[string]string{
+			"input": string(row.Input), "cache_read": string(row.CacheRead), "cache_creation": string(row.CacheCreation),
+			"output": string(row.Output), "reasoning": string(row.ReasoningTokens), "total": string(row.TotalTokens),
+		} {
+			want := map[string]string{"input": "120", "cache_read": "20", "cache_creation": "4", "output": "30", "reasoning": "10", "total": "164"}[name]
+			if got != tokenReportedBridge(want) {
+				t.Errorf("%s=%s want=%s", name, got, tokenReportedBridge(want))
+			}
+		}
+		for _, private := range []string{"PRIVATE", "/root/sdd_explore", "agent_path", "agent_nickname"} {
+			if bytes.Contains(body, []byte(private)) {
+				t.Fatalf("private transcript metadata leaked: %s", body)
+			}
+		}
+		return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(`{"schema":"gentle-ai.telemetry-runtime-delivery/v1","decision":"stored"}`))}, nil
+	})}
+	t.Setenv(telemetry.EndpointEnvVar, "https://telemetry.example.invalid")
+	if got := SendCodex(context.Background(), home, os.Getenv, strings.NewReader(codexBridgeHookForAgent(transcript, "default")), client); got != "stored" {
+		t.Fatal(got)
 	}
 }
 
@@ -187,6 +240,18 @@ func TestCodexTranscriptTailKeepsRecordAtExactBoundary(t *testing.T) {
 	got, err := readCodexTranscriptTail(path)
 	if err != nil || !bytes.Equal(got, want) || len(got) != telemetry.CodexTranscriptMaxBytes {
 		t.Fatalf("tail len=%d err=%v starts-with-record=%t", len(got), err, bytes.HasPrefix(got, record))
+	}
+}
+
+func TestCodexTranscriptHeadIsBounded(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "rollout.jsonl")
+	content := bytes.Repeat([]byte("x"), codexTranscriptHeadMaxBytes+1024)
+	if err := os.WriteFile(path, content, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	got, err := readCodexTranscriptHead(path)
+	if err != nil || len(got) != codexTranscriptHeadMaxBytes || !bytes.Equal(got, content[:codexTranscriptHeadMaxBytes]) {
+		t.Fatalf("head len=%d err=%v", len(got), err)
 	}
 }
 

--- a/internal/components/telemetryruntime/codex_test.go
+++ b/internal/components/telemetryruntime/codex_test.go
@@ -1,0 +1,222 @@
+package telemetryruntime
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/gentleman-programming/gentle-ai/v2/internal/state"
+	"github.com/gentleman-programming/gentle-ai/v2/internal/telemetry"
+)
+
+func codexBridgeHome(t *testing.T, enabled bool) string {
+	t.Helper()
+	home := t.TempDir()
+	t.Setenv("DO_NOT_TRACK", "")
+	t.Setenv("GENTLE_AI_TELEMETRY", "")
+	if err := telemetry.Save(home, telemetry.State{InstallID: "PRIVATE_INSTALL", Enabled: enabled, NoticeShown: true}); err != nil {
+		t.Fatal(err)
+	}
+	return home
+}
+
+func codexBridgeHook(path string) string {
+	encoded, _ := json.Marshal(map[string]any{
+		"session_id": "PRIVATE_SESSION", "transcript_path": "PRIVATE_PARENT", "cwd": "PRIVATE_CWD",
+		"hook_event_name": "SubagentStop", "model": "gpt-5.6-sol", "permission_mode": "default", "turn_id": "PRIVATE_TURN",
+		"agent_id": "PRIVATE_AGENT", "agent_type": "sdd-apply", "agent_transcript_path": path,
+		"stop_hook_active": false, "last_assistant_message": "PRIVATE_MESSAGE",
+	})
+	return string(encoded)
+}
+
+func codexStopBridgeHook(path string) string {
+	encoded, _ := json.Marshal(map[string]any{
+		"session_id": "PRIVATE_SESSION", "transcript_path": path, "cwd": "PRIVATE_CWD",
+		"hook_event_name": "Stop", "model": "gpt-5.6-sol", "permission_mode": "default", "turn_id": "PRIVATE_TURN",
+		"stop_hook_active": false, "last_assistant_message": "PRIVATE_MESSAGE",
+	})
+	return string(encoded)
+}
+
+type codexRoundTrip func(*http.Request) (*http.Response, error)
+
+func (f codexRoundTrip) RoundTrip(request *http.Request) (*http.Response, error) {
+	return f(request)
+}
+
+func TestSendCodexPolicyNormalizeAndSendOnce(t *testing.T) {
+	home := codexBridgeHome(t, true)
+	if err := state.Write(home, state.InstallState{
+		CodexModelAssignments:      map[string]string{"sdd-apply": "medium"},
+		CodexPhaseModelAssignments: map[string]string{"sdd-apply": "gpt-5.6-terra"},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	transcript := filepath.Join(t.TempDir(), "rollout.jsonl")
+	content := `{"type":"turn_context","payload":{"model":"gpt-5.6-sol","effort":"high","summary":"PRIVATE_SUMMARY"}}
+{"type":"event_msg","payload":{"type":"token_count","info":{"last_token_usage":{"input_tokens":7,"output_tokens":2,"total_tokens":9}}}}
+`
+	if err := os.WriteFile(transcript, []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	requests := 0
+	client := &http.Client{Transport: codexRoundTrip(func(r *http.Request) (*http.Response, error) {
+		requests++
+		body, _ := io.ReadAll(r.Body)
+		event, err := telemetry.ParseRuntimeEvent(body)
+		if err != nil || event.Host != "codex" || len(event.Rows) != 1 {
+			t.Fatalf("event=%+v err=%v", event, err)
+		}
+		row := event.Rows[0]
+		if row.AgentClass != "sdd-apply" || row.SelectedEffort != "medium" || row.EffectiveEffort != "high" || row.Model.ID != "gpt-5.6-sol" || row.ModelEvidence != "response" {
+			t.Fatalf("row=%+v", row)
+		}
+		for _, private := range []string{"PRIVATE", transcript, "transcript_path", "agent_id", "last_assistant_message"} {
+			if bytes.Contains(body, []byte(private)) {
+				t.Fatalf("private data leaked: %s", body)
+			}
+		}
+		return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(`{"schema":"gentle-ai.telemetry-runtime-delivery/v1","decision":"stored"}`))}, nil
+	})}
+	t.Setenv(telemetry.EndpointEnvVar, "https://telemetry.example.invalid")
+	before := codexBridgeDisk(t, home)
+	if got := SendCodex(context.Background(), home, os.Getenv, strings.NewReader(codexBridgeHook(transcript)), client); got != "stored" || requests != 1 {
+		t.Fatalf("decision=%q requests=%d", got, requests)
+	}
+	if !reflect.DeepEqual(before, codexBridgeDisk(t, home)) {
+		t.Fatal("Codex bridge mutated disk")
+	}
+}
+
+type codexNoRead struct{ t *testing.T }
+
+func (r codexNoRead) Read([]byte) (int, error) {
+	r.t.Fatal("read before telemetry policy")
+	return 0, io.EOF
+}
+
+func TestSendCodexPolicyBeforeRead(t *testing.T) {
+	home := codexBridgeHome(t, false)
+	if got := SendCodex(context.Background(), home, os.Getenv, codexNoRead{t}, nil); got != "disabled" {
+		t.Fatalf("decision=%q", got)
+	}
+}
+
+func TestSendCodexSelectedModelFallbackAndUnknownAgent(t *testing.T) {
+	home := codexBridgeHome(t, true)
+	if err := state.Write(home, state.InstallState{
+		CodexModelAssignments:      map[string]string{"sdd-apply": "xhigh"},
+		CodexPhaseModelAssignments: map[string]string{"sdd-apply": "gpt-5.4"},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	client := &http.Client{Transport: codexRoundTrip(func(r *http.Request) (*http.Response, error) {
+		body, _ := io.ReadAll(r.Body)
+		event, err := telemetry.ParseRuntimeEvent(body)
+		if err != nil {
+			t.Fatal(err)
+		}
+		row := event.Rows[0]
+		if row.Model.ID != "gpt-5.4" || row.ModelEvidence != "selected" || row.SelectedEffort != "xhigh" {
+			t.Fatalf("row=%+v", row)
+		}
+		return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(`{"schema":"gentle-ai.telemetry-runtime-delivery/v1","decision":"stored"}`))}, nil
+	})}
+	t.Setenv(telemetry.EndpointEnvVar, "https://telemetry.example.invalid")
+	if got := SendCodex(context.Background(), home, os.Getenv, strings.NewReader(codexBridgeHook(filepath.Join(t.TempDir(), "missing.jsonl"))), client); got != "stored" {
+		t.Fatal(got)
+	}
+}
+
+func TestSendCodexStopReadsTranscriptAsOrchestratorUsage(t *testing.T) {
+	home := codexBridgeHome(t, true)
+	transcript := filepath.Join(t.TempDir(), "rollout.jsonl")
+	content := `{"type":"turn_context","payload":{"model":"gpt-5.6-sol","effort":"high"}}
+{"type":"event_msg","payload":{"type":"token_count","info":{"last_token_usage":{"input_tokens":7,"total_tokens":9}}}}
+`
+	if err := os.WriteFile(transcript, []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	client := &http.Client{Transport: codexRoundTrip(func(r *http.Request) (*http.Response, error) {
+		body, _ := io.ReadAll(r.Body)
+		event, err := telemetry.ParseRuntimeEvent(body)
+		if err != nil {
+			t.Fatal(err)
+		}
+		row := event.Rows[0]
+		if row.AgentKind != "orchestrator" || row.AgentClass != "orchestrator" || row.Model.ID != "gpt-5.6-sol" || string(row.Input) != tokenReportedBridge("7") || string(row.TotalTokens) != tokenReportedBridge("9") {
+			t.Fatalf("row=%+v", row)
+		}
+		return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(`{"schema":"gentle-ai.telemetry-runtime-delivery/v1","decision":"stored"}`))}, nil
+	})}
+	t.Setenv(telemetry.EndpointEnvVar, "https://telemetry.example.invalid")
+	if got := SendCodex(context.Background(), home, os.Getenv, strings.NewReader(codexStopBridgeHook(transcript)), client); got != "stored" {
+		t.Fatal(got)
+	}
+}
+
+func TestCodexTranscriptTailIsBoundedAndDropsPartialLine(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "rollout.jsonl")
+	prefix := bytes.Repeat([]byte("x"), telemetry.CodexTranscriptMaxBytes)
+	want := []byte("{\"type\":\"turn_context\",\"payload\":{\"model\":\"gpt-5.4\",\"effort\":\"low\"}}\n")
+	if err := os.WriteFile(path, append(append(prefix, '\n'), want...), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	got, err := readCodexTranscriptTail(path)
+	if err != nil || !bytes.Equal(got, want) || len(got) > telemetry.CodexTranscriptMaxBytes {
+		t.Fatalf("tail len=%d err=%v got-prefix=%q", len(got), err, got[:min(len(got), 32)])
+	}
+}
+
+func TestCodexTranscriptTailKeepsRecordAtExactBoundary(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "rollout.jsonl")
+	record := []byte("{\"type\":\"turn_context\",\"payload\":{\"model\":\"gpt-5.6-sol\",\"effort\":\"high\"}}\n")
+	want := append([]byte(nil), record...)
+	want = append(want, bytes.Repeat([]byte("\n"), telemetry.CodexTranscriptMaxBytes-len(want))...)
+	if err := os.WriteFile(path, append([]byte("discarded\n"), want...), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	got, err := readCodexTranscriptTail(path)
+	if err != nil || !bytes.Equal(got, want) || len(got) != telemetry.CodexTranscriptMaxBytes {
+		t.Fatalf("tail len=%d err=%v starts-with-record=%t", len(got), err, bytes.HasPrefix(got, record))
+	}
+}
+
+func tokenReportedBridge(value string) string {
+	return `{"reported":1,"unavailable":0,"unsupported":0,"sum":` + value + `}`
+}
+
+func codexBridgeDisk(t *testing.T, root string) map[string]string {
+	t.Helper()
+	result := map[string]string{}
+	if err := filepath.WalkDir(root, func(path string, entry os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		rel, _ := filepath.Rel(root, path)
+		info, err := entry.Info()
+		if err != nil {
+			return err
+		}
+		result[rel] = info.Mode().String()
+		if !entry.IsDir() {
+			data, err := os.ReadFile(path)
+			if err != nil {
+				return err
+			}
+			result[rel] += string(data)
+		}
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+	return result
+}

--- a/internal/components/telemetryruntime/codex_test.go
+++ b/internal/components/telemetryruntime/codex_test.go
@@ -26,6 +26,8 @@ func codexBridgeHome(t *testing.T, enabled bool) string {
 	home := t.TempDir()
 	t.Setenv("DO_NOT_TRACK", "")
 	t.Setenv("GENTLE_AI_TELEMETRY", "")
+	t.Setenv("CI", "")
+	t.Setenv("GITHUB_ACTIONS", "")
 	if err := telemetry.Save(home, telemetry.State{InstallID: "PRIVATE_INSTALL", Enabled: enabled, NoticeShown: true}); err != nil {
 		t.Fatal(err)
 	}

--- a/internal/components/telemetryruntime/managed.go
+++ b/internal/components/telemetryruntime/managed.go
@@ -18,6 +18,16 @@ import (
 const ownershipSchema = "gentle-ai.telemetry-runtime-ownership/v1"
 const ownershipMarker = "// gentle-ai:managed telemetry-runtime/v1\n"
 
+// approvedPriorPluginDigests is an append-only provenance allowlist. Each
+// managed plugin change must add the immediately previous embedded asset digest.
+// Commit a9cab7dd embedded telemetry-runtime.ts with SHA-256
+// 902fe09299c0bb04590f12ba993a196b838e1fbbd8a94e96100ea3d5f30182b7.
+const priorPluginDigestA9cab7dd = "902fe09299c0bb04590f12ba993a196b838e1fbbd8a94e96100ea3d5f30182b7"
+
+var approvedPriorPluginDigests = map[string]struct{}{
+	priorPluginDigestA9cab7dd: {},
+}
+
 // Windows exposes writable regular files as 0666 regardless of the requested
 // POSIX permission bits. Retain exact modes elsewhere and never equate a
 // read-only file with a writable managed file.
@@ -120,11 +130,10 @@ func inspect(configDir string) ([][]byte, error) {
 		(!managedModeMatches(0600, os.FileMode(manifest.File.Mode)) && !managedModeMatches(0644, os.FileMode(manifest.File.Mode))) || manifest.File.AfterHash != fmt.Sprintf("%x", sha256.Sum256([]byte(manifest.File.After))) {
 		return nil, conflict
 	}
-	// This first, unreleased adapter has no approved historical asset versions.
-	// A self-consistent user-edited pair is not package provenance. Future asset
-	// upgrades must explicitly retain approved prior digests, never learn from disk.
 	embedded, err := assets.Read("opencode/plugins/telemetry-runtime.ts")
-	if err != nil || manifest.File.After != embedded {
+	embeddedDigest := fmt.Sprintf("%x", sha256.Sum256([]byte(embedded)))
+	_, approvedPrior := approvedPriorPluginDigests[manifest.File.AfterHash]
+	if err != nil || (manifest.File.AfterHash != embeddedDigest && !approvedPrior) {
 		return nil, conflict
 	}
 	for i, path := range paths {

--- a/internal/components/telemetryruntime/managed_test.go
+++ b/internal/components/telemetryruntime/managed_test.go
@@ -5,16 +5,127 @@ import (
 	"crypto/sha256"
 	"encoding/json"
 	"fmt"
-	"github.com/gentleman-programming/gentle-ai/v2/internal/components/mutationjournal"
 	"os"
 	"path/filepath"
 	"runtime"
 	"strings"
 	"testing"
+
+	"github.com/gentleman-programming/gentle-ai/v2/internal/assets"
+	"github.com/gentleman-programming/gentle-ai/v2/internal/components/mutationjournal"
 )
 
-// Exercise the retained guard with a genuine changed prior image, independently
-// of the initial release's intentionally empty historical-asset approval set.
+func TestOpenCodeTelemetryApprovedPriorAssetUpgrade(t *testing.T) {
+	dir := t.TempDir()
+	prior, err := os.ReadFile("testdata/telemetry-runtime-a9cab7dd.ts")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if digest := fmt.Sprintf("%x", sha256.Sum256(prior)); digest != priorPluginDigestA9cab7dd {
+		t.Fatalf("prior asset digest = %s, want %s", digest, priorPluginDigestA9cab7dd)
+	}
+	writeManagedTelemetryFixture(t, dir, prior)
+
+	changed, err := Reconcile(dir)
+	if err != nil {
+		t.Fatalf("upgrade approved prior asset: %v", err)
+	}
+	if len(changed) != 2 {
+		t.Fatalf("upgrade changed %d files, want plugin and manifest", len(changed))
+	}
+	paths := ManagedPaths(dir)
+	current := assets.MustRead("opencode/plugins/telemetry-runtime.ts")
+	if plugin, err := os.ReadFile(paths[0]); err != nil || string(plugin) != current {
+		t.Fatalf("plugin was not upgraded: %v", err)
+	}
+	manifestBytes, err := os.ReadFile(paths[1])
+	if err != nil {
+		t.Fatal(err)
+	}
+	var manifest managedManifest
+	if err := json.Unmarshal(manifestBytes, &manifest); err != nil {
+		t.Fatal(err)
+	}
+	if manifest.File.After != current || manifest.File.AfterHash != fmt.Sprintf("%x", sha256.Sum256([]byte(current))) {
+		t.Fatal("ownership manifest was not refreshed to the current asset")
+	}
+	if err := CheckManaged(dir); err != nil {
+		t.Fatalf("upgraded asset is not currently owned: %v", err)
+	}
+	customPath := filepath.Join(dir, "plugins", "custom.ts")
+	if err := os.WriteFile(customPath, []byte("custom"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	removed, err := RemoveManaged(dir)
+	if err != nil || len(removed) != 2 {
+		t.Fatalf("remove upgraded owned asset: %v, paths=%v", err, removed)
+	}
+	for _, path := range paths {
+		if _, err := os.Lstat(path); !os.IsNotExist(err) {
+			t.Fatalf("owned path remains after uninstall: %s: %v", path, err)
+		}
+	}
+	if custom, err := os.ReadFile(customPath); err != nil || string(custom) != "custom" {
+		t.Fatalf("uninstall changed unrelated file: %q, %v", custom, err)
+	}
+}
+
+func TestOpenCodeTelemetryUnapprovedPriorAssetConflicts(t *testing.T) {
+	dir := t.TempDir()
+	unapproved := []byte(ownershipMarker + "// unapproved historical content\n")
+	writeManagedTelemetryFixture(t, dir, unapproved)
+	paths := ManagedPaths(dir)
+
+	if err := CheckManaged(dir); err == nil {
+		t.Fatal("unapproved prior asset passed ownership validation")
+	}
+	if _, err := Reconcile(dir); err == nil {
+		t.Fatal("unapproved prior asset was upgraded")
+	}
+	if _, err := RemoveManaged(dir); err == nil {
+		t.Fatal("unapproved prior asset was removed")
+	}
+	if plugin, err := os.ReadFile(paths[0]); err != nil || !bytes.Equal(plugin, unapproved) {
+		t.Fatalf("unapproved plugin was not preserved: %v", err)
+	}
+}
+
+func TestOpenCodeTelemetryCurrentAssetRemainsOwned(t *testing.T) {
+	dir := t.TempDir()
+	if changed, err := Reconcile(dir); err != nil || len(changed) != 2 {
+		t.Fatalf("install current asset: changed=%v err=%v", changed, err)
+	}
+	if changed, err := Reconcile(dir); err != nil || len(changed) != 0 {
+		t.Fatalf("current asset is not idempotent: changed=%v err=%v", changed, err)
+	}
+	if err := CheckManaged(dir); err != nil {
+		t.Fatalf("current asset is not owned: %v", err)
+	}
+}
+
+func writeManagedTelemetryFixture(t *testing.T, dir string, content []byte) {
+	t.Helper()
+	paths := ManagedPaths(dir)
+	if err := os.MkdirAll(filepath.Dir(paths[0]), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(paths[0], content, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	manifest := managedManifest{Schema: ownershipSchema, File: mutationjournal.OwnedFile{
+		After: string(content), AfterHash: fmt.Sprintf("%x", sha256.Sum256(content)), Overlay: false, Mode: 0o644,
+	}}
+	raw, err := json.MarshalIndent(manifest, "", "  ")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(paths[1], append(raw, '\n'), 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// Exercise the retained rollback guard with a synthetic changed prior image,
+// independently of the approved-digest upgrade path.
 func TestOpenCodeTelemetryOwnedUpdateRollback(t *testing.T) {
 	for _, edited := range []int{0, 1} {
 		t.Run(fmt.Sprint(edited), func(t *testing.T) {

--- a/internal/components/telemetryruntime/opencode.go
+++ b/internal/components/telemetryruntime/opencode.go
@@ -18,7 +18,7 @@ import (
 )
 
 const OpenCodeSchema = "gentle-ai.telemetry-opencode/v1"
-const openCodeConfigMaxBytes = 65536
+const openCodeConfigMaxBytes = 1 << 20
 
 var errEnvelope = errors.New("invalid OpenCode runtime envelope")
 

--- a/internal/components/telemetryruntime/opencode.go
+++ b/internal/components/telemetryruntime/opencode.go
@@ -8,11 +8,17 @@ import (
 	"errors"
 	"io"
 	"net/http"
+	"os"
+	"strings"
 
+	"github.com/gentleman-programming/gentle-ai/v2/internal/components/filemerge"
+	"github.com/gentleman-programming/gentle-ai/v2/internal/model"
+	"github.com/gentleman-programming/gentle-ai/v2/internal/opencode"
 	"github.com/gentleman-programming/gentle-ai/v2/internal/telemetry"
 )
 
 const OpenCodeSchema = "gentle-ai.telemetry-opencode/v1"
+const openCodeConfigMaxBytes = 65536
 
 var errEnvelope = errors.New("invalid OpenCode runtime envelope")
 
@@ -28,6 +34,7 @@ type openCodeInfo struct {
 	} `json:"time"`
 	ProviderID string `json:"providerID"`
 	ModelID    string `json:"modelID"`
+	Agent      string `json:"agent,omitempty"`
 	Summary    bool   `json:"summary,omitempty"`
 	Tokens     *struct {
 		Input     *json.RawMessage `json:"input,omitempty"`
@@ -113,11 +120,48 @@ func sendOpenCode(ctx context.Context, home string, getenv func(string) string, 
 	if observation == nil {
 		return "ignored", nil
 	}
+	applyOpenCodeAssignment(&observation.Row, readOpenCodeAssignment(home, observation.Agent))
 	batch, err := json.Marshal(telemetry.RuntimeBatch{Schema: telemetry.RuntimeSchema, Registry: json.RawMessage("1"), Host: "opencode", Rows: []telemetry.RuntimeRow{observation.Row}})
 	if err != nil {
 		return "", errEnvelope
 	}
 	return telemetry.SendRuntime(ctx, home, getenv, bytes.NewReader(batch), client), nil
+}
+
+func applyOpenCodeAssignment(row *telemetry.RuntimeRow, assignment model.ModelAssignment) {
+	if telemetry.RuntimeEffortAllowed(assignment.Effort) {
+		row.SelectedEffort = assignment.Effort
+	}
+	if row.ModelEvidence == "unknown" && assignment.ProviderID != "" && assignment.ModelID != "" {
+		row.Model = telemetry.NormalizeRuntimeModel(assignment.ProviderID, assignment.ModelID)
+		row.ModelEvidence = "selected"
+	}
+}
+
+func readOpenCodeAssignment(home, agent string) model.ModelAssignment {
+	if agent == "" {
+		return model.ModelAssignment{}
+	}
+	path := opencode.DefaultSettingsPathForHome(home)
+	file, err := os.Open(path)
+	if err != nil {
+		return model.ModelAssignment{}
+	}
+	defer file.Close()
+	data, err := io.ReadAll(io.LimitReader(file, openCodeConfigMaxBytes+1))
+	if err != nil || len(data) > openCodeConfigMaxBytes {
+		return model.ModelAssignment{}
+	}
+	root, err := filemerge.UnmarshalJSONObject(data)
+	if err != nil {
+		return model.ModelAssignment{}
+	}
+	agents, _ := root["agent"].(map[string]any)
+	definition, _ := agents[agent].(map[string]any)
+	modelSpec, _ := definition["model"].(string)
+	provider, modelID, _ := model.SplitModelSpec(strings.TrimSpace(modelSpec))
+	effort, _ := definition["variant"].(string)
+	return model.ModelAssignment{ProviderID: provider, ModelID: modelID, Effort: effort}
 }
 
 // Reject duplicate keys and case aliases before struct decoding. All accepted
@@ -151,7 +195,7 @@ func strictObjectKeys(d *json.Decoder, depth int) error {
 			return errEnvelope
 		}
 		switch s {
-		case "schema", "info", "role", "time", "created", "completed", "providerID", "modelID", "summary", "tokens", "input", "output", "reasoning", "cache", "read", "write", "error", "name", "data", "statusCode":
+		case "schema", "info", "role", "time", "created", "completed", "providerID", "modelID", "agent", "summary", "tokens", "input", "output", "reasoning", "cache", "read", "write", "error", "name", "data", "statusCode":
 		default:
 			return errEnvelope
 		}

--- a/internal/components/telemetryruntime/opencode.go
+++ b/internal/components/telemetryruntime/opencode.go
@@ -1,4 +1,4 @@
-// Package telemetryruntime owns the OpenCode event adapter and its managed hook.
+// Package telemetryruntime owns native runtime event adapters and managed hooks.
 package telemetryruntime
 
 import (

--- a/internal/components/telemetryruntime/opencode_test.go
+++ b/internal/components/telemetryruntime/opencode_test.go
@@ -1,0 +1,83 @@
+package telemetryruntime
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/gentleman-programming/gentle-ai/v2/internal/model"
+	"github.com/gentleman-programming/gentle-ai/v2/internal/telemetry"
+)
+
+func TestReadOpenCodeAssignment(t *testing.T) {
+	for _, tt := range []struct {
+		name   string
+		config string
+		agent  string
+		want   model.ModelAssignment
+	}{
+		{
+			name:   "reads model and effort for the observed agent",
+			config: `{"agent":{"sdd-apply":{"model":"openai/gpt-5.6","variant":"high"},"private-agent":{"model":"anthropic/claude-opus-5","variant":"xhigh"}}}`,
+			agent:  "sdd-apply",
+			want:   model.ModelAssignment{ProviderID: "openai", ModelID: "gpt-5.6", Effort: "high"},
+		},
+		{name: "missing agent", config: `{"agent":{}}`, agent: "sdd-apply"},
+		{name: "invalid config", config: `{`, agent: "sdd-apply"},
+		{name: "oversized config", config: strings.Repeat(" ", openCodeConfigMaxBytes+1), agent: "sdd-apply"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			home := t.TempDir()
+			t.Setenv("HOME", home)
+			t.Setenv("XDG_CONFIG_HOME", "")
+			path := filepath.Join(home, ".config", "opencode", "opencode.json")
+			if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.WriteFile(path, []byte(tt.config), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			if got := readOpenCodeAssignment(home, tt.agent); got != tt.want {
+				t.Fatalf("readOpenCodeAssignment() = %+v, want %+v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestApplyOpenCodeAssignment(t *testing.T) {
+	for _, tt := range []struct {
+		name       string
+		row        telemetry.RuntimeRow
+		assignment model.ModelAssignment
+		wantModel  telemetry.RuntimeModel
+		wantProof  string
+		wantEffort string
+	}{
+		{
+			name:       "response model wins and selected effort is retained",
+			row:        telemetry.RuntimeRow{Model: telemetry.RuntimeModel{Provider: "openai", ID: "gpt-5.4"}, ModelEvidence: "response", SelectedEffort: "unavailable"},
+			assignment: model.ModelAssignment{ProviderID: "openai", ModelID: "gpt-5.6", Effort: "high"},
+			wantModel:  telemetry.RuntimeModel{Provider: "openai", ID: "gpt-5.4"}, wantProof: "response", wantEffort: "high",
+		},
+		{
+			name:       "selected model fills absent response model",
+			row:        telemetry.RuntimeRow{Model: telemetry.RuntimeModel{Provider: "unknown", ID: "unknown"}, ModelEvidence: "unknown", SelectedEffort: "unavailable"},
+			assignment: model.ModelAssignment{ProviderID: "anthropic", ModelID: "claude-opus-5", Effort: "xhigh"},
+			wantModel:  telemetry.RuntimeModel{Provider: "anthropic", ID: "claude-opus-5"}, wantProof: "selected", wantEffort: "xhigh",
+		},
+		{
+			name:       "invalid effort is unavailable",
+			row:        telemetry.RuntimeRow{Model: telemetry.RuntimeModel{Provider: "unknown", ID: "unknown"}, ModelEvidence: "unknown", SelectedEffort: "unavailable"},
+			assignment: model.ModelAssignment{ProviderID: "private", ModelID: "private", Effort: "turbo"},
+			wantModel:  telemetry.RuntimeModel{Provider: "custom", ID: "custom"}, wantProof: "selected", wantEffort: "unavailable",
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			applyOpenCodeAssignment(&tt.row, tt.assignment)
+			if tt.row.Model != tt.wantModel || tt.row.ModelEvidence != tt.wantProof || tt.row.SelectedEffort != tt.wantEffort {
+				t.Fatalf("row = %+v", tt.row)
+			}
+		})
+	}
+}

--- a/internal/components/telemetryruntime/opencode_test.go
+++ b/internal/components/telemetryruntime/opencode_test.go
@@ -1,6 +1,9 @@
 package telemetryruntime
 
 import (
+	"context"
+	"io"
+	"net/http"
 	"os"
 	"path/filepath"
 	"strings"
@@ -9,6 +12,56 @@ import (
 	"github.com/gentleman-programming/gentle-ai/v2/internal/model"
 	"github.com/gentleman-programming/gentle-ai/v2/internal/telemetry"
 )
+
+type openCodeTestRoundTrip func(*http.Request) (*http.Response, error)
+
+func (fn openCodeTestRoundTrip) RoundTrip(request *http.Request) (*http.Response, error) {
+	return fn(request)
+}
+
+func TestSendOpenCodeReadsAssignmentFromRealisticLargeConfig(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", "")
+	t.Setenv("DO_NOT_TRACK", "")
+	t.Setenv("GENTLE_AI_TELEMETRY", "")
+	t.Setenv("CI", "")
+	t.Setenv("GITHUB_ACTIONS", "")
+	if err := telemetry.Save(home, telemetry.State{InstallID: "local", Enabled: true, NoticeShown: true}); err != nil {
+		t.Fatal(err)
+	}
+	config := `{"padding":"` + strings.Repeat("x", 70*1024) + `","agent":{"gentle-orchestrator":{"model":"openai/gpt-5.6-sol","variant":"medium"}}}`
+	path := filepath.Join(home, ".config", "opencode", "opencode.json")
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(config), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	var got telemetry.RuntimeEvent
+	client := &http.Client{Transport: openCodeTestRoundTrip(func(request *http.Request) (*http.Response, error) {
+		body, err := io.ReadAll(request.Body)
+		if err != nil {
+			t.Fatal(err)
+		}
+		got, err = telemetry.ParseRuntimeEvent(body)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return &http.Response{StatusCode: http.StatusOK, Header: make(http.Header), Body: io.NopCloser(strings.NewReader(`{"schema":"gentle-ai.telemetry-runtime-delivery/v1","decision":"stored"}`))}, nil
+	})}
+	envelope := `{"schema":"gentle-ai.telemetry-opencode/v1","info":{"role":"assistant","time":{"created":1,"completed":3},"providerID":"openai","modelID":"gpt-5.6-sol","agent":"gentle-orchestrator"}}`
+	if decision := SendOpenCode(context.Background(), home, os.Getenv, strings.NewReader(envelope), client); decision != "stored" {
+		t.Fatalf("SendOpenCode() decision = %q, want stored", decision)
+	}
+	if len(got.Rows) != 1 {
+		t.Fatalf("runtime rows = %d, want 1", len(got.Rows))
+	}
+	row := got.Rows[0]
+	if row.AgentKind != "orchestrator" || row.AgentClass != "orchestrator" || row.SelectedEffort != "medium" || row.Model != (telemetry.RuntimeModel{Provider: "openai", ID: "gpt-5.6-sol"}) || row.ModelEvidence != "response" {
+		t.Fatalf("runtime row = %+v", row)
+	}
+}
 
 func TestReadOpenCodeAssignment(t *testing.T) {
 	for _, tt := range []struct {
@@ -19,13 +72,21 @@ func TestReadOpenCodeAssignment(t *testing.T) {
 	}{
 		{
 			name:   "reads model and effort for the observed agent",
-			config: `{"agent":{"sdd-apply":{"model":"openai/gpt-5.6","variant":"high"},"private-agent":{"model":"anthropic/claude-opus-5","variant":"xhigh"}}}`,
+			config: `{"agent":{"sdd-apply":{"model":"openai/gpt-5.6","variant":"high"}}}`,
 			agent:  "sdd-apply",
 			want:   model.ModelAssignment{ProviderID: "openai", ModelID: "gpt-5.6", Effort: "high"},
 		},
+		{name: "reads orchestrator assignment", config: `{"agent":{"gentle-orchestrator":{"model":"openai/gpt-5.6-sol","variant":"medium"}}}`, agent: "gentle-orchestrator", want: model.ModelAssignment{ProviderID: "openai", ModelID: "gpt-5.6-sol", Effort: "medium"}},
+		{name: "reads native build assignment", config: `{"agent":{"build":{"model":"openai/gpt-5.6","variant":"low"}}}`, agent: "build", want: model.ModelAssignment{ProviderID: "openai", ModelID: "gpt-5.6", Effort: "low"}},
+		{name: "reads native plan assignment", config: `{"agent":{"plan":{"model":"openai/gpt-5.6","variant":"max"}}}`, agent: "plan", want: model.ModelAssignment{ProviderID: "openai", ModelID: "gpt-5.6", Effort: "max"}},
+		{name: "reads custom assignment without filtering", config: `{"agent":{"private-agent":{"model":"anthropic/claude-opus-5","variant":"xhigh"}}}`, agent: "private-agent", want: model.ModelAssignment{ProviderID: "anthropic", ModelID: "claude-opus-5", Effort: "xhigh"}},
 		{name: "missing agent", config: `{"agent":{}}`, agent: "sdd-apply"},
 		{name: "invalid config", config: `{`, agent: "sdd-apply"},
-		{name: "oversized config", config: strings.Repeat(" ", openCodeConfigMaxBytes+1), agent: "sdd-apply"},
+		{
+			name:   "oversized config",
+			config: `{"agent":{"sdd-apply":{"model":"openai/gpt-5.6","variant":"high"}},"padding":"` + strings.Repeat("x", openCodeConfigMaxBytes) + `"}`,
+			agent:  "sdd-apply",
+		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			home := t.TempDir()
@@ -72,6 +133,9 @@ func TestApplyOpenCodeAssignment(t *testing.T) {
 			assignment: model.ModelAssignment{ProviderID: "private", ModelID: "private", Effort: "turbo"},
 			wantModel:  telemetry.RuntimeModel{Provider: "custom", ID: "custom"}, wantProof: "selected", wantEffort: "unavailable",
 		},
+		{name: "low effort", row: telemetry.RuntimeRow{SelectedEffort: "unavailable"}, assignment: model.ModelAssignment{Effort: "low"}, wantEffort: "low"},
+		{name: "medium effort", row: telemetry.RuntimeRow{SelectedEffort: "unavailable"}, assignment: model.ModelAssignment{Effort: "medium"}, wantEffort: "medium"},
+		{name: "max effort", row: telemetry.RuntimeRow{SelectedEffort: "unavailable"}, assignment: model.ModelAssignment{Effort: "max"}, wantEffort: "max"},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			applyOpenCodeAssignment(&tt.row, tt.assignment)

--- a/internal/components/telemetryruntime/testdata/telemetry-runtime-a9cab7dd.ts
+++ b/internal/components/telemetryruntime/testdata/telemetry-runtime-a9cab7dd.ts
@@ -1,0 +1,67 @@
+// gentle-ai:managed telemetry-runtime/v1
+// Published plugin 1.18.30 imports SDK V1, not /v2:
+// https://unpkg.com/@opencode-ai/plugin@1.18.30/dist/index.d.ts
+import type { Plugin } from "@opencode-ai/plugin"
+import { execFile } from "node:child_process"
+
+const MAX_IN_FLIGHT = 32
+const MAX_BYTES = 16384
+
+function veto(): boolean {
+  const truthy = (value: string | undefined) => !["", "0", "false"].includes((value ?? "").trim().toLowerCase())
+  return truthy(process.env.DO_NOT_TRACK) || process.env.GENTLE_AI_TELEMETRY === "0"
+    || truthy(process.env.CI) || truthy(process.env.GITHUB_ACTIONS)
+}
+
+// One event -> one native process -> one send attempt. No queue, retry, metric
+// files, session/message identities, dedupe map, policy cache, or SDK retrieval.
+// The hook never awaits the process (and therefore never awaits network).
+const telemetryRuntime: Plugin = async () => {
+  const children = new Set<ReturnType<typeof execFile>>()
+  let disposed = false
+  return {
+    event: async ({ event }) => {
+      if (disposed || veto() || children.size >= MAX_IN_FLIGHT || event.type !== "message.updated") return
+      const info = event.properties.info
+      if (info.role !== "assistant" || info.summary || !Number.isSafeInteger(info.time?.completed)) return
+      try {
+        const tokens = info.tokens
+        const error = info.error
+        const knownErrors = ["ProviderAuthError", "UnknownError", "MessageOutputLengthError", "MessageAbortedError", "APIError"]
+        const body = JSON.stringify({
+          schema: "gentle-ai.telemetry-opencode/v1",
+          info: {
+            role: "assistant",
+            time: { created: info.time.created, completed: info.time.completed },
+            providerID: info.providerID,
+            modelID: info.modelID,
+            tokens: tokens && {
+              input: tokens.input, output: tokens.output, reasoning: tokens.reasoning,
+              cache: tokens.cache && { read: tokens.cache.read, write: tokens.cache.write },
+            },
+            error: error && {
+              name: knownErrors.includes(error.name) ? error.name : "UnknownError",
+              data: { statusCode: error.name === "APIError" ? error.data.statusCode : undefined },
+            },
+          },
+        })
+        if (Buffer.byteLength(body) > MAX_BYTES || veto()) return
+        const child = execFile("gentle-ai", ["telemetry", "runtime", "opencode", "--json"],
+          { timeout: 4000, killSignal: "SIGKILL", maxBuffer: 1024, windowsHide: true },
+          () => { children.delete(child) })
+        children.add(child)
+        child.stdin?.on("error", () => {})
+        child.stdin?.end(body)
+      } catch {
+        // Missing binaries, invalid events and IO failures silently lose coverage.
+      }
+    },
+    dispose: async () => {
+      disposed = true
+      for (const child of children) child.kill("SIGKILL")
+      children.clear()
+    },
+  }
+}
+
+export default telemetryRuntime

--- a/internal/components/uninstall/service.go
+++ b/internal/components/uninstall/service.go
@@ -1315,7 +1315,7 @@ func removeSkillRegistryHook(raw []byte) ([]byte, bool, error) {
 		return raw, false, nil
 	}
 	changed := false
-	for _, hookKey := range []string{"UserPromptSubmit", "SessionStart", "Stop"} {
+	for _, hookKey := range []string{"UserPromptSubmit", "SessionStart", "Stop", "SubagentStop"} {
 		entries, ok := hooksMap[hookKey].([]any)
 		if !ok {
 			continue
@@ -1336,7 +1336,7 @@ func removeSkillRegistryHook(raw []byte) ([]byte, bool, error) {
 			for _, hook := range hooks {
 				hookMap, ok := hook.(map[string]any)
 				cmd, _ := hookMap["command"].(string)
-				if ok && (strings.Contains(cmd, "gentle-ai skill-registry refresh") || strings.Contains(cmd, "gentle-ai review stop-hook")) {
+				if ok && (strings.Contains(cmd, "gentle-ai skill-registry refresh") || strings.Contains(cmd, "gentle-ai review stop-hook") || cmd == "gentle-ai telemetry runtime claude --json") {
 					changed = true
 					continue
 				}

--- a/internal/components/uninstall/service.go
+++ b/internal/components/uninstall/service.go
@@ -1315,7 +1315,7 @@ func removeSkillRegistryHook(raw []byte) ([]byte, bool, error) {
 		return raw, false, nil
 	}
 	changed := false
-	for _, hookKey := range []string{"UserPromptSubmit", "SessionStart", "Stop"} {
+	for _, hookKey := range []string{"UserPromptSubmit", "SessionStart", "SubagentStop", "Stop"} {
 		entries, ok := hooksMap[hookKey].([]any)
 		if !ok {
 			continue
@@ -1336,7 +1336,7 @@ func removeSkillRegistryHook(raw []byte) ([]byte, bool, error) {
 			for _, hook := range hooks {
 				hookMap, ok := hook.(map[string]any)
 				cmd, _ := hookMap["command"].(string)
-				if ok && (strings.Contains(cmd, "gentle-ai skill-registry refresh") || strings.Contains(cmd, "gentle-ai review stop-hook")) {
+				if ok && (strings.Contains(cmd, "gentle-ai skill-registry refresh") || strings.Contains(cmd, "gentle-ai review stop-hook") || cmd == "gentle-ai telemetry runtime codex --json") {
 					changed = true
 					continue
 				}

--- a/internal/components/uninstall/service_test.go
+++ b/internal/components/uninstall/service_test.go
@@ -1632,6 +1632,22 @@ func TestComponentOperationsSDD_ClaudeRemovesSkillRegistryHook(t *testing.T) {
         "matcher": "Bash",
         "hooks": [{"type": "command", "command": "echo pre"}]
       }
+    ],
+    "SubagentStop": [
+      {
+        "hooks": [
+          {"type": "command", "command": "gentle-ai telemetry runtime codex --json", "async": true},
+          {"type": "command", "command": "echo subagent keep"}
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {"type": "command", "command": "gentle-ai telemetry runtime codex --json", "async": true},
+          {"type": "command", "command": "echo stop keep"}
+        ]
+      }
     ]
   }
 }`
@@ -1655,10 +1671,10 @@ func TestComponentOperationsSDD_ClaudeRemovesSkillRegistryHook(t *testing.T) {
 		t.Fatal(err)
 	}
 	text := string(raw)
-	if strings.Contains(text, "gentle-ai skill-registry refresh") {
+	if strings.Contains(text, "gentle-ai skill-registry refresh") || strings.Contains(text, "gentle-ai telemetry runtime codex") {
 		t.Fatalf("managed hook should be removed:\n%s", text)
 	}
-	if !strings.Contains(text, "echo keep") || !strings.Contains(text, "echo pre") {
+	if !strings.Contains(text, "echo keep") || !strings.Contains(text, "echo pre") || !strings.Contains(text, "echo subagent keep") || !strings.Contains(text, "echo stop keep") {
 		t.Fatalf("unrelated hooks should be preserved:\n%s", text)
 	}
 }

--- a/internal/components/uninstall/service_test.go
+++ b/internal/components/uninstall/service_test.go
@@ -1735,6 +1735,41 @@ func TestComponentOperationsSDD_ClaudeRemovesReviewStopHook(t *testing.T) {
 	}
 }
 
+func TestComponentOperationsSDD_ClaudeRemovesTelemetryHooks(t *testing.T) {
+	homeDir := t.TempDir()
+	svc, err := NewService(homeDir, t.TempDir(), "dev")
+	if err != nil {
+		t.Fatal(err)
+	}
+	adapter, _ := svc.registry.Get(model.AgentClaudeCode)
+	settingsPath := adapter.SettingsPath(homeDir)
+	if err := os.MkdirAll(filepath.Dir(settingsPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	initial := `{"hooks":{"Stop":[{"matcher":"","hooks":[{"type":"command","command":"gentle-ai telemetry runtime claude --json","async":true},{"type":"command","command":"echo keep"}]}],"SubagentStop":[{"matcher":"","hooks":[{"type":"command","command":"gentle-ai telemetry runtime claude --json","async":true}]}]}}`
+	if err := os.WriteFile(settingsPath, []byte(initial), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	ops, _, err := svc.componentOperations(adapter, model.ComponentSDD)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, op := range ops {
+		if op.typeID == opRewriteFile && op.path == settingsPath {
+			if _, _, err := op.apply(op.path); err != nil {
+				t.Fatal(err)
+			}
+		}
+	}
+	raw, err := os.ReadFile(settingsPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(raw), "telemetry runtime claude") || !strings.Contains(string(raw), "echo keep") {
+		t.Fatalf("managed telemetry hook removal failed:\n%s", raw)
+	}
+}
+
 func TestComponentOperationsSDD_CodexRemovesSkillRegistryHook(t *testing.T) {
 	homeDir := t.TempDir()
 	workspaceDir := t.TempDir()

--- a/internal/telemetry/runtime.go
+++ b/internal/telemetry/runtime.go
@@ -181,6 +181,29 @@ func runtimeMember(value, choices string) bool {
 	return false
 }
 
+// RuntimeEffortAllowed reports whether value belongs to the runtime telemetry
+// contract's closed effort vocabulary.
+func RuntimeEffortAllowed(value string) bool {
+	return runtimeMember(value, runtimeEfforts)
+}
+
+// NormalizeRuntimeModel keeps model attribution inside the runtime telemetry
+// contract without exposing unregistered provider or model names.
+func NormalizeRuntimeModel(provider, id string) RuntimeModel {
+	m := RuntimeModel{Provider: provider, ID: id}
+	if provider == "" || id == "" {
+		return RuntimeModel{Provider: "unknown", ID: "unknown"}
+	}
+	if runtimeModelOK(m) {
+		return m
+	}
+	m = RuntimeModel{Provider: "custom", ID: "custom"}
+	if provider == "opencode" {
+		m.Provider = "opencode"
+	}
+	return m
+}
+
 // Registry 1: public names verified by the parent against official catalogs.
 // Namespace is a caller assertion, not endpoint/route attestation.
 func runtimeModelOK(m RuntimeModel) bool {
@@ -276,7 +299,7 @@ func normalizeRuntimeRows(rows []RuntimeRow) error {
 			return errRuntimeInput
 		}
 		for _, effort := range []string{r.SelectedEffort, r.EffectiveEffort} {
-			if !runtimeMember(effort, runtimeEfforts) {
+			if !RuntimeEffortAllowed(effort) {
 				return errRuntimeInput
 			}
 		}

--- a/internal/telemetry/runtime.go
+++ b/internal/telemetry/runtime.go
@@ -15,7 +15,7 @@ const RuntimeSchema = "gentle-ai.telemetry-runtime-aggregate/v1"
 const RuntimeMaxBytes = 16384
 
 // Public package categories, not proof of runtime authority or agent-name identity.
-const runtimeAgentClasses = "orchestrator|worker|explore|verify|unknown|sdd-init|sdd-explore|sdd-research|sdd-propose|sdd-spec|sdd-design|sdd-tasks|sdd-apply|sdd-verify|sdd-archive|sdd-onboard|jd-judge-a|jd-judge-b|jd-fix-agent|review-risk|review-readability|review-reliability|review-resilience|review-refuter|review-validator"
+const runtimeAgentClasses = "orchestrator|worker|explore|verify|unknown|sdd-init|sdd-explore|sdd-research|sdd-propose|sdd-spec|sdd-design|sdd-tasks|sdd-apply|sdd-verify|sdd-archive|sdd-onboard|sdd-status|sdd-sync|jd-judge-a|jd-judge-b|jd-fix-agent|review-risk|review-readability|review-reliability|review-resilience|review-refuter|review-validator"
 const runtimeEfforts = "off|minimal|low|medium|high|xhigh|max|not_selected|unknown|custom|unavailable|unsupported"
 
 // RuntimeBatch is the sanitized stdin aggregate, not a persistent batch.

--- a/internal/telemetry/runtime.go
+++ b/internal/telemetry/runtime.go
@@ -181,12 +181,14 @@ func runtimeMember(value, choices string) bool {
 	return false
 }
 
+const runtimeAnthropicModels = "claude-opus-5|claude-haiku-4-5|claude-haiku-4-5-20251001|claude-sonnet-5"
+
 // Registry 1: public names verified by the parent against official catalogs.
 // Namespace is a caller assertion, not endpoint/route attestation.
 func runtimeModelOK(m RuntimeModel) bool {
 	switch m.Provider {
 	case "anthropic":
-		return runtimeMember(m.ID, "claude-opus-5|claude-haiku-4-5|claude-haiku-4-5-20251001|claude-sonnet-5")
+		return runtimeMember(m.ID, runtimeAnthropicModels)
 	case "openai", "openai-codex":
 		return runtimeMember(m.ID, "gpt-6-astra|gpt-5.6-sol|gpt-5.6-terra|gpt-5.6-luna|gpt-5.3-codex-spark|gpt-5.5|gpt-5.4|gpt-5.4-mini|gpt-5.2|gpt-5.3-codex|gpt-5.6")
 	case "opencode":

--- a/internal/telemetry/runtime.go
+++ b/internal/telemetry/runtime.go
@@ -15,7 +15,7 @@ const RuntimeSchema = "gentle-ai.telemetry-runtime-aggregate/v1"
 const RuntimeMaxBytes = 16384
 
 // Public package categories, not proof of runtime authority or agent-name identity.
-const runtimeAgentClasses = "orchestrator|worker|explore|verify|unknown|sdd-apply|sdd-archive|sdd-design|sdd-explore|sdd-init|sdd-onboard|sdd-proposal|sdd-research|sdd-spec|sdd-status|sdd-sync|sdd-tasks|sdd-verify|review-readability|review-reliability|review-resilience|review-risk|jd-fix-agent|jd-judge-a|jd-judge-b"
+const runtimeAgentClasses = "orchestrator|worker|explore|verify|unknown|sdd-init|sdd-explore|sdd-research|sdd-propose|sdd-spec|sdd-design|sdd-tasks|sdd-apply|sdd-verify|sdd-archive|sdd-onboard|jd-judge-a|jd-judge-b|jd-fix-agent|review-risk|review-readability|review-reliability|review-resilience|review-refuter|review-validator"
 const runtimeEfforts = "off|minimal|low|medium|high|xhigh|max|not_selected|unknown|custom|unavailable|unsupported"
 
 // RuntimeBatch is the sanitized stdin aggregate, not a persistent batch.
@@ -272,6 +272,11 @@ func decodeRuntime(data []byte) (RuntimeBatch, error) {
 func normalizeRuntimeRows(rows []RuntimeRow) error {
 	for i := range rows {
 		r := &rows[i]
+		// Deprecated compatibility alias emitted by older registry-1 clients.
+		// Keep it out of the canonical vocabulary and normalize it before storage.
+		if r.AgentClass == "sdd-proposal" {
+			r.AgentClass = "sdd-propose"
+		}
 		if !runtimeMember(r.ModelEvidence, "selected|response|unknown") || !runtimeModelOK(r.Model) || !runtimeMember(r.AgentKind, "orchestrator|built_in|custom|unknown") || !runtimeMember(r.AgentClass, runtimeAgentClasses) {
 			return errRuntimeInput
 		}

--- a/internal/telemetry/runtime_claude.go
+++ b/internal/telemetry/runtime_claude.go
@@ -1,0 +1,240 @@
+package telemetry
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/json"
+	"errors"
+	"io"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+const ClaudeMaxBytes = RuntimeMaxBytes
+const ClaudeTranscriptMaxBytes = 512 * 1024
+const ClaudeAgentMaxBytes = 64 * 1024
+
+var errClaude = errors.New("invalid Claude Code hook event")
+
+// ClaudeHook retains only routing fields and the final-message correlation
+// value required to find current local evidence. Identifiers, prompts, cwd,
+// and permission data are discarded; the message never leaves memory.
+type ClaudeHook struct {
+	HookEventName       string   `json:"-"`
+	AgentType           string   `json:"-"`
+	TranscriptPath      string   `json:"-"`
+	AgentTranscriptPath string   `json:"-"`
+	LastAssistantDigest [32]byte `json:"-"`
+}
+
+// ClaudeUsage is bounded response evidence extracted from a transcript tail.
+type ClaudeUsage struct {
+	Evidence      bool
+	Model         string
+	Input         json.RawMessage
+	Output        json.RawMessage
+	CacheRead     json.RawMessage
+	CacheCreation json.RawMessage
+}
+
+type ClaudeObservation struct {
+	Row RuntimeRow `json:"row"`
+}
+
+// ParseClaudeHook validates one bounded hook object and retains no private
+// identifiers or message content. Unknown fields remain memory-only and are
+// accepted for forward compatibility with Claude's common hook envelope.
+func ParseClaudeHook(input io.Reader) (ClaudeHook, error) {
+	var result ClaudeHook
+	data, err := io.ReadAll(io.LimitReader(input, ClaudeMaxBytes+1))
+	if err != nil || len(data) > ClaudeMaxBytes {
+		return result, errClaude
+	}
+	d := json.NewDecoder(bytes.NewReader(data))
+	d.UseNumber()
+	if openCodeBounded(d, 0) != nil {
+		return result, errClaude
+	}
+	if _, err = d.Token(); err != io.EOF {
+		return result, errClaude
+	}
+	var source struct {
+		HookEventName        string `json:"hook_event_name"`
+		AgentType            string `json:"agent_type"`
+		TranscriptPath       string `json:"transcript_path"`
+		AgentTranscriptPath  string `json:"agent_transcript_path"`
+		LastAssistantMessage string `json:"last_assistant_message"`
+	}
+	if json.Unmarshal(data, &source) != nil || source.HookEventName == "" {
+		return result, errClaude
+	}
+	if source.HookEventName == "SubagentStop" && source.AgentType == "" {
+		return result, errClaude
+	}
+	result = ClaudeHook{HookEventName: source.HookEventName, AgentType: source.AgentType, TranscriptPath: source.TranscriptPath, AgentTranscriptPath: source.AgentTranscriptPath}
+	if source.LastAssistantMessage != "" {
+		result.LastAssistantDigest = sha256.Sum256([]byte(source.LastAssistantMessage))
+	}
+	return result, nil
+}
+
+// ClaudeNamedAgent tests the current runtime registry as data. The generic
+// aggregate classes are not installable Claude agent names.
+func ClaudeNamedAgent(name string) bool {
+	if !runtimeMember(name, runtimeAgentClasses) {
+		return false
+	}
+	return !runtimeMember(name, "orchestrator|worker|explore|verify|unknown")
+}
+
+// ParseClaudeTranscriptTail accepts only a complete, matching final non-empty
+// JSONL record. firstPartial means the bounded tail starts inside an older line.
+func ParseClaudeTranscriptTail(data []byte, firstPartial bool, expectedDigest [32]byte) (ClaudeUsage, bool) {
+	if len(data) > ClaudeTranscriptMaxBytes {
+		return ClaudeUsage{}, false
+	}
+	if expectedDigest == ([32]byte{}) {
+		return ClaudeUsage{}, false
+	}
+	if firstPartial {
+		if i := bytes.IndexByte(data, '\n'); i >= 0 {
+			data = data[i+1:]
+		} else {
+			return ClaudeUsage{}, false
+		}
+	}
+	lines := bytes.Split(data, []byte{'\n'})
+	for i := len(lines) - 1; i >= 0; i-- {
+		line := bytes.TrimSpace(lines[i])
+		if len(line) == 0 {
+			continue
+		}
+		var record struct {
+			Type    string `json:"type"`
+			Message struct {
+				Model   string          `json:"model"`
+				Content json.RawMessage `json:"content"`
+				Usage   *struct {
+					Input         json.RawMessage `json:"input_tokens"`
+					Output        json.RawMessage `json:"output_tokens"`
+					CacheRead     json.RawMessage `json:"cache_read_input_tokens"`
+					CacheCreation json.RawMessage `json:"cache_creation_input_tokens"`
+				} `json:"usage"`
+			} `json:"message"`
+		}
+		if json.Unmarshal(line, &record) != nil || record.Type != "assistant" || record.Message.Usage == nil || len(record.Message.Model) > 256 || !claudeMessageMatches(record.Message.Content, expectedDigest) {
+			return ClaudeUsage{}, false
+		}
+		u := ClaudeUsage{Evidence: true, Model: record.Message.Model, Input: record.Message.Usage.Input, Output: record.Message.Usage.Output, CacheRead: record.Message.Usage.CacheRead, CacheCreation: record.Message.Usage.CacheCreation}
+		valid := true
+		for _, raw := range []json.RawMessage{u.Input, u.Output, u.CacheRead, u.CacheCreation} {
+			if raw != nil && runtimeNumber(raw) == "" {
+				valid = false
+				break
+			}
+		}
+		if !valid {
+			return ClaudeUsage{}, false
+		}
+		return u, true
+	}
+	return ClaudeUsage{}, false
+}
+
+func claudeMessageMatches(raw json.RawMessage, expected [32]byte) bool {
+	var text string
+	if json.Unmarshal(raw, &text) == nil {
+		return sha256.Sum256([]byte(text)) == expected
+	}
+	var blocks []struct {
+		Type string `json:"type"`
+		Text string `json:"text"`
+	}
+	if json.Unmarshal(raw, &blocks) != nil || len(blocks) == 0 {
+		return false
+	}
+	texts := make([]string, 0, len(blocks))
+	for _, block := range blocks {
+		if block.Type == "text" {
+			texts = append(texts, block.Text)
+		}
+	}
+	if len(texts) == 0 {
+		return false
+	}
+	return sha256.Sum256([]byte(strings.Join(texts, ""))) == expected || sha256.Sum256([]byte(strings.Join(texts, "\n"))) == expected
+}
+
+// NormalizeClaude converts one completion plus optional bounded local evidence
+// into the common runtime row. It performs no I/O and retains no source paths.
+func NormalizeClaude(hook ClaudeHook, usage ClaudeUsage, agentDefinition []byte) *ClaudeObservation {
+	if hook.HookEventName != "Stop" && hook.HookEventName != "SubagentStop" {
+		return nil
+	}
+	if hook.HookEventName == "Stop" {
+		// Stop has no unique response identity. A repeated final message can match
+		// an older transcript row when the current row has not been flushed.
+		usage, agentDefinition = ClaudeUsage{}, nil
+	}
+	r := RuntimeRow{Model: RuntimeModel{Provider: "unknown", ID: "unknown"}, ModelEvidence: "unknown", AgentKind: "custom", AgentClass: "unknown", SelectedEffort: "unavailable", EffectiveEffort: "unavailable", Launches: json.RawMessage("1"), Responses: json.RawMessage("null"), ErrorCategory: "none", Duration: RuntimeDuration{Kind: "unavailable", MeasuredCount: json.RawMessage("0"), SumMS: json.RawMessage("null")}}
+	if hook.HookEventName == "Stop" {
+		r.AgentKind, r.AgentClass = "orchestrator", "orchestrator"
+	} else if ClaudeNamedAgent(hook.AgentType) {
+		r.AgentKind, r.AgentClass = "built_in", hook.AgentType
+	}
+	selectedModel, selectedEffort := claudeFrontmatter(agentDefinition)
+	if selectedEffort != "" && runtimeMember(selectedEffort, runtimeEfforts) {
+		r.SelectedEffort = selectedEffort
+	}
+	model := selectedModel
+	if usage.Evidence {
+		r.Launches, r.Responses = json.RawMessage("null"), json.RawMessage("1")
+		if usage.Model != "" {
+			model, r.ModelEvidence = usage.Model, "response"
+		}
+	}
+	if r.ModelEvidence == "unknown" && model != "" {
+		r.ModelEvidence = "selected"
+	}
+	r.Model = claudeModel(model)
+	r.Input, r.Output, r.CacheRead, r.CacheCreation = usage.Input, usage.Output, usage.CacheRead, usage.CacheCreation
+	r.ReasoningTokens = json.RawMessage(`"unsupported"`)
+	r.TotalTokens = json.RawMessage("null")
+	r.tokenObservations()
+	return &ClaudeObservation{Row: r}
+}
+
+func claudeModel(id string) RuntimeModel {
+	if id == "" {
+		return RuntimeModel{Provider: "unknown", ID: "unknown"}
+	}
+	m := RuntimeModel{Provider: "anthropic", ID: id}
+	if strings.HasPrefix(id, "claude-") && runtimeModelOK(m) {
+		return m
+	}
+	return RuntimeModel{Provider: "custom", ID: "custom"}
+}
+
+func claudeFrontmatter(data []byte) (string, string) {
+	if len(data) == 0 || len(data) > ClaudeAgentMaxBytes {
+		return "", ""
+	}
+	text := string(data)
+	if !strings.HasPrefix(text, "---\n") && !strings.HasPrefix(text, "---\r\n") {
+		return "", ""
+	}
+	text = strings.TrimPrefix(strings.TrimPrefix(text, "---\r\n"), "---\n")
+	end := strings.Index(text, "\n---")
+	if end < 0 {
+		return "", ""
+	}
+	var front struct {
+		Model  string `yaml:"model"`
+		Effort string `yaml:"effort"`
+	}
+	if yaml.Unmarshal([]byte(text[:end]), &front) != nil {
+		return "", ""
+	}
+	return strings.TrimSpace(front.Model), strings.TrimSpace(front.Effort)
+}

--- a/internal/telemetry/runtime_claude.go
+++ b/internal/telemetry/runtime_claude.go
@@ -31,6 +31,7 @@ type ClaudeHook struct {
 // ClaudeUsage is bounded response evidence extracted from a transcript tail.
 type ClaudeUsage struct {
 	Evidence      bool
+	Correlated    bool
 	Model         string
 	Input         json.RawMessage
 	Output        json.RawMessage
@@ -88,13 +89,12 @@ func ClaudeNamedAgent(name string) bool {
 	return !runtimeMember(name, "orchestrator|worker|explore|verify|unknown")
 }
 
-// ParseClaudeTranscriptTail accepts only a complete, matching final non-empty
-// JSONL record. firstPartial means the bounded tail starts inside an older line.
+// ParseClaudeTranscriptTail returns the last valid assistant usage record in a
+// subagent transcript. firstPartial means the bounded tail starts inside an
+// older line. Message correlation strengthens the evidence but is not required:
+// agent_transcript_path is already scoped to this single subagent run.
 func ParseClaudeTranscriptTail(data []byte, firstPartial bool, expectedDigest [32]byte) (ClaudeUsage, bool) {
 	if len(data) > ClaudeTranscriptMaxBytes {
-		return ClaudeUsage{}, false
-	}
-	if expectedDigest == ([32]byte{}) {
 		return ClaudeUsage{}, false
 	}
 	if firstPartial {
@@ -123,10 +123,10 @@ func ParseClaudeTranscriptTail(data []byte, firstPartial bool, expectedDigest [3
 				} `json:"usage"`
 			} `json:"message"`
 		}
-		if json.Unmarshal(line, &record) != nil || record.Type != "assistant" || record.Message.Usage == nil || len(record.Message.Model) > 256 || !claudeMessageMatches(record.Message.Content, expectedDigest) {
-			return ClaudeUsage{}, false
+		if json.Unmarshal(line, &record) != nil || record.Type != "assistant" || record.Message.Usage == nil || len(record.Message.Model) > 256 {
+			continue
 		}
-		u := ClaudeUsage{Evidence: true, Model: record.Message.Model, Input: record.Message.Usage.Input, Output: record.Message.Usage.Output, CacheRead: record.Message.Usage.CacheRead, CacheCreation: record.Message.Usage.CacheCreation}
+		u := ClaudeUsage{Evidence: true, Correlated: expectedDigest != ([32]byte{}) && claudeMessageMatches(record.Message.Content, expectedDigest), Model: record.Message.Model, Input: record.Message.Usage.Input, Output: record.Message.Usage.Output, CacheRead: record.Message.Usage.CacheRead, CacheCreation: record.Message.Usage.CacheCreation}
 		valid := true
 		for _, raw := range []json.RawMessage{u.Input, u.Output, u.CacheRead, u.CacheCreation} {
 			if raw != nil && runtimeNumber(raw) == "" {
@@ -135,7 +135,7 @@ func ParseClaudeTranscriptTail(data []byte, firstPartial bool, expectedDigest [3
 			}
 		}
 		if !valid {
-			return ClaudeUsage{}, false
+			continue
 		}
 		return u, true
 	}
@@ -184,6 +184,7 @@ func NormalizeClaude(hook ClaudeHook, usage ClaudeUsage, agentDefinition []byte)
 		r.AgentKind, r.AgentClass = "built_in", hook.AgentType
 	}
 	selectedModel, selectedEffort := claudeFrontmatter(agentDefinition)
+	selectedModel = claudeCanonicalModelID(selectedModel)
 	if selectedEffort != "" && runtimeMember(selectedEffort, runtimeEfforts) {
 		r.SelectedEffort = selectedEffort
 	}
@@ -191,7 +192,7 @@ func NormalizeClaude(hook ClaudeHook, usage ClaudeUsage, agentDefinition []byte)
 	if usage.Evidence {
 		r.Launches, r.Responses = json.RawMessage("null"), json.RawMessage("1")
 		if usage.Model != "" {
-			model, r.ModelEvidence = usage.Model, "response"
+			model, r.ModelEvidence = claudeCanonicalModelID(usage.Model), "response"
 		}
 	}
 	if r.ModelEvidence == "unknown" && model != "" {
@@ -214,6 +215,34 @@ func claudeModel(id string) RuntimeModel {
 		return m
 	}
 	return RuntimeModel{Provider: "custom", ID: "custom"}
+}
+
+// Claude Code frontmatter uses sonnet/opus/haiku aliases, while transcripts
+// may append release or revision suffixes to registry IDs. Selectors that defer
+// model choice carry no selected-model evidence. Registry matching uses the
+// longest current Anthropic ID so overlapping registered IDs stay exact.
+func claudeCanonicalModelID(id string) string {
+	id = strings.TrimSpace(id)
+	switch id {
+	case "", "inherit", "default":
+		return ""
+	case "sonnet":
+		return "claude-sonnet-5"
+	case "opus":
+		return "claude-opus-5"
+	case "haiku":
+		return "claude-haiku-4-5"
+	}
+	longest := ""
+	for _, registered := range strings.Split(runtimeAnthropicModels, "|") {
+		if (id == registered || strings.HasPrefix(id, registered+"-")) && len(registered) > len(longest) {
+			longest = registered
+		}
+	}
+	if longest != "" {
+		return longest
+	}
+	return id
 }
 
 func claudeFrontmatter(data []byte) (string, string) {

--- a/internal/telemetry/runtime_claude_test.go
+++ b/internal/telemetry/runtime_claude_test.go
@@ -9,7 +9,7 @@ import (
 
 const claudeSubagentHook = `{"session_id":"PRIVATE_SESSION","transcript_path":"PRIVATE_MAIN_PATH","cwd":"PRIVATE_CWD","permission_mode":"default","hook_event_name":"SubagentStop","stop_hook_active":false,"agent_id":"PRIVATE_AGENT_ID","agent_type":"sdd-apply","agent_transcript_path":"PRIVATE_AGENT_PATH","last_assistant_message":"FINAL_MESSAGE"}`
 
-func TestClaudeRuntimeSubagentUsesLastAssistantUsage(t *testing.T) {
+func TestClaudeRuntimeSubagentSelectsLastAssistantUsageBeforeTrailingRecords(t *testing.T) {
 	hook, err := ParseClaudeHook(strings.NewReader(claudeSubagentHook))
 	if err != nil {
 		t.Fatal(err)
@@ -21,6 +21,9 @@ func TestClaudeRuntimeSubagentUsesLastAssistantUsage(t *testing.T) {
 	usage, ok := ParseClaudeTranscriptTail(transcript, false, hook.LastAssistantDigest)
 	if !ok {
 		t.Fatal("usage not found")
+	}
+	if !usage.Correlated {
+		t.Fatal("matching final message was not retained as stronger evidence")
 	}
 	o := NormalizeClaude(hook, usage, []byte("---\nname: sdd-apply\nmodel: claude-haiku-4-5\neffort: high\n---\nPRIVATE_PROMPT"))
 	if o == nil {
@@ -43,23 +46,26 @@ func TestClaudeRuntimeSubagentUsesLastAssistantUsage(t *testing.T) {
 	}
 }
 
-func TestClaudeRuntimeRejectsStaleTranscriptUsage(t *testing.T) {
-	stale := []byte(`{"type":"assistant","message":{"model":"claude-opus-5","content":[{"type":"text","text":"STALE_MESSAGE"}],"usage":{"input_tokens":99,"output_tokens":99}}}` + "\n")
-	for _, input := range []string{
-		claudeSubagentHook,
-		strings.Replace(claudeSubagentHook, `"hook_event_name":"SubagentStop","stop_hook_active":false,"agent_id":"PRIVATE_AGENT_ID","agent_type":"sdd-apply","agent_transcript_path":"PRIVATE_AGENT_PATH"`, `"hook_event_name":"Stop","stop_hook_active":false`, 1),
+func TestClaudeRuntimeSubagentUsesUsageWithoutLastMessageCorrelation(t *testing.T) {
+	mismatching := []byte(`{"type":"assistant","message":{"model":"claude-opus-5","content":[{"type":"text","text":"STALE_MESSAGE"}],"usage":{"input_tokens":99,"output_tokens":99}}}` + "\n")
+	for name, input := range map[string]string{
+		"mismatching message": claudeSubagentHook,
+		"missing message":     strings.Replace(claudeSubagentHook, `,"last_assistant_message":"FINAL_MESSAGE"`, "", 1),
 	} {
-		hook, err := ParseClaudeHook(strings.NewReader(input))
-		if err != nil {
-			t.Fatal(err)
-		}
-		if usage, ok := ParseClaudeTranscriptTail(stale, false, hook.LastAssistantDigest); ok || usage.Evidence {
-			t.Fatalf("%s stale usage accepted: %+v", hook.HookEventName, usage)
-		}
-		o := NormalizeClaude(hook, ClaudeUsage{}, nil)
-		if string(o.Row.Launches) != "1" || string(o.Row.Responses) != "null" || string(o.Row.Input) != tokenAbsent {
-			t.Fatalf("%s stale transcript did not fall back: %+v", hook.HookEventName, o.Row)
-		}
+		t.Run(name, func(t *testing.T) {
+			hook, err := ParseClaudeHook(strings.NewReader(input))
+			if err != nil {
+				t.Fatal(err)
+			}
+			usage, ok := ParseClaudeTranscriptTail(mismatching, false, hook.LastAssistantDigest)
+			if !ok || !usage.Evidence || usage.Correlated || string(usage.Input) != "99" {
+				t.Fatalf("optional final-message correlation discarded subagent usage: %+v %v", usage, ok)
+			}
+			o := NormalizeClaude(hook, usage, nil)
+			if string(o.Row.Launches) != "null" || string(o.Row.Responses) != "1" || string(o.Row.Input) != tokenReported("99") {
+				t.Fatalf("optional final-message correlation did not report response: %+v", o.Row)
+			}
+		})
 	}
 }
 
@@ -92,24 +98,70 @@ func TestClaudeRuntimeSubagentCorrelatesMultipleTextBlocks(t *testing.T) {
 	}
 }
 
-func TestClaudeRuntimeSubagentRejectsNonFinalMatchingUsage(t *testing.T) {
+func TestClaudeRuntimeSubagentUsesLastAssistantUsage(t *testing.T) {
 	hook, err := ParseClaudeHook(strings.NewReader(claudeSubagentHook))
 	if err != nil {
 		t.Fatal(err)
 	}
 	matching := `{"type":"assistant","message":{"model":"claude-opus-5","content":"FINAL_MESSAGE","usage":{"input_tokens":66}}}`
 	for name, transcript := range map[string]string{
-		"later valid record":        matching + "\n" + `{"type":"user","message":{"content":"next"}}` + "\n",
-		"partial current assistant": matching + "\n" + `{"type":"assistant","message":{"content":"FINAL_MESSAGE"`,
+		"later non-usage record":    matching + "\n" + `{"type":"user","message":{"content":"next"}}` + "\n",
+		"partial trailing record":   matching + "\n" + `{"type":"assistant","message":{"content":"FINAL_MESSAGE"`,
+		"later malformed JSON line": matching + "\n" + `{bad` + "\n",
 	} {
 		t.Run(name, func(t *testing.T) {
 			usage, ok := ParseClaudeTranscriptTail([]byte(transcript), false, hook.LastAssistantDigest)
-			if ok || usage.Evidence {
-				t.Fatalf("non-final usage accepted: %+v", usage)
+			if !ok || !usage.Evidence || string(usage.Input) != "66" {
+				t.Fatalf("last assistant usage not selected: %+v %v", usage, ok)
 			}
-			o := NormalizeClaude(hook, ClaudeUsage{}, nil)
-			if string(o.Row.Launches) != "1" || string(o.Row.Responses) != "null" || string(o.Row.Input) != tokenAbsent {
-				t.Fatalf("non-final usage did not remain activity-only: %+v", o.Row)
+		})
+	}
+}
+
+func TestClaudeModelAliasesAndUnknownSelectors(t *testing.T) {
+	hook, _ := ParseClaudeHook(strings.NewReader(claudeSubagentHook))
+	for _, tt := range []struct {
+		selector string
+		want     RuntimeModel
+	}{
+		{selector: "sonnet", want: RuntimeModel{Provider: "anthropic", ID: "claude-sonnet-5"}},
+		{selector: "opus", want: RuntimeModel{Provider: "anthropic", ID: "claude-opus-5"}},
+		{selector: "haiku", want: RuntimeModel{Provider: "anthropic", ID: "claude-haiku-4-5"}},
+		{selector: "inherit", want: RuntimeModel{Provider: "unknown", ID: "unknown"}},
+		{selector: "default", want: RuntimeModel{Provider: "unknown", ID: "unknown"}},
+		{selector: "", want: RuntimeModel{Provider: "unknown", ID: "unknown"}},
+	} {
+		t.Run(tt.selector, func(t *testing.T) {
+			definition := []byte("---\nmodel: " + tt.selector + "\n---\n")
+			o := NormalizeClaude(hook, ClaudeUsage{}, definition)
+			if o.Row.Model != tt.want {
+				t.Fatalf("model = %+v, want %+v", o.Row.Model, tt.want)
+			}
+			wantEvidence := "selected"
+			if tt.want.Provider == "unknown" {
+				wantEvidence = "unknown"
+			}
+			if o.Row.ModelEvidence != wantEvidence {
+				t.Fatalf("model evidence = %q, want %q", o.Row.ModelEvidence, wantEvidence)
+			}
+		})
+	}
+}
+
+func TestClaudeDatedTranscriptModelUsesRegistryLongestPrefix(t *testing.T) {
+	hook, _ := ParseClaudeHook(strings.NewReader(claudeSubagentHook))
+	for _, tt := range []struct {
+		model string
+		want  string
+	}{
+		{model: "claude-sonnet-5-20260501", want: "claude-sonnet-5"},
+		{model: "claude-opus-5-1", want: "claude-opus-5"},
+		{model: "claude-haiku-4-5-20251001", want: "claude-haiku-4-5-20251001"},
+	} {
+		t.Run(tt.model, func(t *testing.T) {
+			o := NormalizeClaude(hook, ClaudeUsage{Evidence: true, Model: tt.model, Input: json.RawMessage("1")}, nil)
+			if o.Row.Model != (RuntimeModel{Provider: "anthropic", ID: tt.want}) || o.Row.ModelEvidence != "response" {
+				t.Fatalf("model = %+v evidence = %q", o.Row.Model, o.Row.ModelEvidence)
 			}
 		})
 	}

--- a/internal/telemetry/runtime_claude_test.go
+++ b/internal/telemetry/runtime_claude_test.go
@@ -1,0 +1,207 @@
+package telemetry
+
+import (
+	"crypto/sha256"
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+const claudeSubagentHook = `{"session_id":"PRIVATE_SESSION","transcript_path":"PRIVATE_MAIN_PATH","cwd":"PRIVATE_CWD","permission_mode":"default","hook_event_name":"SubagentStop","stop_hook_active":false,"agent_id":"PRIVATE_AGENT_ID","agent_type":"sdd-apply","agent_transcript_path":"PRIVATE_AGENT_PATH","last_assistant_message":"FINAL_MESSAGE"}`
+
+func TestClaudeRuntimeSubagentUsesLastAssistantUsage(t *testing.T) {
+	hook, err := ParseClaudeHook(strings.NewReader(claudeSubagentHook))
+	if err != nil {
+		t.Fatal(err)
+	}
+	transcript := []byte("not-json\n" +
+		`{"type":"assistant","message":{"model":"claude-haiku-4-5","usage":{"input_tokens":1,"output_tokens":2,"cache_read_input_tokens":3,"cache_creation_input_tokens":4}}}` + "\n" +
+		`{"type":"user","message":{"content":"PRIVATE_PROMPT"}}` + "\n" +
+		`{"type":"assistant","message":{"model":"claude-opus-5","content":[{"type":"text","text":"FINAL_MESSAGE"}],"usage":{"input_tokens":11,"output_tokens":12,"cache_read_input_tokens":13,"cache_creation_input_tokens":14}}}` + "\n")
+	usage, ok := ParseClaudeTranscriptTail(transcript, false, hook.LastAssistantDigest)
+	if !ok {
+		t.Fatal("usage not found")
+	}
+	o := NormalizeClaude(hook, usage, []byte("---\nname: sdd-apply\nmodel: claude-haiku-4-5\neffort: high\n---\nPRIVATE_PROMPT"))
+	if o == nil {
+		t.Fatal("observation missing")
+	}
+	if o.Row.AgentKind != "built_in" || o.Row.AgentClass != "sdd-apply" || o.Row.Model != (RuntimeModel{Provider: "anthropic", ID: "claude-opus-5"}) || o.Row.ModelEvidence != "response" || o.Row.SelectedEffort != "high" || o.Row.EffectiveEffort != "unavailable" {
+		t.Fatalf("row: %+v", o.Row)
+	}
+	for got, want := range map[string]string{string(o.Row.Input): tokenReported("11"), string(o.Row.Output): tokenReported("12"), string(o.Row.CacheRead): tokenReported("13"), string(o.Row.CacheCreation): tokenReported("14"), string(o.Row.ReasoningTokens): `{"reported":0,"unavailable":0,"unsupported":1,"sum":0}`, string(o.Row.TotalTokens): tokenAbsent} {
+		if got != want {
+			t.Fatalf("token %s, want %s", got, want)
+		}
+	}
+	if string(o.Row.Responses) != "1" || string(o.Row.Launches) != "null" || o.Row.Duration.Kind != "unavailable" || o.Row.ErrorCategory != "none" {
+		t.Fatalf("coverage: %+v", o.Row)
+	}
+	out, _ := json.Marshal(o)
+	if strings.Contains(string(out), "PRIVATE") {
+		t.Fatalf("private source leaked: %s", out)
+	}
+}
+
+func TestClaudeRuntimeRejectsStaleTranscriptUsage(t *testing.T) {
+	stale := []byte(`{"type":"assistant","message":{"model":"claude-opus-5","content":[{"type":"text","text":"STALE_MESSAGE"}],"usage":{"input_tokens":99,"output_tokens":99}}}` + "\n")
+	for _, input := range []string{
+		claudeSubagentHook,
+		strings.Replace(claudeSubagentHook, `"hook_event_name":"SubagentStop","stop_hook_active":false,"agent_id":"PRIVATE_AGENT_ID","agent_type":"sdd-apply","agent_transcript_path":"PRIVATE_AGENT_PATH"`, `"hook_event_name":"Stop","stop_hook_active":false`, 1),
+	} {
+		hook, err := ParseClaudeHook(strings.NewReader(input))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if usage, ok := ParseClaudeTranscriptTail(stale, false, hook.LastAssistantDigest); ok || usage.Evidence {
+			t.Fatalf("%s stale usage accepted: %+v", hook.HookEventName, usage)
+		}
+		o := NormalizeClaude(hook, ClaudeUsage{}, nil)
+		if string(o.Row.Launches) != "1" || string(o.Row.Responses) != "null" || string(o.Row.Input) != tokenAbsent {
+			t.Fatalf("%s stale transcript did not fall back: %+v", hook.HookEventName, o.Row)
+		}
+	}
+}
+
+func TestClaudeRuntimeStopNeverAttributesMatchingTranscript(t *testing.T) {
+	input := strings.Replace(claudeSubagentHook, `"hook_event_name":"SubagentStop","stop_hook_active":false,"agent_id":"PRIVATE_AGENT_ID","agent_type":"sdd-apply","agent_transcript_path":"PRIVATE_AGENT_PATH"`, `"hook_event_name":"Stop","stop_hook_active":false`, 1)
+	hook, err := ParseClaudeHook(strings.NewReader(input))
+	if err != nil {
+		t.Fatal(err)
+	}
+	repeated := []byte(`{"type":"assistant","message":{"model":"claude-opus-5","content":"FINAL_MESSAGE","usage":{"input_tokens":77,"output_tokens":88}}}` + "\n")
+	usage, ok := ParseClaudeTranscriptTail(repeated, false, hook.LastAssistantDigest)
+	if !ok {
+		t.Fatal("fixture did not produce matching usage")
+	}
+	o := NormalizeClaude(hook, usage, nil)
+	if string(o.Row.Launches) != "1" || string(o.Row.Responses) != "null" || o.Row.ModelEvidence != "unknown" || o.Row.Model.ID != "unknown" || string(o.Row.Input) != tokenAbsent || string(o.Row.Output) != tokenAbsent {
+		t.Fatalf("Stop attributed replayable transcript evidence: %+v", o.Row)
+	}
+}
+
+func TestClaudeRuntimeSubagentCorrelatesMultipleTextBlocks(t *testing.T) {
+	hook, err := ParseClaudeHook(strings.NewReader(claudeSubagentHook))
+	if err != nil {
+		t.Fatal(err)
+	}
+	transcript := []byte(`{"type":"assistant","message":{"model":"claude-opus-5","content":[{"type":"text","text":"FINAL_"},{"type":"text","text":"MESSAGE"}],"usage":{"input_tokens":55}}}` + "\n")
+	usage, ok := ParseClaudeTranscriptTail(transcript, false, hook.LastAssistantDigest)
+	if !ok || string(usage.Input) != "55" {
+		t.Fatalf("multi-block correlation failed: %+v %v", usage, ok)
+	}
+}
+
+func TestClaudeRuntimeSubagentRejectsNonFinalMatchingUsage(t *testing.T) {
+	hook, err := ParseClaudeHook(strings.NewReader(claudeSubagentHook))
+	if err != nil {
+		t.Fatal(err)
+	}
+	matching := `{"type":"assistant","message":{"model":"claude-opus-5","content":"FINAL_MESSAGE","usage":{"input_tokens":66}}}`
+	for name, transcript := range map[string]string{
+		"later valid record":        matching + "\n" + `{"type":"user","message":{"content":"next"}}` + "\n",
+		"partial current assistant": matching + "\n" + `{"type":"assistant","message":{"content":"FINAL_MESSAGE"`,
+	} {
+		t.Run(name, func(t *testing.T) {
+			usage, ok := ParseClaudeTranscriptTail([]byte(transcript), false, hook.LastAssistantDigest)
+			if ok || usage.Evidence {
+				t.Fatalf("non-final usage accepted: %+v", usage)
+			}
+			o := NormalizeClaude(hook, ClaudeUsage{}, nil)
+			if string(o.Row.Launches) != "1" || string(o.Row.Responses) != "null" || string(o.Row.Input) != tokenAbsent {
+				t.Fatalf("non-final usage did not remain activity-only: %+v", o.Row)
+			}
+		})
+	}
+}
+
+func TestClaudeRuntimeNoUsageBecomesLaunchStyle(t *testing.T) {
+	for _, input := range []string{
+		claudeSubagentHook,
+		strings.Replace(claudeSubagentHook, `"hook_event_name":"SubagentStop","stop_hook_active":false,"agent_id":"PRIVATE_AGENT_ID","agent_type":"sdd-apply","agent_transcript_path":"PRIVATE_AGENT_PATH"`, `"hook_event_name":"Stop","stop_hook_active":false`, 1),
+	} {
+		hook, err := ParseClaudeHook(strings.NewReader(input))
+		if err != nil {
+			t.Fatal(err)
+		}
+		o := NormalizeClaude(hook, ClaudeUsage{}, nil)
+		if o == nil || string(o.Row.Launches) != "1" || string(o.Row.Responses) != "null" {
+			t.Fatalf("no-usage coverage: %+v", o)
+		}
+		if hook.HookEventName == "Stop" && (o.Row.AgentKind != "orchestrator" || o.Row.AgentClass != "orchestrator") {
+			t.Fatalf("orchestrator mapping: %+v", o.Row)
+		}
+	}
+}
+
+func TestClaudeRuntimeAgentClassUsesCurrentAllowlist(t *testing.T) {
+	for _, agentType := range strings.Split(runtimeAgentClasses, "|") {
+		if agentType == "orchestrator" || agentType == "worker" || agentType == "explore" || agentType == "verify" || agentType == "unknown" {
+			continue
+		}
+		input := strings.Replace(claudeSubagentHook, `"agent_type":"sdd-apply"`, `"agent_type":"`+agentType+`"`, 1)
+		hook, err := ParseClaudeHook(strings.NewReader(input))
+		if err != nil {
+			t.Fatal(err)
+		}
+		o := NormalizeClaude(hook, ClaudeUsage{}, nil)
+		if o.Row.AgentKind != "built_in" || o.Row.AgentClass != agentType {
+			t.Fatalf("%s: %+v", agentType, o.Row)
+		}
+	}
+	unknown, err := ParseClaudeHook(strings.NewReader(strings.Replace(claudeSubagentHook, `"agent_type":"sdd-apply"`, `"agent_type":"PRIVATE_CUSTOM"`, 1)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	o := NormalizeClaude(unknown, ClaudeUsage{}, nil)
+	if o.Row.AgentKind != "custom" || o.Row.AgentClass != "unknown" {
+		t.Fatalf("unknown: %+v", o.Row)
+	}
+}
+
+func TestClaudeRuntimeIgnoredAndBounds(t *testing.T) {
+	hook, err := ParseClaudeHook(strings.NewReader(strings.Replace(claudeSubagentHook, "SubagentStop", "SubagentStart", 1)))
+	if err != nil || NormalizeClaude(hook, ClaudeUsage{}, nil) != nil {
+		t.Fatalf("ignored: %v", err)
+	}
+	for _, input := range []string{strings.Repeat("x", ClaudeMaxBytes+1), claudeSubagentHook + `{}`, strings.Replace(claudeSubagentHook, `"agent_id":"PRIVATE_AGENT_ID"`, `"agent_id":"x","agent_id":"y"`, 1)} {
+		if _, err := ParseClaudeHook(strings.NewReader(input)); err == nil {
+			t.Fatal("accepted invalid hook")
+		}
+	}
+}
+
+func TestClaudeTranscriptTailBoundsAndMalformedLines(t *testing.T) {
+	if _, ok := ParseClaudeTranscriptTail(make([]byte, ClaudeTranscriptMaxBytes+1), false, sha256.Sum256([]byte("MATCH"))); ok {
+		t.Fatal("accepted oversized tail")
+	}
+	line := `{"type":"assistant","message":{"model":"claude-opus-5","usage":{"input_tokens":7,"output_tokens":8,"cache_read_input_tokens":9,"cache_creation_input_tokens":10}}}`
+	usage, ok := ParseClaudeTranscriptTail([]byte("partial\n{bad\n"+strings.Replace(line, `"usage"`, `"content":"MATCH","usage"`, 1)+"\n"), true, sha256.Sum256([]byte("MATCH")))
+	if !ok || string(usage.Input) != "7" {
+		t.Fatalf("usage: %+v %v", usage, ok)
+	}
+}
+
+func TestClaudeTranscriptExactBoundaryKeepsFirstRecord(t *testing.T) {
+	line := []byte(`{"type":"assistant","message":{"model":"claude-opus-5","content":"MATCH","usage":{"input_tokens":31}}}` + "\n")
+	usage, ok := ParseClaudeTranscriptTail(line, false, sha256.Sum256([]byte("MATCH")))
+	if !ok || string(usage.Input) != "31" {
+		t.Fatalf("boundary record lost: %+v %v", usage, ok)
+	}
+}
+
+func TestClaudeFrontmatterFallbackAndInvalidValues(t *testing.T) {
+	hook, _ := ParseClaudeHook(strings.NewReader(claudeSubagentHook))
+	o := NormalizeClaude(hook, ClaudeUsage{}, []byte("---\nname: sdd-apply\nmodel: claude-haiku-4-5\neffort: xhigh\n---\nignored"))
+	if o.Row.Model.ID != "claude-haiku-4-5" || o.Row.ModelEvidence != "selected" || o.Row.SelectedEffort != "xhigh" {
+		t.Fatalf("fallback: %+v", o.Row)
+	}
+	o = NormalizeClaude(hook, ClaudeUsage{}, []byte("---\nmodel: PRIVATE_MODEL\neffort: PRIVATE_EFFORT\n---\n"))
+	if o.Row.Model != (RuntimeModel{Provider: "custom", ID: "custom"}) || o.Row.SelectedEffort != "unavailable" {
+		t.Fatalf("custom: %+v", o.Row)
+	}
+	o = NormalizeClaude(hook, ClaudeUsage{Evidence: true, Input: json.RawMessage("1")}, []byte("---\nmodel: claude-haiku-4-5\neffort: low\n---\n"))
+	if o.Row.Model.ID != "claude-haiku-4-5" || o.Row.ModelEvidence != "selected" || string(o.Row.Responses) != "1" {
+		t.Fatalf("model fallback with usage: %+v", o.Row)
+	}
+}

--- a/internal/telemetry/runtime_codex.go
+++ b/internal/telemetry/runtime_codex.go
@@ -1,0 +1,265 @@
+package telemetry
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"io"
+)
+
+const CodexMaxBytes = RuntimeMaxBytes
+const CodexTranscriptMaxBytes = 262144
+
+var errCodex = errors.New("invalid Codex runtime event")
+
+// CodexHook is local-only parsed source metadata. TranscriptPath is used only
+// for the immediate bounded read and must never be serialized or logged.
+type CodexHook struct {
+	Event          string `json:"-"`
+	AgentType      string `json:"-"`
+	TranscriptPath string `json:"-"`
+}
+
+// CodexAssignment is a previously persisted Gentle AI selection. Missing or
+// invalid fields remain unavailable; runtime evidence never invents defaults.
+type CodexAssignment struct {
+	Model  string
+	Effort string
+}
+
+type CodexObservation struct {
+	Row RuntimeRow `json:"row"`
+}
+
+// DecodeCodexHook admits only the documented Stop/SubagentStop input shape.
+// Other hook events are ignored. Private identifiers, paths, and messages are
+// validated but retained only in this local-only value.
+func DecodeCodexHook(input io.Reader) (*CodexHook, error) {
+	data, err := io.ReadAll(io.LimitReader(input, CodexMaxBytes+1))
+	if err != nil || len(data) > CodexMaxBytes {
+		return nil, errCodex
+	}
+	d := json.NewDecoder(bytes.NewReader(data))
+	d.UseNumber()
+	if err := runtimeUnique(d); err != nil {
+		return nil, errCodex
+	}
+	if _, err := d.Token(); err != io.EOF {
+		return nil, errCodex
+	}
+	var root map[string]json.RawMessage
+	if json.Unmarshal(data, &root) != nil || root == nil {
+		return nil, errCodex
+	}
+	event, ok := codexString(root["hook_event_name"], false)
+	if !ok {
+		return nil, errCodex
+	}
+	if event != "SubagentStop" && event != "Stop" {
+		return nil, nil
+	}
+	allowed := map[string]bool{
+		"session_id": true, "transcript_path": true, "cwd": true,
+		"hook_event_name": true, "model": true, "permission_mode": true, "turn_id": true,
+		"agent_id": true, "agent_type": true, "agent_transcript_path": true,
+		"stop_hook_active": true, "last_assistant_message": true,
+	}
+	for key := range root {
+		if !allowed[key] {
+			return nil, errCodex
+		}
+	}
+	for _, key := range []string{"session_id", "cwd", "model", "permission_mode", "turn_id"} {
+		if _, ok := codexString(root[key], false); !ok {
+			return nil, errCodex
+		}
+	}
+	transcriptPath, ok := codexString(root["transcript_path"], true)
+	if !ok {
+		return nil, errCodex
+	}
+	if raw := root["stop_hook_active"]; raw != nil {
+		var active bool
+		if json.Unmarshal(raw, &active) != nil {
+			return nil, errCodex
+		}
+	}
+	if raw := root["last_assistant_message"]; raw != nil {
+		if _, ok := codexString(raw, true); !ok {
+			return nil, errCodex
+		}
+	}
+	hook := &CodexHook{Event: event}
+	if event == "SubagentStop" {
+		for _, key := range []string{"agent_id", "agent_type"} {
+			if _, ok := codexString(root[key], false); !ok {
+				return nil, errCodex
+			}
+		}
+		hook.AgentType, _ = codexString(root["agent_type"], false)
+		agentTranscriptPath, ok := codexString(root["agent_transcript_path"], true)
+		if !ok {
+			return nil, errCodex
+		}
+		hook.TranscriptPath = agentTranscriptPath
+	} else {
+		hook.TranscriptPath = transcriptPath
+	}
+	return hook, nil
+}
+
+func codexString(raw json.RawMessage, nullable bool) (string, bool) {
+	if raw == nil {
+		return "", false
+	}
+	if bytes.Equal(raw, []byte("null")) {
+		return "", nullable
+	}
+	var value string
+	if json.Unmarshal(raw, &value) != nil {
+		return "", false
+	}
+	return value, true
+}
+
+// NormalizeCodex converts one decoded hook plus a bounded transcript tail into
+// one sanitized observation. It performs no filesystem, network, persistence,
+// logging, or lifetime deduplication.
+func NormalizeCodex(source CodexHook, transcript io.Reader, selected CodexAssignment) (*CodexObservation, error) {
+	data, err := io.ReadAll(io.LimitReader(transcript, CodexTranscriptMaxBytes+1))
+	if err != nil || len(data) > CodexTranscriptMaxBytes {
+		return nil, errCodex
+	}
+	model, effort, usage := codexTranscriptEvidence(data)
+	row := RuntimeRow{
+		Model:           RuntimeModel{Provider: "unknown", ID: "unknown"},
+		ModelEvidence:   "unknown",
+		AgentKind:       "custom",
+		AgentClass:      "unknown",
+		SelectedEffort:  codexEffort(selected.Effort),
+		EffectiveEffort: effort,
+		Launches:        json.RawMessage("1"),
+		Responses:       json.RawMessage("1"),
+		Input:           usage.Input,
+		Output:          usage.Output,
+		CacheRead:       usage.CacheRead,
+		CacheCreation:   usage.CacheCreation,
+		ReasoningTokens: usage.Reasoning,
+		TotalTokens:     usage.Total,
+		ErrorCategory:   "none",
+		Duration: RuntimeDuration{
+			Kind:          "unavailable",
+			MeasuredCount: json.RawMessage("0"),
+			SumMS:         json.RawMessage("null"),
+		},
+	}
+	if source.Event == "Stop" {
+		row.AgentKind, row.AgentClass = "orchestrator", "orchestrator"
+		row.Launches = json.RawMessage("null")
+	} else if runtimeMember(source.AgentType, runtimeAgentClasses) {
+		row.AgentKind, row.AgentClass = "built_in", source.AgentType
+	}
+	if model.ID != "" {
+		row.Model, row.ModelEvidence = model, "response"
+	} else if chosen := codexModel(selected.Model); chosen.ID != "" {
+		row.Model, row.ModelEvidence = chosen, "selected"
+	}
+	row.tokenObservations()
+	return &CodexObservation{Row: row}, nil
+}
+
+func codexEffort(value string) string {
+	if value == "none" {
+		return "off"
+	}
+	if runtimeMember(value, runtimeEfforts) && value != "custom" && value != "unavailable" && value != "unsupported" {
+		return value
+	}
+	return "unavailable"
+}
+
+func codexModel(value string) RuntimeModel {
+	if value == "" {
+		return RuntimeModel{}
+	}
+	model := RuntimeModel{Provider: "openai-codex", ID: value}
+	if runtimeModelOK(model) {
+		return model
+	}
+	return RuntimeModel{Provider: "custom", ID: "custom"}
+}
+
+type codexUsage struct {
+	Input, Output, CacheRead, CacheCreation, Reasoning, Total json.RawMessage
+}
+
+func codexTranscriptEvidence(data []byte) (RuntimeModel, string, codexUsage) {
+	model := RuntimeModel{}
+	effort := "unavailable"
+	usage := codexUsage{}
+	hasContext := false
+	for _, line := range bytes.Split(data, []byte("\n")) {
+		if len(bytes.TrimSpace(line)) == 0 {
+			continue
+		}
+		var record map[string]json.RawMessage
+		if json.Unmarshal(line, &record) != nil {
+			continue
+		}
+		kind, ok := codexString(record["type"], false)
+		if !ok {
+			continue
+		}
+		switch kind {
+		case "turn_context":
+			// A turn_context starts a new evidence segment even when its
+			// payload is malformed. Never combine an older turn's model or
+			// effort with token usage observed after a newer context marker.
+			hasContext = true
+			model = RuntimeModel{}
+			effort = "unavailable"
+			usage = codexUsage{}
+			var payload map[string]json.RawMessage
+			if json.Unmarshal(record["payload"], &payload) != nil {
+				continue
+			}
+			if value, ok := codexString(payload["model"], false); ok && value != "" {
+				model = codexModel(value)
+			}
+			if value, ok := codexString(payload["effort"], false); ok {
+				if normalized := codexEffort(value); normalized != "unavailable" {
+					effort = normalized
+				}
+			}
+		case "event_msg":
+			if !hasContext {
+				continue
+			}
+			var payload map[string]json.RawMessage
+			if json.Unmarshal(record["payload"], &payload) != nil {
+				continue
+			}
+			payloadType, ok := codexString(payload["type"], false)
+			if !ok || payloadType != "token_count" {
+				continue
+			}
+			var info, last map[string]json.RawMessage
+			if json.Unmarshal(payload["info"], &info) != nil || json.Unmarshal(info["last_token_usage"], &last) != nil {
+				continue
+			}
+			usage = codexUsage{
+				Input: codexCounter(last["input_tokens"]), Output: codexCounter(last["output_tokens"]),
+				CacheRead: codexCounter(last["cached_input_tokens"]), CacheCreation: codexCounter(last["cache_write_input_tokens"]),
+				Reasoning: codexCounter(last["reasoning_output_tokens"]), Total: codexCounter(last["total_tokens"]),
+			}
+		}
+	}
+	return model, effort, usage
+}
+
+func codexCounter(raw json.RawMessage) json.RawMessage {
+	if number := runtimeNumber(raw); number != "" {
+		return json.RawMessage(number)
+	}
+	return json.RawMessage("null")
+}

--- a/internal/telemetry/runtime_codex.go
+++ b/internal/telemetry/runtime_codex.go
@@ -5,9 +5,12 @@ import (
 	"encoding/json"
 	"errors"
 	"io"
+	"path"
+	"strings"
 )
 
 const CodexMaxBytes = RuntimeMaxBytes
+const CodexTranscriptHeadMaxBytes = 65536
 const CodexTranscriptMaxBytes = 262144
 
 var errCodex = errors.New("invalid Codex runtime event")
@@ -122,6 +125,46 @@ func codexString(raw json.RawMessage, nullable bool) (string, bool) {
 	return value, true
 }
 
+// ResolveCodexAgentType derives a canonical class from the first transcript
+// record only when the hook's agent_type is not already canonical. Source
+// paths and all other session metadata remain local and are discarded.
+func ResolveCodexAgentType(source CodexHook, transcriptHead io.Reader) (CodexHook, error) {
+	if source.Event != "SubagentStop" || runtimeMember(source.AgentType, runtimeAgentClasses) {
+		return source, nil
+	}
+	data, err := io.ReadAll(io.LimitReader(transcriptHead, CodexTranscriptHeadMaxBytes+1))
+	if err != nil || len(data) > CodexTranscriptHeadMaxBytes {
+		return source, errCodex
+	}
+	if newline := bytes.IndexByte(data, '\n'); newline >= 0 {
+		data = data[:newline]
+	}
+	var record map[string]json.RawMessage
+	if json.Unmarshal(data, &record) != nil {
+		return source, nil
+	}
+	kind, ok := codexString(record["type"], false)
+	if !ok || kind != "session_meta" {
+		return source, nil
+	}
+	var payload, sourceValue, subagent, threadSpawn map[string]json.RawMessage
+	if json.Unmarshal(record["payload"], &payload) != nil ||
+		json.Unmarshal(payload["source"], &sourceValue) != nil ||
+		json.Unmarshal(sourceValue["subagent"], &subagent) != nil ||
+		json.Unmarshal(subagent["thread_spawn"], &threadSpawn) != nil {
+		return source, nil
+	}
+	agentPath, ok := codexString(threadSpawn["agent_path"], false)
+	if !ok || agentPath == "" {
+		return source, nil
+	}
+	candidate := strings.ReplaceAll(path.Base(agentPath), "_", "-")
+	if runtimeMember(candidate, runtimeAgentClasses) {
+		source.AgentType = candidate
+	}
+	return source, nil
+}
+
 // NormalizeCodex converts one decoded hook plus a bounded transcript tail into
 // one sanitized observation. It performs no filesystem, network, persistence,
 // logging, or lifetime deduplication.
@@ -226,11 +269,7 @@ func codexTranscriptEvidence(data []byte) (RuntimeModel, string, codexUsage) {
 			if value, ok := codexString(payload["model"], false); ok && value != "" {
 				model = codexModel(value)
 			}
-			if value, ok := codexString(payload["effort"], false); ok {
-				if normalized := codexEffort(value); normalized != "unavailable" {
-					effort = normalized
-				}
-			}
+			effort = codexContextEffort(payload)
 		case "event_msg":
 			if !hasContext {
 				continue
@@ -255,6 +294,24 @@ func codexTranscriptEvidence(data []byte) (RuntimeModel, string, codexUsage) {
 		}
 	}
 	return model, effort, usage
+}
+
+func codexContextEffort(payload map[string]json.RawMessage) string {
+	if value, ok := codexString(payload["effort"], false); ok {
+		if normalized := codexEffort(value); normalized != "unavailable" {
+			return normalized
+		}
+	}
+	var collaborationMode, settings map[string]json.RawMessage
+	if json.Unmarshal(payload["collaboration_mode"], &collaborationMode) != nil ||
+		json.Unmarshal(collaborationMode["settings"], &settings) != nil {
+		return "unavailable"
+	}
+	value, ok := codexString(settings["reasoning_effort"], false)
+	if !ok {
+		return "unavailable"
+	}
+	return codexEffort(value)
 }
 
 func codexCounter(raw json.RawMessage) json.RawMessage {

--- a/internal/telemetry/runtime_codex_test.go
+++ b/internal/telemetry/runtime_codex_test.go
@@ -1,0 +1,217 @@
+package telemetry
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+const codexSubagentHookFixture = `{"session_id":"PRIVATE_SESSION","transcript_path":"PRIVATE_PARENT_PATH","cwd":"PRIVATE_CWD","hook_event_name":"SubagentStop","model":"gpt-5.6-sol","permission_mode":"default","turn_id":"PRIVATE_TURN","agent_id":"PRIVATE_AGENT","agent_type":"sdd-apply","agent_transcript_path":"PRIVATE_AGENT_PATH","stop_hook_active":false,"last_assistant_message":"PRIVATE_MESSAGE"}`
+
+const codexTranscriptFixture = `{"timestamp":"PRIVATE_TIME","type":"turn_context","payload":{"turn_id":"PRIVATE_TURN","cwd":"PRIVATE_CWD","model":"gpt-5.6-sol","effort":"high","summary":"PRIVATE_SUMMARY"}}
+{"timestamp":"PRIVATE_TIME","type":"event_msg","payload":{"type":"token_count","info":{"last_token_usage":{"input_tokens":120,"cached_input_tokens":20,"cache_write_input_tokens":4,"output_tokens":30,"reasoning_output_tokens":10,"total_tokens":164},"total_token_usage":{"input_tokens":999}},"rate_limits":{"plan_type":"PRIVATE_PLAN"}}}
+`
+
+func TestCodexRuntimeCompletedSubagent(t *testing.T) {
+	source, err := DecodeCodexHook(strings.NewReader(codexSubagentHookFixture))
+	if err != nil || source == nil {
+		t.Fatalf("decode hook: source=%+v err=%v", source, err)
+	}
+	o, err := NormalizeCodex(*source, strings.NewReader(codexTranscriptFixture), CodexAssignment{Model: "gpt-5.6-terra", Effort: "medium"})
+	if err != nil || o == nil {
+		t.Fatalf("normalize: observation=%+v err=%v", o, err)
+	}
+	r := o.Row
+	if r.AgentKind != "built_in" || r.AgentClass != "sdd-apply" || r.Model != (RuntimeModel{Provider: "openai-codex", ID: "gpt-5.6-sol"}) || r.ModelEvidence != "response" {
+		t.Fatalf("identity: %+v", r)
+	}
+	if r.SelectedEffort != "medium" || r.EffectiveEffort != "high" || string(r.Launches) != "1" || string(r.Responses) != "1" {
+		t.Fatalf("selection/counts: %+v", r)
+	}
+	for name, got := range map[string]string{
+		"input": string(r.Input), "cache_read": string(r.CacheRead), "cache_creation": string(r.CacheCreation),
+		"output": string(r.Output), "reasoning": string(r.ReasoningTokens), "total": string(r.TotalTokens),
+	} {
+		want := map[string]string{"input": "120", "cache_read": "20", "cache_creation": "4", "output": "30", "reasoning": "10", "total": "164"}[name]
+		if got != tokenReported(want) {
+			t.Errorf("%s = %s, want %s", name, got, tokenReported(want))
+		}
+	}
+	if r.Duration.Kind != "unavailable" || string(r.Duration.MeasuredCount) != "0" || string(r.Duration.SumMS) != "null" || r.ErrorCategory != "none" {
+		t.Fatalf("non-token metrics: %+v", r)
+	}
+	assertRuntimeRetained(t, r, "codex")
+	out, _ := json.Marshal(o)
+	for _, private := range []string{"PRIVATE", "session_id", "transcript_path", "agent_id", "last_assistant_message"} {
+		if strings.Contains(string(out), private) {
+			t.Fatalf("private source data leaked: %s", out)
+		}
+	}
+}
+
+func TestCodexRuntimeUsesExistingAgentClassAllowlist(t *testing.T) {
+	known := ""
+	for _, candidate := range strings.Split(runtimeAgentClasses, "|") {
+		if candidate != "" && candidate != "unknown" && candidate != "orchestrator" {
+			known = candidate
+			break
+		}
+	}
+	if known == "" {
+		t.Fatal("runtime agent-class allowlist has no subagent class")
+	}
+	unknown := "not-a-runtime-agent-class"
+	if runtimeMember(unknown, runtimeAgentClasses) {
+		t.Fatal("test unknown unexpectedly belongs to runtime agent-class allowlist")
+	}
+	for _, tt := range []struct {
+		agentType, wantKind, wantClass string
+	}{
+		{known, "built_in", known},
+		{unknown, "custom", "unknown"},
+		{"", "custom", "unknown"},
+	} {
+		t.Run(tt.agentType, func(t *testing.T) {
+			hook := strings.Replace(codexSubagentHookFixture, `"agent_type":"sdd-apply"`, `"agent_type":"`+tt.agentType+`"`, 1)
+			source, err := DecodeCodexHook(strings.NewReader(hook))
+			if err != nil || source == nil {
+				t.Fatal(err)
+			}
+			o, err := NormalizeCodex(*source, strings.NewReader(""), CodexAssignment{})
+			if err != nil || o == nil || o.Row.AgentKind != tt.wantKind || o.Row.AgentClass != tt.wantClass {
+				t.Fatalf("observation=%+v err=%v", o, err)
+			}
+		})
+	}
+}
+
+func TestCodexRuntimeStopIsOrchestratorAndSelectedFallback(t *testing.T) {
+	hook := `{"session_id":"PRIVATE_SESSION","transcript_path":null,"cwd":"PRIVATE_CWD","hook_event_name":"Stop","model":"gpt-5.6-sol","permission_mode":"default","turn_id":"PRIVATE_TURN","stop_hook_active":false,"last_assistant_message":null}`
+	source, err := DecodeCodexHook(strings.NewReader(hook))
+	if err != nil || source == nil {
+		t.Fatal(err)
+	}
+	o, err := NormalizeCodex(*source, strings.NewReader(""), CodexAssignment{Model: "gpt-5.6-terra", Effort: "medium"})
+	if err != nil || o == nil {
+		t.Fatal(err)
+	}
+	if o.Row.AgentKind != "orchestrator" || o.Row.AgentClass != "orchestrator" || o.Row.Model.ID != "gpt-5.6-terra" || o.Row.ModelEvidence != "selected" || o.Row.SelectedEffort != "medium" || o.Row.EffectiveEffort != "unavailable" || string(o.Row.Launches) != "null" || string(o.Row.Responses) != "1" {
+		t.Fatalf("row: %+v", o.Row)
+	}
+}
+
+func TestCodexRuntimeFinalContextSegmentOwnsEvidence(t *testing.T) {
+	for _, tt := range []struct {
+		name                  string
+		transcript            string
+		selected              CodexAssignment
+		wantModel             RuntimeModel
+		wantModelEvidence     string
+		wantEffort, wantInput string
+	}{
+		{
+			name: "latest context and latest token count win together",
+			transcript: `{"type":"turn_context","payload":{"model":"gpt-5.4","effort":"low"}}
+{"type":"event_msg","payload":{"type":"token_count","info":{"last_token_usage":{"input_tokens":1}}}}
+{"type":"turn_context","payload":{"model":"gpt-5.6-sol","effort":"high"}}
+{"type":"event_msg","payload":{"type":"token_count","info":{"last_token_usage":{"input_tokens":2}}}}
+{"type":"event_msg","payload":{"type":"token_count","info":{"last_token_usage":{"input_tokens":3}}}}
+`,
+			wantModel:         RuntimeModel{Provider: "openai-codex", ID: "gpt-5.6-sol"},
+			wantModelEvidence: "response",
+			wantEffort:        "high",
+			wantInput:         tokenReported("3"),
+		},
+		{
+			name: "invalid final context clears prior turn evidence",
+			transcript: `{"type":"turn_context","payload":{"model":"gpt-5.4","effort":"low"}}
+{"type":"event_msg","payload":{"type":"token_count","info":{"last_token_usage":{"input_tokens":1}}}}
+{"type":"turn_context","payload":{"model":123,"effort":"PRIVATE_EFFORT"}}
+{"type":"event_msg","payload":{"type":"token_count","info":{"last_token_usage":{"input_tokens":2}}}}
+`,
+			selected:          CodexAssignment{Model: "gpt-5.6-terra"},
+			wantModel:         RuntimeModel{Provider: "openai-codex", ID: "gpt-5.6-terra"},
+			wantModelEvidence: "selected",
+			wantEffort:        "unavailable",
+			wantInput:         tokenReported("2"),
+		},
+		{
+			name: "final context without token clears prior usage",
+			transcript: `{"type":"turn_context","payload":{"model":"gpt-5.4","effort":"low"}}
+{"type":"event_msg","payload":{"type":"token_count","info":{"last_token_usage":{"input_tokens":1}}}}
+{"type":"turn_context","payload":{"model":"gpt-5.6-sol","effort":"medium"}}
+`,
+			wantModel:         RuntimeModel{Provider: "openai-codex", ID: "gpt-5.6-sol"},
+			wantModelEvidence: "response",
+			wantEffort:        "medium",
+			wantInput:         tokenAbsent,
+		},
+		{
+			name: "token before any context is not attributed",
+			transcript: `{"type":"event_msg","payload":{"type":"token_count","info":{"last_token_usage":{"input_tokens":7}}}}
+`,
+			wantModel:         RuntimeModel{Provider: "unknown", ID: "unknown"},
+			wantModelEvidence: "unknown",
+			wantEffort:        "unavailable",
+			wantInput:         tokenAbsent,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			source, err := DecodeCodexHook(strings.NewReader(codexSubagentHookFixture))
+			if err != nil || source == nil {
+				t.Fatal(err)
+			}
+			o, err := NormalizeCodex(*source, strings.NewReader(tt.transcript), tt.selected)
+			if err != nil || o == nil {
+				t.Fatal(err)
+			}
+			if o.Row.Model != tt.wantModel || o.Row.ModelEvidence != tt.wantModelEvidence || o.Row.EffectiveEffort != tt.wantEffort || string(o.Row.Input) != tt.wantInput {
+				t.Fatalf("row: %+v", o.Row)
+			}
+		})
+	}
+}
+
+func TestCodexRuntimeStopRetainsOrchestratorTranscriptUsage(t *testing.T) {
+	source := CodexHook{Event: "Stop"}
+	o, err := NormalizeCodex(source, strings.NewReader(codexTranscriptFixture), CodexAssignment{})
+	if err != nil || o == nil {
+		t.Fatal(err)
+	}
+	if o.Row.AgentKind != "orchestrator" || o.Row.AgentClass != "orchestrator" || o.Row.Model.ID != "gpt-5.6-sol" || string(o.Row.Input) != tokenReported("120") || string(o.Row.TotalTokens) != tokenReported("164") {
+		t.Fatalf("row: %+v", o.Row)
+	}
+}
+
+func TestCodexRuntimeHookCasesAndBounds(t *testing.T) {
+	for _, tt := range []struct {
+		name, input string
+		ignored     bool
+		invalid     bool
+	}{
+		{"other event", strings.Replace(codexSubagentHookFixture, "SubagentStop", "SubagentStart", 1), true, false},
+		{"duplicate", strings.Replace(codexSubagentHookFixture, `"session_id":`, `"session_id":"x","session_id":`, 1), false, true},
+		{"case alias", strings.Replace(codexSubagentHookFixture, `"hook_event_name"`, `"Hook_Event_Name"`, 1), false, true},
+		{"nullable parent path", strings.Replace(codexSubagentHookFixture, `"transcript_path":"PRIVATE_PARENT_PATH"`, `"transcript_path":null`, 1), false, false},
+		{"nullable subagent path", strings.Replace(codexSubagentHookFixture, `"agent_transcript_path":"PRIVATE_AGENT_PATH"`, `"agent_transcript_path":null`, 1), false, false},
+		{"missing subagent path", strings.Replace(codexSubagentHookFixture, `,"agent_transcript_path":"PRIVATE_AGENT_PATH"`, "", 1), false, true},
+		{"missing model", strings.Replace(codexSubagentHookFixture, `,"model":"gpt-5.6-sol"`, "", 1), false, true},
+		{"wrong model type", strings.Replace(codexSubagentHookFixture, `"model":"gpt-5.6-sol"`, `"model":153`, 1), false, true},
+		{"wrong active type", strings.Replace(codexSubagentHookFixture, `"stop_hook_active":false`, `"stop_hook_active":"false"`, 1), false, true},
+		{"unknown field", strings.Replace(codexSubagentHookFixture, `"agent_id":`, `"prompt":"PRIVATE_PROMPT","agent_id":`, 1), false, true},
+		{"oversized", strings.Repeat(" ", CodexMaxBytes+1), false, true},
+		{"trailing", codexSubagentHookFixture + `{}`, false, true},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			source, err := DecodeCodexHook(strings.NewReader(tt.input))
+			if (err != nil) != tt.invalid || (err == nil && (source == nil) != tt.ignored) {
+				t.Fatalf("source=%+v err=%v", source, err)
+			}
+		})
+	}
+	if source, _ := DecodeCodexHook(strings.NewReader(codexSubagentHookFixture)); source != nil {
+		if _, err := NormalizeCodex(*source, strings.NewReader(strings.Repeat("x", CodexTranscriptMaxBytes+1)), CodexAssignment{}); err == nil {
+			t.Fatal("oversized transcript accepted")
+		}
+	}
+}

--- a/internal/telemetry/runtime_codex_test.go
+++ b/internal/telemetry/runtime_codex_test.go
@@ -12,6 +12,11 @@ const codexTranscriptFixture = `{"timestamp":"PRIVATE_TIME","type":"turn_context
 {"timestamp":"PRIVATE_TIME","type":"event_msg","payload":{"type":"token_count","info":{"last_token_usage":{"input_tokens":120,"cached_input_tokens":20,"cache_write_input_tokens":4,"output_tokens":30,"reasoning_output_tokens":10,"total_tokens":164},"total_token_usage":{"input_tokens":999}},"rate_limits":{"plan_type":"PRIVATE_PLAN"}}}
 `
 
+const codexRealSubagentTranscriptFixture = `{"timestamp":"PRIVATE_TIME","type":"session_meta","payload":{"id":"PRIVATE_SESSION","source":{"subagent":{"thread_spawn":{"parent_thread_id":"PRIVATE_PARENT","depth":1,"agent_nickname":"PRIVATE_NICKNAME","agent_path":"/root/sdd_explore"}}}}}
+{"timestamp":"PRIVATE_TIME","type":"turn_context","payload":{"turn_id":"PRIVATE_TURN","model":"gpt-5.6-sol","effort":"medium","collaboration_mode":{"settings":{"reasoning_effort":"medium"}}}}
+{"timestamp":"PRIVATE_TIME","type":"event_msg","payload":{"type":"token_count","info":{"last_token_usage":{"input_tokens":120,"cached_input_tokens":20,"cache_write_input_tokens":4,"output_tokens":30,"reasoning_output_tokens":10,"total_tokens":164}}}}
+`
+
 func TestCodexRuntimeCompletedSubagent(t *testing.T) {
 	source, err := DecodeCodexHook(strings.NewReader(codexSubagentHookFixture))
 	if err != nil || source == nil {
@@ -82,6 +87,38 @@ func TestCodexRuntimeUsesExistingAgentClassAllowlist(t *testing.T) {
 				t.Fatalf("observation=%+v err=%v", o, err)
 			}
 		})
+	}
+}
+
+func TestCodexRuntimeDerivesAllowlistedAgentFromFirstSessionMeta(t *testing.T) {
+	for _, tt := range []struct {
+		name, agentType, transcriptHead, wantAgentType string
+	}{
+		{"unknown hook uses underscored task path", "default", codexRealSubagentTranscriptFixture, "sdd-explore"},
+		{"direct allowlisted hook wins", "sdd-apply", codexRealSubagentTranscriptFixture, "sdd-apply"},
+		{"unknown derived name stays unknown", "default", strings.Replace(codexRealSubagentTranscriptFixture, "/root/sdd_explore", "/root/private_custom", 1), "default"},
+		{"only first record is eligible", "default", `{"type":"event_msg","payload":{}}
+` + codexRealSubagentTranscriptFixture, "default"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			source := CodexHook{Event: "SubagentStop", AgentType: tt.agentType}
+			resolved, err := ResolveCodexAgentType(source, strings.NewReader(tt.transcriptHead))
+			if err != nil || resolved.AgentType != tt.wantAgentType {
+				t.Fatalf("resolved=%+v err=%v", resolved, err)
+			}
+		})
+	}
+}
+
+func TestCodexRuntimeEffectiveEffortFallsBackToCollaborationSettings(t *testing.T) {
+	transcript := `{"type":"turn_context","payload":{"model":"gpt-5.6-sol","effort":null,"collaboration_mode":{"settings":{"reasoning_effort":"medium"}}}}
+`
+	o, err := NormalizeCodex(CodexHook{Event: "SubagentStop", AgentType: "sdd-explore"}, strings.NewReader(transcript), CodexAssignment{Effort: "xhigh"})
+	if err != nil || o == nil {
+		t.Fatal(err)
+	}
+	if o.Row.SelectedEffort != "xhigh" || o.Row.EffectiveEffort != "medium" {
+		t.Fatalf("row=%+v", o.Row)
 	}
 }
 

--- a/internal/telemetry/runtime_opencode.go
+++ b/internal/telemetry/runtime_opencode.go
@@ -23,6 +23,7 @@ type OpenCodeObservation struct {
 	ReasoningTokens   json.RawMessage `json:"reasoning_tokens"`
 	MessageDurationMS *int64          `json:"message_duration_ms"`
 	ErrorCategory     string          `json:"error_category,omitempty"`
+	Agent             string          `json:"-"`
 }
 
 // NormalizeOpenCode handles a single completed non-summary assistant message.
@@ -104,16 +105,16 @@ func NormalizeOpenCode(input io.Reader) (*OpenCodeObservation, error) {
 	if err != nil {
 		return nil, err
 	}
-	m := RuntimeModel{Provider: provider, ID: model}
-	if provider == "" || model == "" {
-		m = RuntimeModel{Provider: "unknown", ID: "unknown"}
-	} else if !runtimeModelOK(m) {
-		m = RuntimeModel{Provider: "custom", ID: "custom"}
-		if provider == "opencode" {
-			m.Provider = "opencode"
-		}
+	agent, err := openCodeAgent(info["agent"])
+	if err != nil {
+		return nil, err
 	}
-	r := RuntimeRow{Model: m, ModelEvidence: "response", AgentKind: "unknown", AgentClass: "unknown", SelectedEffort: "unavailable", EffectiveEffort: "unavailable", Launches: json.RawMessage("null"), Responses: json.RawMessage("1")}
+	modelEvidence := "response"
+	if provider == "" || model == "" {
+		modelEvidence = "unknown"
+	}
+	agentKind, agentClass := openCodeAgentAttribution(agent)
+	r := RuntimeRow{Model: NormalizeRuntimeModel(provider, model), ModelEvidence: modelEvidence, AgentKind: agentKind, AgentClass: agentClass, SelectedEffort: "unavailable", EffectiveEffort: "unavailable", Launches: json.RawMessage("null"), Responses: json.RawMessage("1")}
 	tokens := openCodeObject{}
 	if raw, ok := info["tokens"]; ok {
 		tokens, err = openCodeMap(raw)
@@ -128,7 +129,7 @@ func NormalizeOpenCode(input io.Reader) (*OpenCodeObservation, error) {
 			return nil, err
 		}
 	}
-	o := &OpenCodeObservation{MessageDurationMS: &duration}
+	o := &OpenCodeObservation{MessageDurationMS: &duration, Agent: agent}
 	for _, metric := range []struct {
 		raw    json.RawMessage
 		target *json.RawMessage
@@ -163,6 +164,37 @@ func NormalizeOpenCode(input io.Reader) (*OpenCodeObservation, error) {
 	o.ReasoningTokens = r.ReasoningTokens
 	o.ErrorCategory = r.ErrorCategory
 	return o, nil
+}
+
+func openCodeAgent(raw []byte) (string, error) {
+	agent, err := openCodeString(raw)
+	if err != nil || len(agent) > 64 {
+		return "", errOpenCode
+	}
+	for i := 0; i < len(agent); i++ {
+		if agent[i] < 0x20 || agent[i] > 0x7e {
+			return "", errOpenCode
+		}
+	}
+	return agent, nil
+}
+
+func openCodeAgentAttribution(agent string) (kind, class string) {
+	switch agent {
+	case "":
+		return "unknown", "unknown"
+	case "build", "plan", "gentle-orchestrator":
+		return "orchestrator", "orchestrator"
+	case "explore":
+		return "built_in", "explore"
+	case "general":
+		return "built_in", "worker"
+	default:
+		if runtimeMember(agent, runtimeAgentClasses) && agent != "orchestrator" && agent != "worker" && agent != "explore" && agent != "verify" && agent != "unknown" {
+			return "built_in", agent
+		}
+		return "custom", "unknown"
+	}
 }
 
 func openCodeMap(raw []byte) (openCodeObject, error) {

--- a/internal/telemetry/runtime_opencode_test.go
+++ b/internal/telemetry/runtime_opencode_test.go
@@ -7,21 +7,21 @@ import (
 )
 
 // Source-shaped fixture, not a released SDK compatibility claim.
-const openCodeFixture = `{"type":"message.updated","properties":{"info":{"id":"PRIVATE_ID","sessionID":"PRIVATE_SESSION","role":"assistant","parentID":"PRIVATE_PARENT","modelID":"gpt-5.4","providerID":"openai","mode":"build","path":{"cwd":"PRIVATE_PATH","root":"PRIVATE_ROOT"},"cost":0,"time":{"created":1000,"completed":1250},"tokens":{"input":12,"output":8,"reasoning":3,"cache":{"read":2,"write":0}},"finish":"stop"}}}`
+const openCodeFixture = `{"type":"message.updated","properties":{"info":{"id":"PRIVATE_ID","sessionID":"PRIVATE_SESSION","role":"assistant","parentID":"PRIVATE_PARENT","modelID":"gpt-5.4","providerID":"openai","agent":"build","path":{"cwd":"PRIVATE_PATH","root":"PRIVATE_ROOT"},"cost":0,"time":{"created":1000,"completed":1250},"tokens":{"input":12,"output":8,"reasoning":3,"cache":{"read":2,"write":0}},"finish":"stop"}}}`
 
 func TestOpenCodeRuntimeSanitizedIdentity(t *testing.T) {
 	for _, tc := range []struct {
-		provider, model, wantProvider, wantModel string
+		provider, model, wantProvider, wantModel, wantEvidence string
 	}{
-		{"opencode", "PRIVATE_MODEL", "opencode", "custom"},
-		{"opencode", "gpt-5.4", "opencode", "custom"},
-		{"opencode", "custom", "opencode", "custom"},
-		{"OpenCode", "PRIVATE_MODEL", "custom", "custom"},
-		{"PRIVATE_PROVIDER", "PRIVATE_MODEL", "custom", "custom"},
-		{"openai", "PRIVATE_MODEL", "custom", "custom"},
-		{"openai", "gpt-5.4", "openai", "gpt-5.4"},
-		{"opencode", "", "unknown", "unknown"},
-		{"", "PRIVATE_MODEL", "unknown", "unknown"},
+		{"opencode", "PRIVATE_MODEL", "opencode", "custom", "response"},
+		{"opencode", "gpt-5.4", "opencode", "custom", "response"},
+		{"opencode", "custom", "opencode", "custom", "response"},
+		{"OpenCode", "PRIVATE_MODEL", "custom", "custom", "response"},
+		{"PRIVATE_PROVIDER", "PRIVATE_MODEL", "custom", "custom", "response"},
+		{"openai", "PRIVATE_MODEL", "custom", "custom", "response"},
+		{"openai", "gpt-5.4", "openai", "gpt-5.4", "response"},
+		{"opencode", "", "unknown", "unknown", "unknown"},
+		{"", "PRIVATE_MODEL", "unknown", "unknown", "unknown"},
 	} {
 		t.Run(tc.provider+"/"+tc.model, func(t *testing.T) {
 			input := strings.Replace(openCodeFixture, `"providerID":"openai"`, `"providerID":"`+tc.provider+`"`, 1)
@@ -30,8 +30,8 @@ func TestOpenCodeRuntimeSanitizedIdentity(t *testing.T) {
 			if err != nil || o == nil {
 				t.Fatal(err)
 			}
-			if o.Row.Model != (RuntimeModel{Provider: tc.wantProvider, ID: tc.wantModel}) {
-				t.Fatalf("unexpected model: %+v", o.Row.Model)
+			if o.Row.Model != (RuntimeModel{Provider: tc.wantProvider, ID: tc.wantModel}) || o.Row.ModelEvidence != tc.wantEvidence {
+				t.Fatalf("unexpected model attribution: %+v evidence %q", o.Row.Model, o.Row.ModelEvidence)
 			}
 			assertRuntimeRetained(t, o.Row, "opencode")
 		})
@@ -43,13 +43,13 @@ func TestOpenCodeRuntimeCompleted(t *testing.T) {
 	if err != nil || o == nil {
 		t.Fatalf("normalize: %v, %v", o, err)
 	}
-	if o.Row.Model.ID != "gpt-5.4" || o.Row.ModelEvidence != "response" || o.Row.AgentKind != "unknown" || o.Row.SelectedEffort != "unavailable" || o.Row.EffectiveEffort != "unavailable" {
+	if o.Row.Model.ID != "gpt-5.4" || o.Row.ModelEvidence != "response" || o.Row.AgentKind != "orchestrator" || o.Row.AgentClass != "orchestrator" || o.Row.SelectedEffort != "unavailable" || o.Row.EffectiveEffort != "unavailable" {
 		t.Fatalf("row: %+v", o.Row)
 	}
 	if string(o.Row.Input) != tokenReported("12") || string(o.Row.Output) != tokenReported("8") || string(o.Row.CacheRead) != tokenReported("2") || string(o.Row.CacheCreation) != tokenAbsent || string(o.ReasoningTokens) != tokenReported("3") || o.MessageDurationMS == nil || *o.MessageDurationMS != 250 {
 		t.Fatalf("metrics: %+v", o)
 	}
-	if string(o.Row.ReasoningTokens) != tokenReported("3") || o.Row.AgentClass != "unknown" || string(o.Row.TotalTokens) != tokenAbsent || o.Row.ErrorCategory != "none" || o.Row.Duration.Kind != "message" || string(o.Row.Duration.MeasuredCount) != "1" || string(o.Row.Duration.SumMS) != "25e1" {
+	if string(o.Row.ReasoningTokens) != tokenReported("3") || string(o.Row.TotalTokens) != tokenAbsent || o.Row.ErrorCategory != "none" || o.Row.Duration.Kind != "message" || string(o.Row.Duration.MeasuredCount) != "1" || string(o.Row.Duration.SumMS) != "25e1" {
 		t.Fatalf("common metrics: %+v", o.Row)
 	}
 	assertRuntimeRetained(t, o.Row, "opencode")
@@ -64,6 +64,41 @@ func TestOpenCodeRuntimeCompleted(t *testing.T) {
 	again, err := NormalizeOpenCode(strings.NewReader(openCodeFixture))
 	if err != nil || again == nil {
 		t.Fatal("pure normalizer must not lifetime-dedupe")
+	}
+}
+
+func TestOpenCodeRuntimeAgentAttribution(t *testing.T) {
+	for _, tt := range []struct {
+		name       string
+		agent      string
+		wantKind   string
+		wantClass  string
+		wantStored string
+	}{
+		{"native build agent", "build", "orchestrator", "orchestrator", "build"},
+		{"native plan agent", "plan", "orchestrator", "orchestrator", "plan"},
+		{"gentle ai orchestrator", "gentle-orchestrator", "orchestrator", "orchestrator", "gentle-orchestrator"},
+		{"fallback explore agent", "explore", "built_in", "explore", "explore"},
+		{"fallback general agent", "general", "built_in", "worker", "general"},
+		{"named gentle ai agent", "sdd-apply", "built_in", "sdd-apply", "sdd-apply"},
+		{"custom agent", "team-private-agent", "custom", "unknown", "team-private-agent"},
+		{"missing agent", "", "unknown", "unknown", ""},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			input := openCodeFixture
+			if tt.agent == "" {
+				input = strings.Replace(input, `,"agent":"build"`, "", 1)
+			} else {
+				input = strings.Replace(input, `"agent":"build"`, `"agent":"`+tt.agent+`"`, 1)
+			}
+			o, err := NormalizeOpenCode(strings.NewReader(input))
+			if err != nil || o == nil {
+				t.Fatalf("NormalizeOpenCode() = %+v, %v", o, err)
+			}
+			if o.Row.AgentKind != tt.wantKind || o.Row.AgentClass != tt.wantClass || o.Agent != tt.wantStored {
+				t.Fatalf("agent attribution = %q/%q stored %q, want %q/%q stored %q", o.Row.AgentKind, o.Row.AgentClass, o.Agent, tt.wantKind, tt.wantClass, tt.wantStored)
+			}
+		})
 	}
 }
 
@@ -141,7 +176,9 @@ func TestOpenCodeRuntimeBounds(t *testing.T) {
 		strings.Repeat(" ", OpenCodeMaxBytes+1),
 		openCodeFixture + ` {}`,
 		`{"x":` + strings.Repeat(`[`, 34) + `0` + strings.Repeat(`]`, 34) + `}`,
-		strings.Replace(openCodeFixture, `"mode":"build"`, `"mode":"`+strings.Repeat("x", 4097)+`"`, 1),
+		strings.Replace(openCodeFixture, `"agent":"build"`, `"agent":"`+strings.Repeat("x", 4097)+`"`, 1),
+		strings.Replace(openCodeFixture, `"agent":"build"`, `"agent":"`+strings.Repeat("x", 65)+`"`, 1),
+		strings.Replace(openCodeFixture, `"agent":"build"`, `"agent":"bad\nagent"`, 1),
 		strings.Replace(openCodeFixture, `"cost":0`, `"error":{"name":"APIError","data":{"statusCode":999}}`, 1),
 	} {
 		if _, err := NormalizeOpenCode(strings.NewReader(s)); err == nil {

--- a/internal/telemetry/runtime_test.go
+++ b/internal/telemetry/runtime_test.go
@@ -21,8 +21,11 @@ func tokenReported(sum string) string {
 	return `{"reported":1,"unavailable":0,"unsupported":0,"sum":` + sum + `}`
 }
 
-func TestRuntimeAgentClassesMatchConfigurableAgents(t *testing.T) {
+func TestRuntimeAgentClassesMatchPackagedAgents(t *testing.T) {
 	want := append([]string{"orchestrator", "worker", "explore", "verify", "unknown"}, opencode.ConfigurableAgentPhases()...)
+	// Pi packages exactly these additional agents outside the configurable OpenCode phases.
+	piOnlyPackagedAgents := []string{"sdd-status", "sdd-sync"}
+	want = append(want, piOnlyPackagedAgents...)
 	goClasses := strings.Split(runtimeAgentClasses, "|")
 
 	data, err := os.ReadFile("../../contracts/telemetry/runtime/v1/schemas/aggregate.schema.json")
@@ -49,7 +52,7 @@ func TestRuntimeAgentClassesMatchConfigurableAgents(t *testing.T) {
 	for source, got := range map[string][]string{"Go": goClasses, "JSON Schema": schemaClasses} {
 		slices.Sort(got)
 		if !slices.Equal(got, want) {
-			t.Errorf("%s runtime agent classes = %v, want fixed classes plus configurable agents %v", source, got, want)
+			t.Errorf("%s runtime agent classes = %v, want fixed classes plus OpenCode and Pi packaged agents %v", source, got, want)
 		}
 	}
 }

--- a/internal/telemetry/runtime_test.go
+++ b/internal/telemetry/runtime_test.go
@@ -4,9 +4,11 @@ import (
 	"bytes"
 	"encoding/json"
 	"os"
+	"slices"
 	"strings"
 	"testing"
 
+	"github.com/gentleman-programming/gentle-ai/v2/internal/opencode"
 	"github.com/santhosh-tekuri/jsonschema/v6"
 )
 
@@ -17,6 +19,50 @@ const runtimeFixture = `{"schema":"gentle-ai.telemetry-runtime-aggregate/v1","re
 
 func tokenReported(sum string) string {
 	return `{"reported":1,"unavailable":0,"unsupported":0,"sum":` + sum + `}`
+}
+
+func TestRuntimeAgentClassesMatchConfigurableAgents(t *testing.T) {
+	want := append([]string{"orchestrator", "worker", "explore", "verify", "unknown"}, opencode.ConfigurableAgentPhases()...)
+	goClasses := strings.Split(runtimeAgentClasses, "|")
+
+	data, err := os.ReadFile("../../contracts/telemetry/runtime/v1/schemas/aggregate.schema.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var document struct {
+		Definitions struct {
+			Row struct {
+				Properties struct {
+					AgentClass struct {
+						Enum []string `json:"enum"`
+					} `json:"agent_class"`
+				} `json:"properties"`
+			} `json:"row"`
+		} `json:"$defs"`
+	}
+	if err := json.Unmarshal(data, &document); err != nil {
+		t.Fatal(err)
+	}
+	schemaClasses := document.Definitions.Row.Properties.AgentClass.Enum
+
+	slices.Sort(want)
+	for source, got := range map[string][]string{"Go": goClasses, "JSON Schema": schemaClasses} {
+		slices.Sort(got)
+		if !slices.Equal(got, want) {
+			t.Errorf("%s runtime agent classes = %v, want fixed classes plus configurable agents %v", source, got, want)
+		}
+	}
+}
+
+func TestDeprecatedRuntimeAgentClassAliasNormalized(t *testing.T) {
+	body := strings.Replace(runtimeFixture, `"agent_class":"unknown"`, `"agent_class":"sdd-proposal"`, 1)
+	batch, err := decodeRuntime([]byte(body))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := batch.Rows[0].AgentClass; got != "sdd-propose" {
+		t.Fatalf("deprecated agent class normalized to %q, want sdd-propose", got)
+	}
 }
 
 // Retained means preserved by canonicalization in memory, never persisted.

--- a/internal/telemetry/telemetry.go
+++ b/internal/telemetry/telemetry.go
@@ -36,7 +36,7 @@ const EndpointEnvVar = "GENTLE_AI_TELEMETRY_ENDPOINT"
 // enrollment step, before any event is ever built or sent. That one
 // enrollment run sends nothing at all; the first real send only happens on
 // a later trigger. It is never printed by the sender itself.
-const NoticeLine = "Gentle AI sends anonymous usage metrics (version, OS, agents, counters) and may send anonymous runtime usage from supported Pi/OpenCode integrations (public model, effort, agent class, available token usage, timing, error categories); runtime usage is never stored locally; run gentle-ai telemetry disable to opt out."
+const NoticeLine = "Gentle AI sends anonymous usage metrics (version, OS, agents, counters) and may send anonymous runtime usage from supported Pi/OpenCode/Codex integrations (public model, effort, agent class, available token usage, timing, error categories); runtime usage is never stored locally; run gentle-ai telemetry disable to opt out."
 
 // MaxPayloadBytes bounds the JSON POST body per the issue's contract.
 const MaxPayloadBytes = 4096

--- a/internal/telemetry/telemetry_test.go
+++ b/internal/telemetry/telemetry_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func TestNoticeRuntimeDisclosure(t *testing.T) {
-	const want = "Gentle AI sends anonymous usage metrics (version, OS, agents, counters) and may send anonymous runtime usage from supported Pi/OpenCode integrations (public model, effort, agent class, available token usage, timing, error categories); runtime usage is never stored locally; run gentle-ai telemetry disable to opt out."
+	const want = "Gentle AI sends anonymous usage metrics (version, OS, agents, counters) and may send anonymous runtime usage from supported Pi/OpenCode/Codex integrations (public model, effort, agent class, available token usage, timing, error categories); runtime usage is never stored locally; run gentle-ai telemetry disable to opt out."
 	if NoticeLine != want {
 		t.Fatalf("enrollment notice = %q, want %q", NoticeLine, want)
 	}

--- a/internal/telemetrycollector/runtime_dashboard_test.go
+++ b/internal/telemetrycollector/runtime_dashboard_test.go
@@ -73,7 +73,7 @@ func TestRuntimeDashboard(t *testing.T) {
 		{"Runtime usage", "Tokens processed per hour by host", "timeseries"},
 		{"Runtime usage", "Token coverage per field", "table"},
 		{"Runtime usage", "Error observations by category", "barchart"},
-		{"Runtime usage", "Measured request duration", "stat"},
+		{"Runtime usage", "Measured duration by kind", "table"},
 	}
 	var gotPanels []struct{ section, title, kind string }
 	section := ""
@@ -122,8 +122,6 @@ func TestRuntimeDashboard(t *testing.T) {
 			wantUnit := "short"
 			if panel.Title == "RDD adoption %" {
 				wantUnit = "percent"
-			} else if panel.Title == "Measured request duration" {
-				wantUnit = "ms"
 			}
 			if defaults["unit"] != wantUnit {
 				t.Errorf("panel %q unit = %v; want %q", panel.Title, defaults["unit"], wantUnit)
@@ -136,12 +134,15 @@ func TestRuntimeDashboard(t *testing.T) {
 		if strings.Contains(string(configJSON), `"axisPlacement":"right"`) {
 			t.Errorf("panel %q introduces a second y-axis", panel.Title)
 		}
-		if section == "Runtime usage" {
+		if section == "Runtime usage" && panel.Title != "Measured duration by kind" {
 			for _, host := range []string{"pi", "opencode", "claude-code", "codex"} {
 				if !strings.Contains(string(configJSON), `"options":"`+host+`"`) {
 					t.Errorf("runtime panel %q does not pin the %s series color", panel.Title, host)
 				}
 			}
+		}
+		if panel.Title == "Measured duration by kind" && (!strings.Contains(string(configJSON), `"options":"Average ms"`) || !strings.Contains(string(configJSON), `"value":"ms"`)) {
+			t.Error("duration table must format only its average column as milliseconds")
 		}
 	}
 	if !reflect.DeepEqual(gotPanels, wantPanels) {
@@ -211,7 +212,7 @@ func TestRuntimeDashboard(t *testing.T) {
 		{"delivery-opencode", "opencode", time.Date(2026, 1, 2, 11, 30, 0, 0, time.UTC).UnixNano(), map[string]any{
 			"model": map[string]string{"provider": "custom", "id": "custom"}, "model_evidence": "unknown", "agent_kind": "worker", "agent_class": "unknown", "selected_effort": "unknown", "effective_effort": "unknown", "launches": 2, "responses": 2,
 			"input_tokens": token(7, 1, 0, 0), "output_tokens": token(4, 1, 0, 0), "cache_read_tokens": token(99, 0, 1, 0), "cache_creation_tokens": token(99, 0, 0, 1), "reasoning_tokens": token(99, 0, 1, 0), "total_tokens": token(999, 0, 1, 0),
-			"error_category": "provider", "duration": map[string]any{"kind": "request", "measured_count": 1, "sum_ms": 40.0},
+			"error_category": "provider", "duration": map[string]any{"kind": "message", "measured_count": 1, "sum_ms": 40.0},
 		}},
 	}
 	for _, fixture := range runtimeFixtures {
@@ -229,6 +230,17 @@ func TestRuntimeDashboard(t *testing.T) {
 		if _, err := s.db.Exec(`INSERT INTO runtime_rows(delivery_id,ordinal,row_json) VALUES(?,0,?)`, fixture.id, string(raw)); err != nil {
 			t.Fatal(err)
 		}
+	}
+	unavailableDuration, err := json.Marshal(map[string]any{
+		"model": map[string]string{"provider": "openai", "id": "gpt-5"}, "model_evidence": "response", "agent_kind": "orchestrator", "agent_class": "orchestrator", "selected_effort": "high", "effective_effort": "high", "launches": 0, "responses": 0,
+		"input_tokens": token(0, 0, 1, 0), "output_tokens": token(0, 0, 1, 0), "cache_read_tokens": token(0, 0, 1, 0), "cache_creation_tokens": token(0, 0, 1, 0), "reasoning_tokens": token(0, 0, 1, 0), "total_tokens": token(0, 0, 1, 0),
+		"error_category": "none", "duration": map[string]any{"kind": "unavailable", "measured_count": 0, "sum_ms": nil},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := s.db.Exec(`INSERT INTO runtime_rows(delivery_id,ordinal,row_json) VALUES('delivery-codex',1,?)`, string(unavailableDuration)); err != nil {
+		t.Fatal(err)
 	}
 
 	queries := map[string]string{}
@@ -272,7 +284,29 @@ func TestRuntimeDashboard(t *testing.T) {
 	assertSingleNumber("Responses", 5)
 	assertSingleNumber("Deliveries", 2)
 	assertSingleNumber("Hosts reporting", 2)
-	assertSingleNumber("Measured request duration", 30)
+
+	durationRows, err := s.db.Query(queries["Measured duration by kind"])
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer durationRows.Close()
+	var gotDurations [][]any
+	for durationRows.Next() {
+		var kind string
+		var measured int64
+		var average float64
+		if err := durationRows.Scan(&kind, &measured, &average); err != nil {
+			t.Fatal(err)
+		}
+		gotDurations = append(gotDurations, []any{kind, measured, average})
+	}
+	wantDurations := [][]any{{"request", int64(2), float64(25)}, {"message", int64(1), float64(40)}}
+	if !reflect.DeepEqual(gotDurations, wantDurations) {
+		t.Fatalf("duration rows = %#v; want %#v", gotDurations, wantDurations)
+	}
+	if strings.Contains(queries["Measured duration by kind"], "= 'request'") || !strings.Contains(queries["Measured duration by kind"], "<> 'unavailable'") {
+		t.Fatal("duration panel must include every measured kind and exclude unavailable rows")
+	}
 
 	usageRows, err := s.db.Query(queries["Usage by host, subagent, model and effort"])
 	if err != nil {

--- a/internal/telemetrycollector/runtime_dashboard_test.go
+++ b/internal/telemetrycollector/runtime_dashboard_test.go
@@ -16,388 +16,293 @@ func TestRuntimeDashboard(t *testing.T) {
 		t.Fatal(err)
 	}
 	var dashboard struct {
-		Panels []struct {
+		UID      string
+		Title    string
+		Timezone string
+		Refresh  string
+		Time     struct{ From, To string }
+		Panels   []struct {
 			ID          int
 			Title       string
 			Type        string
 			Description string
 			GridPos     struct{ X, Y, W, H int }
 			Datasource  struct{ UID string }
-			Targets     []struct{ QueryText, RawQueryText string }
+			Targets     []struct {
+				QueryType, QueryText, RawQueryText string
+				TimeColumns                        []string
+			}
 			FieldConfig map[string]any
 		}
 	}
 	if err := json.Unmarshal(data, &dashboard); err != nil {
 		t.Fatal(err)
 	}
-	wantRuntimeGrid := map[int][4]int{
-		19: {0, 0, 24, 1}, 20: {0, 1, 24, 5},
-		15: {0, 6, 24, 8}, 16: {0, 14, 24, 8},
-		21: {0, 22, 24, 10}, 17: {0, 32, 24, 8},
-		22: {0, 40, 12, 7}, 18: {12, 40, 12, 7},
+	if dashboard.UID != "gentle-ai-usage" || dashboard.Title != "Gentle AI — Usage" {
+		t.Fatalf("dashboard identity changed: %q %q", dashboard.UID, dashboard.Title)
 	}
+	if dashboard.Timezone != "browser" || dashboard.Refresh != "1m" || dashboard.Time.From != "now-7d" || dashboard.Time.To != "now" {
+		t.Fatalf("dashboard defaults = timezone %q, refresh %q, range %q to %q", dashboard.Timezone, dashboard.Refresh, dashboard.Time.From, dashboard.Time.To)
+	}
+
+	wantPanels := []struct{ section, title, kind string }{
+		{"Adoption", "Unique installs all-time", "stat"},
+		{"Adoption", "Active installs yesterday", "stat"},
+		{"Adoption", "Active installs in range", "stat"},
+		{"Adoption", "New installs in range", "stat"},
+		{"Adoption", "Heartbeats in range", "stat"},
+		{"Adoption", "RDD adoption %", "stat"},
+		{"Adoption", "npm downloads latest day", "stat"},
+		{"Adoption", "GitHub release downloads", "stat"},
+		{"Growth", "Daily active installs", "timeseries"},
+		{"Growth", "Daily new installs", "timeseries"},
+		{"Growth", "Cumulative unique installs", "timeseries"},
+		{"Where Gentle AI runs", "Agent adoption", "barchart"},
+		{"Where Gentle AI runs", "Component adoption", "barchart"},
+		{"Where Gentle AI runs", "OS and architecture", "barchart"},
+		{"Where Gentle AI runs", "Version adoption", "barchart"},
+		{"Runtime usage", "Tokens processed", "stat"},
+		{"Runtime usage", "Responses", "stat"},
+		{"Runtime usage", "Deliveries", "stat"},
+		{"Runtime usage", "Hosts reporting", "stat"},
+		{"Runtime usage", "Tokens processed by host", "barchart"},
+		{"Runtime usage", "Responses by host", "barchart"},
+		{"Runtime usage", "Tokens by model", "table"},
+		{"Runtime usage", "Responses and tokens by selected effort", "table"},
+		{"Runtime usage", "Usage by host, subagent, model and effort", "table"},
+		{"Runtime usage", "Tokens processed per hour by host", "timeseries"},
+		{"Runtime usage", "Token coverage per field", "table"},
+		{"Runtime usage", "Error observations by category", "barchart"},
+		{"Runtime usage", "Measured request duration", "stat"},
+	}
+	var gotPanels []struct{ section, title, kind string }
+	section := ""
+	seenIDs := map[int]bool{}
 	for i, panel := range dashboard.Panels {
-		g := panel.GridPos
-		if want, ok := wantRuntimeGrid[panel.ID]; ok {
-			if got := [4]int{g.X, g.Y, g.W, g.H}; got != want {
-				t.Errorf("panel %d grid = %v; want %v", panel.ID, got, want)
-			}
-			delete(wantRuntimeGrid, panel.ID)
+		if seenIDs[panel.ID] {
+			t.Fatalf("duplicate panel id %d", panel.ID)
 		}
+		seenIDs[panel.ID] = true
+		g := panel.GridPos
 		for _, other := range dashboard.Panels[:i] {
 			o := other.GridPos
 			if g.X < o.X+o.W && o.X < g.X+g.W && g.Y < o.Y+o.H && o.Y < g.Y+g.H {
 				t.Errorf("panels %d and %d overlap", panel.ID, other.ID)
 			}
 		}
-	}
-	if len(wantRuntimeGrid) != 0 {
-		t.Fatalf("missing runtime panels: %v", wantRuntimeGrid)
-	}
-	runtimeQueries := 0
-	for _, panel := range dashboard.Panels {
-		for _, target := range panel.Targets {
-			if target.QueryText != target.RawQueryText {
-				t.Fatalf("panel %d: query texts differ", panel.ID)
-			}
-		}
-		if panel.ID < 15 {
-			if panel.GridPos.Y < 48 {
-				t.Fatalf("legacy panel %d precedes runtime section", panel.ID)
-			}
+		if panel.Type == "row" {
+			section = panel.Title
 			continue
 		}
-		if panel.ID == 19 {
-			if panel.Type != "row" || panel.GridPos.Y != 0 {
-				t.Fatal("runtime section must start at top")
-			}
+		gotPanels = append(gotPanels, struct{ section, title, kind string }{section, panel.Title, panel.Type})
+		if panel.Description == "" {
+			t.Errorf("panel %q has no description", panel.Title)
+		}
+		if panel.Datasource.UID != "gentle-telemetry-sqlite" || len(panel.Targets) != 1 {
+			t.Errorf("panel %q has wrong datasource or target count", panel.Title)
 			continue
 		}
-		runtimeQueries++
-		if panel.Description == "" || panel.Datasource.UID != "gentle-telemetry-sqlite" || panel.GridPos.Y+panel.GridPos.H > 47 {
-			t.Fatalf("runtime panel %d: missing context, datasource or top layout", panel.ID)
+		target := panel.Targets[0]
+		if target.QueryType != "table" || target.RawQueryText == "" || target.QueryText != target.RawQueryText {
+			t.Errorf("panel %q must use one identical table queryText/rawQueryText pair", panel.Title)
 		}
-		if panel.ID == 16 {
-			if panel.Type != "table" || panel.Title != "Usage by agent, model, and effort" {
-				t.Error("usage panel must be a dimensional table")
+		if strings.Contains(target.RawQueryText, "received_at >= ${__from}") && !strings.Contains(target.RawQueryText, "received_at >= ${__from} * 1000000") {
+			t.Errorf("panel %q does not convert the millisecond lower bound to nanoseconds", panel.Title)
+		}
+		if strings.Contains(target.RawQueryText, "received_at <= ${__to}") && !strings.Contains(target.RawQueryText, "received_at <= ${__to} * 1000000") {
+			t.Errorf("panel %q does not convert the millisecond upper bound to nanoseconds", panel.Title)
+		}
+		if panel.Type == "timeseries" && !reflect.DeepEqual(target.TimeColumns, []string{"time"}) {
+			t.Errorf("time-series panel %q does not identify its numeric time column", panel.Title)
+		}
+		defaults, ok := panel.FieldConfig["defaults"].(map[string]any)
+		if !ok {
+			t.Errorf("panel %q has no field defaults", panel.Title)
+		} else {
+			wantUnit := "short"
+			if panel.Title == "RDD adoption %" {
+				wantUnit = "percent"
+			} else if panel.Title == "Measured request duration" {
+				wantUnit = "ms"
 			}
-			for _, phrase := range []string{"receipt-time", "Responses and launches are separate", "— means not reported; it is not zero", "not sessions, users or people", "Response evidence", "Selected evidence", "Effective effort is never inferred", "unknown", "without identity inference", "No custom or private names"} {
-				if !strings.Contains(panel.Description, phrase) {
-					t.Errorf("launch description missing %q", phrase)
+			if defaults["unit"] != wantUnit {
+				t.Errorf("panel %q unit = %v; want %q", panel.Title, defaults["unit"], wantUnit)
+			}
+		}
+		configJSON, err := json.Marshal(panel.FieldConfig)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if strings.Contains(string(configJSON), `"axisPlacement":"right"`) {
+			t.Errorf("panel %q introduces a second y-axis", panel.Title)
+		}
+		if section == "Runtime usage" {
+			for _, host := range []string{"pi", "opencode", "claude-code", "codex"} {
+				if !strings.Contains(string(configJSON), `"options":"`+host+`"`) {
+					t.Errorf("runtime panel %q does not pin the %s series color", panel.Title, host)
 				}
-			}
-			for _, target := range panel.Targets {
-				if !strings.HasSuffix(target.QueryText, `ORDER BY COALESCE(Responses, 0) + COALESCE(Launches, 0) DESC, "Agent observation" ASC, "Model observation" ASC, "Selected → effective" ASC LIMIT 1000`) {
-					t.Error("launch combinations must be bounded and sorted by count then label")
-				}
-				group := strings.SplitN(target.QueryText, "GROUP BY", 2)
-				for _, dimension := range []string{"agent_class", "agent_kind", "host", "model.provider", "model.id", "model_evidence", "selected_effort", "effective_effort"} {
-					if len(group) != 2 || !strings.Contains(group[1], "$."+dimension+"'") {
-						t.Errorf("launch grouping missing %s", dimension)
-					}
-				}
-			}
-		}
-		if panel.ID == 21 {
-			if panel.Type != "table" {
-				t.Fatal("reported tokens must be a full-width dimensional table")
-			}
-			var wantConfig map[string]any
-			if err := json.Unmarshal([]byte(`{
-				"defaults": {"min": 0, "decimals": 0, "noValue": "Not reported", "custom": {"minWidth": 80}},
-				"overrides": [
-					{"matcher": {"id": "byName", "options": "Model observation"}, "properties": [{"id": "custom.width", "value": 340}]},
-					{"matcher": {"id": "byName", "options": "Selected → effective"}, "properties": [{"id": "custom.width", "value": 180}]},
-					{"matcher": {"id": "byRegexp", "options": "^(Input|Output|Cache read|Cache creation|Reasoning|Total)$"}, "properties": [{"id": "mappings", "value": [{"type": "special", "options": {"match": "null", "result": {"text": "—"}}}]}]},
-					{"matcher": {"id": "byName", "options": "Cache creation"}, "properties": [{"id": "displayName", "value": "Cache write"}]}
-				]
-			}`), &wantConfig); err != nil {
-				t.Fatal(err)
-			}
-			if !reflect.DeepEqual(panel.FieldConfig, wantConfig) {
-				t.Errorf("reported token config = %v; want compact null mapping and Cache write display header", panel.FieldConfig)
-			}
-			if !strings.Contains(panel.Description, "— means not reported; it is not zero") {
-				t.Error("reported token description must explain the null display")
-			}
-		}
-		if panel.ID != 16 && panel.ID != 17 && panel.ID != 21 && panel.Type != "barchart" && panel.Type != "stat" {
-			t.Fatalf("runtime panel %d exposes raw columns", panel.ID)
-		}
-		for _, target := range panel.Targets {
-			if strings.Contains(target.QueryText, "GROUP BY") && !strings.HasSuffix(target.QueryText, "LIMIT 1000") {
-				t.Fatalf("runtime panel %d: unbounded groups", panel.ID)
 			}
 		}
 	}
-	if runtimeQueries != 7 {
-		t.Fatalf("expected to execute all seven runtime queries, found %d", runtimeQueries)
+	if !reflect.DeepEqual(gotPanels, wantPanels) {
+		t.Fatalf("panels = %#v; want %#v", gotPanels, wantPanels)
 	}
+
 	s, err := OpenStorage(":memory:")
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer s.Close()
-	from := time.Date(2026, 1, 1, 23, 0, 0, 0, time.UTC).UnixMilli()
-	to := time.Date(2026, 1, 2, 0, 0, 0, 0, time.UTC).UnixMilli()
-	metrics := []string{"input_tokens", "output_tokens", "cache_read_tokens", "cache_creation_tokens", "reasoning_tokens", "total_tokens"}
-	// Two observations share a delivery; receipt time, not a client date, groups them.
-	for i, ns := range []int64{from*1000000 - 1, from * 1000000, to * 1000000, to*1000000 + 1} {
-		if _, err := s.db.Exec(`INSERT INTO runtime_deliveries VALUES (?, ?, '{"host":"codex"}')`, fmt.Sprint(i), ns); err != nil {
+	from := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC).UnixMilli()
+	to := time.Date(2026, 1, 3, 23, 59, 59, 0, time.UTC).UnixMilli()
+	for _, event := range []struct {
+		received                                             int64
+		kind, install, version, os, arch, agents, components string
+		rdd                                                  int
+	}{
+		{from * 1000000, "install", "install-a", "1.0.0", "linux", "amd64", `["codex"]`, `["sdd","skills"]`, 1},
+		{time.Date(2026, 1, 2, 12, 0, 0, 0, time.UTC).UnixNano(), "heartbeat", "install-a", "1.0.0", "linux", "amd64", `["codex"]`, `["sdd","skills"]`, 1},
+		{time.Date(2026, 1, 2, 13, 0, 0, 0, time.UTC).UnixNano(), "install", "install-b", "1.1.0", "darwin", "arm64", `["pi"]`, `["engram"]`, 0},
+		{to * 1000000, "heartbeat", "install-b", "1.1.0", "darwin", "arm64", `["pi"]`, `["engram"]`, 0},
+	} {
+		if _, err := s.db.Exec(`INSERT INTO events(received_at,event,install_id,version,os,arch,agents_json,components_json,rdd_enabled,counters_json) VALUES(?,?,?,?,?,?,?,?,?,NULL)`, event.received, event.kind, event.install, event.version, event.os, event.arch, event.agents, event.components, event.rdd); err != nil {
 			t.Fatal(err)
 		}
-		count := 1
-		if i == 1 {
-			count = 2
-		}
-		for ordinal := 0; ordinal < count; ordinal++ {
-			kind, category, measured, duration := "request", "none", 1, 12.5
-			coverage := "reported"
-			if ordinal == 1 {
-				kind, category, measured, duration, coverage = "unavailable", "unknown", 0, 0, "unsupported"
-			} else if i == 2 {
-				kind, category, duration, coverage = "message", "api", 7.25, "unavailable"
-			}
-			row := map[string]any{
-				"model":          map[string]string{"provider": "openai", "id": "gpt-5"},
-				"model_evidence": "response", "agent_class": "unknown", "agent_kind": "unknown",
-				"selected_effort": "high", "effective_effort": "unavailable",
-				"responses": 2, "launches": 3, "error_category": category,
-				"duration": map[string]any{"kind": kind, "measured_count": measured, "sum_ms": duration},
-			}
-			if ordinal == 1 {
-				row["duration"].(map[string]any)["sum_ms"] = nil
-				row["launches"] = nil
-				row["responses"] = nil
-				row["model"] = map[string]string{"provider": "openai", "id": "null-only"}
-				row["agent_class"] = "null-only"
-			}
-			if i == 2 {
-				row["responses"], row["launches"] = "unsupported", "unsupported"
-				row["model"] = map[string]string{"provider": "openai", "id": "gpt-4"}
-				row["selected_effort"], row["effective_effort"] = "low", "low"
-			}
-			for index, metric := range metrics {
-				// Nonzero unreported sums must never leak into usage.
-				token := map[string]int{"reported": 0, "unavailable": 0, "unsupported": 0, "sum": 99}
-				token[coverage] = 1
-				if coverage == "reported" {
-					token["sum"] = index // Includes explicitly reported zero; total is not inferred.
-				}
-				row[metric] = token
-			}
-			raw, err := json.Marshal(row)
-			if err != nil {
-				t.Fatal(err)
-			}
-			if _, err := s.db.Exec(`INSERT INTO runtime_rows VALUES (?, ?, ?)`, fmt.Sprint(i), ordinal, string(raw)); err != nil {
-				t.Fatal(err)
-			}
-		}
 	}
-	var tokenRows [][]any
-	for _, index := range []int{3, 2, 0, 1, 4, 5} {
-		label := []string{"Input", "Output", "Cache read", "Cache creation", "Reasoning", "Total"}[index]
-		tokenRows = append(tokenRows, []any{label, int64(1), int64(1), int64(1)})
-	}
-	for _, tc := range []struct {
-		title string
-		want  [][]any
+	for _, rollup := range []struct {
+		day, metric, key string
+		value            int
 	}{
-		{"Runtime overview", [][]any{{int64(3), int64(2), int64(3), int64(5), int64(2)}}},
-		{"Responses by model", [][]any{{"openai/gpt-5 · response · codex", int64(2)}}},
-		{"Usage by agent, model, and effort", [][]any{{"unknown / unknown", "codex · openai/gpt-5 · response", "high → unavailable", int64(2), int64(3)}}},
-		{"Token coverage", tokenRows},
-		{"Reported tokens", [][]any{
-			{"codex · openai/gpt-4 · response", "low → low", nil, nil, nil, nil, nil, nil},
-			{"codex · openai/gpt-5 · response", "high → unavailable", int64(0), int64(1), int64(2), int64(3), int64(4), int64(5)},
-			{"codex · openai/null-only · response", "high → unavailable", nil, nil, nil, nil, nil, nil},
-		}},
-		{"Error observations", [][]any{{"api", int64(1)}, {"unknown", int64(1)}}},
-		{"Measured duration", [][]any{{"message", 7.25}, {"request", 12.5}}},
+		{"2026-01-01", "active_install", "install-a", 1},
+		{"2026-01-02", "active_install", "install-a", 1},
+		{"2026-01-02", "active_install", "install-b", 1},
+		{"2026-01-02", "agent", "codex", 1},
+		{"2026-01-02", "agent", "pi", 1},
+		{"2026-01-02", "component", "sdd", 1},
+		{"2026-01-02", "component", "engram", 1},
+		{"2026-01-02", "rdd_enabled", "true", 1},
+		{"2026-01-02", "rdd_enabled", "false", 1},
+		{"2026-01-02", "version", "1.0.0", 1},
+		{"2026-01-02", "version", "1.1.0", 1},
+		{"2026-01-02", "npm_downloads_day", "gentle-pi", 100},
+		{"2026-01-02", "npm_downloads_day", "gentle-engram", 200},
+		{"2026-01-02", "github_release_downloads_total", "v1.0.0", 10},
+		{"2026-01-03", "github_release_downloads_total", "v1.0.0", 20},
+		{"2026-01-03", "github_release_downloads_total", "v1.1.0", 10},
 	} {
-		t.Run(tc.title, func(t *testing.T) {
-			query, found := "", 0
-			for _, panel := range dashboard.Panels {
-				if panel.Title != tc.title {
-					continue
-				}
-				found++
-				if len(panel.Targets) != 1 || panel.Targets[0].QueryText != panel.Targets[0].RawQueryText {
-					t.Fatal("expected one identical queryText/rawQueryText pair")
-				}
-				query = panel.Targets[0].QueryText
-			}
-			if found != 1 {
-				t.Fatalf("expected one runtime panel, found %d", found)
-			}
-			bounds := "d.received_at >= ${__from} * 1000000 AND d.received_at <= ${__to} * 1000000"
-			if !strings.Contains(query, bounds) {
-				t.Fatal("missing inclusive nanosecond receipt bounds")
-			}
-			emptyQuery := strings.NewReplacer("${__from}", "0", "${__to}", "0").Replace(query)
-			query = strings.NewReplacer("${__from}", fmt.Sprint(from), "${__to}", fmt.Sprint(to)).Replace(query)
-			rows, err := s.db.Query(query)
-			if err != nil {
-				t.Fatal(err)
-			}
-			defer rows.Close()
-			columns, err := rows.Columns()
-			if err != nil {
-				t.Fatal(err)
-			}
-			if tc.title == "Usage by agent, model, and effort" {
-				wantColumns := []string{"Agent observation", "Model observation", "Selected → effective", "Responses", "Launches"}
-				if !reflect.DeepEqual(columns, wantColumns) {
-					t.Fatalf("columns = %v; want %v", columns, wantColumns)
-				}
-			}
-			if tc.title == "Reported tokens" {
-				wantColumns := []string{"Model observation", "Selected → effective", "Input", "Output", "Cache read", "Cache creation", "Reasoning", "Total"}
-				if !reflect.DeepEqual(columns, wantColumns) {
-					t.Fatalf("columns (%d) = %v; want exactly %v", len(columns), columns, wantColumns)
-				}
-			}
-			var got [][]any
-			for rows.Next() {
-				values, pointers := make([]any, len(columns)), make([]any, len(columns))
-				for i := range values {
-					pointers[i] = &values[i]
-				}
-				if err := rows.Scan(pointers...); err != nil {
-					t.Fatal(err)
-				}
-				got = append(got, values)
-			}
-			if err := rows.Err(); err != nil {
-				t.Fatal(err)
-			}
-			if !reflect.DeepEqual(got, tc.want) {
-				t.Fatalf("got %#v; want %#v", got, tc.want)
-			}
-			rows.Close()
-			empty, err := s.db.Query(emptyQuery)
-			if err != nil {
-				t.Fatal(err)
-			}
-			defer empty.Close()
-			if empty.Next() || empty.Err() != nil {
-				t.Fatalf("empty receipt range must not invent zeros: %v", empty.Err())
-			}
-		})
+		if _, err := s.db.Exec(`INSERT INTO rollups_daily(day,metric,key,value) VALUES(?,?,?,?)`, rollup.day, rollup.metric, rollup.key, rollup.value); err != nil {
+			t.Fatal(err)
+		}
 	}
-	t.Run("independent usage reports", func(t *testing.T) {
-		// Isolate usage fixtures so other runtime panel expectations stay unchanged.
-		tx, err := s.db.Begin()
+
+	token := func(sum int, reported, unavailable, unsupported int) map[string]int {
+		return map[string]int{"sum": sum, "reported": reported, "unavailable": unavailable, "unsupported": unsupported}
+	}
+	runtimeFixtures := []struct {
+		id, host string
+		received int64
+		row      map[string]any
+	}{
+		{"delivery-codex", "codex", time.Date(2026, 1, 2, 10, 15, 0, 0, time.UTC).UnixNano(), map[string]any{
+			"model": map[string]string{"provider": "openai", "id": "gpt-5"}, "model_evidence": "response", "agent_kind": "orchestrator", "agent_class": "orchestrator", "selected_effort": "high", "effective_effort": "high", "launches": 1, "responses": 3,
+			"input_tokens": token(10, 1, 0, 0), "output_tokens": token(5, 1, 0, 0), "cache_read_tokens": token(2, 1, 0, 0), "cache_creation_tokens": token(1, 1, 0, 0), "reasoning_tokens": token(3, 1, 0, 0), "total_tokens": token(999, 1, 0, 0),
+			"error_category": "none", "duration": map[string]any{"kind": "request", "measured_count": 2, "sum_ms": 50.0},
+		}},
+		{"delivery-opencode", "opencode", time.Date(2026, 1, 2, 11, 30, 0, 0, time.UTC).UnixNano(), map[string]any{
+			"model": map[string]string{"provider": "custom", "id": "custom"}, "model_evidence": "unknown", "agent_kind": "worker", "agent_class": "unknown", "selected_effort": "unknown", "effective_effort": "unknown", "launches": 2, "responses": 2,
+			"input_tokens": token(7, 1, 0, 0), "output_tokens": token(4, 1, 0, 0), "cache_read_tokens": token(99, 0, 1, 0), "cache_creation_tokens": token(99, 0, 0, 1), "reasoning_tokens": token(99, 0, 1, 0), "total_tokens": token(999, 0, 1, 0),
+			"error_category": "provider", "duration": map[string]any{"kind": "request", "measured_count": 1, "sum_ms": 40.0},
+		}},
+	}
+	for _, fixture := range runtimeFixtures {
+		payload, err := json.Marshal(map[string]string{"host": fixture.host})
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer tx.Rollback()
-		for i, report := range []struct{ agent, evidence, responses, launches string }{
-			{"orchestrator", "response", "7", "null"},
-			{"orchestrator", "response", "2", `"unsupported"`},
-			{"subagent", "selected", "null", "6"},
-			{"subagent", "selected", `"unsupported"`, "1"},
-			{"zero", "response", "0", "1.5"},
-			{"zero-launch", "selected", "true", "0"},
-			{"excluded", "selected", "1.5", `"unsupported"`},
-		} {
-			raw := fmt.Sprintf(`{"agent_class":%q,"agent_kind":"unknown","model":{"provider":"openai","id":"gpt-5"},"model_evidence":%q,"selected_effort":"high","effective_effort":"unavailable","responses":%s,"launches":%s}`, report.agent, report.evidence, report.responses, report.launches)
-			// Upper bound must be included, as must the original lower-bound row.
-			if _, err := tx.Exec(`INSERT INTO runtime_rows VALUES ('2', ?, ?)`, i+10, raw); err != nil {
-				t.Fatal(err)
-			}
-		}
-		for _, panel := range dashboard.Panels {
-			if panel.ID != 16 {
-				continue
-			}
-			query := strings.NewReplacer("${__from}", fmt.Sprint(from), "${__to}", fmt.Sprint(to)).Replace(panel.Targets[0].QueryText)
-			rows, err := tx.Query(query)
-			if err != nil {
-				t.Fatal(err)
-			}
-			defer rows.Close()
-			var got [][]any
-			for rows.Next() {
-				var agent, model, effort string
-				var responses, launches any
-				if err := rows.Scan(&agent, &model, &effort, &responses, &launches); err != nil {
-					t.Fatal(err)
-				}
-				got = append(got, []any{agent, model, effort, responses, launches})
-			}
-			if err := rows.Err(); err != nil {
-				t.Fatal(err)
-			}
-			want := [][]any{
-				{"orchestrator / unknown", "codex · openai/gpt-5 · response", "high → unavailable", int64(9), nil},
-				{"subagent / unknown", "codex · openai/gpt-5 · selected", "high → unavailable", nil, int64(7)},
-				{"unknown / unknown", "codex · openai/gpt-5 · response", "high → unavailable", int64(2), int64(3)},
-				{"zero / unknown", "codex · openai/gpt-5 · response", "high → unavailable", int64(0), nil},
-				{"zero-launch / unknown", "codex · openai/gpt-5 · selected", "high → unavailable", nil, int64(0)},
-			}
-			if !reflect.DeepEqual(got, want) {
-				t.Fatalf("usage rows = %#v; want %#v", got, want)
-			}
-		}
-	})
-	t.Run("unavailable-only range", func(t *testing.T) {
-		if _, err := s.db.Exec(`UPDATE runtime_rows SET row_json = json_set(row_json,
-			'$.responses', NULL, '$.launches', NULL,
-			'$.duration.kind', 'unavailable', '$.duration.measured_count', 0, '$.duration.sum_ms', NULL,
-			'$.total_tokens.reported', 0, '$.total_tokens.sum', NULL)`); err != nil {
+		raw, err := json.Marshal(fixture.row)
+		if err != nil {
 			t.Fatal(err)
 		}
-		for _, panel := range dashboard.Panels {
-			if panel.ID != 15 && panel.ID != 16 && panel.ID != 18 && panel.ID != 20 && panel.ID != 21 {
-				continue
-			}
-			query := strings.NewReplacer("${__from}", fmt.Sprint(from), "${__to}", fmt.Sprint(to)).Replace(panel.Targets[0].QueryText)
+		if _, err := s.db.Exec(`INSERT INTO runtime_deliveries(delivery_id,received_at,canonical_payload) VALUES(?,?,?)`, fixture.id, fixture.received, string(payload)); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := s.db.Exec(`INSERT INTO runtime_rows(delivery_id,ordinal,row_json) VALUES(?,0,?)`, fixture.id, string(raw)); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	queries := map[string]string{}
+	for _, panel := range dashboard.Panels {
+		if panel.Type == "row" {
+			continue
+		}
+		query := strings.NewReplacer("${__from}", fmt.Sprint(from), "${__to}", fmt.Sprint(to)).Replace(panel.Targets[0].RawQueryText)
+		queries[panel.Title] = query
+		t.Run("SQL/"+panel.Title, func(t *testing.T) {
 			rows, err := s.db.Query(query)
 			if err != nil {
 				t.Fatal(err)
 			}
-			if panel.ID == 20 {
-				if !rows.Next() {
-					t.Fatal("missing received observations")
-				}
-				var observations, errors int64
-				var responses, launches, tokens any
-				if err := rows.Scan(&observations, &responses, &launches, &tokens, &errors); err != nil {
-					t.Fatal(err)
-				}
-				if observations != 3 || errors != 2 || responses != nil || launches != nil || tokens != nil {
-					t.Fatal("unavailable reports must not become zero or erase observations")
-				}
-			} else if panel.ID == 21 {
-				count := 0
-				for rows.Next() {
-					var model, effort string
-					var input, output, read, creation, reasoning, total any
-					if err := rows.Scan(&model, &effort, &input, &output, &read, &creation, &reasoning, &total); err != nil {
-						t.Fatal(err)
-					}
-					if total != nil {
-						t.Fatal("unreported total must stay null even when categories are reported")
-					}
-					if model == "codex · openai/gpt-5 · response" && (input != int64(0) || output != int64(1) || reasoning != int64(4)) {
-						t.Fatal("missing total must not erase independently reported categories")
-					}
-					count++
-				}
-				if count != 3 {
-					t.Fatalf("got %d combinations; want 3", count)
-				}
-			} else if rows.Next() {
-				t.Fatalf("%s invented a distribution or zero latency", panel.Title)
+			defer rows.Close()
+			if !rows.Next() {
+				t.Fatalf("synthetic fixture did not exercise query: %v", rows.Err())
 			}
-			if err := rows.Err(); err != nil {
-				t.Fatal(err)
-			}
-			rows.Close()
+		})
+	}
+
+	assertSingleNumber := func(title string, want float64) {
+		t.Helper()
+		var got float64
+		if err := s.db.QueryRow(queries[title]).Scan(&got); err != nil {
+			t.Fatalf("%s: %v", title, err)
 		}
-	})
+		if got != want {
+			t.Fatalf("%s = %v; want %v", title, got, want)
+		}
+	}
+	assertSingleNumber("Unique installs all-time", 2)
+	assertSingleNumber("Active installs yesterday", 2)
+	assertSingleNumber("Active installs in range", 2)
+	assertSingleNumber("New installs in range", 2)
+	assertSingleNumber("Heartbeats in range", 2)
+	assertSingleNumber("RDD adoption %", 50)
+	assertSingleNumber("npm downloads latest day", 300)
+	assertSingleNumber("GitHub release downloads", 30)
+	assertSingleNumber("Tokens processed", 32)
+	assertSingleNumber("Responses", 5)
+	assertSingleNumber("Deliveries", 2)
+	assertSingleNumber("Hosts reporting", 2)
+	assertSingleNumber("Measured request duration", 30)
+
+	usageRows, err := s.db.Query(queries["Usage by host, subagent, model and effort"])
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer usageRows.Close()
+	var gotUsage [][]any
+	for usageRows.Next() {
+		values, pointers := make([]any, 9), make([]any, 9)
+		for i := range values {
+			pointers[i] = &values[i]
+		}
+		if err := usageRows.Scan(pointers...); err != nil {
+			t.Fatal(err)
+		}
+		gotUsage = append(gotUsage, values)
+	}
+	wantUsage := [][]any{
+		{"codex", "orchestrator", "orchestrator", "openai/gpt-5", "high", "high", int64(1), int64(3), int64(21)},
+		{"opencode", "worker", "unknown", "custom/custom", "unknown", "unknown", int64(2), int64(2), int64(11)},
+	}
+	if !reflect.DeepEqual(gotUsage, wantUsage) {
+		t.Fatalf("usage rows = %#v; want %#v", gotUsage, wantUsage)
+	}
+	if strings.Contains(queries["Tokens processed"], "$.total_tokens.sum") {
+		t.Fatal("primary token measure must be derived from token categories, not total_tokens")
+	}
+	if !strings.Contains(queries["Token coverage per field"], "$.total_tokens.reported") {
+		t.Fatal("coverage must retain explicitly reported total_tokens")
+	}
 }
 
 func TestRuntimeDashboardEpochBounds(t *testing.T) {

--- a/internal/telemetrycollector/runtime_dashboard_test.go
+++ b/internal/telemetrycollector/runtime_dashboard_test.go
@@ -25,6 +25,7 @@ func TestRuntimeDashboard(t *testing.T) {
 			ID          int
 			Title       string
 			Type        string
+			TimeFrom    string
 			Description string
 			GridPos     struct{ X, Y, W, H int }
 			Datasource  struct{ UID string }
@@ -33,6 +34,7 @@ func TestRuntimeDashboard(t *testing.T) {
 				TimeColumns                        []string
 			}
 			FieldConfig map[string]any
+			Options     map[string]any
 		}
 	}
 	if err := json.Unmarshal(data, &dashboard); err != nil {
@@ -65,12 +67,12 @@ func TestRuntimeDashboard(t *testing.T) {
 		{"Runtime usage", "Responses", "stat"},
 		{"Runtime usage", "Deliveries", "stat"},
 		{"Runtime usage", "Hosts reporting", "stat"},
+		{"Runtime usage", "Usage by host, subagent, model and effort", "table"},
 		{"Runtime usage", "Tokens processed by host", "barchart"},
 		{"Runtime usage", "Responses by host", "barchart"},
 		{"Runtime usage", "Tokens by model", "table"},
 		{"Runtime usage", "Responses and tokens by selected effort", "table"},
-		{"Runtime usage", "Usage by host, subagent, model and effort", "table"},
-		{"Runtime usage", "Tokens processed per hour by host", "timeseries"},
+		{"Runtime usage", "Tokens processed per hour by host (last 24h)", "timeseries"},
 		{"Runtime usage", "Token coverage per field", "table"},
 		{"Runtime usage", "Error observations by category", "barchart"},
 		{"Runtime usage", "Measured duration by kind", "table"},
@@ -120,7 +122,9 @@ func TestRuntimeDashboard(t *testing.T) {
 			t.Errorf("panel %q has no field defaults", panel.Title)
 		} else {
 			wantUnit := "short"
-			if panel.Title == "RDD adoption %" {
+			if panel.Type == "stat" && panel.Title != "RDD adoption %" {
+				wantUnit = "locale"
+			} else if panel.Title == "RDD adoption %" {
 				wantUnit = "percent"
 			}
 			if defaults["unit"] != wantUnit {
@@ -134,11 +138,66 @@ func TestRuntimeDashboard(t *testing.T) {
 		if strings.Contains(string(configJSON), `"axisPlacement":"right"`) {
 			t.Errorf("panel %q introduces a second y-axis", panel.Title)
 		}
-		if section == "Runtime usage" && panel.Title != "Measured duration by kind" {
+		if panel.Type == "stat" {
+			if panel.Options["textMode"] != "value" || panel.Options["colorMode"] != "value" || panel.Options["graphMode"] != "none" {
+				t.Errorf("stat panel %q does not use exact-value neutral presentation", panel.Title)
+			}
+			if !strings.Contains(string(configJSON), `"color":{"fixedColor":"#73BF69","mode":"fixed"}`) || strings.Contains(string(configJSON), `"thresholds"`) {
+				t.Errorf("stat panel %q does not use one fixed color without thresholds", panel.Title)
+			}
+		}
+		if panel.Title == "Tokens processed by host" || panel.Title == "Responses by host" {
+			if panel.Options["xField"] != "Host" || panel.Options["colorByField"] != "Host" {
+				t.Errorf("host bar panel %q must use Host as its category and color field", panel.Title)
+			}
+			if !strings.Contains(target.RawQueryText, "CAST(") || !strings.Contains(target.RawQueryText, " AS TEXT) AS Host") || !strings.Contains(target.RawQueryText, "GROUP BY Host") {
+				t.Errorf("host bar panel %q must return long-form text host rows", panel.Title)
+			}
+			for host, color := range map[string]string{"pi": "#73BF69", "opencode": "#5794F2", "claude-code": "#FF9830", "codex": "#B877D9"} {
+				if !strings.Contains(string(configJSON), `"`+host+`":{"color":"`+color+`"`) {
+					t.Errorf("host bar panel %q does not map %s to its fixed color", panel.Title, host)
+				}
+			}
+		}
+		if panel.Title == "Tokens processed per hour by host (last 24h)" {
+			if panel.TimeFrom != "24h" {
+				t.Error("runtime token trend must override its range to the last 24 hours")
+			}
 			for _, host := range []string{"pi", "opencode", "claude-code", "codex"} {
 				if !strings.Contains(string(configJSON), `"options":"`+host+`"`) {
-					t.Errorf("runtime panel %q does not pin the %s series color", panel.Title, host)
+					t.Errorf("runtime token trend does not pin the %s series color", host)
 				}
+			}
+		}
+		if panel.Type == "table" {
+			footer, ok := panel.Options["footer"].(map[string]any)
+			if !ok || footer["enablePagination"] != false {
+				t.Errorf("table panel %q must scroll without pagination", panel.Title)
+			}
+		}
+		if wantHeight, ok := map[string]int{
+			"Usage by host, subagent, model and effort": 14,
+			"Tokens by model":                         10,
+			"Responses and tokens by selected effort": 10,
+			"Token coverage per field":                11,
+		}[panel.Title]; ok && panel.GridPos.H < wantHeight {
+			t.Errorf("table panel %q height = %d; want at least %d", panel.Title, panel.GridPos.H, wantHeight)
+		}
+		if panel.Title == "Usage by host, subagent, model and effort" {
+			if panel.GridPos.X != 0 || panel.GridPos.Y != 32 || panel.GridPos.W != 24 || !strings.Contains(panel.Description, "which subagent used which model at which effort and how many tokens") {
+				t.Error("usage table must be the full-width runtime centerpiece directly below the stat tiles")
+			}
+		}
+		if panel.Title == "Version adoption" {
+			for _, fragment := range []string{"instr(key, '-')", "substr(key, 1, instr(key, '-') - 1)", "' (main)'", "GROUP BY Version", "LIMIT 10"} {
+				if !strings.Contains(target.RawQueryText, fragment) {
+					t.Errorf("version normalization query missing %q", fragment)
+				}
+			}
+		}
+		if panel.Title == "Agent adoption" || panel.Title == "Component adoption" || panel.Title == "OS and architecture" || panel.Title == "Version adoption" {
+			if panel.Options["showValue"] != "always" || !strings.Contains(string(configJSON), `"fixedColor":"#8AB8A8"`) {
+				t.Errorf("categorical adoption panel %q must show values with one neutral color", panel.Title)
 			}
 		}
 		if panel.Title == "Measured duration by kind" && (!strings.Contains(string(configJSON), `"options":"Average ms"`) || !strings.Contains(string(configJSON), `"value":"ms"`)) {
@@ -185,6 +244,8 @@ func TestRuntimeDashboard(t *testing.T) {
 		{"2026-01-02", "rdd_enabled", "false", 1},
 		{"2026-01-02", "version", "1.0.0", 1},
 		{"2026-01-02", "version", "1.1.0", 1},
+		{"2026-01-02", "version", "1.1.0-0.20260102", 1},
+		{"2026-01-02", "version", "1.1.0-20260102", 2},
 		{"2026-01-02", "npm_downloads_day", "gentle-pi", 100},
 		{"2026-01-02", "npm_downloads_day", "gentle-engram", 200},
 		{"2026-01-02", "github_release_downloads_total", "v1.0.0", 10},
@@ -284,6 +345,56 @@ func TestRuntimeDashboard(t *testing.T) {
 	assertSingleNumber("Responses", 5)
 	assertSingleNumber("Deliveries", 2)
 	assertSingleNumber("Hosts reporting", 2)
+
+	for _, tc := range []struct {
+		title string
+		want  [][]any
+	}{
+		{"Tokens processed by host", [][]any{{"codex", int64(21)}, {"opencode", int64(11)}}},
+		{"Responses by host", [][]any{{"codex", int64(3)}, {"opencode", int64(2)}}},
+	} {
+		t.Run(tc.title+" long format", func(t *testing.T) {
+			rows, err := s.db.Query(queries[tc.title])
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer rows.Close()
+			if columns, err := rows.Columns(); err != nil || !reflect.DeepEqual(columns, []string{"Host", strings.TrimSuffix(tc.title, " by host")}) {
+				t.Fatalf("columns = %v, err = %v", columns, err)
+			}
+			var got [][]any
+			for rows.Next() {
+				var host string
+				var measure int64
+				if err := rows.Scan(&host, &measure); err != nil {
+					t.Fatal(err)
+				}
+				got = append(got, []any{host, measure})
+			}
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Fatalf("rows = %#v; want %#v", got, tc.want)
+			}
+		})
+	}
+
+	versionRows, err := s.db.Query(queries["Version adoption"])
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer versionRows.Close()
+	gotVersions := map[string]int64{}
+	for versionRows.Next() {
+		var version string
+		var installs int64
+		if err := versionRows.Scan(&version, &installs); err != nil {
+			t.Fatal(err)
+		}
+		gotVersions[version] = installs
+	}
+	wantVersions := map[string]int64{"1.0.0": 1, "1.1.0": 1, "1.1.0 (main)": 3}
+	if !reflect.DeepEqual(gotVersions, wantVersions) {
+		t.Fatalf("versions = %#v; want %#v", gotVersions, wantVersions)
+	}
 
 	durationRows, err := s.db.Query(queries["Measured duration by kind"])
 	if err != nil {

--- a/internal/telemetrycollector/runtime_dashboard_test.go
+++ b/internal/telemetrycollector/runtime_dashboard_test.go
@@ -48,6 +48,10 @@ func TestRuntimeDashboard(t *testing.T) {
 	}
 
 	wantPanels := []struct{ section, title, kind string }{
+		{"Active users", "Active users, last 24h", "stat"},
+		{"Active users", "Active users, last 6h", "stat"},
+		{"Active users", "Active users, last 1h", "stat"},
+		{"Active users", "Active users, last 15 min", "stat"},
 		{"Adoption", "Unique installs all-time", "stat"},
 		{"Adoption", "Active installs yesterday", "stat"},
 		{"Adoption", "Active installs in range", "stat"},
@@ -63,29 +67,100 @@ func TestRuntimeDashboard(t *testing.T) {
 		{"Where Gentle AI runs", "Component adoption", "barchart"},
 		{"Where Gentle AI runs", "OS and architecture", "barchart"},
 		{"Where Gentle AI runs", "Version adoption", "barchart"},
-		{"Runtime usage", "Tokens processed", "stat"},
-		{"Runtime usage", "Responses", "stat"},
-		{"Runtime usage", "Deliveries", "stat"},
-		{"Runtime usage", "Hosts reporting", "stat"},
-		{"Runtime usage", "Usage by host, subagent, model and effort", "table"},
-		{"Runtime usage", "Tokens processed by host", "barchart"},
-		{"Runtime usage", "Responses by host", "barchart"},
-		{"Runtime usage", "Tokens by model", "table"},
-		{"Runtime usage", "Responses and tokens by selected effort", "table"},
-		{"Runtime usage", "Tokens processed per hour by host (last 24h)", "timeseries"},
-		{"Runtime usage", "Token coverage per field", "table"},
-		{"Runtime usage", "Error observations by category", "barchart"},
-		{"Runtime usage", "Measured duration by kind", "table"},
+		{"Live activity", "Deliveries, last 15 min", "stat"},
+		{"Live activity", "Responses, last 15 min", "stat"},
+		{"Live activity", "Tokens processed, last 15 min", "stat"},
+		{"Live activity", "Hosts active, last 15 min", "stat"},
+		{"Live activity", "Responses per minute by host (last 3h)", "timeseries"},
+		{"Live activity", "Tokens processed per minute (last 3h)", "timeseries"},
+		{"Live activity", "Tokens processed", "stat"},
+		{"Live activity", "Responses", "stat"},
+		{"Live activity", "Deliveries", "stat"},
+		{"Live activity", "Hosts reporting", "stat"},
+		{"Subagents", "Subagent coverage", "stat"},
+		{"Subagents", "Responses by subagent", "barchart"},
+		{"Subagents", "Tokens processed by subagent", "barchart"},
+		{"Subagents", "Subagent model and effort selection", "table"},
+		{"Subagents", "Most popular models per subagent", "table"},
+		{"Subagents", "Top model per subagent", "barchart"},
+		{"Subagents", "Usage by host, subagent, model and effort", "table"},
+		{"Subagents", "Tokens processed by host", "barchart"},
+		{"Subagents", "Responses by host", "barchart"},
+		{"Subagents", "Tokens by model", "table"},
+		{"Subagents", "Responses and tokens by selected effort", "table"},
+		{"Subagents", "Tokens processed per hour by host (last 24h)", "timeseries"},
+		{"Subagents", "Token coverage per field", "table"},
+		{"Subagents", "Error observations by category", "barchart"},
+		{"Subagents", "Measured duration by kind", "table"},
 	}
 	var gotPanels []struct{ section, title, kind string }
 	section := ""
 	seenIDs := map[int]bool{}
+	wantGrid := map[int][4]int{
+		550: {0, 0, 24, 1},
+		551: {0, 1, 6, 4},
+		552: {6, 1, 6, 4},
+		553: {12, 1, 6, 4},
+		554: {18, 1, 6, 4},
+		100: {0, 5, 24, 1},
+		101: {0, 6, 6, 4},
+		102: {6, 6, 6, 4},
+		103: {12, 6, 6, 4},
+		104: {18, 6, 6, 4},
+		105: {0, 10, 6, 4},
+		106: {6, 10, 6, 4},
+		107: {12, 10, 6, 4},
+		108: {18, 10, 6, 4},
+		200: {0, 14, 24, 1},
+		201: {0, 15, 8, 8},
+		202: {8, 15, 8, 8},
+		203: {16, 15, 8, 8},
+		300: {0, 23, 24, 1},
+		301: {0, 24, 6, 8},
+		302: {6, 24, 6, 8},
+		303: {12, 24, 6, 8},
+		304: {18, 24, 6, 8},
+		400: {0, 32, 24, 1},
+		600: {0, 33, 24, 1},
+		601: {0, 34, 6, 4},
+		602: {6, 34, 6, 4},
+		603: {12, 34, 6, 4},
+		604: {18, 34, 6, 4},
+		605: {0, 38, 12, 8},
+		606: {12, 38, 12, 8},
+		401: {0, 46, 6, 4},
+		402: {6, 46, 6, 4},
+		403: {12, 46, 6, 4},
+		404: {18, 46, 6, 4},
+		500: {0, 50, 24, 1},
+		501: {0, 51, 6, 4},
+		502: {6, 51, 9, 7},
+		503: {15, 51, 9, 7},
+		504: {0, 58, 24, 9},
+		505: {0, 67, 24, 9},
+		506: {0, 76, 24, 7},
+		409: {0, 83, 24, 9},
+		405: {0, 92, 12, 7},
+		406: {12, 92, 12, 7},
+		407: {0, 99, 12, 9},
+		408: {12, 99, 12, 9},
+		410: {0, 108, 12, 8},
+		411: {12, 108, 12, 9},
+		412: {0, 117, 12, 7},
+		413: {12, 117, 12, 9},
+	}
 	for i, panel := range dashboard.Panels {
 		if seenIDs[panel.ID] {
 			t.Fatalf("duplicate panel id %d", panel.ID)
 		}
 		seenIDs[panel.ID] = true
 		g := panel.GridPos
+		if want, ok := wantGrid[panel.ID]; ok {
+			if got := [4]int{g.X, g.Y, g.W, g.H}; got != want {
+				t.Errorf("panel %d grid = %v; want %v", panel.ID, got, want)
+			}
+			delete(wantGrid, panel.ID)
+		}
 		for _, other := range dashboard.Panels[:i] {
 			o := other.GridPos
 			if g.X < o.X+o.W && o.X < g.X+g.W && g.Y < o.Y+o.H && o.Y < g.Y+g.H {
@@ -122,9 +197,9 @@ func TestRuntimeDashboard(t *testing.T) {
 			t.Errorf("panel %q has no field defaults", panel.Title)
 		} else {
 			wantUnit := "short"
-			if panel.Type == "stat" && panel.Title != "RDD adoption %" {
+			if panel.Type == "stat" && panel.Title != "RDD adoption %" && panel.Title != "Subagent coverage" {
 				wantUnit = "locale"
-			} else if panel.Title == "RDD adoption %" {
+			} else if panel.Title == "RDD adoption %" || panel.Title == "Subagent coverage" {
 				wantUnit = "percent"
 			}
 			if defaults["unit"] != wantUnit {
@@ -142,7 +217,11 @@ func TestRuntimeDashboard(t *testing.T) {
 			if panel.Options["textMode"] != "value" || panel.Options["colorMode"] != "value" || panel.Options["graphMode"] != "none" {
 				t.Errorf("stat panel %q does not use exact-value neutral presentation", panel.Title)
 			}
-			if !strings.Contains(string(configJSON), `"color":{"fixedColor":"#73BF69","mode":"fixed"}`) || strings.Contains(string(configJSON), `"thresholds"`) {
+			color := "#73BF69"
+			if panel.Title == "Subagent coverage" {
+				color = "#8AB8A8"
+			}
+			if !strings.Contains(string(configJSON), `"color":{"fixedColor":"`+color+`","mode":"fixed"}`) || strings.Contains(string(configJSON), `"thresholds"`) {
 				t.Errorf("stat panel %q does not use one fixed color without thresholds", panel.Title)
 			}
 		}
@@ -174,18 +253,17 @@ func TestRuntimeDashboard(t *testing.T) {
 			if !ok || footer["enablePagination"] != false {
 				t.Errorf("table panel %q must scroll without pagination", panel.Title)
 			}
-		}
-		if wantHeight, ok := map[string]int{
-			"Usage by host, subagent, model and effort": 14,
-			"Tokens by model":                         10,
-			"Responses and tokens by selected effort": 10,
-			"Token coverage per field":                11,
-		}[panel.Title]; ok && panel.GridPos.H < wantHeight {
-			t.Errorf("table panel %q height = %d; want at least %d", panel.Title, panel.GridPos.H, wantHeight)
+			if panel.GridPos.H != 9 {
+				t.Errorf("table panel %q height = %d; want 9", panel.Title, panel.GridPos.H)
+			}
+		} else if panel.Type == "stat" && panel.GridPos.H != 4 {
+			t.Errorf("stat panel %q height = %d; want 4", panel.Title, panel.GridPos.H)
+		} else if panel.Type == "timeseries" && panel.GridPos.H != 8 {
+			t.Errorf("time-series panel %q height = %d; want 8", panel.Title, panel.GridPos.H)
 		}
 		if panel.Title == "Usage by host, subagent, model and effort" {
-			if panel.GridPos.X != 0 || panel.GridPos.Y != 32 || panel.GridPos.W != 24 || !strings.Contains(panel.Description, "which subagent used which model at which effort and how many tokens") {
-				t.Error("usage table must be the full-width runtime centerpiece directly below the stat tiles")
+			if panel.GridPos.X != 0 || panel.GridPos.Y != 83 || panel.GridPos.W != 24 || !strings.Contains(panel.Description, "which subagent used which model at which effort and how many tokens") {
+				t.Error("usage table must remain a full-width runtime centerpiece after the Subagents section")
 			}
 		}
 		if panel.Title == "Version adoption" {
@@ -200,9 +278,102 @@ func TestRuntimeDashboard(t *testing.T) {
 				t.Errorf("categorical adoption panel %q must show values with one neutral color", panel.Title)
 			}
 		}
+		if panel.Title == "Responses by subagent" || panel.Title == "Tokens processed by subagent" {
+			if panel.Options["xField"] != "Subagent" || panel.Options["showValue"] != "always" || !strings.Contains(string(configJSON), `"fixedColor":"#8AB8A8"`) {
+				t.Errorf("subagent bar panel %q must be a labeled neutral categorical chart", panel.Title)
+			}
+			for _, fragment := range []string{" AS TEXT) AS Subagent", "NOT IN ('orchestrator', 'unknown')", "GROUP BY Subagent", " DESC"} {
+				if !strings.Contains(target.RawQueryText, fragment) {
+					t.Errorf("subagent bar query %q missing %q", panel.Title, fragment)
+				}
+			}
+		}
+		if panel.Title == "Responses by subagent" {
+			for _, fragment := range []string{"$.responses", "$.launches", "COALESCE"} {
+				if !strings.Contains(target.RawQueryText, fragment) {
+					t.Errorf("subagent response query must count launch-only rows; missing %q", fragment)
+				}
+			}
+		}
+		if panel.Title == "Subagent model and effort selection" {
+			if panel.GridPos.W != 24 || !strings.Contains(target.RawQueryText, "NOT IN ('orchestrator', 'unknown')") || !strings.Contains(target.RawQueryText, `ORDER BY Responses DESC, "Tokens processed" DESC`) {
+				t.Error("subagent selection table must be full-width, filtered, and ordered by activity")
+			}
+		}
+		if panel.Title == "Most popular models per subagent" {
+			for _, fragment := range []string{"ROW_NUMBER() OVER (PARTITION BY p.Subagent", "SUM(p.Observations) OVER (PARTITION BY p.Subagent)", "group_concat(DISTINCT Host)", "ORDER BY Subagent ASC, Rank ASC", "NOT IN ('orchestrator', 'unknown')"} {
+				if !strings.Contains(target.RawQueryText, fragment) {
+					t.Errorf("popular-model query missing %q", fragment)
+				}
+			}
+			if panel.GridPos.W != 24 || !strings.Contains(string(configJSON), `"options":"Share of subagent (%)"`) || !strings.Contains(string(configJSON), `"value":"percent"`) {
+				t.Error("popular-model table must be full-width and format share as percent")
+			}
+		}
+		if panel.Title == "Top model per subagent" {
+			if panel.Options["xField"] != "Subagent and model" || panel.Options["showValue"] != "always" || !strings.Contains(string(configJSON), `"fixedColor":"#8AB8A8"`) || !strings.Contains(target.RawQueryText, "WHERE Rank = 1") {
+				t.Error("top-model panel must be a labeled neutral long-format rank-one chart")
+			}
+		}
+		if seconds, ok := map[string]string{
+			"Active users, last 24h":    "86400",
+			"Active users, last 6h":     "21600",
+			"Active users, last 1h":     "3600",
+			"Active users, last 15 min": "900",
+		}[panel.Title]; ok {
+			if strings.Contains(target.RawQueryText, "${__from}") || !strings.Contains(target.RawQueryText, "strftime('%s', 'now')") || !strings.Contains(target.RawQueryText, "- "+seconds+") * 1000000000") || !strings.Contains(target.RawQueryText, "COUNT(DISTINCT install_id)") {
+				t.Errorf("active-user panel %q must use its fixed nanosecond wall-clock window", panel.Title)
+			}
+		}
+		if panel.Title == "Active users, last 24h" && panel.Description != "Installs that opened a Gentle AI session in the last 24 hours; each install reports at most once per day, so shorter windows undercount." {
+			t.Error("24-hour active-user panel must explain opportunistic daily reporting")
+		}
+		if panel.Title == "Deliveries, last 15 min" || panel.Title == "Responses, last 15 min" || panel.Title == "Tokens processed, last 15 min" || panel.Title == "Hosts active, last 15 min" {
+			if strings.Contains(target.RawQueryText, "${__from}") || !strings.Contains(target.RawQueryText, "- 900) * 1000000000") || !strings.Contains(panel.Description, "counts agent responses, not people") {
+				t.Errorf("live stat %q must use a fixed 15-minute window and explain anonymity", panel.Title)
+			}
+		}
+		if panel.Title == "Responses per minute by host (last 3h)" || panel.Title == "Tokens processed per minute (last 3h)" {
+			if panel.TimeFrom != "3h" || strings.Contains(target.RawQueryText, "${__from}") || !strings.Contains(target.RawQueryText, "- 10800) * 1000000000") || !strings.Contains(panel.Description, "counts agent responses, not people") {
+				t.Errorf("live series %q must use a fixed three-hour anonymous-activity window", panel.Title)
+			}
+		}
+		if panel.Title == "Responses per minute by host (last 3h)" {
+			if !strings.Contains(string(configJSON), `"stacking":{"group":"A","mode":"normal"}`) {
+				t.Error("live response series must be stacked")
+			}
+			for _, host := range []string{"pi", "opencode", "claude-code", "codex"} {
+				if !strings.Contains(string(configJSON), `"options":"`+host+`"`) {
+					t.Errorf("live response series does not pin the %s color", host)
+				}
+			}
+		}
+		if panel.Title == "Tokens processed per minute (last 3h)" && !strings.Contains(string(configJSON), `"fixedColor":"#8AB8A8"`) {
+			t.Error("live token series must use the neutral color")
+		}
+		if _, ok := map[string]bool{
+			"Top model per subagent":         true,
+			"Responses by subagent":          true,
+			"Tokens processed by subagent":   true,
+			"Tokens processed by host":       true,
+			"Responses by host":              true,
+			"Error observations by category": true,
+		}[panel.Title]; ok {
+			if panel.GridPos.H != 7 || panel.Options["barWidth"] != 0.6 || panel.Options["groupWidth"] != 0.7 {
+				t.Errorf("low-cardinality bar %q must use h=7, barWidth=0.6, groupWidth=0.7", panel.Title)
+			}
+		}
+		if panel.Title == "Subagent coverage" {
+			if panel.Description != "Share of observations attributed to a named subagent." || !strings.Contains(target.RawQueryText, "NOT IN ('orchestrator', 'unknown')") {
+				t.Error("subagent coverage must describe and calculate named-subagent attribution")
+			}
+		}
 		if panel.Title == "Measured duration by kind" && (!strings.Contains(string(configJSON), `"options":"Average ms"`) || !strings.Contains(string(configJSON), `"value":"ms"`)) {
 			t.Error("duration table must format only its average column as milliseconds")
 		}
+	}
+	if len(wantGrid) != 0 {
+		t.Fatalf("missing position-pinned panels: %v", wantGrid)
 	}
 	if !reflect.DeepEqual(gotPanels, wantPanels) {
 		t.Fatalf("panels = %#v; want %#v", gotPanels, wantPanels)
@@ -226,6 +397,18 @@ func TestRuntimeDashboard(t *testing.T) {
 		{to * 1000000, "heartbeat", "install-b", "1.1.0", "darwin", "arm64", `["pi"]`, `["engram"]`, 0},
 	} {
 		if _, err := s.db.Exec(`INSERT INTO events(received_at,event,install_id,version,os,arch,agents_json,components_json,rdd_enabled,counters_json) VALUES(?,?,?,?,?,?,?,?,?,NULL)`, event.received, event.kind, event.install, event.version, event.os, event.arch, event.agents, event.components, event.rdd); err != nil {
+			t.Fatal(err)
+		}
+	}
+	now := time.Now().UTC().Truncate(time.Second)
+	for _, recent := range []struct {
+		received int64
+		install  string
+	}{
+		{now.Add(-5 * time.Minute).UnixNano(), "install-a"},
+		{now.Add(-30 * time.Minute).UnixNano(), "install-b"},
+	} {
+		if _, err := s.db.Exec(`INSERT INTO events(received_at,event,install_id,version,os,arch,agents_json,components_json,rdd_enabled,counters_json) VALUES(?,'heartbeat',?,'1.1.0','linux','amd64','["codex"]','["sdd"]',1,NULL)`, recent.received, recent.install); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -275,6 +458,16 @@ func TestRuntimeDashboard(t *testing.T) {
 			"input_tokens": token(7, 1, 0, 0), "output_tokens": token(4, 1, 0, 0), "cache_read_tokens": token(99, 0, 1, 0), "cache_creation_tokens": token(99, 0, 0, 1), "reasoning_tokens": token(99, 0, 1, 0), "total_tokens": token(999, 0, 1, 0),
 			"error_category": "provider", "duration": map[string]any{"kind": "message", "measured_count": 1, "sum_ms": 40.0},
 		}},
+		{"delivery-sdd", "pi", time.Date(2026, 1, 2, 12, 0, 0, 0, time.UTC).UnixNano(), map[string]any{
+			"model": map[string]string{"provider": "openai", "id": "gpt-5.6-sol"}, "model_evidence": "selected", "agent_kind": "built_in", "agent_class": "sdd-apply", "selected_effort": "high", "effective_effort": "high", "launches": 3, "responses": 0,
+			"input_tokens": token(6, 1, 0, 0), "output_tokens": token(4, 1, 0, 0), "cache_read_tokens": token(0, 0, 1, 0), "cache_creation_tokens": token(0, 0, 1, 0), "reasoning_tokens": token(0, 0, 1, 0), "total_tokens": token(0, 0, 0, 1),
+			"error_category": "none", "duration": map[string]any{"kind": "unavailable", "measured_count": 0, "sum_ms": nil},
+		}},
+		{"delivery-review", "claude-code", time.Date(2026, 1, 2, 12, 30, 0, 0, time.UTC).UnixNano(), map[string]any{
+			"model": map[string]string{"provider": "anthropic", "id": "claude-sonnet-5"}, "model_evidence": "response", "agent_kind": "built_in", "agent_class": "review-risk", "selected_effort": "xhigh", "effective_effort": "xhigh", "launches": 1, "responses": 5,
+			"input_tokens": token(20, 1, 0, 0), "output_tokens": token(10, 1, 0, 0), "cache_read_tokens": token(5, 1, 0, 0), "cache_creation_tokens": token(0, 0, 1, 0), "reasoning_tokens": token(2, 1, 0, 0), "total_tokens": token(37, 1, 0, 0),
+			"error_category": "none", "duration": map[string]any{"kind": "unavailable", "measured_count": 0, "sum_ms": nil},
+		}},
 	}
 	for _, fixture := range runtimeFixtures {
 		payload, err := json.Marshal(map[string]string{"host": fixture.host})
@@ -302,6 +495,56 @@ func TestRuntimeDashboard(t *testing.T) {
 	}
 	if _, err := s.db.Exec(`INSERT INTO runtime_rows(delivery_id,ordinal,row_json) VALUES('delivery-codex',1,?)`, string(unavailableDuration)); err != nil {
 		t.Fatal(err)
+	}
+	for _, additional := range []struct {
+		delivery string
+		row      map[string]any
+	}{
+		{"delivery-sdd", map[string]any{
+			"model": map[string]string{"provider": "openai-codex", "id": "gpt-5.6-terra"}, "model_evidence": "selected", "agent_kind": "built_in", "agent_class": "sdd-apply", "selected_effort": "medium", "effective_effort": "medium", "launches": 1, "responses": 0,
+			"input_tokens": token(5, 1, 0, 0), "output_tokens": token(3, 1, 0, 0), "cache_read_tokens": token(0, 0, 1, 0), "cache_creation_tokens": token(0, 0, 1, 0), "reasoning_tokens": token(0, 0, 1, 0), "total_tokens": token(0, 0, 0, 1),
+			"error_category": "none", "duration": map[string]any{"kind": "unavailable", "measured_count": 0, "sum_ms": nil},
+		}},
+		{"delivery-review", map[string]any{
+			"model": map[string]string{"provider": "anthropic", "id": "claude-haiku-4-5"}, "model_evidence": "response", "agent_kind": "built_in", "agent_class": "review-risk", "selected_effort": "high", "effective_effort": "high", "launches": 0, "responses": 2,
+			"input_tokens": token(8, 1, 0, 0), "output_tokens": token(4, 1, 0, 0), "cache_read_tokens": token(0, 0, 1, 0), "cache_creation_tokens": token(0, 0, 1, 0), "reasoning_tokens": token(0, 0, 1, 0), "total_tokens": token(12, 1, 0, 0),
+			"error_category": "none", "duration": map[string]any{"kind": "unavailable", "measured_count": 0, "sum_ms": nil},
+		}},
+	} {
+		raw, err := json.Marshal(additional.row)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, err := s.db.Exec(`INSERT INTO runtime_rows(delivery_id,ordinal,row_json) VALUES(?,1,?)`, additional.delivery, string(raw)); err != nil {
+			t.Fatal(err)
+		}
+	}
+	for _, live := range []struct {
+		id, host                 string
+		received                 int64
+		responses, input, output int
+	}{
+		{"live-codex", "codex", now.Add(-5 * time.Minute).UnixNano(), 3, 6, 4},
+		{"live-pi", "pi", now.Add(-10 * time.Minute).UnixNano(), 2, 3, 2},
+	} {
+		payload, err := json.Marshal(map[string]string{"host": live.host})
+		if err != nil {
+			t.Fatal(err)
+		}
+		row, err := json.Marshal(map[string]any{
+			"model": map[string]string{"provider": "unknown", "id": "unknown"}, "model_evidence": "unknown", "agent_kind": "orchestrator", "agent_class": "orchestrator", "selected_effort": "unknown", "effective_effort": "unknown", "launches": 0, "responses": live.responses,
+			"input_tokens": token(live.input, 1, 0, 0), "output_tokens": token(live.output, 1, 0, 0), "cache_read_tokens": token(0, 0, 1, 0), "cache_creation_tokens": token(0, 0, 1, 0), "reasoning_tokens": token(0, 0, 1, 0), "total_tokens": token(live.input+live.output, 1, 0, 0),
+			"error_category": "none", "duration": map[string]any{"kind": "unavailable", "measured_count": 0, "sum_ms": nil},
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, err := s.db.Exec(`INSERT INTO runtime_deliveries(delivery_id,received_at,canonical_payload) VALUES(?,?,?)`, live.id, live.received, string(payload)); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := s.db.Exec(`INSERT INTO runtime_rows(delivery_id,ordinal,row_json) VALUES(?,0,?)`, live.id, string(row)); err != nil {
+			t.Fatal(err)
+		}
 	}
 
 	queries := map[string]string{}
@@ -341,17 +584,26 @@ func TestRuntimeDashboard(t *testing.T) {
 	assertSingleNumber("RDD adoption %", 50)
 	assertSingleNumber("npm downloads latest day", 300)
 	assertSingleNumber("GitHub release downloads", 30)
-	assertSingleNumber("Tokens processed", 32)
-	assertSingleNumber("Responses", 5)
-	assertSingleNumber("Deliveries", 2)
-	assertSingleNumber("Hosts reporting", 2)
+	assertSingleNumber("Active users, last 24h", 2)
+	assertSingleNumber("Active users, last 6h", 2)
+	assertSingleNumber("Active users, last 1h", 2)
+	assertSingleNumber("Active users, last 15 min", 1)
+	assertSingleNumber("Deliveries, last 15 min", 2)
+	assertSingleNumber("Responses, last 15 min", 5)
+	assertSingleNumber("Tokens processed, last 15 min", 15)
+	assertSingleNumber("Hosts active, last 15 min", 2)
+	assertSingleNumber("Tokens processed", 99)
+	assertSingleNumber("Responses", 12)
+	assertSingleNumber("Deliveries", 4)
+	assertSingleNumber("Hosts reporting", 4)
+	assertSingleNumber("Subagent coverage", 100.0*4.0/7.0)
 
 	for _, tc := range []struct {
 		title string
 		want  [][]any
 	}{
-		{"Tokens processed by host", [][]any{{"codex", int64(21)}, {"opencode", int64(11)}}},
-		{"Responses by host", [][]any{{"codex", int64(3)}, {"opencode", int64(2)}}},
+		{"Tokens processed by host", [][]any{{"claude-code", int64(49)}, {"codex", int64(21)}, {"pi", int64(18)}, {"opencode", int64(11)}}},
+		{"Responses by host", [][]any{{"claude-code", int64(7)}, {"codex", int64(3)}, {"opencode", int64(2)}, {"pi", int64(0)}}},
 	} {
 		t.Run(tc.title+" long format", func(t *testing.T) {
 			rows, err := s.db.Query(queries[tc.title])
@@ -375,6 +627,114 @@ func TestRuntimeDashboard(t *testing.T) {
 				t.Fatalf("rows = %#v; want %#v", got, tc.want)
 			}
 		})
+	}
+
+	for _, tc := range []struct {
+		title string
+		want  [][]any
+	}{
+		{"Responses by subagent", [][]any{{"review-risk", int64(8)}, {"sdd-apply", int64(4)}}},
+		{"Tokens processed by subagent", [][]any{{"review-risk", int64(49)}, {"sdd-apply", int64(18)}}},
+	} {
+		t.Run(tc.title+" named rows", func(t *testing.T) {
+			rows, err := s.db.Query(queries[tc.title])
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer rows.Close()
+			var got [][]any
+			for rows.Next() {
+				var subagent string
+				var measure int64
+				if err := rows.Scan(&subagent, &measure); err != nil {
+					t.Fatal(err)
+				}
+				got = append(got, []any{subagent, measure})
+			}
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Fatalf("rows = %#v; want %#v", got, tc.want)
+			}
+		})
+	}
+
+	subagentRows, err := s.db.Query(queries["Subagent model and effort selection"])
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer subagentRows.Close()
+	if columns, err := subagentRows.Columns(); err != nil || !reflect.DeepEqual(columns, []string{"Host", "Subagent", "Provider/model", "Evidence", "Selected effort", "Effective effort", "Launches", "Responses", "Tokens processed", "Avg tokens per response"}) {
+		t.Fatalf("subagent columns = %v, err = %v", columns, err)
+	}
+	var gotSubagents [][]any
+	for subagentRows.Next() {
+		values, pointers := make([]any, 10), make([]any, 10)
+		for i := range values {
+			pointers[i] = &values[i]
+		}
+		if err := subagentRows.Scan(pointers...); err != nil {
+			t.Fatal(err)
+		}
+		gotSubagents = append(gotSubagents, values)
+	}
+	wantSubagents := [][]any{
+		{"claude-code", "review-risk", "anthropic/claude-sonnet-5", "response", "xhigh", "xhigh", int64(1), int64(5), int64(37), 7.4},
+		{"claude-code", "review-risk", "anthropic/claude-haiku-4-5", "response", "high", "high", int64(0), int64(2), int64(12), float64(6)},
+		{"pi", "sdd-apply", "openai/gpt-5.6-sol", "selected", "high", "high", int64(3), int64(0), int64(10), nil},
+		{"pi", "sdd-apply", "openai-codex/gpt-5.6-terra", "selected", "medium", "medium", int64(1), int64(0), int64(8), nil},
+	}
+	if !reflect.DeepEqual(gotSubagents, wantSubagents) {
+		t.Fatalf("subagent rows = %#v; want %#v", gotSubagents, wantSubagents)
+	}
+
+	popularRows, err := s.db.Query(queries["Most popular models per subagent"])
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer popularRows.Close()
+	if columns, err := popularRows.Columns(); err != nil || !reflect.DeepEqual(columns, []string{"Subagent", "Rank", "Provider/model", "Most common selected effort", "Observations", "Share of subagent (%)", "Hosts"}) {
+		t.Fatalf("popular-model columns = %v, err = %v", columns, err)
+	}
+	var gotPopular [][]any
+	for popularRows.Next() {
+		values, pointers := make([]any, 7), make([]any, 7)
+		for i := range values {
+			pointers[i] = &values[i]
+		}
+		if err := popularRows.Scan(pointers...); err != nil {
+			t.Fatal(err)
+		}
+		gotPopular = append(gotPopular, values)
+	}
+	wantPopular := [][]any{
+		{"review-risk", int64(1), "anthropic/claude-sonnet-5", "xhigh", int64(6), float64(75), "claude-code"},
+		{"review-risk", int64(2), "anthropic/claude-haiku-4-5", "high", int64(2), float64(25), "claude-code"},
+		{"sdd-apply", int64(1), "openai/gpt-5.6-sol", "high", int64(3), float64(75), "pi"},
+		{"sdd-apply", int64(2), "openai-codex/gpt-5.6-terra", "medium", int64(1), float64(25), "pi"},
+	}
+	if !reflect.DeepEqual(gotPopular, wantPopular) {
+		t.Fatalf("popular-model rows = %#v; want %#v", gotPopular, wantPopular)
+	}
+
+	topRows, err := s.db.Query(queries["Top model per subagent"])
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer topRows.Close()
+	var gotTop [][]any
+	for topRows.Next() {
+		var label string
+		var observations int64
+		if err := topRows.Scan(&label, &observations); err != nil {
+			t.Fatal(err)
+		}
+		gotTop = append(gotTop, []any{label, observations})
+	}
+	wantTop := [][]any{
+		{"review-risk · anthropic/claude-sonnet-5", int64(6)},
+		{"sdd-apply · openai/gpt-5.6-sol", int64(3)},
+	}
+	if !reflect.DeepEqual(gotTop, wantTop) {
+		t.Fatalf("top-model rows = %#v; want %#v", gotTop, wantTop)
 	}
 
 	versionRows, err := s.db.Query(queries["Version adoption"])
@@ -436,8 +796,12 @@ func TestRuntimeDashboard(t *testing.T) {
 		gotUsage = append(gotUsage, values)
 	}
 	wantUsage := [][]any{
+		{"claude-code", "built_in", "review-risk", "anthropic/claude-sonnet-5", "xhigh", "xhigh", int64(1), int64(5), int64(37)},
 		{"codex", "orchestrator", "orchestrator", "openai/gpt-5", "high", "high", int64(1), int64(3), int64(21)},
 		{"opencode", "worker", "unknown", "custom/custom", "unknown", "unknown", int64(2), int64(2), int64(11)},
+		{"pi", "built_in", "sdd-apply", "openai/gpt-5.6-sol", "high", "high", int64(3), int64(0), int64(10)},
+		{"claude-code", "built_in", "review-risk", "anthropic/claude-haiku-4-5", "high", "high", int64(0), int64(2), int64(12)},
+		{"pi", "built_in", "sdd-apply", "openai-codex/gpt-5.6-terra", "medium", "medium", int64(1), int64(0), int64(8)},
 	}
 	if !reflect.DeepEqual(gotUsage, wantUsage) {
 		t.Fatalf("usage rows = %#v; want %#v", gotUsage, wantUsage)

--- a/internal/telemetrycollector/runtime_event_test.go
+++ b/internal/telemetrycollector/runtime_event_test.go
@@ -151,11 +151,18 @@ func TestRuntimeEventContract(t *testing.T) {
 
 func TestRuntimeEventDeprecatedAgentClassAliasNormalized(t *testing.T) {
 	legacy := strings.Replace(string(runtimeFixture()), `"agent_class":"sdd-apply"`, `"agent_class":"sdd-proposal"`, 1)
+	legacyRow := strings.TrimSuffix(strings.SplitN(legacy, `"rows":[`, 2)[1], `]}`)
+	legacy = strings.TrimSuffix(legacy, `]}`) + `,` + legacyRow + `]}`
 	legacyEvent, err := telemetry.ParseRuntimeEvent([]byte(legacy))
 	if err != nil {
 		t.Fatal(err)
 	}
-	if got := legacyEvent.Rows[0].AgentClass; got != "sdd-propose" {
-		t.Fatalf("deprecated agent class normalized to %q, want sdd-propose", got)
+	if got := len(legacyEvent.Rows); got != 2 {
+		t.Fatalf("parsed %d rows, want 2", got)
+	}
+	for i, row := range legacyEvent.Rows {
+		if got := row.AgentClass; got != "sdd-propose" {
+			t.Fatalf("row %d deprecated agent class normalized to %q, want sdd-propose", i, got)
+		}
 	}
 }

--- a/internal/telemetrycollector/runtime_event_test.go
+++ b/internal/telemetrycollector/runtime_event_test.go
@@ -146,4 +146,16 @@ func TestRuntimeEventContract(t *testing.T) {
 	if bytes.Contains(canonical, []byte("batch_id")) {
 		t.Fatal("local identity in transport")
 	}
+
+}
+
+func TestRuntimeEventDeprecatedAgentClassAliasNormalized(t *testing.T) {
+	legacy := strings.Replace(string(runtimeFixture()), `"agent_class":"sdd-apply"`, `"agent_class":"sdd-proposal"`, 1)
+	legacyEvent, err := telemetry.ParseRuntimeEvent([]byte(legacy))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := legacyEvent.Rows[0].AgentClass; got != "sdd-propose" {
+		t.Fatalf("deprecated agent class normalized to %q, want sdd-propose", got)
+	}
 }


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #4477

---

## 🏷️ PR Type

- [ ] `type:bug` — Bug fix (non-breaking change that fixes an issue)
- [x] `type:feature` — New feature (non-breaking change that adds functionality)
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring (no functional changes)
- [ ] `type:chore` — Build, CI, or tooling changes
- [ ] `type:breaking-change` — Breaking change (fix or feature that changes existing behavior)

---

## 📝 Summary

Runtime telemetry now answers "which subagent ran, on which model, at which effort, with how many tokens" for all four hosts, and the provisioned Grafana dashboard tells that story.

- OpenCode: the managed plugin forwards the producing agent; the normalizer maps it to the closed vocabulary and fills the selected effort and fallback model from the local assignment; managed plugin upgrades accept approved prior digests.
- Claude Code and Codex: new `gentle-ai telemetry runtime claude|codex --json` producers wired through managed `Stop`/`SubagentStop` hooks, with bounded transcript reads for model and usage and no identifiers or content leaving the machine.
- Contract: `agent_class` vocabulary aligned with the installed agents (`sdd-propose` canonical, `sdd-proposal` accepted and normalized, `review-refuter`/`review-validator` added, Pi-only `sdd-status`/`sdd-sync` kept) with a parity test.
- Dashboard: active users, adoption, growth, where Gentle AI runs, live activity, runtime usage, subagents and most popular models per subagent; every SQL statement executes against synthetic SQLite fixtures in the pinned test.

`size:exception` rationale: the change spans contract, four producers, collector normalization, managed asset upgrade and the dashboard JSON (the dashboard alone is ~2,000 generated JSON lines); the work units are separate commits reviewable one by one, and the maintainer requested a single PR per repository for this delivery.

---

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/telemetry/runtime.go`, `contracts/telemetry/runtime/v1/schemas/aggregate.schema.json` | `agent_class` vocabulary aligned with installed agents; `sdd-proposal` alias normalized; parity test |
| `internal/assets/opencode/plugins/telemetry-runtime.ts`, `internal/telemetry/runtime_opencode.go`, `internal/components/telemetryruntime/opencode.go` | OpenCode agent attribution, selected effort/model from `opencode.json` (1 MiB read bound) |
| `internal/components/telemetryruntime/managed.go` | Approved prior digest allowlist so `gentle-ai sync` upgrades the managed plugin |
| `internal/telemetry/runtime_claude.go`, `internal/components/telemetryruntime/claude.go` | Claude Code producer: `SubagentStop`/`Stop` hook input, bounded transcript usage, alias mapping |
| `internal/telemetry/runtime_codex.go`, `internal/components/telemetryruntime/codex.go` | Codex producer: agent from `session_meta` thread spawn path, `turn_context` model/effort, `token_count` usage |
| `internal/cli/telemetry_runtime.go` | `claude` and `codex` verbs; hook stdin completes on the first JSON object with a 3 s budget |
| `internal/components/sdd/inject.go`, `internal/components/uninstall/service.go` | Managed Claude and Codex telemetry hooks, idempotent install and removal |
| `deploy/telemetry/grafana/dashboards/gentle-ai-usage.json`, `internal/telemetrycollector/runtime_dashboard_test.go` | Dashboard redesign with SQLite-backed pinned tests |
| `docs/telemetry.md` | Producer behavior, vocabulary, upgrade note, limitations |

---

## 🤖 AI Assistance

Select exactly one option. Do not check both options.

- [ ] **None** — No material AI assistance was used.
- [x] **Material assistance used** — Complete all applicable declaration fields below.

**Tool/model (if known):** OpenAI Codex CLI (gpt-5.6) for implementation under strict TDD, orchestrated from Claude Code (Claude Fable 5.1).

**Material scope:** Producers, normalizers, hook injection, dashboard JSON and tests were written by Codex from specifications derived from production data and host documentation; all merges, verification runs and end-to-end tests were executed and reviewed by the maintainer's session.

**Verification performed:** `go run ./internal/gofmtcheck`, `go vet ./...`, `go test` for telemetry, collector, telemetryruntime, uninstall, assets, opencode, sdd and the full `internal/cli` package, `cd e2e && ./docker-test.sh` (3/3 platforms), plus live end-to-end runs from Pi, OpenCode, Claude Code and Codex against the production collector (attributed `built_in` rows received for each host).

---

## 🧪 Test Plan

- [x] Unit tests pass (`go test ./...` for every touched package, including the full `internal/cli` package)
- [x] Go format passes (`go run ./internal/gofmtcheck`)
- [x] E2E tests pass (`cd e2e && ./docker-test.sh`, 3/3)
- [x] Manually tested locally: each host ran a headless session that launched a named subagent; the collector stored `built_in/sdd-explore` (pi, opencode, claude-code) and `built_in/review-risk` (codex) rows with model, effort and tokens.

Benchmark validation: N/A — telemetry producers, contract vocabulary and dashboard; no review-lifecycle, gate, recovery or delivery behavior changed.

---

## ✅ Contributor Checklist

- [x] PR is linked to an issue with `status:approved`
- [x] PR stays within 400 changed lines, or I have requested/obtained maintainer-applied `size:exception` with rationale documented
- [x] I have added the appropriate `type:*` label to this PR
- [x] Unit tests pass (`go test ./...`)
- [x] Go format passes (`go run ./internal/gofmtcheck`)
- [x] E2E tests pass (`cd e2e && ./docker-test.sh`)
- [x] Benchmark validation completed, or this change is not applicable to the benchmark (explain why in the Test Plan).
- [x] I have updated documentation if necessary
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] I understand, reviewed, and take responsibility for the complete submission
- [x] I selected exactly one AI-assistance option and, if material assistance was used, completed all applicable declaration fields
- [x] My commits do not include `Co-Authored-By` trailers

---

## 💬 Notes for Reviewers

- Codex skips hooks silently after `~/.codex/hooks.json` changes until the user trusts them on the next interactive start; `codex exec` needs `--dangerously-bypass-hook-trust` for automated runs.
- The Codex orchestrator asset still uses hyphenated `task_name` values (`sdd-design`) that Codex 0.153 rejects; tracked separately.
- Historical `unknown` rows cannot be repaired: observations are anonymous and one-shot.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added automatic telemetry collection for Claude Code and Codex.
  - Added agent, model, and effort attribution for Claude Code, Codex, and OpenCode activity.
  - Added privacy safeguards that filter invalid, oversized, or sensitive telemetry data.
  - Added support for updated agent classifications, including `sdd-propose`, `review-refuter`, and `review-validator`.
- **Documentation**
  - Expanded telemetry setup and integration guidance for Claude Code, Codex, and OpenCode.
- **Bug Fixes**
  - Improved telemetry hook installation, deduplication, and cleanup during uninstall.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->