### PR TITLE
fix(pi): honor model assignments for native review roles

### DIFF
--- a/docs/pi-provider-routing.md
+++ b/docs/pi-provider-routing.md
@@ -1,0 +1,21 @@
+# Configure native Pi review roles
+
+Configure `review-refuter` and `review-validator` through gentle-pi's model configuration. Go reads those same saved assignments for native role capture; it never writes configuration or creates another routing format.
+
+## Resolution
+
+Go reads `GENTLE_PI_CONFIG_HOME/models.json` when that existing locator is set, otherwise `~/.pi/gentle-ai/models.json`. Only an absent global file falls back to `<validated repository>/.pi/gentle-ai/models.json`; entries are never merged. Unrelated entries are ignored and the file remains untouched.
+
+An assignment is a model string or an object containing optional `model` and `thinking` fields. A missing assignment or `{}` leaves the original Pi arguments unchanged, using **Pi's persisted defaults**, not the active session. There is no special `default` role entry.
+
+Explicit values travel only as `--model` and `--thinking` argv pairs. Thinking accepts `off`, `minimal`, `low`, `medium`, `high`, `xhigh`, and `max`. Pi owns model resolution and model-dependent clamping; Go has no model registry.
+
+## Invalid configuration stops before execution
+
+Repair the assignment through gentle-pi and retry the offered capture. Go intentionally validates more strictly than gentle-pi normalization: malformed files (including legacy project files), invalid selected fields, empty model strings, and unknown selected fields fail rather than silently falling back to another paid model. Unrelated entries do not affect routing.
+
+Go still owns binding validation, prompt materialization, request hashes, and admission. The transport receives only argv overrides and the unchanged opaque stdin prompt; its environment allowlist and discovery lockdown are unchanged.
+
+## Verification boundary
+
+Tests exercise local helper subprocesses and both native capture/admission paths, including malformed-config refusal without spawning. They do **not** prove organic execution by the real Pi runtime. That proof and the linked gentle-pi configuration UI work remain separate; no paid model invocation is required by these tests.

--- a/internal/agents/pi/review_routing.go
+++ b/internal/agents/pi/review_routing.go
@@ -1,0 +1,89 @@
+package pi
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+)
+
+// ReviewRouting contains argv-only overrides; zero values retain Pi's persisted defaults.
+type ReviewRouting struct{ Model, Thinking string }
+
+// ResolveReviewRouting reads gentle-pi's assignment authority without modifying it.
+// root must be the validated repository root, never the transport scratch directory.
+func ResolveReviewRouting(root, role string) (ReviewRouting, error) {
+	var route ReviewRouting
+	dir, set := os.LookupEnv("GENTLE_PI_CONFIG_HOME")
+	if !set {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return route, fmt.Errorf("locate Pi routing home: %w", err)
+		}
+		dir = filepath.Join(home, ".pi", "gentle-ai")
+	}
+	path := filepath.Join(dir, "models.json")
+	data, err := os.ReadFile(path)
+	if os.IsNotExist(err) {
+		path = filepath.Join(root, ".pi", "gentle-ai", "models.json")
+		data, err = os.ReadFile(path)
+	}
+	if os.IsNotExist(err) {
+		return route, nil
+	}
+	if err != nil {
+		return route, fmt.Errorf("read Pi routing %s: %w", path, err)
+	}
+	invalid := func() (ReviewRouting, error) {
+		return ReviewRouting{}, fmt.Errorf("invalid Pi routing for %s in %s; repair the assignment using gentle-pi model configuration before retrying", role, path)
+	}
+	var config map[string]json.RawMessage
+	if json.Unmarshal(data, &config) != nil || config == nil {
+		return invalid()
+	}
+	entry, exists := config[role]
+	if !exists {
+		return route, nil
+	}
+	var model string
+	if json.Unmarshal(entry, &model) == nil && string(entry) != "null" {
+		route.Model = strings.TrimSpace(model)
+		if route.Model == "" {
+			return invalid()
+		}
+	} else {
+		var fields map[string]json.RawMessage
+		if json.Unmarshal(entry, &fields) != nil || fields == nil {
+			return invalid()
+		}
+		for key, value := range fields {
+			switch key {
+			case "model":
+				if json.Unmarshal(value, &model) != nil {
+					return invalid()
+				}
+				route.Model = strings.TrimSpace(model)
+				if route.Model == "" {
+					return invalid()
+				}
+			case "thinking":
+				if json.Unmarshal(value, &route.Thinking) != nil {
+					return invalid()
+				}
+				switch route.Thinking {
+				case "off", "minimal", "low", "medium", "high", "xhigh", "max":
+				default:
+					return invalid()
+				}
+			default:
+				return invalid()
+			}
+		}
+	}
+	if route.Model != "" && !regexp.MustCompile(`^[A-Za-z0-9._~:@/+%-]+$`).MatchString(route.Model) {
+		return invalid()
+	}
+	return route, nil
+}

