### PR TITLE
fix(pi): report retained resources after uninstall

### DIFF
--- a/internal/agents/pi/adapter.go
+++ b/internal/agents/pi/adapter.go
@@ -18,16 +18,17 @@ import (
 )
 
 const (
-	piMCPAdapterPackage      = "npm:pi-mcp-adapter"
-	piMCPAdapterPackageSpec  = "npm:pi-mcp-adapter"
-	piMCPAdapterDependency   = "pi-mcp-adapter"
-	piMCPAdapterVersion      = "2.6.0"
-	piMCPAdapterVersionRange = "^2.6.0"
-	piAppendSystemFile       = "APPEND_SYSTEM.md"
-	piEngramMCPConfigFile    = "mcp.json"
-	piSettingsFile           = "settings.json"
-	piNPMDirectory           = "npm"
-	piNPMPackageFile         = "package.json"
+	piMCPAdapterPackage         = "npm:pi-mcp-adapter"
+	piMCPAdapterPackageSpec     = "npm:pi-mcp-adapter"
+	piGentleEngramPackageSource = "npm:gentle-engram"
+	piMCPAdapterDependency      = "pi-mcp-adapter"
+	piMCPAdapterVersion         = "2.6.0"
+	piMCPAdapterVersionRange    = "^2.6.0"
+	piAppendSystemFile          = "APPEND_SYSTEM.md"
+	piEngramMCPConfigFile       = "mcp.json"
+	piSettingsFile              = "settings.json"
+	piNPMDirectory              = "npm"
+	piNPMPackageFile            = "package.json"
 )
 
 var legacyPiSubagentPackageIdentities = map[string]struct{}{
@@ -46,6 +47,21 @@ const gentleAgentsGentlePiVersion = "2.5.0"
 var retiredPiPackageIdentities = map[string]struct{}{
 	"npm:@juicesharp/rpiv-todo": {},
 	"npm:pi-subagents-j0k3r":    {},
+}
+
+var managedPackageSources = []string{
+	"npm:gentle-pi",
+	piGentleEngramPackageSource,
+	piMCPAdapterPackage,
+	"npm:@juicesharp/rpiv-ask-user-question",
+	"npm:pi-web-access",
+	"npm:pi-btw",
+}
+
+// ManagedPackageSources returns every Pi package source installed by this
+// adapter. Callers receive a copy so package ownership remains adapter-owned.
+func ManagedPackageSources() []string {
+	return slices.Clone(managedPackageSources)
 }
 
 var piWalkDir = filepath.WalkDir
@@ -245,15 +261,14 @@ func (a *Adapter) CapabilityManifest() capabilitymanifest.AgentCapabilityManifes
 }
 
 func (a *Adapter) InstallCommand(profile system.PlatformProfile) ([][]string, error) {
-	return [][]string{
-		{"pi", "install", "npm:gentle-pi"},
-		{"pi", "install", "npm:gentle-engram"},
-		{"pi", "install", "npm:pi-mcp-adapter"},
-		a.engramInitCommand(),
-		{"pi", "install", "npm:@juicesharp/rpiv-ask-user-question"},
-		{"pi", "install", "npm:pi-web-access"},
-		{"pi", "install", "npm:pi-btw"},
-	}, nil
+	commands := make([][]string, 0, len(managedPackageSources)+1)
+	for _, source := range ManagedPackageSources() {
+		commands = append(commands, []string{"pi", "install", source})
+		if source == piMCPAdapterPackage {
+			commands = append(commands, a.engramInitCommand())
+		}
+	}
+	return commands, nil
 }
 
 func (a *Adapter) engramInitCommand() []string {

--- a/internal/agents/pi/adapter_test.go
+++ b/internal/agents/pi/adapter_test.go
@@ -254,6 +254,25 @@ func TestAdapterDetectMissingPiBinary(t *testing.T) {
 	}
 }
 
