### PR TITLE
fix(pi): retire legacy prompt blocks across lifecycle

### DIFF
--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -880,10 +880,19 @@ func (s agentRoutingGuidanceStep) Run() error {
 		return fmt.Errorf("create adapter for %q: %w", s.agent, err)
 	}
 
-	// Pi (and any future agent without a managed system prompt) owns its own
-	// prompt delivery outside gentle-ai, so there is nothing to strip or
-	// inject here: skip the step entirely rather than writing routing
-	// guidance into a file gentle-ai does not own (issue #4063).
+	// Pi owns its prompt delivery, but old installs left only allowlisted
+	// Gentle AI sections in APPEND_SYSTEM.md. Retire those before skipping prompt
+	// injection so install and every sync path converge without recreating routing.
+	if adapter.Agent() == model.AgentPi {
+		result, err := sdd.RetirePiSystemPromptBlocks(s.homeDir, adapter)
+		if err != nil {
+			return fmt.Errorf("retire stale Pi system prompt blocks: %w", err)
+		}
+		if s.changedFiles != nil && result.Changed {
+			*s.changedFiles = append(*s.changedFiles, result.Files...)
+		}
+		return nil
+	}
 	if !adapter.SupportsSystemPrompt() {
 		return nil
 	}
@@ -1715,9 +1724,6 @@ func (s componentApplyStep) Run() error {
 						return fmt.Errorf("inject persona for %q: %w", adapter.Agent(), err)
 					}
 				}
-				if _, err := sdd.RetirePiSystemPromptBlocks(s.homeDir, adapter); err != nil {
-					return fmt.Errorf("retire stale Pi system prompt blocks: %w", err)
-				}
 				continue
 			}
 			targetDir := componentInjectionDirScoped(s.homeDir, s.workspaceDir, s.scope, adapter)
@@ -2220,6 +2226,11 @@ func backupTargets(homeDir, workspaceDir string, scope InstallScope, selection m
 		}
 	}
 	if containsAgent(resolved.Agents, model.AgentPi) {
+		for _, adapter := range adapters {
+			if adapter.Agent() == model.AgentPi {
+				paths[adapter.SystemPromptFile(homeDir)] = struct{}{}
+			}
+		}
 		for _, path := range communitytool.PiCodeGraphPaths(homeDir, workspaceDir) {
 			paths[path] = struct{}{}
 		}

--- a/internal/cli/run_component_paths_test.go
+++ b/internal/cli/run_component_paths_test.go
@@ -784,6 +784,16 @@ func TestRemoteAuthorizationLeavesPiPackagePromptUntouched(t *testing.T) {
 	}
 }
 