--- a/internal/agents/pi/review_routing_test.go
+++ b/internal/agents/pi/review_routing_test.go
@@ -1,0 +1,79 @@
+package pi
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestResolveReviewRouting(t *testing.T) {
+	for _, tc := range []struct {
+		name, config, model, thinking string
+		invalid                       bool
+	}{
+		{"string", `{"review-refuter":"provider/model"}`, "provider/model", "", false},
+		{"model", `{"review-refuter":{"model":" provider/model "}}`, "provider/model", "", false},
+		{"independent", `{"review-refuter":{"model":"a","thinking":"max"},"review-validator":{"model":"b","thinking":"off"}}`, "a", "max", false},
+		{"empty", `{"review-refuter":{}}`, "", "", false},
+		{"missing", `{"unrelated":false}`, "", "", false},
+		{"syntax", `{`, "", "", true},
+		{"array", `[]`, "", "", true},
+		{"null", `null`, "", "", true},
+		{"bad selected", `{"review-refuter":false}`, "", "", true},
+		{"bad model", `{"review-refuter":{"model":"bad model","thinking":"high"}}`, "", "", true},
+		{"bad thinking", `{"review-refuter":{"thinking":"huge"}}`, "", "", true},
+		{"unknown field", `{"review-refuter":{"typo":"a"}}`, "", "", true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("GENTLE_PI_CONFIG_HOME", t.TempDir())
+			path := filepath.Join(os.Getenv("GENTLE_PI_CONFIG_HOME"), "models.json")
+			if err := os.WriteFile(path, []byte(tc.config), 0600); err != nil {
+				t.Fatal(err)
+			}
+			got, err := ResolveReviewRouting(t.TempDir(), "review-refuter")
+			if (err != nil) != tc.invalid {
+				t.Fatalf("routing error = %v", err)
+			}
+			if !tc.invalid && (got.Model != tc.model || got.Thinking != tc.thinking) {
+				t.Fatalf("routing = %+v", got)
+			}
+		})
+	}
+}
+
+func TestResolveReviewRoutingPrecedenceAndThinking(t *testing.T) {
+	home, repo, custom := t.TempDir(), t.TempDir(), t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	t.Setenv("GENTLE_PI_CONFIG_HOME", custom)
+	write := func(dir, value string) {
+		t.Helper()
+		if err := os.MkdirAll(dir, 0700); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(dir, "models.json"), []byte(value), 0600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	check := func(model, thinking string) {
+		t.Helper()
+		got, err := ResolveReviewRouting(repo, "review-validator")
+		if err != nil || got.Model != model || got.Thinking != thinking {
+			t.Fatalf("routing = %+v, %v", got, err)
+		}
+	}
+	check("", "")
+	write(filepath.Join(repo, ".pi", "gentle-ai"), `{"review-validator":"project"}`)
+	check("project", "")
+	for _, level := range []string{"off", "minimal", "low", "medium", "high", "xhigh", "max"} {
+		write(custom, `{"review-validator":{"thinking":"`+level+`"}}`)
+		check("", level)
+	}
+	write(custom, `{}`)
+	check("", "") // An existing global file never merges project entries.
+	if err := os.Unsetenv("GENTLE_PI_CONFIG_HOME"); err != nil {
+		t.Fatal(err)
+	}
+	write(filepath.Join(home, ".pi", "gentle-ai"), `{"review-validator":"home"}`)
+	check("home", "")
+}

--- a/internal/cli/review_committed_correction_test.go
+++ b/internal/cli/review_committed_correction_test.go
@@ -327,10 +327,10 @@ func TestSelectorlessCommittedCorrectionClosesOnTargetedValidation(t *testing.T)
 			}
 			request := status.ValidationRequest
 			previous := reviewProviderRoleHostAdapter
-			reviewProviderRoleHostAdapter = func() reviewerprovider.Adapter {
+			reviewProviderRoleHostAdapter = func(reviewerprovider.Role, string) (reviewerprovider.Adapter, error) {
 				return providerTestAdapterFunc(func(context.Context, reviewerprovider.Invocation) ([]byte, error) {
 					return providerTargetedValidationPayload(t, *request), nil
-				})
+				}), nil
 			}
 			t.Cleanup(func() { reviewProviderRoleHostAdapter = previous })
 			var terminalOutput bytes.Buffer
@@ -389,10 +389,10 @@ func TestStagedCorrectionClosesOnTargetedValidation(t *testing.T) {
 	}
 	request := status.ValidationRequest
 	previous := reviewProviderRoleHostAdapter
-	reviewProviderRoleHostAdapter = func() reviewerprovider.Adapter {
+	reviewProviderRoleHostAdapter = func(reviewerprovider.Role, string) (reviewerprovider.Adapter, error) {
 		return providerTestAdapterFunc(func(context.Context, reviewerprovider.Invocation) ([]byte, error) {
 			return providerTargetedValidationPayload(t, *request), nil
-		})
+		}), nil
 	}
 	t.Cleanup(func() { reviewProviderRoleHostAdapter = previous })
 	var terminalOutput bytes.Buffer

--- a/internal/cli/review_last_event_closure_test.go
+++ b/internal/cli/review_last_event_closure_test.go
@@ -408,10 +408,10 @@ func TestTargetedValidatorCaptureRequiresNoVerificationEvidenceAndLeavesNoStrand
 	}
 
 	originalAdapter := reviewProviderRoleHostAdapter
