### PR TITLE
fix(sdd): keep informational edit-root notes out of blockedReasons

### DIFF
--- a/internal/assets/assets_test.go
+++ b/internal/assets/assets_test.go
@@ -1983,6 +1983,8 @@ func TestSDDStatusContractPreservesFrozenExternalV2Projection(t *testing.T) {
 		"archive: [<instruction strings>]",
 		"nextRecommended: propose | spec | design | tasks | apply | verify | remediate | archive | sdd-new | select-change | resolve-blockers",
 		"blockedReasons: []",
+		// #4372: the non-blocking diagnostics channel that keeps blockedReasons a pure gate.
+		"notes: []",
 		"Manual fallback status MUST stay shape-compatible with native `gentle-ai.sdd-status` JSON",
 	} {
 		if !strings.Contains(content, want) {

--- a/internal/assets/skills/_shared/sdd-status-contract.md
+++ b/internal/assets/skills/_shared/sdd-status-contract.md
@@ -24,7 +24,8 @@ Native `gentle-ai.sdd-status/v2` is the sole status contract. A request for v1 o
 - When `sdd-attempt status` carries a `gentle-ai.sdd-integration.consent/v1` consent block, the ledger is ASKING, not reporting. Treat it as a Lossless Blocking Prompt: relay the complete envelope in order, preserve answer tokens and invocations, and never answer on their behalf. In a non-interactive runtime, emit the complete envelope and STOP. Attempts that never ran the work are not evidence about the candidate.
 - For every store, treat native status JSON as authoritative over prompt inference or manually reconstructed state.
 - When `blockedReasons` is non-empty, do not proceed to terminal, archive, or apply work. Return or report `blockedReasons` and stop unless `nextRecommended` is `verify`, in which case verification may run only to remediate or refresh evidence for the blockers. When `nextRecommended` is `resolve-blockers`, always report `blockedReasons` and stop. When `nextRecommended` is a planning token (`propose`, `spec`, `design`, or `tasks`), launch the corresponding planning phase — missing planning artifacts are the expected output of those phases, not genuine blockers.
-- `nextRecommended` is a bounded machine token for routing, not human prose. Route only by `nextRecommended` and dependency states. Human-readable explanation belongs in `blockedReasons`.
+- `notes` is a separate, always-present array of informational diagnostics. A non-empty `notes` NEVER blocks anything: never withhold apply, sync, archive, or a terminal route because a note is present, and never read a note as a blocker. Report notes next to the route you report, so a human sees a future authority need before reaching it. `blockedReasons` stays reserved for genuine blockers, so the gate above reads `blockedReasons` alone.
+- `nextRecommended` is a bounded machine token for routing, not human prose. Route only by `nextRecommended` and dependency states. A genuine blocker's human-readable explanation belongs in `blockedReasons`; a non-blocking explanation belongs in `notes`.
 - If the binary is unavailable, fall back to this prompt contract and the manual status schema below. Manual fallback status MUST stay shape-compatible with native `gentle-ai.sdd-status` JSON even when values are reconstructed manually.
 
 ## Status Schema
@@ -101,11 +102,12 @@ phaseInstructions:
   archive: [<instruction strings>]
 nextRecommended: propose | spec | design | tasks | apply | verify | remediate | archive | sdd-new | select-change | resolve-blockers
 blockedReasons: []
+notes: []
 ```
 
 `reviewOffer` is optional and appears only after strict independent verification passes while review mode is enabled. It is a fresh mode-only offer with exactly `available` and `invocation`; it carries no lineage, receipt, binding, successor, gate, transaction, or previous review result. Disabled review mode is structural absence. Repeated status reads may present the same fresh offer and no offered, declined, burned, or historical authority changes archive readiness.
 
-`phaseInstructions` is optional and appears only when instructions are requested. It carries execution-phase keys (`apply`, `verify`, `remediate`, `archive`); planning-phase instructions (`propose`, `spec`, `design`, `tasks`) are surfaced in dispatcher markdown. `consent` is structurally absent everywhere except an OpenSpec-backed native status that reports `blocked(edit_authority_missing)`; manual fallback MUST NOT reconstruct it. Empty path fields MUST be arrays, not null. `changeName` and `changeRoot` are nullable; all other non-optional sections should be present in fallback output so consumers can parse native and manual status the same way.
+`phaseInstructions` is optional and appears only when instructions are requested. It carries execution-phase keys (`apply`, `verify`, `remediate`, `archive`); planning-phase instructions (`propose`, `spec`, `design`, `tasks`) are surfaced in dispatcher markdown. `consent` is structurally absent everywhere except an OpenSpec-backed native status that reports `blocked(edit_authority_missing)`; manual fallback MUST NOT reconstruct it. Empty path fields MUST be arrays, not null. `blockedReasons` and `notes` are always arrays as well, both `[]` rather than null when empty. `changeName` and `changeRoot` are nullable; all other non-optional sections should be present in fallback output so consumers can parse native and manual status the same way.
 
 ## Apply State
 
@@ -139,6 +141,7 @@ A change whose tasks.md work units target paths outside `allowedEditRoots` never
 
 - Detection is conservative prose inspection: backticked path-like tokens inside markdown checkbox lines that resolve to a path outside the authorized roots. A different repository is named by its Git root; a same-repository target is narrowed to its containing edit root; a directory in no Git repository is named as itself. A backticked path immediately followed by `(read-only)` (case-insensitive) is a read-only input and not an edit target; the marker annotates only the path it follows, so an unmarked path on the same line still counts.
 - An OpenSpec-backed native status that reports `blocked(edit_authority_missing)` also carries the typed `gentle-ai.sdd-integration.consent/v1` envelope as the optional `consent` block: headline, reason, `value`, the missing roots as evidence, exactly two choices with answer tokens `granted` and `declined` (each with label, effect, and an exact invocation), and an off-path note.
+- A later work unit's own unauthorized root does NOT block the current work unit. It is reported as a `note(future_edit_roots)` entry in `notes` naming that future root, so the current unit's `applyState` stays `ready` and `blockedReasons` stays empty until that work unit is reached.
 - Answer flow: the orchestrator relays the COMPLETE envelope losslessly as a blocking prompt. Only on the human's explicit `granted` answer does the agent execute the envelope's named grant invocation, verbatim and exactly once, then re-enter through native status. The agent NEVER runs the grant unprompted and NEVER answers on the human's behalf.
 - Decline stays blocked: the agent runs the envelope's decline invocation, nothing is persisted, the change stays `blocked(edit_authority_missing)`, and the reason names all three exits.
 
@@ -151,3 +154,4 @@ Every command that acts on a change MUST show status before launching an executo
 - Task progress and unchecked task list when tasks exist.
 - Next recommended action.
 - `blockedReasons` whenever it is non-empty, including a `verify` route that must refresh stale or post-remediation evidence, plus any edit-root blockers.
+- `notes` whenever it is non-empty, labeled as informational and explicitly not a blocker.

--- a/internal/sddstatus/edit_authority.go
+++ b/internal/sddstatus/edit_authority.go
@@ -382,9 +382,12 @@ func detectUnauthorizedEditRootsForCurrentWorkUnit(tasksText, workspaceRoot stri
 }
 
 // futureEditRootsNote reports a later work unit's own unauthorized edit
-// targets without blocking the current work unit (#4103). It carries no
-// `blocked(...)` reason code, so it never flips applyState — it exists purely
-// so a human sees the future authority need before reaching that work unit.
+// targets without blocking the current work unit (#4103). It is an informational
+// diagnostic, so it travels on the non-blocking `notes` channel (#4372): it
+// carries no `blocked(...)` reason code, never flips applyState, and — since a
+// non-empty `blockedReasons` is a gate in every consumer contract — must never
+// reach that gated field. It exists purely so a human sees the future authority
+// need before reaching that work unit.
 func futureEditRootsNote(roots []string) string {
 	quoted := make([]string, 0, len(roots))
 	for _, root := range roots {
@@ -404,7 +407,7 @@ func futureEditRootsNote(roots []string) string {
 // It also returns the unauthorized edit roots so the caller can raise the typed
 // consent question naming exactly them (#2563, S4b of #2540). Detection is
 // scoped to the current work unit (#4103): a future work unit's own
-// unauthorized roots are reported through reasons as an informational note,
+// unauthorized roots are reported through the non-blocking notes channel (#4372),
 // never as a blocker.
 func applyEditAuthorityBlock(applyState ApplyState, reasons *blockerReasons, tasksText string, workspaceRoot string, allowedEditRoots []string) (ApplyState, []string) {
 	if applyState != ApplyReady {
@@ -412,7 +415,7 @@ func applyEditAuthorityBlock(applyState ApplyState, reasons *blockerReasons, tas
 	}
 	roots, futureRoots := detectUnauthorizedEditRootsForCurrentWorkUnit(tasksText, workspaceRoot, allowedEditRoots)
 	if len(futureRoots) != 0 {
-		reasons.genuine = append(reasons.genuine, futureEditRootsNote(futureRoots))
+		reasons.notes = append(reasons.notes, futureEditRootsNote(futureRoots))
 	}
 	if len(roots) == 0 {
 		return applyState, nil

--- a/internal/sddstatus/edit_authority_exits_test.go
+++ b/internal/sddstatus/edit_authority_exits_test.go
@@ -87,10 +87,19 @@ func TestReadOnlyMarkerIsTokenScoped(t *testing.T) {
 	if status.ApplyState != ApplyBlocked || !strings.Contains(reasons, "blocked(edit_authority_missing)") {
 		t.Fatalf("mixed line with an unmarked write target did not block: applyState = %q, blockedReasons = %v", status.ApplyState, status.BlockedReasons)
 	}
-	for _, root := range []string{realPath(t, serviceB), realPath(t, serviceC)} {
-		if !strings.Contains(reasons, root) {
-			t.Fatalf("blocked reason does not name the unmarked target root %s: %s", root, reasons)
-		}
+	if !strings.Contains(reasons, realPath(t, serviceC)) {
+		t.Fatalf("blocked reason does not name the unmarked write target root %s: %s", realPath(t, serviceC), reasons)
+	}
+	// service-b is named only by the later work unit, whose misplaced marker
+	// annotates nothing. That root is a real future authority need, so it must
+	// stay visible — on the informational notes channel, never as a blocker for
+	// the current unit (#4372).
+	if strings.Contains(reasons, realPath(t, serviceB)) {
+		t.Fatalf("a future work unit's root was reported as a current blocker: %s", reasons)
+	}
+	notes := strings.Join(status.Notes, "\n")
+	if !strings.Contains(notes, realPath(t, serviceB)) {
+		t.Fatalf("notes do not name the later work unit's unmarked root %s: %v", realPath(t, serviceB), status.Notes)
 	}
 }
 

--- a/internal/sddstatus/edit_authority_extraction_test.go
+++ b/internal/sddstatus/edit_authority_extraction_test.go
@@ -1,6 +1,7 @@
 package sddstatus
 
 import (
+	"encoding/json"
 	"path/filepath"
 	"reflect"
 	"strings"
@@ -166,10 +167,12 @@ func TestReportedFalsePositiveProseDoesNotBlockEditAuthorityApply(t *testing.T) 
 	}
 }
 
-// TestFutureWorkUnitEditAuthorityRootIsInformationalNotBlocking pins #4103: a future
-// work unit (a higher leading task number, e.g. "2.1" following "1.x") that
-// genuinely targets an external root must not block the current work unit's
-// apply. Its unauthorized root is reported informationally instead.
+// TestFutureWorkUnitEditAuthorityRootIsInformationalNotBlocking pins #4103's
+// scoping fix and #4372's channel split: a future work unit (a higher leading
+// task number, e.g. "2.1" following "1.x") that genuinely targets an external
+// root must not block the current work unit's apply, and the informational
+// report of that root must travel on `notes` — never on the gated
+// `blockedReasons` a consumer contract reads as "stop".
 func TestFutureWorkUnitEditAuthorityRootIsInformationalNotBlocking(t *testing.T) {
 	workspace := t.TempDir()
 	planning := filepath.Join(workspace, "planning")
@@ -202,9 +205,44 @@ func TestFutureWorkUnitEditAuthorityRootIsInformationalNotBlocking(t *testing.T)
 	if strings.Contains(reasons, "blocked(edit_authority_missing)") {
 		t.Fatalf("future work unit's external root produced a blocking reason: %v", status.BlockedReasons)
 	}
+	if len(status.BlockedReasons) != 0 {
+		t.Fatalf("a non-blocking informational note reached the gated blockedReasons: %v", status.BlockedReasons)
+	}
 	wantDeploy := realPath(t, deploy)
-	if !strings.Contains(reasons, "note(future_edit_roots)") || !strings.Contains(reasons, wantDeploy) {
-		t.Fatalf("blocked reasons must carry an informational future-edit-roots note naming %q: %v", wantDeploy, status.BlockedReasons)
+	notes := strings.Join(status.Notes, "\n")
+	if !strings.Contains(notes, "note(future_edit_roots)") || !strings.Contains(notes, wantDeploy) {
+		t.Fatalf("notes must carry an informational future-edit-roots note naming %q: %v", wantDeploy, status.Notes)
+	}
+
+	// The consumer-visible document is the surface that actually contradicted the
+	// contracts in #4372, so pin the split after projection too.
+	projected, err := ProjectStatusV2(status)
+	if err != nil {
+		t.Fatal(err)
+	}
+	payload, err := json.Marshal(projected)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var document map[string]json.RawMessage
+	if err := json.Unmarshal(payload, &document); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := document["notes"]; !ok {
+		t.Fatalf("v2 document omitted the notes field: %s", payload)
+	}
+	var projectedBlockers, projectedNotes []string
+	if err := json.Unmarshal(document["blockedReasons"], &projectedBlockers); err != nil {
+		t.Fatal(err)
+	}
+	if err := json.Unmarshal(document["notes"], &projectedNotes); err != nil {
+		t.Fatal(err)
+	}
+	if len(projectedBlockers) != 0 {
+		t.Fatalf("v2 blockedReasons retained the informational note: %v", projectedBlockers)
+	}
+	if len(projectedNotes) != len(status.Notes) {
+		t.Fatalf("v2 notes = %v, want the resolved notes %v", projectedNotes, status.Notes)
 	}
 }
 

--- a/internal/sddstatus/status.go
+++ b/internal/sddstatus/status.go
@@ -98,6 +98,13 @@ type TaskProgress struct {
 type blockerReasons struct {
 	expectedPlanning []string
 	genuine          []string
+	// notes carries informational diagnostics that must never gate a phase. It
+	// is deliberately a separate channel: the public `blockedReasons` is a gate
+	// (every consumer contract forbids apply, archive, and terminal work on a
+	// non-empty value), so routing a note that says "this does not block the
+	// current work unit" through it made the producer contradict itself
+	// (#4372). Notes are route-independent and never pass through finalize.
+	notes []string
 }
 
 func (reasons blockerReasons) forRoute(nextRecommended string) []string {
@@ -190,6 +197,11 @@ type Status struct {
 	PhaseInstructions *PhaseInstructions  `json:"phaseInstructions,omitempty"`
 	NextRecommended   string              `json:"nextRecommended"`
 	BlockedReasons    []string            `json:"blockedReasons"`
+	// Notes carries non-blocking diagnostics for a consumer to report, never to
+	// gate on: a non-empty Notes never withholds apply, sync, archive, or a
+	// terminal route. Always serialized as an array — `[]` when there is nothing
+	// to report — so a consumer never special-cases a missing or null field.
+	Notes []string `json:"notes"`
 	// runtimeAttemptTokens carries the ledger's live attempt tokens alongside
 	// RuntimeStatus so status can ask the one readiness predicate the same
 	// question compact acquire asks, and name the same continuation acquire
@@ -716,6 +728,7 @@ func resolveByPreferenceOrder(options ResolveOptions) (Status, error) {
 	}
 	applyReviewOfferRouting(context.Background(), &status, workspaceRoot, reviewDisabled)
 	status.BlockedReasons = blockedReasons.finalize(status.NextRecommended, status.BlockedReasons)
+	status.Notes = append(status.Notes, blockedReasons.notes...)
 	if runtimeRemediationComplete && status.Dependencies.Verify == DependencyReady && status.Dependencies.Archive == DependencyBlocked && status.NextRecommended == string(PhaseVerify) {
 		status.verifyRefreshReason = runtimeRemediationVerifyRefreshInstruction
 	}
@@ -1012,9 +1025,11 @@ func resolveEngramStatus(workspaceRoot string, requestedChange string, includeIn
 		status.NextRecommended = "archived"
 		status.Archived = &ArchivedProjection{Path: fmt.Sprintf("sdd/%s/archive-report", changeName)}
 		status.BlockedReasons = []string{}
+		status.Notes = []string{}
 		status.RemediationState = RemediationState{}
 	} else {
 		status.BlockedReasons = blockedReasons.finalize(status.NextRecommended, status.BlockedReasons)
+		status.Notes = append(status.Notes, blockedReasons.notes...)
 	}
 	if runtimeRemediationComplete && status.Dependencies.Verify == DependencyReady && status.Dependencies.Archive == DependencyBlocked && status.NextRecommended == string(PhaseVerify) {
 		status.verifyRefreshReason = runtimeRemediationVerifyRefreshInstruction
@@ -1322,6 +1337,12 @@ func RenderMarkdown(status Status) string {
 			lines = append(lines, fmt.Sprintf("- %s", reason))
 		}
 	}
+	if len(status.Notes) > 0 {
+		lines = append(lines, "", "### Notes", "Informational only. These do not block the route reported above.")
+		for _, note := range status.Notes {
+			lines = append(lines, fmt.Sprintf("- %s", note))
+		}
+	}
 	lines = append(lines, "", "### JSON", "```json", string(jsonBytes), "```")
 	return strings.Join(lines, "\n")
 }
@@ -1359,6 +1380,12 @@ func RenderDispatcherMarkdown(status Status) string {
 		lines = append(lines, "", "### Blocked Reasons")
 		for _, reason := range status.BlockedReasons {
 			lines = append(lines, fmt.Sprintf("- %s", reason))
+		}
+	}
+	if len(status.Notes) > 0 {
+		lines = append(lines, "", "### Notes", "Informational only. These do not block the route reported above.")
+		for _, note := range status.Notes {
+			lines = append(lines, fmt.Sprintf("- %s", note))
 		}
 	}
 	if extra, ok := nonPhaseRoutingInstructions(status); ok {
@@ -1544,6 +1571,7 @@ func baseStatus(store ArtifactStore, workspaceRoot string, grantedRoots []string
 		},
 		NextRecommended: next,
 		BlockedReasons:  reasons,
+		Notes:           []string{},
 	}
 }
 

--- a/internal/sddstatus/status_notes_test.go
+++ b/internal/sddstatus/status_notes_test.go
@@ -1,0 +1,75 @@
+package sddstatus
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// This file pins the #4372 contract split: `blockedReasons` carries only genuine
+// blockers, and informational diagnostics live in the separate, always-present
+// `notes` array. The contradiction it removes was real: the producer appended
+// `note(future_edit_roots)` to the same channel it used for blocking reasons
+// while deliberately keeping `applyState: ready` and `nextRecommended: apply`,
+// and every consumer contract says a non-empty `blockedReasons` forbids apply.
+// A consumer that obeyed its own documented gate therefore stopped on a note the
+// producer had already declared non-blocking.
+//
+// The routing split itself is pinned end to end by
+// TestFutureWorkUnitEditAuthorityRootIsInformationalNotBlocking, which owns the
+// fixture; the tests here cover the serialized shape and the human-facing
+// renderers that consumers rely on.
+
+// TestStatusNotesIsAlwaysASerializedArray keeps the new field's shape stable for
+// consumers: an empty note set must project as `[]`, never as a missing key or a
+// JSON null a consumer would have to special-case.
+func TestStatusNotesIsAlwaysASerializedArray(t *testing.T) {
+	status := baseStatus(ArtifactStoreOpenSpec, "/repo", nil, nil, nil, "apply", nil)
+	if status.Notes == nil {
+		t.Fatal("baseStatus left Notes nil, want an empty array")
+	}
+	projected, err := ProjectStatusV2(status)
+	if err != nil {
+		t.Fatal(err)
+	}
+	payload, err := json.Marshal(projected)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var document map[string]json.RawMessage
+	if err := json.Unmarshal(payload, &document); err != nil {
+		t.Fatal(err)
+	}
+	raw, ok := document["notes"]
+	if !ok {
+		t.Fatalf("v2 document omitted the notes field: %s", payload)
+	}
+	if string(raw) != "[]" {
+		t.Fatalf("empty notes projected as %s, want []", raw)
+	}
+}
+
+// TestRenderersReportNotesOutsideBlockedReasons keeps the human-facing surfaces
+// honest: a reader must see the note, and must not read it under a heading that
+// says blocked.
+func TestRenderersReportNotesOutsideBlockedReasons(t *testing.T) {
+	status := baseStatus(ArtifactStoreOpenSpec, "/repo", nil, nil, nil, "apply", nil)
+	status.Notes = []string{"note(future_edit_roots): a later work unit targets /elsewhere"}
+
+	for name, rendered := range map[string]string{
+		"markdown":   RenderMarkdown(status),
+		"dispatcher": RenderDispatcherMarkdown(status),
+	} {
+		t.Run(name, func(t *testing.T) {
+			if !strings.Contains(rendered, "### Notes") {
+				t.Fatalf("%s omitted the notes section:\n%s", name, rendered)
+			}
+			if !strings.Contains(rendered, "note(future_edit_roots)") {
+				t.Fatalf("%s omitted the note text:\n%s", name, rendered)
+			}
+			if strings.Contains(rendered, "### Blocked Reasons") {
+				t.Fatalf("%s reported an informational note under blocked reasons:\n%s", name, rendered)
+			}
+		})
+	}
+}

--- a/internal/sddstatus/status_v2.go
+++ b/internal/sddstatus/status_v2.go
@@ -32,6 +32,7 @@ type StatusV2Projection struct {
 	PhaseInstructions *phaseInstructionsV2         `json:"phaseInstructions,omitempty"`
 	NextRecommended   string                       `json:"nextRecommended"`
 	BlockedReasons    []string                     `json:"blockedReasons"`
+	Notes             []string                     `json:"notes"`
 }
 
 type planningHomeV2 struct {
@@ -140,6 +141,7 @@ func ProjectStatusV2(status Status) (StatusV2Projection, error) {
 		Archived:        status.Archived,
 		NextRecommended: status.NextRecommended,
 		BlockedReasons:  status.BlockedReasons,
+		Notes:           status.Notes,
 	}
 	if status.PhaseInstructions != nil {
 		projected.PhaseInstructions = &phaseInstructionsV2{

--- a/internal/sddstatus/status_v2_clean_break_test.go
+++ b/internal/sddstatus/status_v2_clean_break_test.go
@@ -87,6 +87,9 @@ func TestSDDStatusV2CleanBreak(t *testing.T) {
 			"schemaName", "schemaVersion", "changeName", "artifactStore", "planningHome", "changeRoot",
 			"artifactPaths", "contextFiles", "artifacts", "taskProgress", "dependencies", "applyState",
 			"actionContext", "relationships", "remediationState", "nextRecommended", "blockedReasons",
+			// notes is #4372's deliberate additive extension: the non-blocking
+			// diagnostics channel that keeps `blockedReasons` a pure gate.
+			"notes",
 		})
 		assertJSONNestedKeys(t, document, "artifactPaths", []string{"proposal", "specs", "design", "tasks", "applyProgress", "verifyReport"})
 		assertJSONNestedKeys(t, document, "contextFiles", []string{"proposal", "specs", "design", "tasks", "applyProgress", "verifyReport"})


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #4372

---

## 🏷️ PR Type

- [x] `type:bug` — Bug fix (non-breaking change that fixes an issue)

---

## 📝 Summary

Fixes the producer side of the contract contradiction tracked in #4372: native SDD status reported an informational diagnostic through the same field it uses for genuine blockers.

`internal/sddstatus/edit_authority.go` reported a later work unit's unauthorized edit root as `note(future_edit_roots)` while deliberately keeping `applyState: ready` and `nextRecommended: apply` (#4103). The note was appended to `blockerReasons.genuine`, which serializes into the public `blockedReasons` field — and every consumer contract reads a non-empty `blockedReasons` as "stop". An orchestrator that obeyed its own documented gate therefore refused an apply the producer had already declared ready.

Observed with the real CLI before this change, on a change whose current work unit is fully authorized and whose later work unit names an external directory:

```json
{ "applyState": "ready", "nextRecommended": "apply",
  "blockedReasons": ["note(future_edit_roots): ... this does not block the current work unit ..."] }
```

After this change the same invocation returns `blockedReasons: []` and moves the note to a new, always-present `notes` array. `blockedReasons` becomes a pure blocker gate, so the existing consumer rule ("non-empty `blockedReasons` forbids apply, sync, and archive") becomes accurate instead of contradictory. No consumer has to parse prose or weaken its gate.

The note remains visible: both CLI renderers print a labelled `### Notes` section, and the frozen external `StatusV2Projection` carries `notes`.

---

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/sddstatus/status.go` | New non-blocking `blockerReasons.notes` channel; `Status.Notes` field (`json:"notes"`, always an array); both resolvers drain notes into `Status.Notes` after `finalize`, so notes never pass through route-dependent reason rendering; `### Notes` sections in `RenderMarkdown` and `RenderDispatcherMarkdown` |
| `internal/sddstatus/edit_authority.go` | `applyEditAuthorityBlock` writes `futureEditRootsNote` to `reasons.notes` instead of `reasons.genuine`; doc comments updated |
| `internal/sddstatus/status_v2.go` | `StatusV2Projection.Notes` and its projection |
| `internal/sddstatus/status_v2_clean_break_test.go` | The exact v2 key-set guard extended with `notes` — a deliberate, documented additive v2 field |
| `internal/sddstatus/status_notes_test.go` (new) | Pins `notes` as an always-serialized array and the renderers' separate `### Notes` surface |
| `internal/sddstatus/edit_authority_extraction_test.go` | #4103 pin updated to the new contract: the future root must reach `notes` and must never reach `blockedReasons`; asserts the projected document too |
| `internal/sddstatus/edit_authority_exits_test.go` | `TestReadOnlyMarkerIsTokenScoped` rewritten to the split: the current unit's unmarked write target still blocks on `service-c`, the later unit's root is a note on `service-b`, never a current blocker |
| `internal/assets/skills/_shared/sdd-status-contract.md` | Documents `notes` (gate rule, v2 sample, array shape, edit-authority note case, status-output requirement). One source that installs to every client adapter |
| `internal/assets/assets_test.go` | Frozen-contract field list extended with `notes: []` |

---

## 🤖 AI Assistance

- [ ] **None** — No material AI assistance was used.
- [x] **Material assistance used** — Complete all applicable declaration fields below.

**Tool/model (if known):** Pi coding agent (el Gentleman harness). Orchestrating model per session configuration; read-only mapping and verification ran as separate Pi subagents.

**Material scope:**

- Diagnosed the producer/consumer contradiction, chose the additive `notes` channel, and authored the Go change, the new/updated tests, and the shared contract documentation.
- One read-only scout subagent enumerated every adapter family (claude, codex, opencode, kimi, qwen, gemini, kiro, cursor, windsurf, antigravity, hermes, generic) and confirmed no shipped adapter parses `blockedReasons` in code — only markdown prompts, whose gate wording stays correct and needed no change.
- One read-only verifier subagent re-ran the suites and independently falsified the new pins by reverting the fix in a throwaway overlay copy (both pins failed), enumerated every writer to the gated fields, and found no path by which the note can reach `blockedReasons`.

**Verification performed:** human review of the full diff; `go test` on `internal/sddstatus`, `internal/assets`, `internal/components`; `go vet`; `gofmt`; the baseline comparison and re-runs documented in the Test Plan; plus the end-to-end before/after CLI evidence quoted above.

---

## 🧪 Test Plan

**Unit Tests**

```bash
GOTOOLCHAIN=local go test ./internal/sddstatus/... ./internal/assets/... ./internal/components/... -count=1
```

All three packages pass (`sddstatus` ~71s, `assets` ~5s, `components` all subpackages green).

**Package-timeout and environment caveats (not caused by this change)**

- `go test ./...` on this author machine reports failures in `internal/reviewtransaction`: `maintenance authority component "/var" is unsafe` and `review store lock could not be acquired: not a directory`. Both are macOS `/var` → `/private/var` symlink artifacts in `t.TempDir()`. The identical tests fail on unmodified `origin/main` at `a7502587` with the same messages, so they are pre-existing and unrelated.
- In the same full run, `internal/cli` reported `FAIL ... 600.056s`. That was the 600s per-package default timeout being exceeded while other suites ran in parallel, not a functional failure: `go test ./internal/cli -count=1` passes in isolation (~552s) and passes again with `-timeout 30m` (588s).

**Go Format**

```bash
GOTOOLCHAIN=local go run ./internal/gofmtcheck
```

**E2E Tests** (Docker required)

- [ ] Unit tests pass (`go test ./...`)
- [ ] Go format passes (`go run ./internal/gofmtcheck`)
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`)
- [x] Manually tested locally

Manual evidence — same repository fixture (authorized current work unit, later work unit naming an external non-Git directory), old vs new binary:

```
BEFORE  applyState=ready nextRecommended=apply
        blockedReasons=["note(future_edit_roots): ... this does not block the current work unit ..."]
        notes=<absent>
AFTER   applyState=ready nextRecommended=apply
        blockedReasons=[]
        notes=["note(future_edit_roots): ... this does not block the current work unit ..."]
```

`go test ./...` is left unchecked because of the macOS symlink artifacts above; the author-machine full-suite run is not reproducible green in this environment. E2E is left unchecked as Docker was not used. This change does not touch `e2e/`.

**Benchmark validation:** N/A. This is not a review-lifecycle, recovery, delivery, or benchmark change. The status payload gains an additive field that no consumer gates on; a read-only sweep confirmed every `bench/` reader of `blockedReasons` asserts on genuinely blocked populations, which this change does not alter.

---

## ✅ Contributor Checklist

- [x] PR is linked to an issue with `status:approved`
- [x] PR stays within 400 changed lines (198: 181 additions + 17 deletions)
- [x] I have added the appropriate `type:*` label to this PR
- [ ] Unit tests pass (`go test ./...`) — see the macOS `/var` caveat in the Test Plan; the `internal/cli` failure was resolved as a timeout
- [x] Go format passes (`go run ./internal/gofmtcheck`)
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`) — not applicable, Docker not used
- [x] Benchmark validation completed, or this change is not applicable to the benchmark (explained in the Test Plan)
- [x] I have updated documentation if necessary
- [x] My commits follow Conventional Commits format
- [x] I understand, reviewed, and take responsibility for the complete submission
- [x] I selected exactly one AI-assistance option and completed all applicable declaration fields
- [x] My commits do not include `Co-Authored-By` trailers

---

## 💬 Notes for Reviewers

- The v2 document is a frozen public shape with an exact-key guard in `status_v2_clean_break_test.go`. Adding `notes` is a deliberate, additive extension of that key set; the guard was extended in the same commit rather than bypassed.
- `notes` is route-independent on purpose: it is appended after `blockedReasons.finalize`, so it can never influence `nextRecommended`.
- The terminal Engram projection clears `notes` alongside `blockedReasons`. That is not dead code: an archive report present with unfinished tasks is an inconsistent but representable state, and a closed change should report neither blockers nor pending notes.
- `RenderNativePhasePrompt` has no production caller (only tests), so it was intentionally left without a `### Notes` section. Flagging it explicitly so the omission is a decision, not an oversight.
- Consumer-side follow-up, deliberately out of scope here: Gentle Pi's native-status decoder does not model `notes` (it accepts `null`/absent). It does not drop the field and does not gate on it, so no behavior is affected. The consumer contract alignment ships separately.
