### PR TITLE
fix(sdd): discover Engram changes from early artifacts

### DIFF
--- a/internal/app/sdd_engram_early_artifacts_test.go
+++ b/internal/app/sdd_engram_early_artifacts_test.go
@@ -1,0 +1,71 @@
+package app
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func writeEarlyArtifactAppFile(t *testing.T, path, content string, mode os.FileMode) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("MkdirAll(%s): %v", filepath.Dir(path), err)
+	}
+	if err := os.WriteFile(path, []byte(content), mode); err != nil {
+		t.Fatalf("WriteFile(%s): %v", path, err)
+	}
+}
+
+func installEarlyArtifactEngramExport(t *testing.T) {
+	t.Helper()
+	fixture := filepath.Join(t.TempDir(), "engram-export.json")
+	writeEarlyArtifactAppFile(t, fixture, `{"observations":[
+  {"title":"sdd/early-artifacts/explore","content":"# Explore\n","project":"gentle-ai","scope":"project"},
+  {"title":"sdd/early-artifacts/pre-proposal","content":"# Pre-proposal\n","project":"gentle-ai","scope":"project"}
+]}
+`, 0o644)
+
+	binDir := t.TempDir()
+	if runtime.GOOS == "windows" {
+		writeEarlyArtifactAppFile(t, filepath.Join(binDir, "engram.cmd"), "@echo off\r\nif /I not \"%~1\"==\"export\" exit /b 2\r\nif \"%~2\"==\"\" exit /b 2\r\nif \"%ENGRAM_EARLY_ARTIFACT_EXPORT%\"==\"\" exit /b 2\r\ncopy /Y \"%ENGRAM_EARLY_ARTIFACT_EXPORT%\" \"%~2\" >nul\r\nexit /b %errorlevel%\r\n", 0o755)
+	} else {
+		writeEarlyArtifactAppFile(t, filepath.Join(binDir, "engram"), "#!/bin/sh\nif [ \"$1\" != \"export\" ] || [ -z \"$2\" ] || [ -z \"$ENGRAM_EARLY_ARTIFACT_EXPORT\" ]; then exit 2; fi\nexec cp \"$ENGRAM_EARLY_ARTIFACT_EXPORT\" \"$2\"\n", 0o755)
+	}
+	t.Setenv("ENGRAM_EARLY_ARTIFACT_EXPORT", fixture)
+	t.Setenv("ENGRAM_PROJECT", "gentle-ai")
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+}
+
+func TestRunArgsEngramEarlyArtifactsDiscoverAtPublicCommandBoundary(t *testing.T) {
+	installEarlyArtifactEngramExport(t)
+	setupMockHome(t, t.TempDir())
+
+	root := t.TempDir()
+	writeEarlyArtifactAppFile(t, filepath.Join(root, "openspec", "config.yaml"), "sdd:\n  artifact_store: engram\n", 0o644)
+
+	for _, command := range []string{"sdd-status", "sdd-continue"} {
+		t.Run(command, func(t *testing.T) {
+			var output bytes.Buffer
+			if err := RunArgs([]string{command, "--cwd", root, "--json"}, &output); err != nil {
+				t.Fatalf("RunArgs(%s): %v", command, err)
+			}
+			var status struct {
+				ChangeName      *string `json:"changeName"`
+				NextRecommended string  `json:"nextRecommended"`
+				Dependencies    struct {
+					Proposal string `json:"proposal"`
+				} `json:"dependencies"`
+			}
+			if err := json.Unmarshal(output.Bytes(), &status); err != nil {
+				t.Fatalf("decode %s output: %v\n%s", command, err, output.String())
+			}
+			if status.ChangeName == nil || *status.ChangeName != "early-artifacts" || status.NextRecommended != "propose" || status.Dependencies.Proposal != "blocked" {
+				t.Fatalf("%s status = change %v next %q proposal %q, want discovered early-artifacts routed to propose without proposal completion\n%s", command, status.ChangeName, status.NextRecommended, status.Dependencies.Proposal, strings.TrimSpace(output.String()))
+			}
+		})
+	}
+}