-	reviewProviderRoleHostAdapter = func() reviewerprovider.Adapter {
+	reviewProviderRoleHostAdapter = func(reviewerprovider.Role, string) (reviewerprovider.Adapter, error) {
 		return providerTestAdapterFunc(func(context.Context, reviewerprovider.Invocation) ([]byte, error) {
 			return providerTargetedValidationPayload(t, request), nil
-		})
+		}), nil
 	}
 	t.Cleanup(func() { reviewProviderRoleHostAdapter = originalAdapter })
 
@@ -502,10 +502,10 @@ func TestTargetedValidationCaptureClosesWithoutVerificationEvidence(t *testing.T
 		t.Fatal(err)
 	}
 	originalAdapter := reviewProviderRoleHostAdapter
-	reviewProviderRoleHostAdapter = func() reviewerprovider.Adapter {
+	reviewProviderRoleHostAdapter = func(reviewerprovider.Role, string) (reviewerprovider.Adapter, error) {
 		return providerTestAdapterFunc(func(context.Context, reviewerprovider.Invocation) ([]byte, error) {
 			return providerTargetedValidationPayload(t, request), nil
-		})
+		}), nil
 	}
 	t.Cleanup(func() { reviewProviderRoleHostAdapter = originalAdapter })
 	var terminalOutput bytes.Buffer
@@ -537,10 +537,10 @@ func TestConcurrentAndReplayedTargetedValidatorCaptureHasOneCloser(t *testing.T)
 		t.Fatal(err)
 	}
 	originalAdapter := reviewProviderRoleHostAdapter
-	reviewProviderRoleHostAdapter = func() reviewerprovider.Adapter {
+	reviewProviderRoleHostAdapter = func(reviewerprovider.Role, string) (reviewerprovider.Adapter, error) {
 		return providerTestAdapterFunc(func(context.Context, reviewerprovider.Invocation) ([]byte, error) {
 			return providerTargetedValidationPayload(t, request), nil
-		})
+		}), nil
 	}
 	t.Cleanup(func() { reviewProviderRoleHostAdapter = originalAdapter })
 	args := []string{
@@ -630,10 +630,10 @@ func TestTargetedValidatorCaptureIssuesAcknowledgementWithoutFinalize(t *testing
 	}
 
 	originalAdapter := reviewProviderRoleHostAdapter
-	reviewProviderRoleHostAdapter = func() reviewerprovider.Adapter {
+	reviewProviderRoleHostAdapter = func(reviewerprovider.Role, string) (reviewerprovider.Adapter, error) {
 		return providerTestAdapterFunc(func(context.Context, reviewerprovider.Invocation) ([]byte, error) {
 			return providerTargetedValidationPayload(t, request), nil
-		})
+		}), nil
 	}
 	t.Cleanup(func() { reviewProviderRoleHostAdapter = originalAdapter })
 
@@ -853,10 +853,10 @@ func TestTargetedValidatorCaptureEscalatesRejectedCorrectionWithoutFinalize(t *t
 		t.Fatal(err)
 	}
 	originalAdapter := reviewProviderRoleHostAdapter
-	reviewProviderRoleHostAdapter = func() reviewerprovider.Adapter {
+	reviewProviderRoleHostAdapter = func(reviewerprovider.Role, string) (reviewerprovider.Adapter, error) {
 		return providerTestAdapterFunc(func(context.Context, reviewerprovider.Invocation) ([]byte, error) {
 			return failedPayload, nil
-		})
+		}), nil
 	}
 	t.Cleanup(func() { reviewProviderRoleHostAdapter = originalAdapter })
 
@@ -1279,10 +1279,10 @@ func TestLineageEscalationPublishesEscalationCauseInClosureAndStatusEnvelopes(t 
 		t.Fatal(err)
 	}
 	originalAdapter := reviewProviderRoleHostAdapter
-	reviewProviderRoleHostAdapter = func() reviewerprovider.Adapter {
+	reviewProviderRoleHostAdapter = func(reviewerprovider.Role, string) (reviewerprovider.Adapter, error) {
 		return providerTestAdapterFunc(func(context.Context, reviewerprovider.Invocation) ([]byte, error) {
 			return failedPayload, nil
-		})
+		}), nil
 	}
 	t.Cleanup(func() { reviewProviderRoleHostAdapter = originalAdapter })
 