+func TestManagedPackageSourcesReturnsCanonicalCopy(t *testing.T) {
+	want := []string{
+		"npm:gentle-pi",
+		"npm:gentle-engram",
+		"npm:pi-mcp-adapter",
+		"npm:@juicesharp/rpiv-ask-user-question",
+		"npm:pi-web-access",
+		"npm:pi-btw",
+	}
+	got := ManagedPackageSources()
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("ManagedPackageSources() = %v, want %v", got, want)
+	}
+	got[0] = "changed"
+	if sources := ManagedPackageSources(); sources[0] != want[0] {
+		t.Fatalf("ManagedPackageSources() exposed mutable adapter state: %v", sources)
+	}
+}
+
 func TestAdapterInstallCommandSequenceUsesNpmWhenPnpmIsUnavailable(t *testing.T) {
 	a := &Adapter{
 		lookPath: func(file string) (string, error) {

--- a/internal/cli/uninstall.go
+++ b/internal/cli/uninstall.go
@@ -88,6 +88,8 @@ func RenderUninstallReport(result componentuninstall.Result) string {
 	// printed further down under manual cleanup.
 	if len(result.FailedAgents) > 0 {
 		_, _ = fmt.Fprintf(&b, "Managed uninstall partially complete: %s failed\n", strings.Join(agentLabels(result.FailedAgents), ", "))
+	} else if len(result.RetainedPiResources) > 0 || len(result.OptionalPiPackageCleanupCommands) > 0 {
+		_, _ = fmt.Fprintln(&b, "Managed uninstall finished; Pi resources retained for review")
 	} else {
 		_, _ = fmt.Fprintln(&b, "Managed uninstall complete")
 	}
@@ -104,6 +106,8 @@ func RenderUninstallReport(result componentuninstall.Result) string {
 	appendPathSection(&b, "Rewritten files", result.ChangedFiles)
 	appendPathSection(&b, "Deleted files", result.RemovedFiles)
 	appendPathSection(&b, "Deleted directories", result.RemovedDirectories)
+	appendPathSection(&b, "Retained Pi resources (not deleted)", result.RetainedPiResources)
+	appendOptionalPiPackageCleanup(&b, result.OptionalPiPackageCleanupCommands)
 	appendPathSection(&b, "Manual cleanup required", result.ManualActions)
 
 	return strings.TrimRight(b.String(), "\n")
@@ -163,6 +167,18 @@ func promptUninstallConfirm(flags UninstallFlags, stdout io.Writer, stdin io.Rea
 		return false, fmt.Errorf("no confirmation provided (use --yes to skip prompt)")
 	}
 	return strings.EqualFold(strings.TrimSpace(scanner.Text()), "yes"), nil
+}
+
+func appendOptionalPiPackageCleanup(b *strings.Builder, commands []string) {
+	if len(commands) == 0 {
+		return
+	}
+
+	_, _ = fmt.Fprintln(b, "\nOptional Pi package cleanup:")
+	_, _ = fmt.Fprintln(b, "  Review shared or user-modified packages/resources before removing them:")
+	for _, command := range commands {
+		_, _ = fmt.Fprintf(b, "  - %s\n", command)
+	}
 }
 
 func appendPathSection(b *strings.Builder, title string, paths []string) {

--- a/internal/cli/uninstall.go
+++ b/internal/cli/uninstall.go
@@ -88,7 +88,7 @@ func RenderUninstallReport(result componentuninstall.Result) string {
 	// printed further down under manual cleanup.
 	if len(result.FailedAgents) > 0 {
 		_, _ = fmt.Fprintf(&b, "Managed uninstall partially complete: %s failed\n", strings.Join(agentLabels(result.FailedAgents), ", "))
-	} else if len(result.RetainedPiResources) > 0 || len(result.OptionalPiPackageCleanupCommands) > 0 {
+	} else if len(result.RetainedPiResources) > 0 {
 		_, _ = fmt.Fprintln(&b, "Managed uninstall finished; Pi resources retained for review")
 	} else {
 		_, _ = fmt.Fprintln(&b, "Managed uninstall complete")

--- a/internal/cli/uninstall_report_header_test.go
+++ b/internal/cli/uninstall_report_header_test.go
@@ -30,3 +30,37 @@ func TestRenderUninstallReportHeaderStaysCompleteWhenNothingFailed(t *testing.T)
 		t.Fatalf("header = %q, want the unchanged complete header", header)
 	}
 }
+
+func TestRenderUninstallReportDistinguishesRetainedPiResourcesAndCommands(t *testing.T) {
+	report := RenderUninstallReport(componentuninstall.Result{
+		RetainedPiResources: []string{"/home/test/.pi/agent/agents"},
+		OptionalPiPackageCleanupCommands: []string{
+			"pi remove npm:gentle-pi",
+			"pi remove npm:gentle-engram",
+			"pi remove npm:pi-mcp-adapter",
+			"pi remove npm:@juicesharp/rpiv-ask-user-question",
+			"pi remove npm:pi-web-access",
+			"pi remove npm:pi-btw",
+		},
+	})
+	header := strings.SplitN(report, "\n", 2)[0]
+	if header == "Managed uninstall complete" {
+		t.Fatalf("header = %q, must distinguish retained Pi state", header)
+	}
+	for _, want := range []string{
+		"Retained Pi resources (not deleted)",
+		"/home/test/.pi/agent/agents",
+		"Optional Pi package cleanup",
+		"Review shared or user-modified packages/resources before removing them",
+		"pi remove npm:gentle-pi",
+		"pi remove npm:gentle-engram",
+		"pi remove npm:pi-mcp-adapter",
+		"pi remove npm:@juicesharp/rpiv-ask-user-question",
+		"pi remove npm:pi-web-access",
+		"pi remove npm:pi-btw",
+	} {
+		if !strings.Contains(report, want) {
+			t.Fatalf("report missing %q:\n%s", want, report)
+		}
+	}
+}

--- a/internal/cli/uninstall_report_header_test.go
+++ b/internal/cli/uninstall_report_header_test.go
@@ -31,6 +31,13 @@ func TestRenderUninstallReportHeaderStaysCompleteWhenNothingFailed(t *testing.T)
 	}
 }
 
+func TestRenderUninstallReportAdvisoryOnly(t *testing.T) {
+	report := RenderUninstallReport(componentuninstall.Result{OptionalPiPackageCleanupCommands: []string{"pi remove npm:gentle-pi"}})
+	if strings.SplitN(report, "\n", 2)[0] != "Managed uninstall complete" || !strings.Contains(report, "pi remove npm:gentle-pi") {
+		t.Fatalf("advice must not imply retained resources:\n%s", report)
+	}
+}
+
 func TestRenderUninstallReportDistinguishesRetainedPiResourcesAndCommands(t *testing.T) {
 	report := RenderUninstallReport(componentuninstall.Result{
 		RetainedPiResources: []string{"/home/test/.pi/agent/agents"},

--- a/internal/components/uninstall/service.go
+++ b/internal/components/uninstall/service.go
@@ -764,7 +764,7 @@ func retainedPiResources(homeDir, workspaceDir string) []string {
 
 	retained := make([]string, 0, len(paths))
 	for _, path := range paths {
-		if _, err := os.Stat(path); err == nil || !os.IsNotExist(err) {
+		if _, err := os.Lstat(path); err == nil || !os.IsNotExist(err) {
 			retained = append(retained, path)
 		}
 	}

--- a/internal/components/uninstall/service.go
+++ b/internal/components/uninstall/service.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/gentleman-programming/gentle-ai/v2/internal/agents"
 	"github.com/gentleman-programming/gentle-ai/v2/internal/agents/claude"
+	"github.com/gentleman-programming/gentle-ai/v2/internal/agents/pi"
 	"github.com/gentleman-programming/gentle-ai/v2/internal/assets"
 	"github.com/gentleman-programming/gentle-ai/v2/internal/backup"
 	"github.com/gentleman-programming/gentle-ai/v2/internal/components/communitytool"
@@ -40,13 +41,15 @@ type Snapshotter interface {
 }
 
 type Result struct {
-	Manifest               backup.Manifest
-	BackupPath             string
-	ChangedFiles           []string
-	RemovedFiles           []string
-	RemovedDirectories     []string
-	ManualActions          []string
-	AgentsRemovedFromState []model.AgentID
+	Manifest                         backup.Manifest
+	BackupPath                       string
+	ChangedFiles                     []string
+	RemovedFiles                     []string
+	RemovedDirectories               []string
+	RetainedPiResources              []string
+	OptionalPiPackageCleanupCommands []string
+	ManualActions                    []string
+	AgentsRemovedFromState           []model.AgentID
 	// FailedAgents lists the agents whose cleanup did not complete. They are
 	// deliberately left in state.json so the recorded state keeps matching the
 	// disk, and each one is named in ManualActions with the command that
@@ -633,6 +636,11 @@ func (s *Service) executePlan(p plan, agentsToRemove []model.AgentID) (Result, e
 		}
 	}
 
+	if slices.Contains(agentsToRemove, model.AgentPi) {
+		result.RetainedPiResources = retainedPiResources(s.homeDir, s.workspaceDir)
+		result.OptionalPiPackageCleanupCommands = optionalPiPackageCleanupCommands()
+	}
+
 	result.FailedAgents = failedAgents(failures, agentsToRemove)
 	result.ManualActions = append(result.ManualActions, failureManualActions(failures, agentsToRemove, s.homeDir)...)
 
@@ -737,6 +745,42 @@ func firstOrEmpty(items []string) string {
 		return ""
 	}
 	return items[0]
+}
+
+// retainedPiResources returns existing Pi-owned runtime and configuration paths
+// that gentle-ai deliberately leaves intact because they can be shared with Pi,
+// gentle-pi packages, or user-managed configuration.
+func retainedPiResources(homeDir, workspaceDir string) []string {
+	paths := []string{
+		filepath.Join(homeDir, ".pi", "agent", "agents"),
+		filepath.Join(homeDir, ".pi", "agent", "chains"),
+		filepath.Join(homeDir, ".pi", "agent", "gentle-ai"),
+		filepath.Join(homeDir, ".pi", "agent", "subagents.json"),
+		filepath.Join(homeDir, ".pi", "gentle-ai"),
+	}
+	if workspaceDir != "" {
+		paths = append(paths, filepath.Join(workspaceDir, ".pi", "gentle-ai"))
+	}
+
+	retained := make([]string, 0, len(paths))
+	for _, path := range paths {
+		if _, err := os.Stat(path); err == nil || !os.IsNotExist(err) {
+			retained = append(retained, path)
+		}
+	}
+	return retained
+}
+
+// optionalPiPackageCleanupCommands mirrors the Pi adapter's canonical package
+// sources. Each command remains separate because Pi 0.85.1 supports
+// `pi remove <source>`, not a bulk remove form.
+func optionalPiPackageCleanupCommands() []string {
+	sources := pi.ManagedPackageSources()
+	commands := make([]string, 0, len(sources))
+	for _, source := range sources {
+		commands = append(commands, "pi remove "+source)
+	}
+	return commands
 }
 
 func manualActionForNonEmptyDirectory(path string) (string, bool) {

--- a/internal/components/uninstall/service_test.go
+++ b/internal/components/uninstall/service_test.go
@@ -2,6 +2,7 @@ package uninstall
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io/fs"
 	"os"
@@ -9,6 +10,7 @@ import (
 	"runtime"
 	"slices"
 	"strings"
+	"syscall"
 	"testing"
 	"time"
 
@@ -663,6 +665,22 @@ func TestPartialUninstallPiDoesNotReportAbsentRetainedResources(t *testing.T) {
 	if len(result.RetainedPiResources) != 0 {
 		t.Fatalf("RetainedPiResources = %v, want none for absent paths", result.RetainedPiResources)
 	}
+	t.Run("dangling link", func(t *testing.T) {
+		path := filepath.Join(svc.homeDir, ".pi", "gentle-ai")
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Symlink(filepath.Join(svc.homeDir, "missing"), path); err != nil {
+			if runtime.GOOS == "windows" && errors.Is(err, syscall.Errno(1314)) {
+				t.Skipf("symlink privilege unavailable: %v", err)
+			}
+			t.Fatal(err)
+		}
+		result, err := svc.PartialUninstall([]model.AgentID{model.AgentPi}, nil)
+		if target, linkErr := os.Readlink(path); err != nil || linkErr != nil || target != filepath.Join(svc.homeDir, "missing") || !slices.Contains(result.RetainedPiResources, path) {
+			t.Fatalf("dangling link must remain and be reported: result=%+v err=%v linkErr=%v", result, err, linkErr)
+		}
+	})
 }
 
 func TestCompleteUninstallKeepsExecutableRemovalAction(t *testing.T) {

--- a/internal/components/uninstall/service_test.go
+++ b/internal/components/uninstall/service_test.go
@@ -589,6 +589,99 @@ func TestExecutePlanPiUninstallPreservesDriftedChildAndGentlePiSource(t *testing
 	}
 }
 
+func TestPartialUninstallPiReportsRetainedResourcesAndOptionalCleanup(t *testing.T) {
+	homeDir := t.TempDir()
+	workspaceDir := t.TempDir()
+	svc, err := NewService(homeDir, workspaceDir, "dev")
+	if err != nil {
+		t.Fatal(err)
+	}
+	svc.snapshotter = stubSnapshotter{}
+
+	retainedPaths := []string{
+		filepath.Join(homeDir, ".pi", "agent", "agents"),
+		filepath.Join(homeDir, ".pi", "agent", "chains"),
+		filepath.Join(homeDir, ".pi", "agent", "gentle-ai"),
+		filepath.Join(homeDir, ".pi", "agent", "subagents.json"),
+		filepath.Join(homeDir, ".pi", "gentle-ai"),
+		filepath.Join(workspaceDir, ".pi", "gentle-ai"),
+	}
+	for _, path := range retainedPaths {
+		if filepath.Ext(path) == ".json" {
+			if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.WriteFile(path, []byte(`{"user":"owned"}`), 0o644); err != nil {
+				t.Fatal(err)
+			}
+			continue
+		}
+		if err := os.MkdirAll(path, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	result, err := svc.PartialUninstall([]model.AgentID{model.AgentPi}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !slices.Equal(result.RetainedPiResources, retainedPaths) {
+		t.Fatalf("RetainedPiResources = %v, want %v", result.RetainedPiResources, retainedPaths)
+	}
+	wantCommands := []string{
+		"pi remove npm:gentle-pi",
+		"pi remove npm:gentle-engram",
+		"pi remove npm:pi-mcp-adapter",
+		"pi remove npm:@juicesharp/rpiv-ask-user-question",
+		"pi remove npm:pi-web-access",
+		"pi remove npm:pi-btw",
+	}
+	if !slices.Equal(result.OptionalPiPackageCleanupCommands, wantCommands) {
+		t.Fatalf("OptionalPiPackageCleanupCommands = %v, want %v", result.OptionalPiPackageCleanupCommands, wantCommands)
+	}
+	for _, path := range retainedPaths {
+		if _, err := os.Stat(path); err != nil {
+			t.Fatalf("retained Pi resource %q was deleted: %v", path, err)
+		}
+		if slices.Contains(result.RemovedDirectories, path) || slices.Contains(result.RemovedFiles, path) {
+			t.Fatalf("retained Pi resource %q was reported as removed: %#v", path, result)
+		}
+	}
+}
+
+func TestPartialUninstallPiDoesNotReportAbsentRetainedResources(t *testing.T) {
+	svc, err := NewService(t.TempDir(), t.TempDir(), "dev")
+	if err != nil {
+		t.Fatal(err)
+	}
+	svc.snapshotter = stubSnapshotter{}
+
+	result, err := svc.PartialUninstall([]model.AgentID{model.AgentPi}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(result.RetainedPiResources) != 0 {
+		t.Fatalf("RetainedPiResources = %v, want none for absent paths", result.RetainedPiResources)
+	}
+}
+
+func TestCompleteUninstallKeepsExecutableRemovalAction(t *testing.T) {
+	svc, err := NewService(t.TempDir(), t.TempDir(), "dev")
+	if err != nil {
+		t.Fatal(err)
+	}
+	svc.snapshotter = stubSnapshotter{}
+
+	result, err := svc.CompleteUninstall()
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := "To completely remove gentle-ai from your system, delete the executable (e.g., rm -f $(which gentle-ai))"
+	if !slices.Contains(result.ManualActions, want) {
+		t.Fatalf("ManualActions = %v, want %q", result.ManualActions, want)
+	}
+}
+
 func piCodeGraphProbeForServiceTest(string) (communitytool.PiCodeGraphMCPProbeResult, error) {
 	return communitytool.PiCodeGraphMCPProbeResult{
 		AdapterAvailable: true,

--- a/internal/tui/screens/uninstall.go
+++ b/internal/tui/screens/uninstall.go
@@ -381,7 +381,11 @@ func RenderUninstallResult(result componentuninstall.Result, err error, mode mod
 			b.WriteString(styles.SubtextStyle.Render(result.Manifest.DisplayLabel()))
 		}
 	} else {
-		b.WriteString(styles.SuccessStyle.Render("✓ Uninstall complete"))
+		if len(result.RetainedPiResources) > 0 || len(result.OptionalPiPackageCleanupCommands) > 0 {
+			b.WriteString(styles.SuccessStyle.Render("✓ Managed uninstall finished; Pi resources retained for review"))
+		} else {
+			b.WriteString(styles.SuccessStyle.Render("✓ Uninstall complete"))
+		}
 		b.WriteString("\n\n")
 		if result.Manifest.ID != "" {
 			b.WriteString(styles.SubtextStyle.Render("Backup: "))
@@ -398,6 +402,24 @@ func RenderUninstallResult(result componentuninstall.Result, err error, mode mod
 		if len(result.AgentsRemovedFromState) > 0 {
 			b.WriteString("\n")
 			b.WriteString(styles.UnselectedStyle.Render("Updated state.json: " + strings.Join(uninstallAgentLabels(result.AgentsRemovedFromState), ", ")))
+		}
+		if len(result.RetainedPiResources) > 0 {
+			b.WriteString("\n\n")
+			b.WriteString(styles.WarningStyle.Render("Retained Pi resources (not deleted):"))
+			for _, path := range result.RetainedPiResources {
+				b.WriteString("\n")
+				b.WriteString(styles.UnselectedStyle.Render("  • " + path))
+			}
+		}
+		if len(result.OptionalPiPackageCleanupCommands) > 0 {
+			b.WriteString("\n\n")
+			b.WriteString(styles.WarningStyle.Render("Optional Pi package cleanup:"))
+			b.WriteString("\n")
+			b.WriteString(styles.UnselectedStyle.Render("  Review shared or user-modified packages/resources before removing them:"))
+			for _, command := range result.OptionalPiPackageCleanupCommands {
+				b.WriteString("\n")
+				b.WriteString(styles.UnselectedStyle.Render("  • " + command))
+			}
 		}
 		if len(result.ManualActions) > 0 {
 			b.WriteString("\n\n")

--- a/internal/tui/screens/uninstall.go
+++ b/internal/tui/screens/uninstall.go
@@ -381,7 +381,7 @@ func RenderUninstallResult(result componentuninstall.Result, err error, mode mod
 			b.WriteString(styles.SubtextStyle.Render(result.Manifest.DisplayLabel()))
 		}
 	} else {
-		if len(result.RetainedPiResources) > 0 || len(result.OptionalPiPackageCleanupCommands) > 0 {
+		if len(result.RetainedPiResources) > 0 {
 			b.WriteString(styles.SuccessStyle.Render("✓ Managed uninstall finished; Pi resources retained for review"))
 		} else {
 			b.WriteString(styles.SuccessStyle.Render("✓ Uninstall complete"))
@@ -402,24 +402,6 @@ func RenderUninstallResult(result componentuninstall.Result, err error, mode mod
 		if len(result.AgentsRemovedFromState) > 0 {
 			b.WriteString("\n")
 			b.WriteString(styles.UnselectedStyle.Render("Updated state.json: " + strings.Join(uninstallAgentLabels(result.AgentsRemovedFromState), ", ")))
-		}
-		if len(result.RetainedPiResources) > 0 {
-			b.WriteString("\n\n")
-			b.WriteString(styles.WarningStyle.Render("Retained Pi resources (not deleted):"))
-			for _, path := range result.RetainedPiResources {
-				b.WriteString("\n")
-				b.WriteString(styles.UnselectedStyle.Render("  • " + path))
-			}
-		}
-		if len(result.OptionalPiPackageCleanupCommands) > 0 {
-			b.WriteString("\n\n")
-			b.WriteString(styles.WarningStyle.Render("Optional Pi package cleanup:"))
-			b.WriteString("\n")
-			b.WriteString(styles.UnselectedStyle.Render("  Review shared or user-modified packages/resources before removing them:"))
-			for _, command := range result.OptionalPiPackageCleanupCommands {
-				b.WriteString("\n")
-				b.WriteString(styles.UnselectedStyle.Render("  • " + command))
-			}
 		}
 		if len(result.ManualActions) > 0 {
 			b.WriteString("\n\n")
@@ -462,6 +444,24 @@ func RenderUninstallResult(result componentuninstall.Result, err error, mode mod
 	}
 
 	b.WriteString("\n\n")
+	if len(result.RetainedPiResources) > 0 {
+		b.WriteString(styles.WarningStyle.Render("Retained Pi resources (not deleted):"))
+		for _, path := range result.RetainedPiResources {
+			b.WriteString("\n")
+			b.WriteString(styles.UnselectedStyle.Render("  • " + path))
+		}
+		b.WriteString("\n\n")
+	}
+	if len(result.OptionalPiPackageCleanupCommands) > 0 {
+		b.WriteString(styles.WarningStyle.Render("Optional Pi package cleanup:"))
+		b.WriteString("\n")
+		b.WriteString(styles.UnselectedStyle.Render("  Review shared or user-modified packages/resources before removing them:"))
+		for _, command := range result.OptionalPiPackageCleanupCommands {
+			b.WriteString("\n")
+			b.WriteString(styles.UnselectedStyle.Render("  • " + command))
+		}
+		b.WriteString("\n\n")
+	}
 	b.WriteString(styles.HelpStyle.Render("enter: return • esc: back • q: quit"))
 	return b.String()
 }

--- a/internal/tui/screens/uninstall_result_test.go
+++ b/internal/tui/screens/uninstall_result_test.go
@@ -1,6 +1,8 @@
 package screens
 
 import (
+	"errors"
+	"fmt"
 	"strings"
 	"testing"
 
@@ -66,6 +68,31 @@ func TestRenderUninstallConfirmIncludesEngramProjectScopeDetails(t *testing.T) {
 	}
 	if !strings.Contains(out, ".engram/") {
 		t.Fatalf("RenderUninstallConfirm() should mention .engram project data removal; got:\n%s", out)
+	}
+}
+
+func TestRenderUninstallResultPiAdviceStatus(t *testing.T) {
+	for _, retained := range []bool{false, true} {
+		for _, failed := range []bool{false, true} {
+			t.Run(fmt.Sprintf("retained=%t/failed=%t", retained, failed), func(t *testing.T) {
+				result := componentuninstall.Result{OptionalPiPackageCleanupCommands: []string{"pi remove npm:gentle-pi"}}
+				result.Manifest.ID = "backup-test"
+				if retained {
+					result.RetainedPiResources = []string{"/retained/pi"}
+				}
+				var err error
+				if failed {
+					err = errors.New("cleanup failed")
+				}
+				out := RenderUninstallResult(result, err, "", nil, "", false, nil, nil)
+				if !strings.Contains(out, "pi remove npm:gentle-pi") || !strings.Contains(out, "backup-test") || strings.Contains(out, "/retained/pi") != retained || strings.Contains(out, "Pi resources retained for review") != (retained && !failed) || strings.Contains(out, "✓ Uninstall complete") != (!retained && !failed) {
+					t.Fatalf("incorrect Pi report:\n%s", out)
+				}
+				if failed && (!strings.Contains(out, "✗ Uninstall failed") || !strings.Contains(out, "cleanup failed") || !strings.Contains(out, "Backup created before failure")) {
+					t.Fatalf("missing failure details:\n%s", out)
+				}
+			})
+		}
 	}
 }
 

--- a/internal/tui/screens/uninstall_result_test.go
+++ b/internal/tui/screens/uninstall_result_test.go
@@ -69,6 +69,41 @@ func TestRenderUninstallConfirmIncludesEngramProjectScopeDetails(t *testing.T) {
 	}
 }
 
+func TestRenderUninstallResultDistinguishesRetainedPiResourcesAndCommands(t *testing.T) {
+	out := RenderUninstallResult(componentuninstall.Result{
+		RetainedPiResources: []string{"/home/test/.pi/gentle-ai"},
+		OptionalPiPackageCleanupCommands: []string{
+			"pi remove npm:gentle-pi",
+			"pi remove npm:gentle-engram",
+			"pi remove npm:pi-mcp-adapter",
+			"pi remove npm:@juicesharp/rpiv-ask-user-question",
+			"pi remove npm:pi-web-access",
+			"pi remove npm:pi-btw",
+		},
+	}, nil, model.UninstallModePartial, nil, model.EngramUninstallScopeGlobal, false, nil, nil)
+
+	for _, want := range []string{
+		"Pi resources retained for review",
+		"Retained Pi resources (not deleted)",
+		"/home/test/.pi/gentle-ai",
+		"Optional Pi package cleanup",
+		"Review shared or user-modified packages/resources before removing them",
+		"pi remove npm:gentle-pi",
+		"pi remove npm:gentle-engram",
+		"pi remove npm:pi-mcp-adapter",
+		"pi remove npm:@juicesharp/rpiv-ask-user-question",
+		"pi remove npm:pi-web-access",
+		"pi remove npm:pi-btw",
+	} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("RenderUninstallResult() missing %q:\n%s", want, out)
+		}
+	}
+	if strings.Contains(out, "✓ Uninstall complete") {
+		t.Fatalf("RenderUninstallResult() reports a complete uninstall despite retained Pi state:\n%s", out)
+	}
+}
+
 func TestRenderUninstallResultIncludesSelectedProfiles(t *testing.T) {
 	out := RenderUninstallResult(componentuninstall.Result{}, nil, model.UninstallModePartial, []string{"cheap", "fast"}, model.EngramUninstallScopeGlobal, false, nil, nil)
 


### PR DESCRIPTION
## 🔗 Linked Issue
Closes #4460

## 🏷️ PR Type
- [x] `type:bug` — Bug fix

## 📝 Summary
Make Pi uninstall reports truthful without deleting shared or user-modified resources. Report retained paths and optional manual package-removal commands instead of claiming everything was removed.

Review follow-up: optional advice no longer implies that paths were retained; retained details remain visible on TUI errors; dangling symlinks are reported without deleting them.

## 📂 Changes
| File / Area | What Changed |
|---|---|
| `internal/agents/pi` | Share the canonical six package sources between installation and cleanup guidance. |
| `internal/components/uninstall` | Return retained paths and optional commands; use `Lstat` to include dangling links. |
| `internal/cli`, `internal/tui/screens` | Separate optional advice from retained-state headlines; preserve Pi guidance on TUI failures. |
| Corresponding tests | Cover package-source consistency, absent/retained paths, dangling-link preservation, advisory-only results, and error rendering. Windows privilege handling recognizes wrapped errno 1314. |

## 🤖 AI Assistance
- [ ] **None**
- [x] **Material assistance used**

**Tool/model (if known):** el Gentleman in Pi with delegated implementation, verification, and native review.

**Material scope:** Investigation, implementation, tests, review follow-up, and PR description.

**Verification performed:** Full uncached Linux tests by the writer and independent verifier; parent focused reruns and direct inspection. New regressions were independently run against archived pre-correction production and failed for the expected causes. That sensitivity proof is not evidence of original TDD chronology; the writer's original RED run was transcript-only. Final native review approved and acknowledged. These are automated-agent checks, not manual human testing.

## 🧪 Test Plan
- [x] `go test ./... -count=1` — final Linux suite passed.
- [x] `go test ./internal/components/uninstall ./internal/cli ./internal/tui/screens -count=1` — final focused suite passed.
- [x] `go run ./internal/gofmtcheck` and `git diff --check` — passed.
- [x] Windows compile-only: `GOOS=windows GOARCH=amd64 go test -c -o <temporary-executable> ./internal/components/uninstall` — passed; not Windows execution.
- [ ] Local Docker E2E — intentionally not run; required remote E2E checks must pass on the new head.
- [ ] Manual interactive uninstall — not claimed.

**Benchmark Validation:** N/A to the reporting change: no review lifecycle, gate, recovery, delivery, or measured benchmark contract changes.

**Additional deterministic battery evidence:** The cross-lane battery on the initial candidate and independent exact shared base `df21d32b4badd3123c02afe62398ba0dbb557d94` both reported 11 PASS / 4 FAIL / 3 SKIP. The same three OpenCode repository-context mismatches and missing relative schema reference reproduce on that base with byte-identical harness/schema files. These are pre-existing failures, not a green battery claim; schema conformance remains unverified. No cross-lane rerun is claimed for this reporting-only follow-up.

An initial independent test attempt used an overly restrictive verifier `umask` and failed an unrelated permissions fixture. It was preserved and excluded from candidate-regression evidence; the final suites passed under the original inherited environment.

## 🤖 Automated Checks
All 16 current checks passed on final head `acaa13dde01e67545b40e1ac9a01edd8d19670dd`: CI `34591542139` and PR Validation `34591542113` / `34591643743` / `34591690547`. This includes the Windows runtime and both organic E2E platforms. No bypass requested.

## ✅ Contributor Checklist
- [x] Linked issue has `status:approved`.
- [x] Within the 400-line budget: **357 additions + 27 deletions = 384**.
- [x] API confirmed exactly one type label: `type:bug`.
- [x] Final full Linux suite and formatting passed.
- [x] Fresh remote CI/E2E complete on the final head.
- [x] User-facing cleanup guidance updated.
- [x] Conventional Commits; no `Co-Authored-By` trailers.
- [ ] Human contributor has reviewed and accepts responsibility for the complete submission.
- [x] Material AI assistance disclosed.

## 💬 Notes for Reviewers
Start with retained-resource detection, then the CLI/TUI projections and failure cases. There is no recursive deletion or automatic `pi remove`; commands are advice only.

The `PI_CODING_AGENT_DIR` concern was checked against the existing adapter contract: that override belongs to the separate CodeGraph path integration, while normal Pi configuration paths remain canonical. This PR does not broaden that product contract.

Initial native review `review-14924391499149bc` and final correction review `review-ca3517d862e5b56f` were approved and acknowledged. Final reviewed tree: `a593c33bd7952a30a292fa5b1c1ea2ed03b69bc0`. Review approval does not replace CI.

Guard-population note: the CLI changes format reports and guidance; no new admission, repair, governance, or security guard is introduced.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Pi agent setup now installs its managed package sources consistently.
  - Uninstall reports identify Pi resources retained for review instead of indicating a fully complete removal.
  - Uninstall results list retained resource paths and provide optional `pi remove` commands for package cleanup.
  - The terminal interface displays retained resources and available cleanup commands clearly.

- **Bug Fixes**
  - Pi uninstall preserves shared or user-managed resources while continuing to remove the agent executable and related managed components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

**Final advisory disposition:** Additional custom/project-path discovery is outside this bounded canonical-path report. When workspace equals HOME, the same retained path may be displayed twice; this is a non-blocking presentation limitation, not a deletion or preservation defect. The hardcoded installation preview is unchanged from the base and still lists the same six sources; unifying that separate preview is follow-up work. The original retained-headline and TUI-error findings are corrected and regression-tested, regardless of their old thread status.