--- a/internal/sddstatus/engram_early_artifacts_test.go
+++ b/internal/sddstatus/engram_early_artifacts_test.go
@@ -1,0 +1,112 @@
+package sddstatus
+
+import (
+	"path/filepath"
+	"slices"
+	"testing"
+)
+
+func TestResolveEngramEarlyArtifactsDiscoverAndRouteToPropose(t *testing.T) {
+	cases := []struct {
+		name   string
+		titles []string
+	}{
+		{name: "explore only", titles: []string{"explore"}},
+		{name: "pre-proposal only", titles: []string{"pre-proposal"}},
+		{name: "combined early artifacts", titles: []string{"explore", "pre-proposal"}},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			root := t.TempDir()
+			write(t, filepath.Join(root, "openspec", "config.yaml"), "sdd:\n  artifact_store: engram\n")
+			t.Setenv("ENGRAM_PROJECT", "gentle-ai")
+
+			observations := make([]engramObservation, 0, len(tt.titles))
+			for _, title := range tt.titles {
+				observations = append(observations, engramObservation{
+					Title:   "sdd/early-artifacts/" + title,
+					Content: "# Early artifact\n",
+					Project: "gentle-ai",
+					Scope:   "project",
+				})
+			}
+			t.Cleanup(stubEngramExport(t, observations))
+
+			for _, requestedChange := range []string{"", "early-artifacts"} {
+				status, err := Resolve(ResolveOptions{CWD: root, ChangeName: requestedChange})
+				if err != nil {
+					t.Fatalf("Resolve(change=%q): %v", requestedChange, err)
+				}
+				if got := ptrValue(status.ChangeName); got != "early-artifacts" {
+					t.Fatalf("Resolve(change=%q) ChangeName = %q, want early-artifacts", requestedChange, got)
+				}
+				if status.NextRecommended != string(PhasePropose) {
+					t.Fatalf("Resolve(change=%q) NextRecommended = %q, want propose", requestedChange, status.NextRecommended)
+				}
+				if status.Artifacts["proposal"] != ArtifactMissing || status.Dependencies.Proposal != DependencyBlocked {
+					t.Fatalf("Resolve(change=%q) treated early artifacts as a proposal: artifacts=%v dependencies=%#v", requestedChange, status.Artifacts, status.Dependencies)
+				}
+			}
+		})
+	}
+}
+
+func TestResolveEngramEarlyArtifactsWithProposalRoutesToSpec(t *testing.T) {
+	root := t.TempDir()
+	write(t, filepath.Join(root, "openspec", "config.yaml"), "sdd:\n  artifact_store: engram\n")
+	t.Setenv("ENGRAM_PROJECT", "gentle-ai")
+	t.Cleanup(stubEngramExport(t, []engramObservation{
+		{Title: "sdd/early-artifacts/explore", Content: "# Explore\n", Project: "gentle-ai", Scope: "project"},
+		{Title: "sdd/early-artifacts/pre-proposal", Content: "# Pre-proposal\n", Project: "gentle-ai", Scope: "project"},
+		{Title: "sdd/early-artifacts/proposal", Content: "# Proposal\n", Project: "gentle-ai", Scope: "project"},
+	}))
+
+	for _, requestedChange := range []string{"", "early-artifacts"} {
+		status, err := Resolve(ResolveOptions{CWD: root, ChangeName: requestedChange})
+		if err != nil {
+			t.Fatalf("Resolve(change=%q): %v", requestedChange, err)
+		}
+		if got := ptrValue(status.ChangeName); got != "early-artifacts" || status.NextRecommended != string(PhaseSpec) {
+			t.Fatalf("Resolve(change=%q) = change %q next %q, want early-artifacts/spec", requestedChange, got, status.NextRecommended)
+		}
+		if status.Artifacts["proposal"] != ArtifactDone || status.Dependencies.Proposal != DependencyAllDone {
+			t.Fatalf("proposal completion = artifacts=%v dependencies=%#v, want proposal done only after its titled artifact", status.Artifacts, status.Dependencies)
+		}
+	}
+}
+
+func TestEngramEarlyArtifactsPreserveProjectArchiveAndSelectionRules(t *testing.T) {
+	observations := []engramObservation{
+		{Title: "sdd/early/explore", Project: "gentle-ai", Scope: "project"},
+		{Title: "sdd/current/pre-proposal", Project: "gentle-ai", Scope: "project"},
+		{Title: "sdd/foreign/explore", Project: "another-project", Scope: "project"},
+		{Title: "sdd/personal/pre-proposal", Project: "gentle-ai", Scope: "personal"},
+		{Title: "sdd/archived/explore", Project: "gentle-ai", Scope: "project"},
+		{Title: "sdd/archived/archive-report", Project: "gentle-ai", Scope: "project"},
+	}
+	if got, want := collectEngramChanges(observations, "gentle-ai"), []string{"current", "early"}; !slices.Equal(got, want) {
+		t.Fatalf("collectEngramChanges() = %v, want %v; foreign, personal, and archived changes must remain excluded", got, want)
+	}
+
+	root := t.TempDir()
+	write(t, filepath.Join(root, "openspec", "config.yaml"), "sdd:\n  artifact_store: engram\n")
+	t.Setenv("ENGRAM_PROJECT", "gentle-ai")
+	t.Cleanup(stubEngramExport(t, observations))
+
+	status, err := Resolve(ResolveOptions{CWD: root})
+	if err != nil {
+		t.Fatalf("Resolve(auto): %v", err)
+	}
+	if status.NextRecommended != "select-change" || status.ChangeName != nil {
+		t.Fatalf("Resolve(auto) = change %q next %q, want ambiguous selection between the two active project changes", ptrValue(status.ChangeName), status.NextRecommended)
+	}
+
+	archived, err := Resolve(ResolveOptions{CWD: root, ChangeName: "archived"})
+	if err != nil {
+		t.Fatalf("Resolve(archived): %v", err)
+	}
+	if archived.Archived == nil || archived.NextRecommended != "archived" {
+		t.Fatalf("Resolve(archived) = archived %#v next %q, want existing archive projection", archived.Archived, archived.NextRecommended)
+	}
+}