--- a/internal/cli/review_pi_role_routing_test.go
+++ b/internal/cli/review_pi_role_routing_test.go
@@ -1,0 +1,135 @@
+package cli
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"path/filepath"
+	"runtime"
+	"slices"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/gentleman-programming/gentle-ai/v2/internal/reviewerprovider"
+)
+
+func TestPiCaptureWindowsFallbackPreservesParentTest(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Skip("Windows-only fallback; requires Windows execution")
+	}
+	for _, role := range []reviewerprovider.Role{reviewerprovider.RoleRefuter, reviewerprovider.RoleTargetedValidator} {
+		continued := false
+		t.Run(string(role), func(t *testing.T) {
+			raw := []byte("original fake adapter result")
+			assertRoutedPiCapture(t, "", role, raw, nil)
+			continued = true
+			adapter, err := reviewProviderRoleHostAdapter(role, "")
+			if err != nil {
+				t.Fatal(err)
+			}
+			got, err := adapter.Review(t.Context(), reviewerprovider.NewInvocation(nil))
+			if err != nil || !bytes.Equal(got, raw) {
+				t.Fatalf("fallback result = %q, %v", got, err)
+			}
+		})
+		if !continued {
+			t.Errorf("%s helper skipped the parent capture assertions", role)
+		}
+	}
+}
+
+// Keep the real resolver and transport where the POSIX fixture is supported.
+func assertRoutedPiCapture(t *testing.T, repo string, wantRole reviewerprovider.Role, raw []byte, execute []string) {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		// Retain the platform-neutral capture/admission assertions in callers.
+		overrideProviderRoleHostAdapter(t, providerTestAdapter{raw: raw})
+		return
+	}
+	dir := t.TempDir()
+	t.Setenv("GENTLE_PI_CONFIG_HOME", dir)
+	config := filepath.Join(dir, "models.json")
+	write := func(path string, data []byte) {
+		t.Helper()
+		if err := os.WriteFile(path, data, 0700); err != nil {
+			t.Fatal(err)
+		}
+	}
+	saved := []byte(`{"review-refuter":{"model":"provider/refuter","thinking":"max"},"review-validator":{"model":"provider/validator","thinking":"off"}}`)
+	write(config, saved)
+	executable, argv, response := filepath.Join(dir, "pi"), filepath.Join(dir, "argv"), filepath.Join(dir, "response")
+	write(response, raw)
+	write(executable, []byte("#!/bin/sh\nprintf '%s\\n' \"$@\" > "+strconv.Quote(argv)+"\ncat > "+strconv.Quote(filepath.Join(dir, "stdin"))+"\ncat "+strconv.Quote(response)+"\n"))
+	previous := reviewProviderRoleHostAdapter
+	t.Cleanup(func() { reviewProviderRoleHostAdapter = previous })
+	reviewProviderRoleHostAdapter = func(role reviewerprovider.Role, root string) (reviewerprovider.Adapter, error) {
+		if role != wantRole || root != repo {
+			t.Fatalf("routing context = %s %s", role, root)
+		}
+		adapter, err := previous(role, root)
+		if err != nil {
+			return nil, err
+		}
+		adapter.(*reviewerprovider.PiAdapter).LookPath = func(string) (string, error) { return executable, nil }
+		return adapter, nil
+	}
+	materialize := slices.Clone(execute)
+	materialize[slices.Index(materialize, "--execute=true")] = "--materialize=true"
+	var prompt bytes.Buffer
+	if err := RunReview(materialize, &prompt); err != nil {
+		t.Fatal(err)
+	}
+	for _, invalid := range []string{`{`, `{"review-refuter":{"thinking":"invalid"},"review-validator":{"model":false}}`} {
+		write(config, []byte(invalid))
+		if err := RunReview(execute, io.Discard); err == nil || !strings.Contains(err.Error(), "invalid Pi routing") {
+			t.Fatalf("malformed routing capture = %v", err)
+		}
+		if _, err := os.Stat(argv); !os.IsNotExist(err) {
+			t.Fatalf("malformed routing spawned Pi: %v", err)
+		}
+	}
+	baseArgs := "--print\n--mode\ntext\n--no-session\n--no-tools\n--no-extensions\n--no-skills\n--no-prompt-templates\n--no-themes\n--no-context-files\n--no-approve\n"
+	for _, tc := range []struct{ assignment, flags string }{
+		{`"provider/only"`, "--model\nprovider/only\n"},
+		{`{"thinking":"off"}`, "--thinking\noff\n"},
+		{`{}`, ""},
+		{"", ""},
+	} {
+		data := `{}`
+		if tc.assignment != "" {
+			data = `{"review-refuter":` + tc.assignment + `,"review-validator":` + tc.assignment + `}`
+		}
+		write(config, []byte(data))
+		adapter, err := reviewProviderRoleHostAdapter(wantRole, repo)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, err := adapter.Review(t.Context(), reviewerprovider.NewInvocation(prompt.Bytes())); err != nil {
+			t.Fatal(err)
+		}
+		got, err := os.ReadFile(argv)
+		if err != nil || string(got) != baseArgs+tc.flags {
+			t.Fatalf("assignment %s argv = %q, %v", data, got, err)
+		}
+	}
+	write(config, saved)
+	t.Cleanup(func() {
+		stdin, err := os.ReadFile(filepath.Join(dir, "stdin"))
+		if err != nil || !bytes.Equal(stdin, prompt.Bytes()) {
+			t.Errorf("capture changed materialized stdin: %v", err)
+		}
+		got, err := os.ReadFile(argv)
+		suffix := "--model\nprovider/refuter\n--thinking\nmax\n"
+		if wantRole == reviewerprovider.RoleTargetedValidator {
+			suffix = "--model\nprovider/validator\n--thinking\noff\n"
+		}
+		if err != nil || string(got) != baseArgs+suffix {
+			t.Errorf("subprocess argv = %q, %v; want %q", got, err, baseArgs+suffix)
+		}
+		unchanged, err := os.ReadFile(config)
+		if err != nil || !bytes.Equal(unchanged, saved) {
+			t.Errorf("capture changed routing config: %v", err)
+		}
+	})
+}

