### PR TITLE
fix(review): offer the committed-range START for an empty workspace candidate

### DIFF
--- a/internal/cli/review_facade.go
+++ b/internal/cli/review_facade.go
@@ -1028,6 +1028,13 @@ func runReviewStatus(ctx context.Context, args []string, stdout io.Writer) error
 		}
 		var native reviewtransaction.TargetStatusResult
 		var liveSnapshot reviewtransaction.Snapshot
+		// derivedCommittedRange carries the executable base-diff status a
+		// selectorless STATUS derives when the fresh workspace candidate froze
+		// zero paths and the remote default branch names an unambiguous
+		// committed range (issue #4412). It stays nil whenever any step of that
+		// derivation is not certain, so the fallback base_ref collect is
+		// preserved byte-for-byte.
+		var derivedCommittedRange *ReviewTargetStatusResult
 		// Issue #3932: a continuation START issued carries the opaque
 		// repository context, so it is a resume of an existing lineage, never
 		// a pre-named fresh START. A process cwd that does not hold that
@@ -1084,6 +1091,15 @@ func runReviewStatus(ctx context.Context, args []string, stdout io.Writer) error
 				}
 			} else {
 				native = reviewFreshAtomicTargetStatus(target, liveSnapshot)
+				// Issue #4412: a selectorless STATUS that classifies this empty
+				// workspace candidate must not hand back the unroutable
+				// external.select_base_ref collect when the reviewed work is
+				// simply already committed. Derive the committed-range START the
+				// `--base-ref --committed-only` STATUS path already publishes, and
+				// keep the collect fallback for every ambiguous repository shape.
+				if requestedLineage == "" && selectedBaseRef == "" && !*workspaceOverlay {
+					derivedCommittedRange = reviewDerivedCommittedRangeStatus(ctx, root, builder, liveSnapshot, target, *contract, intendedScope)
+				}
 			}
 		} else {
 			native, liveSnapshot, err = reviewtransaction.AssessTargetStatusWithSnapshot(ctx, root, reviewtransaction.TargetStatusRequest{
@@ -1111,6 +1127,7 @@ func runReviewStatus(ctx context.Context, args []string, stdout io.Writer) error
 		}
 		result := newReviewTargetStatusResultForContract(native, *contract)
 		result.intendedUntracked = intendedScope
+		result.derivedCommittedRange = derivedCommittedRange
 		// Issue #4040: publish the digest once, here, before every path that
 		// could suppress it — the compact-reviewing replacement immediately
 		// below (which deliberately zeros Digest for the #1972 fail-closed
@@ -1368,8 +1385,17 @@ func runReviewStatus(ctx context.Context, args []string, stdout io.Writer) error
 				}
 			}
 			startLineage := strings.TrimSpace(*lineage)
+			startTargetIdentity := native.TargetIdentity
+			// Issue #4412: the derived committed-range START binds the base-diff
+			// identity, so its lineage must derive from that identity, exactly as
+			// the `--base-ref --committed-only` STATUS path derives it. Deriving
+			// it from the empty workspace identity would create the lineage under
+			// a name no later selectorless STATUS would look for.
+			if result.derivedCommittedRange != nil {
+				startTargetIdentity = result.derivedCommittedRange.TargetIdentity
+			}
 			if native.Action == reviewtransaction.TargetStatusActionStart {
-				startLineage, err = reviewStatusStartLineage(ctx, root, native.TargetIdentity, *lineage, *recoverySuccessor)
+				startLineage, err = reviewStatusStartLineage(ctx, root, startTargetIdentity, *lineage, *recoverySuccessor)
 				if err != nil {
 					return fmt.Errorf("select STATUS atomic START lineage: %w", err)
 				}
@@ -1474,6 +1500,49 @@ func reviewFreshAtomicTargetStatus(target reviewtransaction.Target, snapshot rev
 			TargetIdentity:     snapshot.Identity, Selector: target,
 		},
 	}
+}
+
+// reviewDerivedCommittedRangeStatus is the selectorless STATUS fallback for the
+// fresh workspace candidate that froze zero paths because the reviewed work is
+// already committed (issue #4412). It resolves the remote default branch's
+// unique merge-base and re-classifies the exact `--base-ref <merge-base>
+// --committed-only` target the working STATUS path already understands, so the
+// unroutable empty_candidate_base_ref_required collect is replaced by an
+// executable committed-range START.
+//
+// It returns nil for every repository shape the derivation cannot resolve -- no
+// origin/HEAD, a criss-cross history, an empty range, a Git fault, or a derived
+// range that still nets zero paths -- so newReviewNextTransition keeps today's
+// collect transition byte-for-byte. It reuses the same snapshot, status, and
+// result computation as the working `--base-ref --committed-only` route rather
+// than re-deriving target identity, evidence, or projection here.
+func reviewDerivedCommittedRangeStatus(ctx context.Context, root string, builder reviewtransaction.SnapshotBuilder, live reviewtransaction.Snapshot, target reviewtransaction.Target, contract string, intended reviewIntendedUntrackedScope) *ReviewTargetStatusResult {
+	if live.Kind != reviewtransaction.TargetCurrentChanges || len(live.Paths) != 0 {
+		return nil
+	}
+	base, err := reviewtransaction.ResolveCommittedRangeBase(ctx, root)
+	if err != nil || base == "" {
+		return nil
+	}
+	derivedTarget := reviewtransaction.Target{
+		Kind: reviewtransaction.TargetBaseDiff, BaseRef: base,
+		IntendedUntracked: append([]string{}, target.IntendedUntracked...),
+	}
+	snapshot, err := builder.BuildStoredSnapshot(ctx, derivedTarget)
+	if err != nil || len(snapshot.Paths) == 0 {
+		// A non-empty commit range whose trees still coincide (an empty commit)
+		// has no candidate to review, so the collect fallback stays truthful.
+		return nil
+	}
+	native := reviewFreshAtomicTargetStatus(derivedTarget, snapshot)
+	if native.Action != reviewtransaction.TargetStatusActionStart {
+		return nil
+	}
+	result := newReviewTargetStatusResultForContract(native, contract)
+	result.repositoryRoot = root
+	result.intendedUntracked = intended
+	result.committedRangeBaseRef = base
+	return &result
 }
 
 // reviewFreshStatusPreflight makes the fresh, store-free STATUS classification