--- a/internal/sddstatus/status.go
+++ b/internal/sddstatus/status.go
@@ -1189,7 +1189,7 @@ func projectFromGitConfig(content string) string {
 	return ""
 }
 
-var engramTitlePattern = regexp.MustCompile(`^sdd/([^/]+)/(proposal|spec|design|tasks|apply-progress|verify-report|state|archive-report)$`)
+var engramTitlePattern = regexp.MustCompile(`^sdd/([^/]+)/(explore|pre-proposal|proposal|spec|design|tasks|apply-progress|verify-report|state|archive-report)$`)
 
 func collectEngramChanges(observations []engramObservation, project string) []string {
 	// An Engram-backed change has no directory to move, so nothing about the


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #4506

Refs #1730, specifically [the early-artifact occurrence](https://github.com/Gentleman-Programming/gentle-ai/issues/1730#issuecomment-5614083256). The broader issue remains open: this PR does not fix unmarked-store detection or generated instruction/documentation alignment.

---

## 🏷️ PR Type

- [x] `type:bug` — Bug fix (non-breaking change that fixes an issue)
- [ ] `type:feature` — New feature (non-breaking change that adds functionality)
- [ ] `type:docs` — Documentation only
- [ ] `type:refactor` — Code refactoring (no functional changes)
- [ ] `type:chore` — Build, CI, or tooling changes
- [ ] `type:breaking-change` — Breaking change (fix or feature that changes existing behavior)

---

## 📝 Summary

- Recognize `explore` and `pre-proposal` in the shared Engram artifact-title filter, so both automatic discovery and explicit-name lookup preserve early changes.
- Keep the existing router: early artifacts establish existence, not proposal completion. Early-only changes recommend `propose`; a real proposal advances to `spec`.
- Cover the resolver and both public commands without changing store selection, routing, or artifact schemas.

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/sddstatus/status.go` | One-line expansion of the shared title pattern. |
| `internal/sddstatus/engram_early_artifacts_test.go` | Early-only and proposal controls; project/personal filtering, archive behavior, and ambiguous selection. |
| `internal/app/sdd_engram_early_artifacts_test.go` | Public `sdd-status`/`sdd-continue` tests with isolated fake export and native Windows `.cmd` fixture selection. |

GitHub API-confirmed diff: 3 files, 184 additions / 1 deletion.

---

## 🤖 AI Assistance

- [ ] **None** — No material AI assistance was used.
- [x] **Material assistance used** — Complete all applicable declaration fields below.

**Tool/model (if known):** Pi; implementation writer reported `gpt-5.6-terra`.

**Material scope:** Reproduction, implementation, regression tests, independent verification, and delivery preparation.

**Verification performed:** Writer recorded RED before the production change and GREEN afterward. A separate verifier reproduced the named CLI commands, found a portability defect in the test fixture, and validated its correction. Exact checks and limitations follow.

---

## 🧪 Test Plan

### Passed

- `go build ./...`
- `go vet ./...`
- `go run ./internal/gofmtcheck`
- `go test ./internal/sddstatus -count=1`
- `go test ./internal/app -run '^TestRunArgsEngramEarlyArtifactsDiscoverAtPublicCommandBoundary$' -count=1`
- `git diff --check`
- `GOOS=windows GOARCH=amd64 go test -c -o <temporary-output>/app.test.exe ./internal/app` — compilation only.
- Independent compiled-binary runs of `sdd-status early-change --cwd <fixture> --json --instructions` and `sdd-continue early-change --cwd <fixture> --json --instructions`: early-only observations resolve the named change and recommend `propose` without blockers; adding a proposal recommends `spec`.

CLI fixtures explicitly selected Engram, used matching project identity and a deterministic fake export, and retained historical OpenSpec artifacts as a non-authoritative control. No real user memory was exported.

### Incomplete and baseline failures

`go test ./internal/...` timed out after 300 seconds; **the full internal suite is not claimed to pass**. `internal/app` passed during that run. The only observed failing package was `internal/agents/pi`:

- `TestDiscoverCodeGraphChildrenUsesProjectOverrideAndPreservesPackageSource`
- `TestDiscoverCodeGraphChildrenUsesNormalizedRuntimeIdentity`

Both failures were reproduced with `go test ./internal/agents/pi` in a separate clean checkout of the exact base `d521b5e360ba441abaf894b64463fd53805cbb16`. Remaining results after the timeout are unverified; no unrelated fixes are included.

- [ ] Unit tests pass (`go test ./...`) — not run; internal-suite limit described above.
- [x] Go format passes (`go run ./internal/gofmtcheck`).
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`) — not run.
- [x] Manually tested locally — isolated Linux/amd64 CLI controls only.

