### PR TITLE
feat(tui): adapt model picker viewport

### DIFF
--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -1013,11 +1013,24 @@ func (m Model) Init() tea.Cmd {
 	return tea.Batch(updateCmd, advisoryCmd)
 }
 
+func (m *Model) syncModelPickerViewport() {
+	reservedRows := 0
+	if m.Screen == ScreenProfileCreate {
+		reservedRows = 7
+	}
+	m.ModelPicker.Viewport = screens.ModelPickerViewport{
+		Width:        m.Width,
+		Height:       m.Height,
+		ReservedRows: reservedRows,
+	}
+}
+
 func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	switch msg := msg.(type) {
 	case tea.WindowSizeMsg:
 		m.Width = msg.Width
 		m.Height = msg.Height
+		m.syncModelPickerViewport()
 		m.clampAdvisoryScroll()
 		return m, nil
 	case TickMsg:
@@ -1484,8 +1497,6 @@ func (m Model) View() string {
 	case ScreenProfiles:
 		return screens.RenderProfiles(m.ProfileList, m.Cursor, m.ProfileDeleteErr)
 	case ScreenProfileCreate:
-		picker := m.ModelPicker
-		picker.Viewport = screens.ModelPickerViewport{Width: m.Width, Height: m.Height, ReservedRows: 7}
 		return screens.RenderProfileCreate(
 			m.ProfileCreateStep,
 			m.ProfileDraft,
@@ -1494,7 +1505,7 @@ func (m Model) View() string {
 			m.ProfileNameErr,
 			m.ProfileEditMode,
 			m.Selection.ModelAssignments,
-			picker,
+			m.ModelPicker,
 			m.Cursor,
 		)
 	case ScreenProfileDelete:
@@ -1551,9 +1562,7 @@ func (m Model) View() string {
 	case ScreenCommunityToolResult:
 		return screens.RenderCommunityToolResult(m.CommunityToolResults, m.CommunityToolErr)
 	case ScreenModelPicker:
-		picker := m.ModelPicker
-		picker.Viewport = screens.ModelPickerViewport{Width: m.Width, Height: m.Height}
-		return screens.RenderModelPicker(m.Selection.ModelAssignments, picker, m.Cursor)
+		return screens.RenderModelPicker(m.Selection.ModelAssignments, m.ModelPicker, m.Cursor)
 	case ScreenDependencyTree:
 		return screens.RenderDependencyTree(m.DependencyPlan, m.Selection, m.Cursor)
 	case ScreenSkillPicker:
@@ -4168,6 +4177,7 @@ func (m *Model) setScreen(next Screen) {
 	}
 	m.PreviousScreen = m.Screen
 	m.Screen = next
+	m.syncModelPickerViewport()
 	m.Cursor = 0
 	// Safe default: start on "Keep current version" (index 2) so an accidental
 	// Enter press does not trigger an upgrade.

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -1484,6 +1484,8 @@ func (m Model) View() string {
 	case ScreenProfiles:
 		return screens.RenderProfiles(m.ProfileList, m.Cursor, m.ProfileDeleteErr)
 	case ScreenProfileCreate:
+		picker := m.ModelPicker
+		picker.Viewport = screens.ModelPickerViewport{Width: m.Width, Height: m.Height, ReservedRows: 7}
 		return screens.RenderProfileCreate(
 			m.ProfileCreateStep,
 			m.ProfileDraft,
@@ -1492,7 +1494,7 @@ func (m Model) View() string {
 			m.ProfileNameErr,
 			m.ProfileEditMode,
 			m.Selection.ModelAssignments,
-			m.ModelPicker,
+			picker,
 			m.Cursor,
 		)
 	case ScreenProfileDelete:
@@ -1549,7 +1551,9 @@ func (m Model) View() string {
 	case ScreenCommunityToolResult:
 		return screens.RenderCommunityToolResult(m.CommunityToolResults, m.CommunityToolErr)
 	case ScreenModelPicker:
-		return screens.RenderModelPicker(m.Selection.ModelAssignments, m.ModelPicker, m.Cursor)
+		picker := m.ModelPicker
+		picker.Viewport = screens.ModelPickerViewport{Width: m.Width, Height: m.Height}
+		return screens.RenderModelPicker(m.Selection.ModelAssignments, picker, m.Cursor)
 	case ScreenDependencyTree:
 		return screens.RenderDependencyTree(m.DependencyPlan, m.Selection, m.Cursor)
 	case ScreenSkillPicker:

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -413,11 +413,13 @@ func TestModelPickerView_ForwardsMeasuredViewportToNormalAndProfileFlows(t *test
 	m := NewModel(system.DetectionResult{}, "dev")
 	m.Screen = ScreenModelPicker
 	m.ModelPicker = screens.ModelPickerState{AvailableIDs: []string{"openai"}}
-	m.Width, m.Height = 100, 30
+	updated, _ := m.Update(tea.WindowSizeMsg{Width: 100, Height: 30})
+	m = updated.(Model)
 	if out := m.View(); !strings.Contains(out, "Role:") {
 		t.Fatalf("roomy normal picker omitted guidance:\n%s", out)
 	}
-	m.Width, m.Height = 40, 12
+	updated, _ = m.Update(tea.WindowSizeMsg{Width: 40, Height: 12})
+	m = updated.(Model)
 	if out := m.View(); strings.Contains(out, "Role:") {
 		t.Fatalf("constrained normal picker retained guidance:\n%s", out)
 	}
@@ -425,9 +427,40 @@ func TestModelPickerView_ForwardsMeasuredViewportToNormalAndProfileFlows(t *test
 	m.Screen = ScreenProfileCreate
 	m.ProfileCreateStep = 1
 	m.ModelPicker.ForProfile = true
-	m.Width, m.Height = 80, 14
+	updated, _ = m.Update(tea.WindowSizeMsg{Width: 80, Height: 14})
+	m = updated.(Model)
 	if out := m.View(); strings.Contains(out, "Role:") {
 		t.Fatalf("profile frame was not reserved from the picker viewport:\n%s", out)
+	}
+}
+
+func TestModelPickerViewport_PersistsResizeBeforeProfileNavigation(t *testing.T) {
+	m := NewModel(system.DetectionResult{}, "dev")
+	m.Screen = ScreenProfileCreate
+	m.ProfileCreateStep = 1
+	m.ModelPicker = screens.ModelPickerState{
+		ForProfile:   true,
+		Mode:         screens.ModeProviderSelect,
+		AvailableIDs: []string{"a", "b", "c", "d", "e", "f", "g", "h", "i", "j"},
+		Providers:    map[string]opencode.Provider{},
+		SDDModels:    map[string][]opencode.Model{},
+	}
+	for _, id := range m.ModelPicker.AvailableIDs {
+		m.ModelPicker.Providers[id] = opencode.Provider{ID: id, Name: id}
+	}
+
+	updated, _ := m.Update(tea.WindowSizeMsg{Width: 40, Height: 14})
+	state := updated.(Model)
+	if got, want := state.ModelPicker.Viewport, (screens.ModelPickerViewport{Width: 40, Height: 14, ReservedRows: 7}); got != want {
+		t.Fatalf("ModelPicker.Viewport = %+v, want %+v", got, want)
+	}
+
+	for range state.ModelPicker.AvailableIDs {
+		updated, _ = state.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("j")})
+		state = updated.(Model)
+	}
+	if got, want := state.ModelPicker.ProviderScroll, len(state.ModelPicker.AvailableIDs)-state.ModelPicker.Viewport.ListCapacity(); got != want {
+		t.Fatalf("ProviderScroll = %d, want %d using persisted viewport", got, want)
 	}
 }
 

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -409,6 +409,28 @@ func TestSanitizeKnownModelEfforts_UnknownModelDataPreservesStoredEffort(t *test
 	}
 }
 
+func TestModelPickerView_ForwardsMeasuredViewportToNormalAndProfileFlows(t *testing.T) {
+	m := NewModel(system.DetectionResult{}, "dev")
+	m.Screen = ScreenModelPicker
+	m.ModelPicker = screens.ModelPickerState{AvailableIDs: []string{"openai"}}
+	m.Width, m.Height = 100, 30
+	if out := m.View(); !strings.Contains(out, "Role:") {
+		t.Fatalf("roomy normal picker omitted guidance:\n%s", out)
+	}
+	m.Width, m.Height = 40, 12
+	if out := m.View(); strings.Contains(out, "Role:") {
+		t.Fatalf("constrained normal picker retained guidance:\n%s", out)
+	}
+
+	m.Screen = ScreenProfileCreate
+	m.ProfileCreateStep = 1
+	m.ModelPicker.ForProfile = true
+	m.Width, m.Height = 80, 14
+	if out := m.View(); strings.Contains(out, "Role:") {
+		t.Fatalf("profile frame was not reserved from the picker viewport:\n%s", out)
+	}
+}
+
 func TestProfileCreateContinueSanitizesStaleEffort(t *testing.T) {
 	m := NewModel(system.DetectionResult{}, "dev")
 	m.Screen = ScreenProfileCreate

--- a/internal/tui/screens/model_picker.go
+++ b/internal/tui/screens/model_picker.go
@@ -30,6 +30,46 @@ const (
 const maxVisibleItems = 10
 const maxVisiblePhaseRows = 16
 
+// visibleListStart keeps the focused row inside a scrollable list's adaptive viewport.
+func visibleListStart(cursor, scroll, itemCount, capacity int) int {
+	capacity = max(1, capacity)
+	maxStart := max(0, itemCount-capacity)
+	scroll = min(max(0, scroll), maxStart)
+	if cursor < scroll {
+		return cursor
+	}
+	if cursor >= scroll+capacity {
+		return min(cursor-capacity+1, maxStart)
+	}
+	return scroll
+}
+
+// ModelPickerViewport carries the terminal space available to a picker. Zero
+// dimensions retain the fixed legacy capacities for deterministic rendering.
+type ModelPickerViewport struct {
+	Width        int
+	Height       int
+	ReservedRows int
+}
+
+func (viewport ModelPickerViewport) ListCapacity() int {
+	if viewport.Height <= 0 {
+		return maxVisibleItems
+	}
+	return max(1, viewport.Height-viewport.ReservedRows-6)
+}
+
+func (viewport ModelPickerViewport) PhaseCapacity() int {
+	if viewport.Height <= 0 {
+		return maxVisiblePhaseRows
+	}
+	return max(1, viewport.Height-viewport.ReservedRows-9)
+}
+
+func (viewport ModelPickerViewport) showsGuidance() bool {
+	return viewport.Width >= 60 && viewport.PhaseCapacity() >= 5
+}
+
 // RuntimeCatalogDiscoveryMsg is delivered after OpenCode resolves project models.
 type RuntimeCatalogDiscoveryMsg struct {
 	RequestID  uint64
@@ -127,6 +167,7 @@ type ModelPickerState struct {
 	// When true, the row list still includes optional profile-scoped Judgment Day
 	// agents alongside SDD rows.
 	ForProfile bool
+	Viewport   ModelPickerViewport
 
 	catalogDiscover RuntimeCatalogDiscoverer
 }
@@ -290,6 +331,36 @@ func ModelPickerRowAt(state ModelPickerState, index int) (ModelPickerRow, bool) 
 	return rows[index], true
 }
 
+// ModelPickerGuidance describes the focused picker row without changing its
+// assignment semantics. Unknown agent IDs are runtime custom/native agents.
+func ModelPickerGuidance(row ModelPickerRow) string {
+	switch row.Kind {
+	case ModelPickerRowKindSetAllSDD:
+		return "Applies one model to all SDD phases."
+	case ModelPickerRowKindSetAllCustom:
+		return "Applies one model to all custom/native agents."
+	case ModelPickerRowKindSeparator:
+		return "Section divider; not selectable."
+	}
+	roles := map[string]string{
+		SDDOrchestratorPhase: "Coordinates the workflow and delegates work.",
+		"sdd-init":           "Initializes the change workflow.", "sdd-explore": "Maps the codebase and constraints.",
+		"sdd-research": "Researches supporting evidence.", "sdd-propose": "Frames the proposed change.",
+		"sdd-spec": "Defines behavioral requirements.", "sdd-design": "Designs the implementation.",
+		"sdd-tasks": "Breaks the work into tasks.", "sdd-apply": "Applies approved tasks.",
+		"sdd-verify": "Verifies the implemented change.", "sdd-archive": "Archives completed workflow artifacts.",
+		"sdd-onboard": "Guides workflow onboarding.", "jd-judge-a": "Independently reviews the change.",
+		"jd-judge-b": "Independently reviews the change.", "jd-fix-agent": "Applies bounded review corrections.",
+		"review-risk": "Reviews risk and security.", "review-resilience": "Reviews operational resilience.",
+		"review-readability": "Reviews clarity and maintainability.", "review-reliability": "Reviews testing and reliability.",
+		"review-refuter": "Challenges inferential review findings.", "review-validator": "Validates targeted corrections.",
+	}
+	if guidance, ok := roles[row.AgentID]; ok {
+		return guidance
+	}
+	return "A custom/native agent; assignment applies only to this agent."
+}
+
 // SeparatorRowIdx returns the index of the "--- Judgment Day ---" separator
 // row in ModelPickerRows(). Returns -1 if there are no JD phases (and thus
 // no separator). This is used by the TUI to skip the separator during
@@ -362,8 +433,8 @@ func handleProviderNav(key string, state *ModelPickerState) bool {
 	case "down", "j":
 		if state.ProviderCursor < len(entries)-1 {
 			state.ProviderCursor++
-			if state.ProviderCursor >= state.ProviderScroll+maxVisibleItems {
-				state.ProviderScroll = state.ProviderCursor - maxVisibleItems + 1
+			if state.ProviderCursor >= state.ProviderScroll+state.Viewport.ListCapacity() {
+				state.ProviderScroll = state.ProviderCursor - state.Viewport.ListCapacity() + 1
 			}
 		}
 		return true
@@ -402,8 +473,8 @@ func handleModelNav(
 	case "down", "j":
 		if state.ModelCursor < len(models)-1 {
 			state.ModelCursor++
-			if state.ModelCursor >= state.ModelScroll+maxVisibleItems {
-				state.ModelScroll = state.ModelCursor - maxVisibleItems + 1
+			if state.ModelCursor >= state.ModelScroll+state.Viewport.ListCapacity() {
+				state.ModelScroll = state.ModelCursor - state.Viewport.ListCapacity() + 1
 			}
 		}
 		return true, assignments
@@ -701,8 +772,8 @@ func handleEffortNav(
 	case "down", "j":
 		if state.EffortCursor < len(opts)-1 {
 			state.EffortCursor++
-			if state.EffortCursor >= state.EffortScroll+maxVisibleItems {
-				state.EffortScroll = state.EffortCursor - maxVisibleItems + 1
+			if state.EffortCursor >= state.EffortScroll+state.Viewport.ListCapacity() {
+				state.EffortScroll = state.EffortCursor - state.Viewport.ListCapacity() + 1
 			}
 		}
 	case "enter":
@@ -746,17 +817,15 @@ func renderEffortSelect(state ModelPickerState) string {
 
 	opts := effortOptionsFromLevels(state.SelectedModelEffortLevels)
 
-	end := state.EffortScroll + maxVisibleItems
-	if end > len(opts) {
-		end = len(opts)
-	}
+	start := visibleListStart(state.EffortCursor, state.EffortScroll, len(opts), state.Viewport.ListCapacity())
+	end := min(start+state.Viewport.ListCapacity(), len(opts))
 
-	if state.EffortScroll > 0 {
+	if start > 0 {
 		b.WriteString(styles.SubtextStyle.Render("  ↑ more"))
 		b.WriteString("\n")
 	}
 
-	for i := state.EffortScroll; i < end; i++ {
+	for i := start; i < end; i++ {
 		opt := opts[i]
 		focused := i == state.EffortCursor
 
@@ -842,14 +911,25 @@ func renderPhaseList(
 	}
 
 	b.WriteString(styles.SubtextStyle.Render("Current assignments:"))
-	b.WriteString("\n\n")
+	b.WriteString("\n")
 
 	rows := ModelPickerRowsForState(state)
 	identityRows := ModelPickerRowsForStateWithIdentity(state)
+	if state.Viewport.showsGuidance() && cursor >= 0 && cursor < len(identityRows) {
+		b.WriteString(styles.SubtextStyle.Render("Role: " + ModelPickerGuidance(identityRows[cursor])))
+		b.WriteString("\n")
+	}
+	b.WriteString("\n")
+
+	capacity := state.Viewport.PhaseCapacity()
+	if state.Viewport.showsGuidance() {
+		capacity--
+	}
+	capacity = max(1, capacity)
 	start, end := 0, len(rows)
-	if len(rows) > maxVisiblePhaseRows {
-		start = max(0, min(cursor-maxVisiblePhaseRows+1, len(rows)-maxVisiblePhaseRows))
-		end = start + maxVisiblePhaseRows
+	if len(rows) > capacity {
+		start = max(0, min(cursor-capacity+1, len(rows)-capacity))
+		end = start + capacity
 	}
 	if start > 0 {
 		b.WriteString(styles.SubtextStyle.Render("  ↑ more assignments") + "\n")
@@ -936,17 +1016,15 @@ func renderProviderSelect(state ModelPickerState) string {
 
 	entries := ProviderEntries(state)
 
-	end := state.ProviderScroll + maxVisibleItems
-	if end > len(entries) {
-		end = len(entries)
-	}
+	start := visibleListStart(state.ProviderCursor, state.ProviderScroll, len(entries), state.Viewport.ListCapacity())
+	end := min(start+state.Viewport.ListCapacity(), len(entries))
 
-	if state.ProviderScroll > 0 {
+	if start > 0 {
 		b.WriteString(styles.SubtextStyle.Render("  ↑ more"))
 		b.WriteString("\n")
 	}
 
-	for i := state.ProviderScroll; i < end; i++ {
+	for i := start; i < end; i++ {
 		entry := entries[i]
 		label := fmt.Sprintf("%s (%d models)", entry.Name, entry.ModelCount)
 		focused := i == state.ProviderCursor
@@ -991,10 +1069,8 @@ func renderModelSelect(state ModelPickerState) string {
 	b.WriteString(styles.SubtextStyle.Render("Search: " + modelSearchDisplay(state.ModelSearch)))
 	b.WriteString("\n\n")
 
-	end := state.ModelScroll + maxVisibleItems
-	if end > len(models) {
-		end = len(models)
-	}
+	start := visibleListStart(state.ModelCursor, state.ModelScroll, len(models), state.Viewport.ListCapacity())
+	end := min(start+state.Viewport.ListCapacity(), len(models))
 
 	if len(models) == 0 {
 		b.WriteString(styles.WarningStyle.Render("  No models match your search."))
@@ -1003,12 +1079,12 @@ func renderModelSelect(state ModelPickerState) string {
 		return b.String()
 	}
 
-	if state.ModelScroll > 0 {
+	if start > 0 {
 		b.WriteString(styles.SubtextStyle.Render("  ↑ more"))
 		b.WriteString("\n")
 	}
 
-	for i := state.ModelScroll; i < end; i++ {
+	for i := start; i < end; i++ {
 		m := models[i]
 		label := m.Name
 		if m.Cost.Input > 0 || m.Cost.Output > 0 {

--- a/internal/tui/screens/model_picker_test.go
+++ b/internal/tui/screens/model_picker_test.go
@@ -3,6 +3,7 @@ package screens
 import (
 	"context"
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -14,6 +15,177 @@ import (
 
 // makeTestState builds a minimal ModelPickerState with one provider and models
 // so that handleModelNav can reach the "enter" branch.
+func TestModelPickerViewport_AdaptiveAndLegacyCapacities(t *testing.T) {
+	legacy := ModelPickerViewport{}
+	if got := legacy.PhaseCapacity(); got != maxVisiblePhaseRows {
+		t.Fatalf("legacy phase capacity = %d, want %d", got, maxVisiblePhaseRows)
+	}
+	if got := legacy.ListCapacity(); got != maxVisibleItems {
+		t.Fatalf("legacy list capacity = %d, want %d", got, maxVisibleItems)
+	}
+
+	short := ModelPickerViewport{Width: 80, Height: 12}
+	if got := short.PhaseCapacity(); got >= maxVisiblePhaseRows || got < 1 {
+		t.Fatalf("short phase capacity = %d, want adaptive value in [1,%d)", got, maxVisiblePhaseRows)
+	}
+	tall := ModelPickerViewport{Width: 80, Height: 40}
+	if got := tall.ListCapacity(); got <= maxVisibleItems {
+		t.Fatalf("tall list capacity = %d, want > %d", got, maxVisibleItems)
+	}
+}
+
+func TestModelPickerViewport_RenderersKeepFocusedRowVisibleAfterResize(t *testing.T) {
+	viewport := ModelPickerViewport{Width: 80, Height: 12}
+
+	t.Run("provider", func(t *testing.T) {
+		state := ModelPickerState{
+			Mode:           ModeProviderSelect,
+			Viewport:       viewport,
+			ProviderCursor: 9,
+			ProviderScroll: 0,
+			AvailableIDs:   make([]string, 10),
+			Providers:      make(map[string]opencode.Provider),
+			SDDModels:      make(map[string][]opencode.Model),
+		}
+		for i := range state.AvailableIDs {
+			id := fmt.Sprintf("provider-%02d", i)
+			state.AvailableIDs[i] = id
+			state.Providers[id] = opencode.Provider{ID: id, Name: id}
+		}
+
+		if out := renderProviderSelect(state); !strings.Contains(out, "▸ provider-09") {
+			t.Fatalf("resized provider picker hid focused row:\n%s", out)
+		}
+	})
+
+	t.Run("model", func(t *testing.T) {
+		models := make([]opencode.Model, 10)
+		for i := range models {
+			models[i] = opencode.Model{ID: fmt.Sprintf("model-%02d", i), Name: fmt.Sprintf("model-%02d", i)}
+		}
+		state := ModelPickerState{
+			Mode:             ModeModelSelect,
+			Viewport:         viewport,
+			SelectedProvider: "test",
+			ModelCursor:      9,
+			ModelScroll:      0,
+			SDDModels:        map[string][]opencode.Model{"test": models},
+		}
+		focused := FilteredModelEntries(state)[state.ModelCursor].Name
+
+		if out := renderModelSelect(state); !strings.Contains(out, "▸ "+focused) {
+			t.Fatalf("resized model picker hid focused row %q:\n%s", focused, out)
+		}
+	})
+
+	t.Run("effort", func(t *testing.T) {
+		levels := make([]string, 10)
+		for i := range levels {
+			levels[i] = fmt.Sprintf("level-%02d", i)
+		}
+		state := ModelPickerState{
+			Mode:                      ModeEffortSelect,
+			Viewport:                  viewport,
+			EffortCursor:              9,
+			EffortScroll:              0,
+			SelectedModelEffortLevels: levels,
+		}
+		focused := effortOptionsFromLevels(levels)[state.EffortCursor]
+
+		if out := renderEffortSelect(state); !strings.Contains(out, "▸ "+focused) {
+			t.Fatalf("resized effort picker hid focused row %q:\n%s", focused, out)
+		}
+	})
+}
+
+func TestModelPickerViewport_NavigationAndRenderingShareCapacity(t *testing.T) {
+	state := ModelPickerState{
+		Mode:         ModeProviderSelect,
+		Viewport:     ModelPickerViewport{Width: 80, Height: 12},
+		AvailableIDs: []string{"a", "b", "c", "d", "e", "f", "g", "h", "i", "j"},
+		Providers:    map[string]opencode.Provider{},
+		SDDModels:    map[string][]opencode.Model{},
+	}
+	for _, id := range state.AvailableIDs {
+		state.Providers[id] = opencode.Provider{ID: id, Name: id}
+	}
+	capacity := state.Viewport.ListCapacity()
+	for range state.AvailableIDs {
+		handleProviderNav("j", &state)
+	}
+	if state.ProviderScroll != len(state.AvailableIDs)-capacity {
+		t.Fatalf("provider scroll = %d, want %d for capacity %d", state.ProviderScroll, len(state.AvailableIDs)-capacity, capacity)
+	}
+	out := renderProviderSelect(state)
+	if strings.Count(out, "models)") != capacity {
+		t.Fatalf("rendered provider rows = %d, want %d:\n%s", strings.Count(out, "models)"), capacity, out)
+	}
+}
+
+func TestModelPickerViewport_ModelEffortAndPhaseUseSharedCapacities(t *testing.T) {
+	viewport := ModelPickerViewport{Width: 40, Height: 12}
+	models := make([]opencode.Model, 10)
+	levels := make([]string, 10)
+	for i := range models {
+		models[i] = opencode.Model{ID: fmt.Sprintf("model-%02d", i), Name: fmt.Sprintf("model-%02d", i)}
+		levels[i] = fmt.Sprintf("level-%02d", i)
+	}
+	modelState := ModelPickerState{Mode: ModeModelSelect, Viewport: viewport, SelectedProvider: "test", SDDModels: map[string][]opencode.Model{"test": models}}
+	for range models {
+		handleModelNav("j", &modelState, nil)
+	}
+	if got, want := modelState.ModelScroll, len(models)-viewport.ListCapacity(); got != want {
+		t.Fatalf("model scroll = %d, want %d", got, want)
+	}
+	if got := strings.Count(renderModelSelect(modelState), "model-"); got != viewport.ListCapacity() {
+		t.Fatalf("rendered model rows = %d, want %d", got, viewport.ListCapacity())
+	}
+
+	effortState := ModelPickerState{Mode: ModeEffortSelect, Viewport: viewport, SelectedModelEffortLevels: levels}
+	for range levels {
+		effortState, _ = handleEffortNav("j", effortState, nil)
+	}
+	if got, want := effortState.EffortScroll, len(effortOptionsFromLevels(levels))-viewport.ListCapacity(); got != want {
+		t.Fatalf("effort scroll = %d, want %d", got, want)
+	}
+	if got := strings.Count(renderEffortSelect(effortState), "level-"); got != viewport.ListCapacity() {
+		t.Fatalf("rendered effort rows = %d, want %d", got, viewport.ListCapacity())
+	}
+
+	phaseState := ModelPickerState{Viewport: viewport, AvailableIDs: []string{"test"}}
+	phaseRows := ModelPickerRowsForState(phaseState)
+	phaseOutput := RenderModelPicker(nil, phaseState, 0)
+	if !strings.Contains(phaseOutput, phaseRows[viewport.PhaseCapacity()-1]) || strings.Contains(phaseOutput, phaseRows[viewport.PhaseCapacity()]) {
+		t.Fatalf("phase rendering did not use capacity %d:\n%s", viewport.PhaseCapacity(), phaseOutput)
+	}
+}
+
+func TestModelPickerGuidance_UsesRoleAndSyntheticFallbacks(t *testing.T) {
+	if got := ModelPickerGuidance(ModelPickerRow{Kind: ModelPickerRowKindAgent, AgentID: "sdd-apply"}); !strings.Contains(got, "Applies") {
+		t.Fatalf("sdd-apply guidance = %q, want role guidance", got)
+	}
+	if got := ModelPickerGuidance(ModelPickerRow{Kind: ModelPickerRowKindSetAllSDD}); !strings.Contains(got, "all SDD") {
+		t.Fatalf("bulk guidance = %q, want synthetic guidance", got)
+	}
+	if got := ModelPickerGuidance(ModelPickerRow{Kind: ModelPickerRowKindSeparator}); !strings.Contains(got, "not selectable") {
+		t.Fatalf("separator guidance = %q, want non-selectable guidance", got)
+	}
+	if got := ModelPickerGuidance(ModelPickerRow{Kind: ModelPickerRowKindAgent, AgentID: "custom-agent"}); !strings.Contains(got, "custom") {
+		t.Fatalf("custom guidance = %q, want custom fallback", got)
+	}
+}
+
+func TestRenderPhaseList_HidesGuidanceWhenConstrained(t *testing.T) {
+	state := ModelPickerState{AvailableIDs: []string{"openai"}, Viewport: ModelPickerViewport{Width: 40, Height: 12}}
+	if out := RenderModelPicker(nil, state, 0); strings.Contains(out, "Role:") {
+		t.Fatalf("constrained picker rendered secondary guidance:\n%s", out)
+	}
+	state.Viewport = ModelPickerViewport{Width: 100, Height: 30}
+	if out := RenderModelPicker(nil, state, 0); !strings.Contains(out, "Role:") {
+		t.Fatalf("roomy picker omitted role guidance:\n%s", out)
+	}
+}
+
 func makeTestState(phaseIdx int) *ModelPickerState {
 	const providerID = "test-provider"
 	testModels := []opencode.Model{

--- a/internal/tui/screens/profile_create_test.go
+++ b/internal/tui/screens/profile_create_test.go
@@ -88,6 +88,22 @@ func TestRenderProfileCreate_Step2_ShowsCreateAndSync(t *testing.T) {
 	}
 }
 
+func TestRenderProfileCreate_Step1_ReservesProfileFrameInViewport(t *testing.T) {
+	draft := model.Profile{Name: "compact"}
+	picker := screens.ModelPickerState{
+		ForProfile:   true,
+		AvailableIDs: []string{"openai"},
+		Viewport:     screens.ModelPickerViewport{Width: 80, Height: 14, ReservedRows: 7},
+	}
+	output := screens.RenderProfileCreate(1, draft, "", 0, "", false, nil, picker, 0)
+	if strings.Contains(output, "Role:") {
+		t.Fatalf("constrained profile picker rendered secondary guidance:\n%s", output)
+	}
+	if !strings.Contains(output, "gentle-orchestrator") {
+		t.Fatalf("profile picker lost its first row:\n%s", output)
+	}
+}
+
 func TestRenderProfileCreate_Step1_ShowsJDRowsAssignmentAndClearHelp(t *testing.T) {
 	draft := model.Profile{Name: "cheap"}
 	picker := screens.ModelPickerState{


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #2301

---

## 🏷️ PR Type

- [x] `type:feature`

---

## 📝 Summary

- Make model-picker list capacity adapt to measured terminal dimensions.
- Keep focused provider, model, and effort entries visible after resize.
- Add compact role guidance that yields to constrained layouts.

---

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/tui` | Forward viewports through normal and profile flows. |
| `internal/tui/screens` | Add adaptive windows, focus-safe scrolling, and contextual guidance. |
| TUI tests | Cover zero, short, tall, profile, guidance, and resize behavior. |

---

## 🤖 AI Assistance

- [x] **Material assistance used**

**Tool/model (if known):** Pi coding-agent subagents

**Material scope:** Scope analysis, implementation, tests, verification, and PR drafting.

**Verification performed:** Independent review found and verified a resize-focus fix; focused TUI tests, isolated TUI package tests, formatting check, and diff check were run.

---

## 🧪 Test Plan

- [ ] Unit tests pass (`go test ./...`). Attempted in an isolated OpenCode environment; unrelated failures remain in `internal/reviewtransaction` (macOS temporary-path safety) and `internal/update` (system Bash 3 incompatibility).
- [x] Go format passes (`go run ./internal/gofmtcheck`)
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`)
- [x] Focused model-picker and isolated `internal/tui`/`internal/tui/screens` tests pass.
- [ ] Manually tested locally

Benchmark validation: N/A. This is a TUI layout/guidance change and does not affect benchmark behavior.

---

## ✅ Contributor Checklist

- [x] PR is linked to an approved issue with `status:approved`
- [x] PR stays within 400 changed lines (350 changed lines)
- [x] I have added the appropriate `type:*` label to this PR
- [ ] Unit tests pass (`go test ./...`), see Test Plan
- [x] Go format passes
- [ ] E2E tests pass
- [x] Benchmark validation is not applicable
- [x] Documentation is not necessary for this internal UI behavior
- [x] Commit follows Conventional Commits
- [x] I reviewed and take responsibility for this submission
- [x] Material AI assistance is disclosed
- [x] No `Co-Authored-By` trailers

---

## 💬 Notes for Reviewers

Native review could not run because its frozen candidate-view directory was rejected as unsafe/writable by the local controller. The implementation received an independent verifier pass instead. Please focus on viewport capacity and focus visibility after resize, especially in profile flows.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Model picker lists now adapt to the available terminal size.
  * Focused items remain visible when the terminal is resized.
  * Additional role guidance appears when sufficient space is available.

* **Bug Fixes**
  * Improved model picker rendering within profile creation so content fits constrained screens without overlapping or being cut off.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->