--- a/internal/cli/review_next_transition.go
+++ b/internal/cli/review_next_transition.go
@@ -221,6 +221,21 @@ func newReviewNextTransition(status ReviewTargetStatusResult, selectedLenses []s
 			// instead, and — exactly like the refusal it replaces — name it
 			// without deriving it, so the caller keeps choosing the scope.
 			if status.Projection.Kind == reviewtransaction.TargetCurrentChanges && len(status.Projection.Paths) == 0 {
+				// Issue #4412: when STATUS could resolve the remote default
+				// branch's unique merge-base, the reviewed work is already
+				// committed and the truthful answer is the executable
+				// committed-range START the working `--base-ref --committed-only`
+				// STATUS path already publishes, not the unroutable
+				// external.select_base_ref collect (transition_input.submission
+				// is a closed oneOf, so no submission was ever schema-legal).
+				// The collect below stays the fallback for every repository
+				// shape the derivation cannot resolve.
+				if derived := status.derivedCommittedRange; derived != nil {
+					return reviewExecuteTransition("fresh_target_ready", "review.start",
+						reviewStartArguments(*derived, input.StartLineage, input.RuntimeAgent, derived.intendedUntracked),
+						[]ReviewTransitionArgument{{Name: "target_identity", Value: derived.TargetIdentity}},
+						ReviewTransitionBinding{LineageID: input.StartLineage, TargetIdentity: derived.TargetIdentity}, nil)
+				}
 				return reviewCollectTransition("empty_candidate_base_ref_required", ReviewTransitionInput{
 					Name: "base_ref", Schema: "gentle-ai.review-base-ref-selection/v1", CaptureOperation: "external.select_base_ref",
 					Arguments: reviewTargetArguments(status),
@@ -777,7 +792,15 @@ func reviewStartArguments(status ReviewTargetStatusResult, lineage string, runti
 	}
 	switch status.Projection.Kind {
 	case reviewtransaction.TargetBaseDiff:
-		arguments = append(arguments, ReviewTransitionArgument{Name: "base-ref", Value: status.Projection.BaseTree}, ReviewTransitionArgument{Name: "committed-only", Value: "true"})
+		baseRef := status.Projection.BaseTree
+		// Issue #4412: a selectorless STATUS that derived a committed range
+		// discloses the exact merge-base commit it resolved, not the tree
+		// object the derived snapshot froze, so the caller can see and
+		// override the scope it was offered.
+		if status.committedRangeBaseRef != "" {
+			baseRef = status.committedRangeBaseRef
+		}
+		arguments = append(arguments, ReviewTransitionArgument{Name: "base-ref", Value: baseRef}, ReviewTransitionArgument{Name: "committed-only", Value: "true"})
 	case reviewtransaction.TargetBaseWorkspaceOverlay:
 		arguments = append(arguments, ReviewTransitionArgument{Name: "base-ref", Value: status.Projection.BaseTree}, ReviewTransitionArgument{Name: "workspace-overlay", Value: "true"})
 	}

--- a/internal/cli/review_next_transition_empty_candidate_test.go
+++ b/internal/cli/review_next_transition_empty_candidate_test.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"bytes"
 	"strings"
 	"testing"
 
@@ -30,43 +31,112 @@ func emptyWorkspaceCandidateStatus() ReviewTargetStatusResult {
 	}
 }
 
-func TestNegotiatedStatusCollectsBaseRefForEmptyWorkspaceCandidate(t *testing.T) {
-	got := newReviewNextTransition(emptyWorkspaceCandidateStatus(), nil, nil, nil, reviewNextTransitionInput{StartLineage: "review-empty-candidate"})
+// derivedCommittedRangeBaseCommit is the merge-base commit a derived
+// committed-range START discloses. It is deliberately a commit-shaped OID, not
+// a tree, so the test can tell the two apart.
+const derivedCommittedRangeBaseCommit = "1111111111111111111111111111111111111111"
 
-	if got.Kind != reviewNextTransitionCollect {
-		t.Fatalf("empty workspace candidate transition kind = %q, want %q; re-offering an executable START loops on a preflight refusal", got.Kind, reviewNextTransitionCollect)
-	}
-	if got.ReasonCode != "empty_candidate_base_ref_required" {
-		t.Fatalf("empty workspace candidate reason code = %q, want %q", got.ReasonCode, "empty_candidate_base_ref_required")
-	}
-	if got.Execute != nil {
-		t.Fatalf("empty workspace candidate carries an executable transition %#v, want none", got.Execute)
-	}
-	if got.Collect == nil || len(got.Collect.Inputs) != 1 {
-		t.Fatalf("empty workspace candidate collection = %#v, want exactly one input", got.Collect)
-	}
-	input := got.Collect.Inputs[0]
-	if input.Name != "base_ref" {
-		t.Fatalf("collected input name = %q, want %q", input.Name, "base_ref")
-	}
-	if input.CaptureOperation != "external.select_base_ref" {
-		t.Fatalf("collected input capture operation = %q, want %q", input.CaptureOperation, "external.select_base_ref")
+// derivedCommittedRangeStatus is the base-diff status the selectorless
+// derivation hands newReviewNextTransition when the fresh workspace candidate
+// froze zero paths and the remote default branch named an unambiguous committed
+// range (issue #4412). Its identity is recomputed from its own published
+// components so the transition carries the same target-evidence token the
+// working `--base-ref --committed-only` STATUS path publishes, and so the
+// committedRangeBaseRef override is exercised end to end.
+func derivedCommittedRangeStatus() *ReviewTargetStatusResult {
+	baseTree := strings.Repeat("c", 40)
+	candidateTree := strings.Repeat("d", 40)
+	pathsDigest := "sha256:" + strings.Repeat("e", 64)
+	return &ReviewTargetStatusResult{
+		Schema:                ReviewIntegrationStatusSchema,
+		Contract:              ReviewIntegrationContractV2,
+		Operation:             "review.status",
+		Applicability:         reviewtransaction.TargetApplicabilityUnrelated,
+		Action:                reviewtransaction.TargetStatusActionStart,
+		Replayability:         reviewtransaction.ReplayabilityNotReplayable,
+		TargetIdentity:        reviewtransaction.IdentityForComponents(reviewtransaction.TargetBaseDiff, reviewtransaction.ProjectionWorkspace, baseTree, candidateTree, pathsDigest),
+		repositoryRoot:        "/review-empty-candidate-repo",
+		committedRangeBaseRef: derivedCommittedRangeBaseCommit,
+		Projection: ReviewTargetStatusProjection{
+			Kind:                 reviewtransaction.TargetBaseDiff,
+			Projection:           reviewtransaction.ProjectionWorkspace,
+			BaseTree:             baseTree,
+			CurrentCandidateTree: candidateTree,
+			PathsDigest:          pathsDigest,
+			Paths:                []string{"internal/cli/review_next_transition.go"},
+		},
 	}
 }
 
-// The refusal in PR #2505 deliberately names base_ref without deriving it, so
-// the continuation that replaces it must not derive one either. A collection
-// that shipped a base value would silently choose a review scope the caller
-// never asked for.
-func TestNegotiatedEmptyCandidateCollectionDoesNotDeriveBaseRef(t *testing.T) {
+// TestNegotiatedStatusDerivesCommittedRangeStartForEmptyWorkspaceCandidate pins
+// the new policy (issue #4412): when the remote default branch names an
+// unambiguous committed range, the unroutable empty_candidate_base_ref_required
+// collect is replaced by the executable committed-range START the working
+// `--base-ref --committed-only` STATUS path already publishes. Its arguments
+// disclose the derived base commit and committed-only=true, and it never carries
+// the empty workspace target.
+func TestNegotiatedStatusDerivesCommittedRangeStartForEmptyWorkspaceCandidate(t *testing.T) {
+	status := emptyWorkspaceCandidateStatus()
+	derived := derivedCommittedRangeStatus()
+	status.derivedCommittedRange = derived
+
+	got := newReviewNextTransition(status, nil, nil, nil, reviewNextTransitionInput{StartLineage: "review-empty-candidate"})
+
+	if got.Kind != reviewNextTransitionExecute || got.ReasonCode != "fresh_target_ready" {
+		t.Fatalf("derived empty workspace transition = %q/%q, want %q/%q; an unambiguous committed range must not fall back to the unroutable collect", got.Kind, got.ReasonCode, reviewNextTransitionExecute, "fresh_target_ready")
+	}
+	if got.Execute == nil || got.Execute.Operation != "review.start" {
+		t.Fatalf("derived empty workspace execute = %#v, want review.start", got.Execute)
+	}
+	arguments, err := reviewTransitionArgumentMap(got.Execute.Arguments, got.Execute.Operation)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if arguments["base-ref"] != derivedCommittedRangeBaseCommit {
+		t.Fatalf("derived START base-ref = %q, want the derived base commit %q (never the tree object)", arguments["base-ref"], derivedCommittedRangeBaseCommit)
+	}
+	if arguments["committed-only"] != "true" {
+		t.Fatalf("derived START committed-only = %q, want true", arguments["committed-only"])
+	}
+	if arguments["target"] != derived.TargetIdentity {
+		t.Fatalf("derived START target = %q, want the base-diff identity %q", arguments["target"], derived.TargetIdentity)
+	}
+	if arguments["target"] == status.TargetIdentity {
+		t.Fatalf("derived START carried the empty workspace target %q", status.TargetIdentity)
+	}
+	if got.Execute.Binding.TargetIdentity != derived.TargetIdentity {
+		t.Fatalf("derived START binding target = %q, want %q", got.Execute.Binding.TargetIdentity, derived.TargetIdentity)
+	}
+	if err := got.Validate(); err != nil {
+		t.Fatalf("derived empty workspace transition Validate() = %v, want nil", err)
+	}
+}
+
+// TestNegotiatedStatusCollectsBaseRefForAmbiguousCommittedRange pins the
+// retained fallback: with no derived status (no origin/HEAD, a criss-cross
+// history, an empty range, or a Git fault) the transition stays exactly today's
+// external.select_base_ref collect.
+func TestNegotiatedStatusCollectsBaseRefForAmbiguousCommittedRange(t *testing.T) {
 	got := newReviewNextTransition(emptyWorkspaceCandidateStatus(), nil, nil, nil, reviewNextTransitionInput{StartLineage: "review-empty-candidate"})
 
+	if got.Kind != reviewNextTransitionCollect {
+		t.Fatalf("ambiguous empty workspace candidate transition kind = %q, want %q; the fallback must stay the collect", got.Kind, reviewNextTransitionCollect)
+	}
+	if got.ReasonCode != "empty_candidate_base_ref_required" {
+		t.Fatalf("ambiguous empty workspace candidate reason code = %q, want %q", got.ReasonCode, "empty_candidate_base_ref_required")
+	}
+	if got.Execute != nil {
+		t.Fatalf("ambiguous empty workspace candidate carries an executable transition %#v, want none", got.Execute)
+	}
 	if got.Collect == nil || len(got.Collect.Inputs) != 1 {
-		t.Fatalf("empty workspace candidate collection = %#v, want exactly one input", got.Collect)
+		t.Fatalf("ambiguous empty workspace candidate collection = %#v, want exactly one input", got.Collect)
 	}
 	input := got.Collect.Inputs[0]
+	if input.Name != "base_ref" || input.CaptureOperation != "external.select_base_ref" {
+		t.Fatalf("ambiguous collected input = %#v, want the base_ref external selection", input)
+	}
 	if input.Submission != nil {
-		t.Fatalf("collected base_ref input carries submission descriptor %#v, want none: only plan_correction and run_targeted_validation may carry one", input.Submission)
+		t.Fatalf("collected base_ref input carries submission descriptor %#v, want none: no submission is schema-legal for external.select_base_ref", input.Submission)
 	}
 	for _, argument := range input.Arguments {
 		if argument.Name == "base_ref" || argument.Name == "base-ref" {
@@ -98,6 +168,23 @@ func TestNegotiatedEmptyCandidateCollectionSatisfiesStatusTargetValidation(t *te
 
 	if err := result.validateNextTransitionTargets(); err != nil {
 		t.Fatalf("empty workspace candidate validateNextTransitionTargets() = %v, want nil", err)
+	}
+}
+
+// The derived committed-range execute is the other admissible shape for the
+// zero-path workspace branch, so status-target validation must accept it while
+// still refusing every malformed variant of both forms.
+func TestNegotiatedDerivedCommittedRangeSatisfiesStatusTargetValidation(t *testing.T) {
+	result := emptyWorkspaceCandidateStatus()
+	result.derivedCommittedRange = derivedCommittedRangeStatus()
+	result.NextTransition = &ReviewNextTransition{}
+	*result.NextTransition = newReviewNextTransition(result, nil, nil, nil, reviewNextTransitionInput{StartLineage: "review-empty-candidate"})
+
+	if result.NextTransition.Kind != reviewNextTransitionExecute {
+		t.Fatalf("derived status transition kind = %q, want %q", result.NextTransition.Kind, reviewNextTransitionExecute)
+	}
+	if err := result.validateNextTransitionTargets(); err != nil {
+		t.Fatalf("derived committed-range validateNextTransitionTargets() = %v, want nil", err)
 	}
 }
 
@@ -158,6 +245,67 @@ func TestNegotiatedEmptyCandidateCollectionRejectsMalformedStatusTarget(t *testi
 	}
 }
 
+func TestNegotiatedDerivedCommittedRangeRejectsMalformedStatusTarget(t *testing.T) {
+	setArgument := func(transition *ReviewNextTransition, name, value string) {
+		for index := range transition.Execute.Arguments {
+			if transition.Execute.Arguments[index].Name == name {
+				transition.Execute.Arguments[index].Value = value
+				return
+			}
+		}
+		t.Fatalf("derived execute has no %q argument to mutate", name)
+	}
+	tests := []struct {
+		name   string
+		mutate func(*ReviewTargetStatusResult)
+	}{
+		{
+			name: "execute without the derived committed range",
+			mutate: func(result *ReviewTargetStatusResult) {
+				result.derivedCommittedRange = nil
+			},
+		},
+		{
+			name: "wrong base-ref",
+			mutate: func(result *ReviewTargetStatusResult) {
+				setArgument(result.NextTransition, "base-ref", strings.Repeat("2", 40))
+			},
+		},
+		{
+			name: "wrong target",
+			mutate: func(result *ReviewTargetStatusResult) {
+				setArgument(result.NextTransition, "target", "sha256:"+strings.Repeat("a", 64))
+			},
+		},
+		{
+			name: "dropped committed-only",
+			mutate: func(result *ReviewTargetStatusResult) {
+				setArgument(result.NextTransition, "committed-only", "false")
+			},
+		},
+		{
+			name: "wrong operation",
+			mutate: func(result *ReviewTargetStatusResult) {
+				result.NextTransition.Execute.Operation = "review.validate"
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := emptyWorkspaceCandidateStatus()
+			result.derivedCommittedRange = derivedCommittedRangeStatus()
+			result.NextTransition = &ReviewNextTransition{}
+			*result.NextTransition = newReviewNextTransition(result, nil, nil, nil, reviewNextTransitionInput{StartLineage: "review-empty-candidate"})
+			tt.mutate(&result)
+
+			if err := result.validateNextTransitionTargets(); err == nil {
+				t.Fatal("malformed derived committed-range transition passed status-target validation")
+			}
+		})
+	}
+}
+
 // Regression: a fresh candidate that really has changed paths keeps the
 // executable START it always returned.
 func TestNegotiatedStatusKeepsStartForNonEmptyWorkspaceCandidate(t *testing.T) {
@@ -199,5 +347,161 @@ func TestNegotiatedStatusStopsZeroPathBaseDiffCandidate(t *testing.T) {
 	status.NextTransition = &got
 	if err := status.validateNextTransitionTargets(); err != nil {
 		t.Fatalf("zero-path base-diff validateNextTransitionTargets() = %v, want nil", err)
+	}
+}
+
+// committedRangeReviewRepo builds a repository whose remote default branch
+// (origin/main) sits behind HEAD, so the selectorless workspace candidate is
+// empty while an unambiguous committed range exists above it.
+func committedRangeReviewRepo(t *testing.T) string {
+	t.Helper()
+	repo := initReviewCLIRepo(t)
+	origin := t.TempDir()
+	runReviewCLIGit(t, origin, "init", "--bare", "-q")
+	runReviewCLIGit(t, repo, "remote", "add", "origin", origin)
+	runReviewCLIGit(t, repo, "push", "-q", "origin", "HEAD:refs/heads/main")
+	runReviewCLIGit(t, repo, "fetch", "-q", "origin")
+	runReviewCLIGit(t, repo, "symbolic-ref", "refs/remotes/origin/HEAD", "refs/remotes/origin/main")
+	writeReviewStartCandidate(t, repo, "tracked.txt", "base\ncommitted\n", 0o644)
+	runReviewCLIGit(t, repo, "add", "tracked.txt")
+	runReviewCLIGit(t, repo, "commit", "-qm", "committed candidate")
+	return repo
+}
+
+// TestNegotiatedStatusDerivedCommittedRangePayloadValidatesAgainstPublishedSchema
+// is the execution-based proof that the real selectorless STATUS payload for a
+// committed-range candidate still validates against the published status-v7
+// schema, and that the emitted START discloses the derived merge-base commit and
+// committed-only=true.
+func TestNegotiatedStatusDerivedCommittedRangePayloadValidatesAgainstPublishedSchema(t *testing.T) {
+	reviewEnabledHome(t)
+	repo := committedRangeReviewRepo(t)
+	expectedBase := strings.TrimSpace(runReviewCLIGit(t, repo, "merge-base", "HEAD", "refs/remotes/origin/main"))
+
+	var output bytes.Buffer
+	if err := RunReview([]string{"status", "--cwd", repo, "--contract", ReviewIntegrationContractV2, "--agent", "claude-code", "--next-transition"}, &output); err != nil {
+		t.Fatalf("selectorless STATUS for a committed-range candidate: %v\n%s", err, output.String())
+	}
+	var status ReviewTargetStatusResult
+	decodeStrictReviewJSON(t, output.Bytes(), &status)
+	if status.Projection.Kind != reviewtransaction.TargetCurrentChanges || len(status.Projection.Paths) != 0 {
+		t.Fatalf("envelope projection = %#v, want the classified empty workspace candidate", status.Projection)
+	}
+	if status.NextTransition == nil || status.NextTransition.Kind != reviewNextTransitionExecute ||
+		status.NextTransition.ReasonCode != "fresh_target_ready" || status.NextTransition.Execute == nil {
+		t.Fatalf("next_transition = %#v, want an executable fresh_target_ready START", status.NextTransition)
+	}
+	arguments, err := reviewTransitionArgumentMap(status.NextTransition.Execute.Arguments, status.NextTransition.Execute.Operation)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if arguments["base-ref"] != expectedBase {
+		t.Fatalf("derived base-ref = %q, want the remote default branch merge-base %q", arguments["base-ref"], expectedBase)
+	}
+	if arguments["committed-only"] != "true" {
+		t.Fatalf("derived committed-only = %q, want true", arguments["committed-only"])
+	}
+	if arguments["base-ref"] == status.Projection.BaseTree {
+		t.Fatalf("derived base-ref=%q disclosed the tree object instead of the derived commit", arguments["base-ref"])
+	}
+	validatePublishedReviewSchema(t, compileWholeNativeStatusSchema(t, "status-v7.schema.json"), output.Bytes())
+}
+
+// crissCrossReviewRepo builds a repository with two merge commits that share
+// two merge bases, so `git merge-base --all HEAD origin/main` names more than
+// one candidate and the committed-range derivation must fall back.
+func crissCrossReviewRepo(t *testing.T) string {
+	t.Helper()
+	repo := initReviewCLIRepo(t)
+	base := strings.TrimSpace(runReviewCLIGit(t, repo, "rev-parse", "HEAD"))
+	runReviewCLIGit(t, repo, "checkout", "-q", "-b", "x")
+	writeReviewStartCandidate(t, repo, "x.txt", "x\n", 0o644)
+	runReviewCLIGit(t, repo, "add", "x.txt")
+	runReviewCLIGit(t, repo, "commit", "-qm", "x")
+	xCommit := strings.TrimSpace(runReviewCLIGit(t, repo, "rev-parse", "HEAD"))
+	runReviewCLIGit(t, repo, "checkout", "-q", "-b", "y", base)
+	writeReviewStartCandidate(t, repo, "y.txt", "y\n", 0o644)
+	runReviewCLIGit(t, repo, "add", "y.txt")
+	runReviewCLIGit(t, repo, "commit", "-qm", "y")
+	yCommit := strings.TrimSpace(runReviewCLIGit(t, repo, "rev-parse", "HEAD"))
+	runReviewCLIGit(t, repo, "checkout", "-q", "x")
+	runReviewCLIGit(t, repo, "merge", "-q", "--no-ff", "-m", "merge y into x", yCommit)
+	runReviewCLIGit(t, repo, "checkout", "-q", "y")
+	runReviewCLIGit(t, repo, "merge", "-q", "--no-ff", "-m", "merge x into y", xCommit)
+	origin := t.TempDir()
+	runReviewCLIGit(t, origin, "init", "--bare", "-q")
+	runReviewCLIGit(t, repo, "remote", "add", "origin", origin)
+	runReviewCLIGit(t, repo, "push", "-q", "origin", "y:refs/heads/main")
+	runReviewCLIGit(t, repo, "fetch", "-q", "origin")
+	runReviewCLIGit(t, repo, "symbolic-ref", "refs/remotes/origin/HEAD", "refs/remotes/origin/main")
+	runReviewCLIGit(t, repo, "checkout", "-q", "x")
+	if merges := strings.Fields(runReviewCLIGit(t, repo, "merge-base", "--all", "HEAD", "refs/remotes/origin/main")); len(merges) != 2 {
+		t.Fatalf("criss-cross fixture produced %d merge bases %q, want exactly two", len(merges), merges)
+	}
+	return repo
+}
+
+// TestNegotiatedStatusAmbiguousCommittedRangeFallsBackToCollect pins the
+// retained fallback for every ambiguous repository shape: the transition stays
+// today's external.select_base_ref collect, the envelope still validates, and no
+// executable START is offered.
+func TestNegotiatedStatusAmbiguousCommittedRangeFallsBackToCollect(t *testing.T) {
+	shapes := []struct {
+		name    string
+		arrange func(t *testing.T) string
+	}{
+		{
+			name: "no origin/HEAD",
+			arrange: func(t *testing.T) string {
+				return initReviewCLIRepo(t)
+			},
+		},
+		{
+			name: "empty committed range",
+			arrange: func(t *testing.T) string {
+				repo := initReviewCLIRepo(t)
+				origin := t.TempDir()
+				runReviewCLIGit(t, origin, "init", "--bare", "-q")
+				runReviewCLIGit(t, repo, "remote", "add", "origin", origin)
+				runReviewCLIGit(t, repo, "push", "-q", "origin", "HEAD:refs/heads/main")
+				runReviewCLIGit(t, repo, "fetch", "-q", "origin")
+				runReviewCLIGit(t, repo, "symbolic-ref", "refs/remotes/origin/HEAD", "refs/remotes/origin/main")
+				return repo
+			},
+		},
+		{
+			name: "origin/HEAD names a missing branch",
+			arrange: func(t *testing.T) string {
+				repo := initReviewCLIRepo(t)
+				runReviewCLIGit(t, repo, "remote", "add", "origin", t.TempDir())
+				runReviewCLIGit(t, repo, "symbolic-ref", "refs/remotes/origin/HEAD", "refs/remotes/origin/does-not-exist")
+				return repo
+			},
+		},
+		{
+			name:    "criss-cross merge bases",
+			arrange: crissCrossReviewRepo,
+		},
+	}
+
+	for _, shape := range shapes {
+		t.Run(shape.name, func(t *testing.T) {
+			reviewEnabledHome(t)
+			repo := shape.arrange(t)
+			var output bytes.Buffer
+			if err := RunReview([]string{"status", "--cwd", repo, "--contract", ReviewIntegrationContractV2, "--agent", "claude-code", "--next-transition"}, &output); err != nil {
+				t.Fatalf("selectorless STATUS for an ambiguous committed range: %v\n%s", err, output.String())
+			}
+			var status ReviewTargetStatusResult
+			decodeStrictReviewJSON(t, output.Bytes(), &status)
+			if status.NextTransition == nil || status.NextTransition.Kind != reviewNextTransitionCollect ||
+				status.NextTransition.ReasonCode != "empty_candidate_base_ref_required" {
+				t.Fatalf("ambiguous committed range transition = %#v, want the empty_candidate_base_ref_required collect", status.NextTransition)
+			}
+			if status.NextTransition.Execute != nil {
+				t.Fatalf("ambiguous committed range offered an executable START: %#v", status.NextTransition.Execute)
+			}
+			validatePublishedReviewSchema(t, compileWholeNativeStatusSchema(t, "status-v7.schema.json"), output.Bytes())
+		})
 	}
 }

--- a/internal/cli/review_status_contract.go
+++ b/internal/cli/review_status_contract.go
@@ -104,6 +104,21 @@ type ReviewTargetStatusResult struct {
 	repositoryRoot    string
 	rddMode           reviewtransaction.RDDModeStatus
 	rddModeResolved   bool
+	// derivedCommittedRange is the executable base-diff status a selectorless
+	// STATUS derived from the remote default branch's unique merge-base when
+	// the fresh workspace candidate froze zero paths (issue #4412). Its
+	// presence turns the otherwise-unroutable base_ref collect into the
+	// committed-range START the working `--base-ref --committed-only` STATUS
+	// path already publishes; validateNextTransitionTargets validates the
+	// emitted execute against this exact derived status.
+	derivedCommittedRange *ReviewTargetStatusResult
+	// committedRangeBaseRef, when non-empty, is the base *commit* STATUS
+	// derived for a set derivedCommittedRange. reviewStartArguments prefers it
+	// over Projection.BaseTree for a base-diff projection so the emitted START
+	// discloses the exact merge-base commit STATUS resolved (never the tree
+	// object the derived snapshot froze), letting the caller see and override
+	// the offered scope.
+	committedRangeBaseRef string
 }
 
 // ReviewActionEligibility remains an additive compatibility detail for older
@@ -785,6 +800,22 @@ func (result ReviewTargetStatusResult) validateNextTransitionTargets() error {
 		if result.Projection.Kind == reviewtransaction.TargetCurrentChanges && len(result.Projection.Paths) == 0 {
 			if result.NextTransition.Kind == reviewNextTransitionCollect && result.NextTransition.ReasonCode == "intended_untracked_selection_required" {
 				return result.validateIntendedUntrackedSelectionTransition()
+			}
+			// Issue #4412: when STATUS resolved the remote default branch's
+			// unique merge-base it offers the executable committed-range START
+			// the `--base-ref --committed-only` STATUS path already publishes,
+			// instead of the unroutable base_ref collect. Validating that
+			// execute against the exact derived base-diff status that produced
+			// it still refuses a hand-edited base-ref, target, evidence token,
+			// or committed-only flag.
+			if result.NextTransition.Kind == reviewNextTransitionExecute {
+				if result.derivedCommittedRange == nil {
+					// refusal:by-design world-action: only a provider code fix can render a committed-range execute without the derived base-diff status that proves its scope
+					return errors.New("fresh empty workspace target lacks a base-ref collection transition")
+				}
+				derived := *result.derivedCommittedRange
+				derived.NextTransition = result.NextTransition
+				return derived.validateStartNextTransition()
 			}
 			if result.NextTransition.Kind != reviewNextTransitionCollect || result.NextTransition.ReasonCode != "empty_candidate_base_ref_required" ||
 				result.NextTransition.Collect == nil || len(result.NextTransition.Collect.Inputs) != 1 {

--- a/internal/reviewtransaction/target_status.go
+++ b/internal/reviewtransaction/target_status.go
@@ -238,6 +238,56 @@ func selectorlessCommittedBaseDiffAncestors(ctx context.Context, repo string) ([
 	return ancestors, nil
 }
 
+// ResolveCommittedRangeBase returns the single merge-base commit between HEAD
+// and the remote default branch, but only when that committed range is
+// unambiguous (issue #4412). STATUS derives the committed-range START a
+// selectorless empty workspace candidate needs from exactly this base, so an
+// ambiguous repository must fall back to today's base_ref collect rather than
+// silently pick a scope the caller never named.
+//
+// The base is deliberately the remote default branch (refs/remotes/origin/HEAD)
+// and never the local branch upstream: for a fully pushed branch `@{upstream}`
+// names the last pushed commit, whose range is empty, which is precisely the
+// state that produces the zero-path candidate this derivation serves. Every
+// other outcome -- no origin/HEAD, a criss-cross history, an empty range, or any
+// Git fault -- is returned as an error so the caller keeps the truthful
+// fallback.
+func ResolveCommittedRangeBase(ctx context.Context, repo string) (string, error) {
+	refOutput, err := runGit(ctx, repo, nil, nil, "symbolic-ref", "--quiet", "refs/remotes/origin/HEAD")
+	if err != nil {
+		return "", err
+	}
+	ref := strings.TrimSpace(string(refOutput))
+	if ref == "" {
+		return "", fmt.Errorf("refs/remotes/origin/HEAD does not resolve to a remote branch") // refusal:by-design world-action: an absent remote default branch is not a decision a command can make unambiguous; the caller falls back to collecting a base_ref
+	}
+	head, err := resolveCommit(ctx, repo, "HEAD")
+	if err != nil {
+		return "", err
+	}
+	bases, err := runGit(ctx, repo, nil, nil, "merge-base", "--all", head, ref)
+	if err != nil {
+		return "", err
+	}
+	merges := strings.Fields(string(bases))
+	if len(merges) != 1 {
+		return "", fmt.Errorf("remote default branch history has %d merge bases", len(merges)) // refusal:by-design world-action: a criss-cross history has no single base to derive, so the caller falls back to collecting a base_ref
+	}
+	base := merges[0]
+	if base == head {
+		return "", fmt.Errorf("HEAD is the remote default branch merge-base") // refusal:by-design world-action: an empty committed range has no candidate to review, so the caller falls back to collecting a base_ref
+	}
+	countOutput, err := runGit(ctx, repo, nil, nil, "rev-list", "--count", base+".."+head)
+	if err != nil {
+		return "", err
+	}
+	count, err := strconv.Atoi(strings.TrimSpace(string(countOutput)))
+	if err != nil || count <= 0 {
+		return "", fmt.Errorf("committed range between the merge-base and HEAD is empty") // refusal:by-design world-action: an empty committed range has no candidate to review, so the caller falls back to collecting a base_ref
+	}
+	return base, nil
+}
+
 // selectorlessCommittedBaseDiffMatchedPredecessor finds the lineage's frozen
 // candidate tree among ancestors, stopping at its frozen base tree.
 func selectorlessCommittedBaseDiffMatchedPredecessor(ancestors []selectorlessCommittedBaseDiffAncestor, state CompactState) string {


### PR DESCRIPTION
Closes #4412

## Summary

- A selectorless negotiated STATUS on a clean, fully committed worktree froze zero paths and answered with an `empty_candidate_base_ref_required` collect whose `external.select_base_ref` input can never be submitted: `transition_input.submission` is a closed oneOf (correction-plan, targeted-validation, capture-result) and no operation accepts the selection. Retrying START with the collect's own target loops forever on `stale_target_identity`.
- STATUS now resolves the remote default branch's unique merge-base and re-publishes the executable committed-range START that the working `--base-ref <rev> --committed-only` route already produces, so the caller is never left guessing an operation the envelope never named.
- The emitted `--base-ref` is the resolved merge-base **commit**, not `Projection.BaseTree`, so the offered scope is disclosed instead of a tree object silently standing in for a base (see #3203 for the same hazard on the remediation path).
- The old collect stays the fallback, byte for byte, for every repository shape the derivation cannot resolve.

## Derivation rules

Base = `merge-base HEAD <refs/remotes/origin/HEAD>`, offered only when **exactly one** merge-base exists, `base != HEAD`, and `rev-list --count base..HEAD` is non-empty. Deliberately never `@{upstream}`: on a fully pushed branch that names the last pushed commit, whose range is empty — precisely the state that produces this stop. Any failure (no `origin/HEAD`, criss-cross history, empty range, git fault) keeps today's collect.

No published schema changed: an `execute` transition is already legal for this reason code under status v7, and a typed continuation would have required a new contract version.

## Review attention

`internal/cli/review_next_transition_empty_candidate_test.go` previously encoded the opposite policy (`TestNegotiatedEmptyCandidateCollectionDoesNotDeriveBaseRef`, from PR #2505/#2584: a collection must not pre-supply a base because that would silently choose the caller's review scope). That blanket prohibition is replaced by tests for the new policy: derive only when unambiguous, disclose the exact base commit in the emitted arguments, and fall back to the collect otherwise. This is the deliberate policy reversal in this PR.

## Files

| File | Change |
|------|--------|
| `internal/reviewtransaction/target_status.go` | `ResolveCommittedRangeBase` with the ambiguity guards |
| `internal/cli/review_facade.go` | `reviewDerivedCommittedRangeStatus`, gated to selectorless STATUS, reusing the existing snapshot/status/result computation |
| `internal/cli/review_next_transition.go` | Zero-path workspace branch emits the derived execute; `reviewStartArguments` discloses the base commit |
| `internal/cli/review_status_contract.go` | Validator accepts the derived execute and re-validates it against the derived status, so a hand-edited base-ref, target or evidence token is still refused |
| `internal/cli/review_next_transition_empty_candidate_test.go` | New policy tests plus ambiguity fallbacks |

## Test plan

- [x] `go build ./...`
- [x] `go test ./internal/cli/ -run 'EmptyCandidate|NextTransition|StatusContract|StartConvergence|ProviderArtifactContract|UnachievableLens|TransitionCommand' -count=1` — ok
- [x] `go test ./internal/reviewtransaction/ -run 'CommittedRange|TargetStatus|Snapshot' -count=1` — ok
- [x] Payload validated against `status-v7.schema.json`
- [x] Field-verified: selectorless STATUS went from `collect/empty_candidate_base_ref_required` to `execute/fresh_target_ready` with `--base-ref=<merge-base commit> --committed-only=true`, and a full review round through the Pi facade then completed (approved, lineage `review-76a8181dddcb43b1`)

Note: `go test ./internal/...` reports pre-existing local failures in this environment (`review store lock could not be acquired: not a directory`); they reproduce identically with this change stashed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Selectorless `review status` can now automatically start a review for an unambiguous committed range in a fresh workspace.
  * The review uses the resolved merge-base commit and committed-only mode for accurate base-diff comparisons.

* **Bug Fixes**
  * Avoids unnecessary base-reference selection when the committed range can be determined automatically.
  * Preserves the existing base-reference selection flow when the repository history is ambiguous, empty, unavailable, or cannot be resolved.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->