--- a/internal/cli/review_provider_role_capture.go
+++ b/internal/cli/review_provider_role_capture.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/gentleman-programming/gentle-ai/v2/internal/agents/pi"
 	"github.com/gentleman-programming/gentle-ai/v2/internal/model"
 	"github.com/gentleman-programming/gentle-ai/v2/internal/reviewerprovider"
 	"github.com/gentleman-programming/gentle-ai/v2/internal/reviewtransaction"
@@ -29,7 +30,19 @@ type reviewProviderRoleCaptureArtifact struct {
 // reviewProviderRoleHostAdapter is the one seam through which role capture
 // spawns the Go-owned pi process. Tests substitute a fake transport here; the
 // lens path keeps its host-mediated refusal in reviewProviderAdapterFor.
-var reviewProviderRoleHostAdapter = func() reviewerprovider.Adapter { return reviewerprovider.NewPiAdapter() }
+var reviewProviderRoleHostAdapter = func(role reviewerprovider.Role, root string) (reviewerprovider.Adapter, error) {
+	key := "review-refuter"
+	if role == reviewerprovider.RoleTargetedValidator {
+		key = "review-validator"
+	}
+	route, err := pi.ResolveReviewRouting(root, key)
+	if err != nil {
+		return nil, err
+	}
+	adapter := reviewerprovider.NewPiAdapter()
+	adapter.Model, adapter.Thinking = route.Model, route.Thinking
+	return adapter, nil
+}
 
 // reviewProviderRoleCaptureTimeout bounds one role capture operation so a full
 // Go-owned adversarial pi run fits while a stalled provider cannot hang --execute
@@ -205,7 +218,11 @@ func RunReviewCaptureRefuter(args []string, stdout io.Writer) error {
 			return err
 		}
 	} else {
-		raw, hostErr := reviewProviderRoleHostAdapter().Review(ctx, request.Invocation)
+		adapter, routingErr := reviewProviderRoleHostAdapter(reviewerprovider.RoleRefuter, binding.root)
+		if routingErr != nil {
+			return reviewPreflightError(routingErr)
+		}
+		raw, hostErr := adapter.Review(ctx, request.Invocation)
 		if hostErr != nil {
 			return reviewPreflightError(fmt.Errorf("invoke provider refuter: %w", hostErr))
 		}
@@ -278,7 +295,11 @@ func RunReviewCaptureValidation(args []string, stdout io.Writer) error {
 		}
 		return encodeReviewJSON(stdout, closure)
 	}
-	raw, hostErr := reviewProviderRoleHostAdapter().Review(ctx, request.Invocation)
+	adapter, routingErr := reviewProviderRoleHostAdapter(reviewerprovider.RoleTargetedValidator, binding.root)
+	if routingErr != nil {
+		return reviewPreflightError(routingErr)
+	}
+	raw, hostErr := adapter.Review(ctx, request.Invocation)
 	if hostErr != nil {
 		return reviewPreflightError(fmt.Errorf("invoke provider targeted validator: %w", hostErr))
 	}