+func TestInstallRoutingCleanupRetiresPiPrompt(t *testing.T) {
+	home := t.TempDir()
+	path := systemPromptFileFor(t, home, model.AgentPi)
+	mustWriteFile(t, path, []byte("user\n<!-- gentle-ai:agent-routing -->\nstale\n<!-- /gentle-ai:agent-routing -->\n"))
+	runInstallInjectionSteps(t, newTestInstallRuntime(t, home, model.Selection{Agents: []model.AgentID{model.AgentPi}}))
+	if got := readTextFile(t, path); strings.Contains(got, "gentle-ai:agent-routing") || !strings.Contains(got, "user") {
+		t.Fatalf("install Pi cleanup = %q", got)
+	}
+}
+
 func TestInstallRemoteAuthorizationIndependentOfComponents(t *testing.T) {
 	for _, persona := range []model.PersonaID{"", model.PersonaCustom} {
 		t.Run(string(persona), func(t *testing.T) {
@@ -996,12 +1006,10 @@ func TestInstallRoutingGuidanceWorkspaceScopeDeliversOpenCodeToHome(t *testing.T
 	}
 }
 
-// TestAgentRoutingGuidanceStepSkipsAgentsWithoutSystemPrompt covers issue
-// #4063: Pi reports SupportsSystemPrompt()==false because gentle-pi owns its
-// system prompt, so the routing guidance step must leave Pi's
-// APPEND_SYSTEM.md untouched instead of writing an agent-routing block into a
-// file gentle-ai does not own.
-func TestAgentRoutingGuidanceStepSkipsAgentsWithoutSystemPrompt(t *testing.T) {
+// TestAgentRoutingGuidanceStepRetiresPiManagedBlocks covers issue #3508: Pi
+// owns APPEND_SYSTEM.md, so routing never injects a new block but does remove
+// the paired stale block an older gentle-ai release wrote.
+func TestAgentRoutingGuidanceStepRetiresPiManagedBlocks(t *testing.T) {
 	home := t.TempDir()
 	promptPath := systemPromptFileFor(t, home, model.AgentPi)
 	existing := "user text before\n" +
@@ -1024,8 +1032,8 @@ func TestAgentRoutingGuidanceStepSkipsAgentsWithoutSystemPrompt(t *testing.T) {
 	}
 
 	got := readTextFile(t, promptPath)
-	if got != existing {
-		t.Fatalf("agentRoutingGuidanceStep rewrote Pi's system prompt file, want a no-op:\ngot  = %q\nwant = %q", got, existing)
+	if strings.Contains(got, "gentle-ai:agent-routing") || !strings.Contains(got, "user text before") || !strings.Contains(got, "user text after") {
+		t.Fatalf("Pi routing cleanup = %q, want only user content", got)
 	}
 }
 
@@ -1061,9 +1069,8 @@ func TestRoutingGuidancePathsWorkspaceScopeReportOrchestratorPromptAgentsAtHome(
 }
 
 // TestRoutingGuidancePathsExcludesAgentsWithoutSystemPrompt covers issue
-// #4063: Pi's APPEND_SYSTEM.md must never be listed as a routing guidance
-// target, because the step that would write it is now a no-op for Pi and
-// declaring the path would only add a backup target nothing ever writes.
+// #4063: routing injection does not own Pi's APPEND_SYSTEM.md; cleanup backup
+// coverage is asserted separately.
 func TestRoutingGuidancePathsExcludesAgentsWithoutSystemPrompt(t *testing.T) {
 	home := t.TempDir()
 	adapters := resolveAdapters([]model.AgentID{model.AgentPi, model.AgentClaudeCode})
@@ -1132,6 +1139,18 @@ func TestBackupTargetsIncludeRoutingGuidancePathsWithoutAnyComponent(t *testing.
 		if !containsPath(targets, path) {
 			t.Fatalf("backupTargets missing routing guidance path %q\ntargets = %v", path, targets)
 		}
+	}
+}
+
+func TestBackupTargetsIncludePiPromptForRoutingCleanup(t *testing.T) {
+	home := t.TempDir()
+	selection := model.Selection{Agents: []model.AgentID{model.AgentPi}}
+	targets, err := backupTargets(home, "", ScopeGlobal, selection, planner.ResolvedPlan{Agents: selection.Agents})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if want := systemPromptFileFor(t, home, model.AgentPi); !containsPath(targets, want) {
+		t.Fatalf("backup targets = %v, missing Pi cleanup path %q", targets, want)
 	}
 }
 

--- a/internal/cli/sync.go
+++ b/internal/cli/sync.go
@@ -686,6 +686,11 @@ func syncBackupTargets(homeDir, workspaceDir string, selection model.Selection, 
 	for _, path := range routingGuidancePaths(homeDir, workspaceDir, ScopeGlobal, adapters) {
 		paths[path] = struct{}{}
 	}
+	for _, adapter := range adapters {
+		if adapter.Agent() == model.AgentPi {
+			paths[adapter.SystemPromptFile(homeDir)] = struct{}{}
+		}
+	}
 	if configDir := openCodeTelemetryConfigDir(homeDir, workspaceDir, ScopeGlobal, selection.Agents); configDir != "" {
 		for _, path := range telemetryruntime.ManagedPaths(configDir) {
 			paths[path] = struct{}{}
@@ -1212,11 +1217,6 @@ func (s componentSyncStep) Run() error {
 					return fmt.Errorf("sync persona for %q: %w", adapter.Agent(), err)
 				}
 				s.countChanged(boolToInt(res.Changed), res.Files...)
-				retireRes, err := sdd.RetirePiSystemPromptBlocks(s.homeDir, adapter)
-				if err != nil {
-					return fmt.Errorf("retire stale Pi system prompt blocks: %w", err)
-				}
-				s.countChanged(boolToInt(retireRes.Changed), retireRes.Files...)
 				continue
 			}
 			targetDir := componentInjectionDir(s.homeDir, s.workspaceDir, adapter)

--- a/internal/cli/sync_test.go
+++ b/internal/cli/sync_test.go
@@ -855,6 +855,7 @@ func TestSyncPersonaPathsAndBackupTargetsTrackOnlyPiWorkspaceConfig(t *testing.T
 	adapters := resolveAdapters(selection.Agents)
 	want := filepath.Join(workspace, ".pi", "gentle-ai", "persona.json")
 	unwanted := filepath.Join(home, ".pi", "gentle-ai", "persona.json")
+	prompt := systemPromptFileFor(t, home, model.AgentPi)
 
 	paths := syncPersonaPathsWithWorkspace(home, workspace, selection, adapters)
 	if !containsPath(paths, want) || containsPath(paths, unwanted) {
@@ -864,13 +865,41 @@ func TestSyncPersonaPathsAndBackupTargetsTrackOnlyPiWorkspaceConfig(t *testing.T
 	if err != nil {
 		t.Fatalf("syncBackupTargets() error = %v", err)
 	}
-	if !containsPath(targets, want) || containsPath(targets, unwanted) {
-		t.Fatalf("sync backup targets = %v, want only workspace Pi config %q", targets, want)
+	if !containsPath(targets, want) || !containsPath(targets, prompt) || containsPath(targets, unwanted) {
+		t.Fatalf("sync backup targets = %v, want workspace Pi config %q and cleanup path %q", targets, want, prompt)
 	}
 
 	selection.Persona = model.PersonaCustom
 	if paths := syncPersonaPathsWithWorkspace(home, workspace, selection, adapters); len(paths) != 0 {
 		t.Fatalf("custom sync persona paths = %v, want none", paths)
+	}
+}
+
+func TestSyncRoutingCleanupReportsPiPromptForNormalAndExplicitSync(t *testing.T) {
+	for _, components := range [][]model.ComponentID{nil, {model.ComponentPersona}} {
+		home := t.TempDir()
+		path := systemPromptFileFor(t, home, model.AgentPi)
+		mustWriteFile(t, path, []byte("user\n<!-- gentle-ai:agent-routing -->\nstale\n<!-- /gentle-ai:agent-routing -->\n"))
+		changed := runSyncInjectionSteps(t, home, model.Selection{Agents: []model.AgentID{model.AgentPi}, Components: components, Persona: model.PersonaNeutral})
+		if !containsPath(changed, path) || strings.Contains(readTextFile(t, path), "gentle-ai:agent-routing") {
+			t.Fatalf("sync components %v changed=%v prompt=%q", components, changed, path)
+		}
+	}
+}
+
+func TestRunSyncExplicitPiRetiresStaleRoutingAndReportsIt(t *testing.T) {
+	home := t.TempDir()
+	previous := osUserHomeDir
+	osUserHomeDir = func() (string, error) { return home, nil }
+	t.Cleanup(func() { osUserHomeDir = previous })
+	path := systemPromptFileFor(t, home, model.AgentPi)
+	mustWriteFile(t, path, []byte("user\n<!-- gentle-ai:agent-routing -->\nstale\n<!-- /gentle-ai:agent-routing -->\n"))
+	result, err := RunSync([]string{"--agent", "pi"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !containsPath(result.ChangedFiles, path) || strings.Contains(readTextFile(t, path), "gentle-ai:agent-routing") {
+		t.Fatalf("explicit sync changed=%v prompt=%q", result.ChangedFiles, path)
 	}
 }
 
@@ -5230,11 +5259,9 @@ func TestRunSyncWithSelectionPiRetiresStaleSystemPromptBlocks(t *testing.T) {
 		t.Fatalf("RunSyncWithSelection() error = %v", err)
 	}
 
-	// Routing guidance is scheduled per agent too, but the step is a no-op for
-	// Pi (issue #4063: gentle-pi owns the Pi system prompt), so nothing writes
-	// an agent-routing block back into the file. Only the leading and trailing
-	// user content must survive, byte-exact.
-	want := "user text before\n\nuser text after\n"
+	// Routing cleanup removes only paired markers; Pi still never receives a
+	// newly injected agent-routing block.
+	want := "user text before\n\n\n\n\n\nuser text after\n"
 	got := readTextFile(t, appendSystemPath)
 	if got != want {
 		t.Fatalf("APPEND_SYSTEM.md = %q, want %q", got, want)
@@ -5277,7 +5304,7 @@ func TestRunSyncWithSelectionPiRoutingGuidanceIsNotRewritten(t *testing.T) {
 	if strings.Contains(got, "gentle-ai:agent-routing") {
 		t.Fatalf("APPEND_SYSTEM.md still carries an agent-routing block: %q", got)
 	}
-	want := "user text before\n\nuser text after\n"
+	want := "user text before\n\n\n\nuser text after\n"
 	if got != want {
 		t.Fatalf("APPEND_SYSTEM.md = %q, want %q", got, want)
 	}
@@ -5306,8 +5333,8 @@ func TestRunSyncWithSelectionPiRetirementDoesNotTouchOtherAgents(t *testing.T) {
 		t.Fatalf("RunSyncWithSelection() error = %v", err)
 	}
 
-	if got := readTextFile(t, appendSystemPath); strings.Contains(got, "sdd-orchestrator") {
-		t.Fatalf("Pi APPEND_SYSTEM.md still carries a stale block: %q", got)
+	if _, err := os.Lstat(appendSystemPath); !os.IsNotExist(err) {
+		t.Fatalf("Pi APPEND_SYSTEM.md remains after owned-only cleanup: %v", err)
 	}
 	if got := readTextFile(t, claudePath); !strings.Contains(got, "KEEP-CLAUDE-SDD") {
 		t.Fatalf("Claude system prompt lost unrelated content: %q", got)

--- a/internal/components/sdd/inject.go
+++ b/internal/components/sdd/inject.go
@@ -2924,64 +2924,74 @@ func stripBareOrchestratorForFilePrompt(content string) string {
 	return result
 }
 
-// legacyPiSystemPromptSectionIDs lists every gentle-ai:-marked section that a
-// Pi install made before the capability manifest started reporting
-// SupportsSystemPrompt()==false for Pi (see 965187e6) could have left behind
-// in the Pi adapter's SystemPromptFile. Nothing manages this file anymore, so
-// none of these blocks self-heal on install/sync/uninstall. The
-// "codegraph-guidance" entry mirrors communitytool.codeGraphGuidanceSectionID,
-// which is unexported; agentguidance.RoutingSectionID covers the routing
-// guidance block a defect once wrote here instead of skipping Pi (#4063).
+// legacyPiSystemPromptSectionIDs are the only marker pairs this cleanup owns.
+// Pi's package owns APPEND_SYSTEM.md, so unmarked and non-allowlisted content
+// must never be interpreted as Gentle AI content.
 var legacyPiSystemPromptSectionIDs = []string{
-	"sdd-orchestrator",
-	"strict-tdd-mode",
-	"persona",
-	"codegraph-guidance",
-	agentguidance.RoutingSectionID,
+	"persona", "engram-protocol", "sdd-orchestrator", "strict-tdd-mode",
+	"agent-routing", "trigger-rules", "codegraph-guidance",
 }
 
-// RetirePiSystemPromptBlocks removes any gentle-ai managed markdown sections
-// (and a bare legacy SDD orchestrator block) that an older gentle-ai build
-// wrote into the Pi adapter's SystemPromptFile. gentle-pi owns the Pi system
-// prompt, so this file should carry no gentle-ai content going forward.
-//
-// It is safe to call unconditionally: a missing file is a no-op, and repeated
-// calls are idempotent. Content outside the managed markers is preserved
-// byte-for-byte. If nothing but whitespace remains after stripping, the file
-// is rewritten with that whitespace-only remainder rather than deleted: a
-// whitespace-only file is harmless (Pi appends nothing), the rewrite is
-// recoverable and consistent with every other managed-section rewrite, and
-// only the uninstall call site registers a backup target for this file.
-//
-// Only ever call this with the Pi adapter. Unlike the SupportsSystemPrompt()
-// gated helpers elsewhere in this package, it strips these sections
-// unconditionally regardless of what the adapter reports.
+// RetirePiSystemPromptBlocks removes only complete legacy managed sections from
+// Pi's APPEND_SYSTEM.md. It refuses a direct file symlink but permits symlinked
+// parent directories, preserving regular-file mode and every unowned byte.
 func RetirePiSystemPromptBlocks(homeDir string, adapter agents.Adapter) (InjectionResult, error) {
 	promptPath := adapter.SystemPromptFile(homeDir)
-
-	existing, err := readFileOrEmpty(promptPath)
-	if err != nil {
-		return InjectionResult{}, err
-	}
-
-	updated := existing
-	if hasLegacyBareOrchestrator(updated) {
-		updated = stripBareOrchestratorForFilePrompt(updated)
-	}
-	for _, sectionID := range legacyPiSystemPromptSectionIDs {
-		updated = filemerge.InjectMarkdownSection(updated, sectionID, "")
-	}
-
-	if updated == existing {
+	info, err := os.Lstat(promptPath)
+	if os.IsNotExist(err) {
 		return InjectionResult{}, nil
 	}
+	if err != nil {
+		return InjectionResult{}, fmt.Errorf("stat Pi system prompt %q: %w", promptPath, err)
+	}
+	if info.Mode()&os.ModeSymlink != 0 || !info.Mode().IsRegular() {
+		return InjectionResult{}, fmt.Errorf("Pi system prompt %q is not a regular file", promptPath)
+	}
 
-	writeResult, err := filemerge.WriteFileAtomic(promptPath, []byte(updated), 0o644)
+	existing, err := os.ReadFile(promptPath)
+	if err != nil {
+		return InjectionResult{}, fmt.Errorf("read Pi system prompt %q: %w", promptPath, err)
+	}
+	updated, removed := removePiManagedSections(string(existing))
+	if !removed {
+		return InjectionResult{}, nil
+	}
+	if strings.TrimSpace(updated) == "" {
+		if err := os.Remove(promptPath); err != nil {
+			return InjectionResult{}, fmt.Errorf("remove empty Pi system prompt %q: %w", promptPath, err)
+		}
+		return InjectionResult{Changed: true, Files: []string{promptPath}}, nil
+	}
+	writeResult, err := filemerge.WriteFileAtomic(promptPath, []byte(updated), info.Mode().Perm())
 	if err != nil {
 		return InjectionResult{}, err
 	}
-
 	return InjectionResult{Changed: writeResult.Changed, Files: []string{promptPath}}, nil
+}
+
+func removePiManagedSections(content string) (string, bool) {
+	removed := false
+	for _, sectionID := range legacyPiSystemPromptSectionIDs {
+		open := "<!-- gentle-ai:" + sectionID + " -->"
+		close := "<!-- /gentle-ai:" + sectionID + " -->"
+		for search := 0; ; {
+			start := strings.Index(content[search:], open)
+			if start < 0 {
+				break
+			}
+			start += search
+			end := strings.Index(content[start+len(open):], close)
+			if end < 0 {
+				search = start + len(open)
+				continue
+			}
+			end += start + len(open) + len(close)
+			content = content[:start] + content[end:]
+			removed = true
+			search = start
+		}
+	}
+	return content, removed
 }
 
 const instructionsFrontmatter = "---\n" +

--- a/internal/components/sdd/inject_pi_cleanup_test.go
+++ b/internal/components/sdd/inject_pi_cleanup_test.go
@@ -55,17 +55,12 @@ func TestRetirePiSystemPromptBlocksStripsManagedSectionsAndPreservesUserContent(
 	if err != nil {
 		t.Fatalf("ReadFile: %v", err)
 	}
-	want := "user text before\n\nuser text after\n"
+	want := "user text before\n\n\n\n\n\n\n\n\n\nuser text after\n"
 	if string(got) != want {
 		t.Fatalf("APPEND_SYSTEM.md content = %q, want %q", string(got), want)
 	}
 }
 
-// TestRetirePiSystemPromptBlocksStripsAgentRoutingBlock covers issue #4063:
-// an older build could have written a gentle-ai:agent-routing block into
-// Pi's APPEND_SYSTEM.md before the routing step learned to skip agents that
-// do not support a managed system prompt. This block is retired the same way
-// as the other legacy sections.
 func TestRetirePiSystemPromptBlocksStripsAgentRoutingBlock(t *testing.T) {
 	home := t.TempDir()
 	adapter := pi.NewAdapter()
@@ -98,22 +93,17 @@ func TestRetirePiSystemPromptBlocksStripsAgentRoutingBlock(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ReadFile: %v", err)
 	}
-	want := "user text before\n\nuser text after\n"
+	want := "user text before\n\n\n\nuser text after\n"
 	if string(got) != want {
 		t.Fatalf("APPEND_SYSTEM.md content = %q, want %q", string(got), want)
 	}
 }
 
-func TestRetirePiSystemPromptBlocksKeepsWhitespaceOnlyFile(t *testing.T) {
+func TestRetirePiSystemPromptBlocksDeletesOwnedEmptyFile(t *testing.T) {
 	home := t.TempDir()
 	adapter := pi.NewAdapter()
 	promptPath := adapter.SystemPromptFile(home)
-
-	fixture := "   \n" +
-		"<!-- gentle-ai:persona -->\n" +
-		"persona body\n" +
-		"<!-- /gentle-ai:persona -->\n"
-
+	fixture := "   \n<!-- gentle-ai:persona -->\npersona body\n<!-- /gentle-ai:persona -->\n"
 	if err := os.MkdirAll(filepath.Dir(promptPath), 0o755); err != nil {
 		t.Fatalf("MkdirAll: %v", err)
 	}
@@ -122,20 +112,11 @@ func TestRetirePiSystemPromptBlocksKeepsWhitespaceOnlyFile(t *testing.T) {
 	}
 
 	result, err := RetirePiSystemPromptBlocks(home, adapter)
-	if err != nil {
-		t.Fatalf("RetirePiSystemPromptBlocks() error = %v", err)
+	if err != nil || !result.Changed {
+		t.Fatalf("RetirePiSystemPromptBlocks() = %#v, %v", result, err)
 	}
-	if !result.Changed {
-		t.Fatal("RetirePiSystemPromptBlocks() Changed = false, want true")
-	}
-
-	got, err := os.ReadFile(promptPath)
-	if err != nil {
-		t.Fatalf("APPEND_SYSTEM.md was removed after whitespace-only cleanup, want it kept: %v", err)
-	}
-	want := "   \n"
-	if string(got) != want {
-		t.Fatalf("APPEND_SYSTEM.md content = %q, want %q", string(got), want)
+	if _, err := os.Lstat(promptPath); !os.IsNotExist(err) {
+		t.Fatalf("APPEND_SYSTEM.md remains after owned-only cleanup: %v", err)
 	}
 }
 
@@ -143,16 +124,12 @@ func TestRetirePiSystemPromptBlocksMissingFileIsNoop(t *testing.T) {
 	home := t.TempDir()
 	adapter := pi.NewAdapter()
 	promptPath := adapter.SystemPromptFile(home)
-
 	result, err := RetirePiSystemPromptBlocks(home, adapter)
-	if err != nil {
-		t.Fatalf("RetirePiSystemPromptBlocks() error = %v", err)
-	}
-	if result.Changed {
-		t.Fatal("RetirePiSystemPromptBlocks() Changed = true, want false for missing file")
+	if err != nil || result.Changed {
+		t.Fatalf("RetirePiSystemPromptBlocks() = %#v, %v", result, err)
 	}
 	if _, err := os.Stat(promptPath); !os.IsNotExist(err) {
-		t.Fatalf("RetirePiSystemPromptBlocks() created a file that did not exist before, stat err = %v", err)
+		t.Fatalf("RetirePiSystemPromptBlocks() created a file: %v", err)
 	}
 }
 
@@ -160,41 +137,94 @@ func TestRetirePiSystemPromptBlocksSecondRunIsNoop(t *testing.T) {
 	home := t.TempDir()
 	adapter := pi.NewAdapter()
 	promptPath := adapter.SystemPromptFile(home)
-
-	fixture := "user text\n" +
-		"\n" +
-		"<!-- gentle-ai:sdd-orchestrator -->\n" +
-		"SDD body\n" +
-		"<!-- /gentle-ai:sdd-orchestrator -->\n"
-
+	fixture := "user text\n<!-- gentle-ai:sdd-orchestrator -->\nSDD body\n<!-- /gentle-ai:sdd-orchestrator -->\n"
 	if err := os.MkdirAll(filepath.Dir(promptPath), 0o755); err != nil {
-		t.Fatalf("MkdirAll: %v", err)
+		t.Fatal(err)
 	}
 	if err := os.WriteFile(promptPath, []byte(fixture), 0o644); err != nil {
-		t.Fatalf("WriteFile: %v", err)
+		t.Fatal(err)
 	}
-
 	if _, err := RetirePiSystemPromptBlocks(home, adapter); err != nil {
-		t.Fatalf("first RetirePiSystemPromptBlocks() error = %v", err)
+		t.Fatal(err)
 	}
 	cleaned, err := os.ReadFile(promptPath)
 	if err != nil {
-		t.Fatalf("ReadFile after first run: %v", err)
+		t.Fatal(err)
 	}
-
 	second, err := RetirePiSystemPromptBlocks(home, adapter)
-	if err != nil {
-		t.Fatalf("second RetirePiSystemPromptBlocks() error = %v", err)
+	if err != nil || second.Changed {
+		t.Fatalf("second cleanup = %#v, %v", second, err)
 	}
-	if second.Changed {
-		t.Fatal("second RetirePiSystemPromptBlocks() Changed = true, want false (idempotent)")
+	got, err := os.ReadFile(promptPath)
+	if err != nil || string(got) != string(cleaned) {
+		t.Fatalf("second run mutated file: %q, %v", got, err)
+	}
+}
+
+func TestRetirePiSystemPromptBlocksSafeguards(t *testing.T) {
+	home := t.TempDir()
+	adapter := pi.NewAdapter()
+	path := adapter.SystemPromptFile(home)
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte("user\r\n<!-- gentle-ai:persona -->\r\nmanaged\r\n<!-- /gentle-ai:persona -->\r\ntail"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := RetirePiSystemPromptBlocks(home, adapter); err != nil {
+		t.Fatal(err)
+	}
+	if got, _ := os.ReadFile(path); string(got) != "user\r\n\r\ntail" {
+		t.Fatalf("unowned bytes changed: %q", got)
+	}
+	if info, _ := os.Stat(path); info.Mode().Perm() != 0o600 {
+		t.Fatalf("mode = %v, want 0600", info.Mode())
+	}
+	if err := os.WriteFile(path, []byte("<!-- gentle-ai:persona -->\nunpaired"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if result, err := RetirePiSystemPromptBlocks(home, adapter); err != nil || result.Changed {
+		t.Fatalf("unpaired cleanup = %#v, %v", result, err)
 	}
 
-	got, err := os.ReadFile(promptPath)
-	if err != nil {
-		t.Fatalf("ReadFile after second run: %v", err)
+	target := filepath.Join(home, "target")
+	if err := os.WriteFile(target, []byte("keep"), 0o600); err != nil {
+		t.Fatal(err)
 	}
-	if string(got) != string(cleaned) {
-		t.Fatalf("second run mutated file: got %q, want %q", string(got), string(cleaned))
+	if err := os.Remove(path); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(target, path); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := RetirePiSystemPromptBlocks(home, adapter); err == nil {
+		t.Fatal("direct symlink accepted")
+	}
+	if link, err := os.Readlink(path); err != nil || link != target {
+		t.Fatalf("direct symlink changed: %q, %v", link, err)
+	}
+	if got, _ := os.ReadFile(target); string(got) != "keep" {
+		t.Fatalf("direct symlink target changed: %q", got)
+	}
+
+	linkedHome, parent := t.TempDir(), filepath.Join(t.TempDir(), "agent")
+	if err := os.MkdirAll(parent, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(linkedHome, ".pi"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(parent, filepath.Join(linkedHome, ".pi", "agent")); err != nil {
+		t.Fatal(err)
+	}
+	linkedPath := filepath.Join(linkedHome, ".pi", "agent", "APPEND_SYSTEM.md")
+	if err := os.WriteFile(linkedPath, []byte("<!-- gentle-ai:persona -->\nmanaged\n<!-- /gentle-ai:persona -->\nuser"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := RetirePiSystemPromptBlocks(linkedHome, adapter); err != nil {
+		t.Fatal(err)
+	}
+	if got, _ := os.ReadFile(linkedPath); string(got) != "\nuser" {
+		t.Fatalf("linked parent cleanup = %q", got)
 	}
 }

--- a/internal/components/uninstall/service_test.go
+++ b/internal/components/uninstall/service_test.go
@@ -453,7 +453,7 @@ func TestExecutePlanRetiresStalePiSystemPromptBlocks(t *testing.T) {
 	}
 
 	got := string(mustReadServiceFile(t, promptPath))
-	want := "user text\n"
+	want := "user text\n\n\n"
 	if got != want {
 		t.Fatalf("APPEND_SYSTEM.md = %q, want %q", got, want)
 	}


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #3508

## 🏷️ PR Type

- [x] `type:bug` — Bug fix (non-breaking change that fixes an issue)

## 📝 Summary

Retire the allowlisted legacy Gentle AI sections from Pi's `APPEND_SYSTEM.md` through one cleanup owner shared by install, normal sync, explicit Pi sync, and uninstall. The migration preserves user bytes and file mode, refuses direct file symlinks, supports symlinked parent directories, deletes only an owned-section cleanup that leaves whitespace, and never recreates `agent-routing`.

This supersedes the broader implementation approach in #3515 with the paired-marker-only ownership boundary approved in #3508.

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/components/sdd` | Added byte-preserving paired-marker Pi cleanup and focused safety coverage. |
| `internal/cli` | Routed install and both sync paths through the shared cleanup and included the target in backup planning. |
| `internal/components/uninstall` | Preserved uninstall integration and reporting coverage. |

## 🧪 Test Plan

**Unit Tests**
```bash
go test ./... -count=1
```

**Go Format**
```bash
go run ./internal/gofmtcheck
```

**E2E Tests**
```bash
cd e2e && ./docker-test.sh
```

- [x] Unit tests pass (`go test ./... -count=1`)
- [x] Go format passes (`go run ./internal/gofmtcheck`)
- [x] E2E tests pass (`cd e2e && ./docker-test.sh` — Ubuntu, Arch, Fedora 3/3)
- [x] Manually verified lifecycle and symlink behavior through focused tests

## ✅ Contributor Checklist

- [x] PR is linked to an issue with `status:approved`
- [x] PR stays within 400 changed lines (363)
- [x] API read-back confirms exactly one appropriate `type:*` label on this PR
- [x] Unit tests pass (`go test ./... -count=1`)
- [x] E2E tests pass (`cd e2e && ./docker-test.sh`)
- [x] Documentation is unchanged because this is a migration invariant
- [x] Commit follows Conventional Commits format
- [x] Commit contains no `Co-Authored-By` trailer


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Pi routing synchronization now removes stale managed routing and trigger sections from the system prompt.
  * Changes are reported correctly for both regular and explicitly targeted Pi syncs.
  * Prompt files containing only retired managed content are removed.
  * Cleanup preserves file permissions and safely handles unsupported file types and line endings.

* **Reliability**
  * Pi system prompts are now included in backups, allowing cleanup changes to be rolled back.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->