**Benchmark validation:** N/A. This changes SDD artifact discovery, not review lifecycle, gates, recovery, delivery, or benchmark implementation/corpus/claims.

Native Windows, Darwin, OpenCode, and real Engram persistence were not exercised. Cross-compilation does not validate Windows batch execution. The local binary reported `vcs.modified=true` without embedded `vcs.revision`; source/build-command provenance was recorded, but pristine embedded provenance is not claimed. RDD was off; no RDD receipt is claimed.

---

## 🤖 Automated Checks

| Check | Status | Description |
|-------|--------|-------------|
| Check PR Cognitive Load | ⏳ | Must remain within 400 additions + deletions. |
| Check Issue Reference | ⏳ | `Closes #4506`. |
| Check Issue Has `status:approved` | ⏳ | #4506 approval verified before PR creation. |
| Check PR Has `type:*` Label | ⏳ | Exactly one `type:bug` label requested on creation. |
| Unit Tests | ⏳ | CI result pending; local limitations documented above. |
| Go Format | ⏳ | Local check passed; CI pending. |
| E2E Tests | ⏳ | Not run locally. |

---

## ✅ Contributor Checklist

- [x] PR is linked to an issue with `status:approved` — #4506 approval read back before publication.
- [x] PR stays within 400 changed lines — GitHub API confirms 184 additions + 1 deletion = 185.
- [x] I have added the appropriate `type:*` label to this PR — GitHub API confirms exactly one: `type:bug`.
- [ ] Unit tests pass (`go test ./...`) — not claimed.
- [x] Go format passes (`go run ./internal/gofmtcheck`).
- [ ] E2E tests pass (`cd e2e && ./docker-test.sh`) — not run.
- [x] Benchmark validation is not applicable; rationale is in the Test Plan.
- [x] Documentation update is not necessary for this focused title-classification fix.
- [x] Commit follows Conventional Commits format.
- [ ] I understand, reviewed, and take responsibility for the complete submission — human attestation not inferred.
- [x] Exactly one AI-assistance option is selected and the applicable fields are completed.
- [x] Commit contains no `Co-Authored-By` trailer.

---

## 💬 Notes for Reviewers

The production change is deliberately one line. Early evidence must not imply a completed proposal. Existing project/scope/archive checks and phase routing remain unchanged.

Early-context locator delivery is not expanded by this PR. It fixes discovery and routing, not the complete downstream proposal-context handoff. #1730 remains the tracker for its broader outstanding scope.

- [x] N/A — no qualifying security, integrity, admission, repair, or governance guard is added or changed; this is artifact-title classification.
- [x] N/A — no `guard:population` declaration or baseline change applies.
- [x] No declaration/registry check is presented as proof of guard completeness.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Engram integration to recognize early exploration and pre-proposal artifacts.
  * Projects with only early artifacts now correctly continue through the proposal phase.
  * Existing project, scope, archive, and artifact-selection behavior remains supported. 


<!-- end of auto-generated comment: release notes by coderabbit.ai -->