--- a/internal/cli/review_provider_role_materialize_test.go
+++ b/internal/cli/review_provider_role_materialize_test.go
@@ -139,7 +139,7 @@ func overrideProviderRoleHostAdapter(t *testing.T, adapter reviewerprovider.Adap
 	t.Helper()
 	previous := reviewProviderRoleHostAdapter
 	t.Cleanup(func() { reviewProviderRoleHostAdapter = previous })
-	reviewProviderRoleHostAdapter = func() reviewerprovider.Adapter { return adapter }
+	reviewProviderRoleHostAdapter = func(reviewerprovider.Role, string) (reviewerprovider.Adapter, error) { return adapter, nil }
 }
 
 type controlledDeadlineContext struct {
@@ -220,9 +220,10 @@ func TestReviewCaptureRefuterExecutesGoOwnedPiAndClosesOnTheRefuterEvent(t *test
 	if err := RunReview(append(append([]string{"capture-refuter"}, binding...), "--execute=true"), io.Discard); err == nil || !strings.Contains(err.Error(), "requires --agent") {
 		t.Fatalf("agent-free refuter execution refusal = %v", err)
 	}
-	overrideProviderRoleHostAdapter(t, providerTestAdapter{raw: piRefuterRawResult(t, repo, store, record)})
+	execute := append(append([]string{"capture-refuter"}, binding...), "--agent", string(model.AgentPi), "--execute=true")
+	assertRoutedPiCapture(t, repo, reviewerprovider.RoleRefuter, piRefuterRawResult(t, repo, store, record), execute)
 	var output bytes.Buffer
-	if err := RunReview(append(append([]string{"capture-refuter"}, binding...), "--agent", string(model.AgentPi), "--execute=true"), &output); err != nil {
+	if err := RunReview(execute, &output); err != nil {
 		t.Fatal(err)
 	}
 	var terminal reviewLastEventClosureResult
@@ -601,11 +602,11 @@ func TestReviewCaptureValidationMaterializesExecutesAndCloses(t *testing.T) {
 
 	// Execution: the rendered vector spawns the Go-owned pi transport and the
 	// raw bytes close the bounded correction on their terminal capture.
-	overrideProviderRoleHostAdapter(t, providerTestAdapter{raw: providerTargetedValidationPayload(t, request)})
 	execute := []string{"capture-validation", "--cwd=" + repo}
 	for _, argument := range input.Arguments {
 		execute = append(execute, argument.Token)
 	}
+	assertRoutedPiCapture(t, repo, reviewerprovider.RoleTargetedValidator, providerTargetedValidationPayload(t, request), execute)
 	var captured bytes.Buffer
 	if err := RunReview(execute, &captured); err != nil {
 		t.Fatal(err)

--- a/internal/cli/review_recover_intended_untracked_test.go
+++ b/internal/cli/review_recover_intended_untracked_test.go
@@ -99,10 +99,10 @@ func escalateReviewForRecovery(t *testing.T, repo string, started ReviewFacadeSt
 	}
 	t.Setenv(reviewPiHostRelayContractEnvironment, reviewPiHostRelayContract)
 	previous := reviewProviderRoleHostAdapter
-	reviewProviderRoleHostAdapter = func() reviewerprovider.Adapter {
+	reviewProviderRoleHostAdapter = func(reviewerprovider.Role, string) (reviewerprovider.Adapter, error) {
 		return providerTestAdapterFunc(func(context.Context, reviewerprovider.Invocation) ([]byte, error) {
 			return payload, nil
-		})
+		}), nil
 	}
 	t.Cleanup(func() { reviewProviderRoleHostAdapter = previous })
 	if err := RunReviewCaptureValidation([]string{

--- a/internal/cli/review_recovery_target_kind_test.go
+++ b/internal/cli/review_recovery_target_kind_test.go
@@ -250,10 +250,10 @@ func escalatedCurrentChangesRecoveryFixture(t *testing.T, lineage string) (strin
 	}
 	t.Setenv(reviewPiHostRelayContractEnvironment, reviewPiHostRelayContract)
 	previous := reviewProviderRoleHostAdapter
-	reviewProviderRoleHostAdapter = func() reviewerprovider.Adapter {
+	reviewProviderRoleHostAdapter = func(reviewerprovider.Role, string) (reviewerprovider.Adapter, error) {
 		return providerTestAdapterFunc(func(context.Context, reviewerprovider.Invocation) ([]byte, error) {
 			return failedPayload, nil
-		})
+		}), nil
 	}
 	t.Cleanup(func() { reviewProviderRoleHostAdapter = previous })
 	if err := RunReviewCaptureValidation([]string{
@@ -327,10 +327,10 @@ func escalatedBaseDiffRecoveryFixture(t *testing.T, repo, lineage, baseRef strin
 	}
 	t.Setenv(reviewPiHostRelayContractEnvironment, reviewPiHostRelayContract)
 	previous := reviewProviderRoleHostAdapter
-	reviewProviderRoleHostAdapter = func() reviewerprovider.Adapter {
+	reviewProviderRoleHostAdapter = func(reviewerprovider.Role, string) (reviewerprovider.Adapter, error) {
 		return providerTestAdapterFunc(func(context.Context, reviewerprovider.Invocation) ([]byte, error) {
 			return failedPayload, nil
-		})
+		}), nil
 	}
 	t.Cleanup(func() { reviewProviderRoleHostAdapter = previous })
 	if err := RunReviewCaptureValidation([]string{

--- a/internal/cli/review_repository_context_test.go
+++ b/internal/cli/review_repository_context_test.go
@@ -281,10 +281,10 @@ func TestNegotiatedStatusReturnsProviderOwnedTargetedValidationRequest(t *testin
 		LineageID: started.LineageID, TargetIdentity: request.CorrectionTargetIdentity, Revision: request.ExpectedRevision,
 	}))
 	previous := reviewProviderRoleHostAdapter
-	reviewProviderRoleHostAdapter = func() reviewerprovider.Adapter {
+	reviewProviderRoleHostAdapter = func(reviewerprovider.Role, string) (reviewerprovider.Adapter, error) {
 		return providerTestAdapterFunc(func(context.Context, reviewerprovider.Invocation) ([]byte, error) {
 			return providerTargetedValidationPayload(t, *request), nil
-		})
+		}), nil
 	}
 	t.Cleanup(func() { reviewProviderRoleHostAdapter = previous })
 	var output bytes.Buffer

--- a/internal/reviewerprovider/pi_adapter.go
+++ b/internal/reviewerprovider/pi_adapter.go
@@ -18,8 +18,9 @@ const piReviewerWaitDelay = 5 * time.Second
 // PiAdapter invokes a brand-new print-mode pi process with an opaque provider
 // invocation and returns its raw final bytes without interpreting them.
 type PiAdapter struct {
-	LookPath       func(string) (string, error)
-	commandContext func(context.Context, string, ...string) *exec.Cmd
+	Model, Thinking string
+	LookPath        func(string) (string, error)
+	commandContext  func(context.Context, string, ...string) *exec.Cmd
 }
 
 // NewPiAdapter returns an adapter using the pi binary resolved from PATH.
@@ -48,9 +49,16 @@ func (adapter *PiAdapter) Review(ctx context.Context, invocation Invocation) ([]
 	if commandContext == nil {
 		commandContext = exec.CommandContext
 	}
-	command := commandContext(ctx, binary,
+	arguments := []string{
 		"--print", "--mode", "text", "--no-session", "--no-tools", "--no-extensions",
-		"--no-skills", "--no-prompt-templates", "--no-themes", "--no-context-files", "--no-approve")
+		"--no-skills", "--no-prompt-templates", "--no-themes", "--no-context-files", "--no-approve"}
+	if adapter.Model != "" {
+		arguments = append(arguments, "--model", adapter.Model)
+	}
+	if adapter.Thinking != "" {
+		arguments = append(arguments, "--thinking", adapter.Thinking)
+	}
+	command := commandContext(ctx, binary, arguments...)
 	command.Dir = scratch
 	command.Env = piRuntimeEnvironment()
 	command.WaitDelay = piReviewerWaitDelay

--- a/internal/reviewerprovider/pi_adapter_test.go
+++ b/internal/reviewerprovider/pi_adapter_test.go
@@ -206,7 +206,9 @@ func TestPiAdapterHelperProcess(t *testing.T) {
 	}
 	if outputPath := piAdapterHelperOption(piAdapterHelperOutputPathArgument); outputPath != "" {
 		var output []byte
-		if mode == "environment" {
+		if mode == "arguments" {
+			output = []byte(strings.Join(os.Args, "\x00"))
+		} else if mode == "environment" {
 			output = []byte(strings.Join(os.Environ(), "\x00"))
 		} else {
 			var err error
@@ -232,6 +234,38 @@ func TestPiAdapterHelperProcess(t *testing.T) {
 		os.Exit(1)
 	}
 	os.Exit(0)
+}
+
+func TestPiAdapterRoutingArguments(t *testing.T) {
+	for _, route := range []struct{ model, thinking string }{{"", ""}, {"provider/model", ""}, {"", "off"}, {"other/model", "max"}} {
+		t.Run(route.model+route.thinking, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "argv")
+			adapter := &PiAdapter{Model: route.model, Thinking: route.thinking,
+				LookPath: func(string) (string, error) { return "pi", nil },
+				commandContext: func(ctx context.Context, _ string, args ...string) *exec.Cmd {
+					return exec.CommandContext(ctx, os.Args[0], append([]string{"-test.run=^TestPiAdapterHelperProcess$", "--", piAdapterHelperModeArgument + "arguments", piAdapterHelperOutputPathArgument + path}, args...)...)
+				},
+			}
+			if _, err := adapter.Review(t.Context(), NewInvocation([]byte("opaque"))); err != nil {
+				t.Fatal(err)
+			}
+			raw, err := os.ReadFile(path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			got := strings.Split(string(raw), "\x00")[5:]
+			want := []string{"--print", "--mode", "text", "--no-session", "--no-tools", "--no-extensions", "--no-skills", "--no-prompt-templates", "--no-themes", "--no-context-files", "--no-approve"}
+			if route.model != "" {
+				want = append(want, "--model", route.model)
+			}
+			if route.thinking != "" {
+				want = append(want, "--thinking", route.thinking)
+			}
+			if !slices.Equal(got, want) {
+				t.Fatalf("child argv = %q, want %q", got, want)
+			}
+		})
+	}
 }
 
 func piAdapterHelperOption(prefix string) string {


### PR DESCRIPTION
## 🔗 Linked Issue
Closes #4461

## 🏷️ PR Type
- [x] `type:bug` — Bug fix

## 📝 Summary
Honor independent model/thinking assignments for provider-owned `review-refuter` and `review-validator` subprocesses using the existing canonical Pi role-assignment store. Resolve before spawning; keep Go-owned prompts, bindings, and admission unchanged.

**Delivery hold:** The maintainer requested completing the companion gentle-pi model-picker UI before merging this PR. UI exposure is a subsequent linked change, not part of this native Go diff.

## 📂 Changes
| File / Area | What Changed |
|---|---|
| `internal/agents/pi/review_routing.go` and tests | Resolve canonical persisted assignments and fail closed on malformed selected configuration. |
| `internal/reviewerprovider/pi_adapter.go` and tests | Append optional model/thinking argv without altering transport authority. |
| `internal/cli/review_provider_role_capture.go` | Wire explicit roles and validated repository roots into both capture paths. |
| CLI capture tests | Exercise subprocess argv/stdin propagation and native admission; retain Windows admission assertions. |
| `docs/pi-provider-routing.md` | Document precedence, persisted-default fallback, canonical UI integration, and evidence limits. |

A missing assignment preserves persisted Pi defaults, not the active interactive session. Configuration normalization is deliberately stricter than gentle-pi for malformed selected values; this is documented. No duplicate configuration authority or retired local review agents are introduced.

## 🤖 AI Assistance
- [ ] **None**
- [x] **Material assistance used**

**Tool/model (if known):** el Gentleman in Pi with delegated implementation, verification, and native review.

**Material scope:** Investigation, implementation, tests, documentation, and this PR description.

**Verification performed:** Full uncached Linux tests independently run by implementation and parent sessions; separate delivery verifier ran the compiled driven harness and deterministic cross-lane battery. Native review approved and acknowledged. These are automated-agent checks, not a claim of manual human testing.

## 🧪 Test Plan
- [x] `go test ./... -count=1` — full Linux suite passed.
- [x] `go run ./internal/gofmtcheck` and `git diff --check` — passed.
- [ ] `cd e2e && ./docker-test.sh` — intentionally not run locally; required remote E2E checks must pass.
- [ ] Manually tested locally — no organic Pi or native Windows execution claimed.

**Benchmark Validation:** Built the product with `go build -trimpath -o "$RUNNER_TEMP/gentle-ai" ./cmd/gentle-ai` and harness from `bench/` with `go build -o "$RUNNER_TEMP/gentle-ai-bench" .`, then reproduced CI:

```sh
"$RUNNER_TEMP/gentle-ai-bench" run --binary "$RUNNER_TEMP/gentle-ai" --out "$RUNNER_TEMP/bench-portable.json"
"$RUNNER_TEMP/gentle-ai-bench" run --binary "$RUNNER_TEMP/gentle-ai" --only j105-compiled-provider-capture-retries-same-binding --out "$RUNNER_TEMP/bench-provider-capture.json"
```

Portable corpus: **69 completed / 0 unsupported / 0 failed**. Focused j105: **1 / 0 / 0**. Both CI JSON assertions passed. Routing audit of j75, j105, j106, and j123 found no stale role-default pins. Optional axes and real-model tiers were not run.

**Deterministic cross-lane battery: FAILED.** `./scripts/cross-lane-battery.sh --binary <built-binary>` reports 11 PASS / 4 FAIL / 3 SKIP. Three OpenCode binding checks refuse repository-context mismatches; schema compilation cannot resolve relative `status-v5.schema.json`. The same failures appear in the separate uninstall candidate, and the affected harness/schema surfaces are unchanged by either diff. Independent execution of the exact shared base `df21d32b4badd3123c02afe62398ba0dbb557d94` reproduced all four same-observable failures with a byte-identical harness/schema set. They predate both candidates; this remains a red battery, and schema conformance was not reached.

Helper subprocess tests establish argv propagation and provider admission, not organic Pi runtime proof. No paid model calls were made.

## 🤖 Automated Checks
All 16 current checks passed on `61672d4ac65b936638ea1588c9b2df04dfffffa8` (CI `34587265787`, PR Validation `34588845026`). Earlier size-check failures were superseded after the explicitly approved exception. The companion-UI delivery hold remains in force; no merge bypass is requested.

## ✅ Contributor Checklist
- [x] Linked issue has `status:approved`.
- [x] Explicitly authorized maintainer `size:exception` applied and verified on this PR.
- [x] Exactly one type requested: `type:bug` (API-verified after creation).
- [x] Full Linux unit suite and Go format passed.
- [x] Remote E2E checks passed for the current head.
- [x] Applicable portable and focused driven benchmark commands executed; red cross-lane results disclosed separately.
- [x] Configuration contract and limitations documented.
- [x] Conventional Commit; no `Co-Authored-By` trailers.
- [ ] Human contributor has reviewed and accepts responsibility for the complete submission.
- [x] Material AI assistance disclosed.

## 💬 Notes for Reviewers
Review the resolver first, then the adapter argv, then both capture paths and admission tests.

**Size-exception rationale:** 424 additions + 36 deletions = **460 changed lines**, within the previously authorized 500-line implementation cap. One cohesive slice keeps both role integrations, canonical configuration resolution, mechanical factory updates, regression tests, and documentation together. Splitting would separate otherwise unwired routing from the capture behavior it proves. The protected PR label was subsequently explicitly authorized, applied through the canonical workflow, and verified by API.

Native review: `review-67a1862d353ca48c`, approved and acknowledged for the unchanged source candidate before committing. This does not replace CI or the delivery hold.

The stable UI integration surface is the existing `models.json` role-assignment contract, not a new provider envelope. Companion UI and real Pi/Windows proof are separate. CLI changes consume the existing validated root/role and adapter path; provider authority and admission guards remain unchanged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Review roles can now use model and thinking settings from Pi configuration.
  - Configuration supports custom locations and defined precedence rules.
  - Invalid routing configuration is rejected with clear errors.
  - Selected settings are passed to Pi when launching review tasks.

- **Documentation**
  - Added guidance covering configuration formats, precedence, validation, and verification boundaries.

- **Tests**
  - Expanded coverage for role routing, argument handling, configuration precedence, malformed settings, and platform-specific behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

**Suppressed review claims checked:** canonical Pi also treats set-empty/whitespace/relative config locators literally, and both readers use last-member-wins JSON semantics. No Go/canonical divergence was found for those cases. No parser or locator hardening is added independently.
