### PR TITLE
fix(sdd): make research persistence orchestrator-owned

### DIFF
--- a/internal/assets/claude/agents/sdd-research.md
+++ b/internal/assets/claude/agents/sdd-research.md
@@ -18,4 +18,4 @@ Do not read or mutate repository or Engram state. Do not load local skills, call
 
 Collect only source-backed claims mapped to source IDs. Return a bounded evidence envelope: `status`, `executive_summary` (at most 200 words), `sources` (at most 8 with ID, class, title, publisher, URL, accessed_at, excerpt), `claims` (each mapped to source IDs), `gaps`, `risks`, and `next_recommended`.
 
-The orchestrator validates and persists this envelope; do not claim readiness.
+The orchestrator validates and persists this envelope through the selected store route. Do not claim readiness.

--- a/internal/assets/opencode/commands/sdd-research.md
+++ b/internal/assets/opencode/commands/sdd-research.md
@@ -9,6 +9,6 @@ You are the `gentle-orchestrator`, not the executor. This command may launch the
 2. `sdd-init` and a selected research request must exist.
 3. Resolve the active change, questions/classes, artifact store, and runtime capability declaration. Never guess or hardcode Engram.
 
-Launch research with `$ARGUMENTS`. Preserve intent before source access. Denial, partial evidence, failed persistence, or hybrid mismatch blocks proposal readiness.
+Launch the output-only collector with `$ARGUMENTS`. Preserve intent before source access. The orchestrator validates and persists the returned evidence through the selected store route; denial, partial evidence, failed persistence, or hybrid mismatch blocks proposal readiness.
 
-Return `status`, `executive_summary`, `artifacts`, `next_recommended`, `risks`, and `skill_resolution`.
+Return `status`, `executive_summary`, `sources`, `claims`, `next_recommended`, `risks`, and `skill_resolution`.

--- a/internal/assets/skills/_shared/persistence-contract.md
+++ b/internal/assets/skills/_shared/persistence-contract.md
@@ -53,7 +53,7 @@ Token cost warning: hybrid consumes MORE tokens per operation. Use only when you
 
 ### Research reconciliation
 
-For selected research, readiness follows the selected artifact-store mode: `openspec` validates only OpenSpec; `engram` validates only Engram; `hybrid` writes and reads both stores with identical revision and bytes; `none` cannot make selected research ready.
+The orchestrator validates the returned collector envelope and persists it through the selected store route. For selected research, readiness follows the selected artifact-store mode: `openspec` validates only OpenSpec; `engram` validates only Engram; `hybrid` writes and reads both stores with identical revision and bytes; `none` cannot make selected research ready.
 
 For hybrid `gentle-ai.sdd-preproposal/v1`, retain pre-write intent and canonical desired content before any write. On one-sided failure, never derive content from either surviving store: use the retained values to write a new positive revision to both stores, then read and compare both before readiness. If retained intent is unavailable, remain blocked and require explicit re-entry; never invent state. A matching restart restores the request and evidence references.
 
@@ -104,13 +104,15 @@ Sub-agents launch with a fresh context and NO access to the orchestrator's instr
 
 Who reads, who writes:
 - Non-SDD (general task): orchestrator searches engram, passes summary in prompt; sub-agent saves discoveries via `mem_save`
-- SDD (phase with dependencies): sub-agent reads artifacts directly from backend; sub-agent saves its artifact
-- SDD (phase without dependencies, e.g. explore): nobody reads; sub-agent saves its artifact
+- SDD (artifact-producing phase with dependencies): sub-agent reads artifacts directly from backend; sub-agent saves its artifact
+- SDD (artifact-producing phase without dependencies, e.g. explore): nobody reads; sub-agent saves its artifact
+- SDD research collector: child reads no local artifacts or Engram state and saves nothing; it returns evidence for the orchestrator to validate and persist through the selected store route
 
 Why this split:
 - Orchestrator reads for non-SDD: it knows what context is relevant; sub-agents doing their own searches waste tokens on irrelevant results
 - Sub-agents read for SDD: SDD artifacts are large; inlining them in the orchestrator prompt would consume the entire context window
-- Sub-agents always write: they have the complete detail on what happened; nuance is lost by the time results flow back to the orchestrator
+- Artifact-producing SDD sub-agents write: they have the complete detail on what happened; nuance is lost by the time results flow back to the orchestrator
+- The output-only SDD research collector returns evidence without persistence so the orchestrator can apply the selected-store and hybrid-readiness gate
 
 ## Orchestrator Prompt Instructions for Sub-Agents
 
@@ -123,7 +125,7 @@ If you make important discoveries, decisions, or fix bugs, you MUST save them to
 Do NOT return without saving what you learned. This is how the team builds persistent knowledge across sessions.
 ```
 
-SDD (with dependencies):
+SDD (artifact-producing phase with dependencies):
 ```
 Artifact store mode: {engram|openspec|hybrid|none}
 Read these artifacts before starting (search returns truncated previews):
@@ -143,7 +145,7 @@ After completing your work, you MUST call:
 If you return without calling mem_save, the next phase CANNOT find your artifact and the pipeline BREAKS.
 ```
 
-SDD (no dependencies):
+SDD (artifact-producing phase with no dependencies):
 ```
 Artifact store mode: {engram|openspec|hybrid|none}
 

--- a/internal/assets/skills/_shared/research-lifecycle.md
+++ b/internal/assets/skills/_shared/research-lifecycle.md
@@ -1,6 +1,6 @@
 # SDD Research Lifecycle Contract
 
-Research is optional until selected. Selection makes this fail-closed contract mandatory; research produces evidence, while the orchestrator owns product decisions and proposal admission.
+Research is optional until selected. Selection makes this fail-closed contract mandatory; the output-only research collector produces evidence, while the orchestrator validates and persists its returned envelope through the selected store route, owns product decisions, and admits proposals.
 
 ## Evidence artifact
 

--- a/internal/assets/skills/_shared/sdd-phase-common.md
+++ b/internal/assets/skills/_shared/sdd-phase-common.md
@@ -18,6 +18,8 @@ NOTE: the preferred path is (1) — exact skill paths selected by the orchestrat
 
 ## B. Artifact Retrieval
 
+**`sdd-research` collector exception:** this output-only collector does not read local artifacts, repository state, or Engram state, and does not use artifact locators. It returns its evidence envelope to the orchestrator, which validates and persists it through the selected store route. Sections B and C do not apply to `sdd-research`; every other phase follows them unchanged.
+
 The orchestrator injects the artifact store and the locators native status already resolved (`artifactStore` and `artifactPaths` from `gentle-ai sdd-status --json --instructions`). Read what you are given.
 
 **Do NOT detect the artifact store, and do NOT branch on it.** The dispatcher resolved it from the store the workspace DECLARES. An agent that re-derives the store disagrees with the authority that launched it, which is exactly how a phase ends up reading a store the workspace never declared — or reading nothing at all and returning an empty result.
@@ -38,7 +40,7 @@ A required locator reported as `<unresolved>` means the artifact does not exist.
 
 ## C. Artifact Persistence
 
-Every phase that produces an artifact MUST persist it. Skipping this BREAKS the pipeline — downstream phases will not find your output.
+Every artifact-producing phase other than the output-only `sdd-research` collector MUST persist it. Skipping this BREAKS the pipeline — downstream phases will not find your output.
 
 Persist to the store the orchestrator reported, using that artifact's locator. As in section B, the store is told to you; do not detect it. The write mechanisms below differ because writing a file and saving an observation are genuinely different operations, not because the agent gets to choose between them.
 

--- a/internal/assets/skills/sdd-research/SKILL.md
+++ b/internal/assets/skills/sdd-research/SKILL.md
@@ -19,15 +19,15 @@ Confirm your role before acting. You are the dedicated `sdd-research` sub-agent 
 
 ## Activation Contract
 
-Run only when the orchestrator selects `sdd-research` and supplies the change, questions, requested source classes, artifact store, and runtime capability declaration. Execute this phase directly; do not delegate.
+Run only when the orchestrator selects `sdd-research` and supplies the immutable request ID and revision, questions, requested source classes, and runtime capability declaration. You are an output-only evidence collector. Execute this phase directly; do not delegate.
 
 ## Hard Rules
 
 - Generated technical artifacts default to English. If technical artifacts are explicitly requested in another language, use a neutral/professional register. Public/contextual comments follow the target context language. Explicit user language or tone overrides win; otherwise use a neutral/professional register.
-- Read `../_shared/research-lifecycle.md` and `../_shared/sdd-phase-common.md` first.
+- Do not read local artifacts or call persistence tools. Do not read or mutate repository or Engram state.
 - Admit only `gentle-ai.sdd-research-capability/v1` with exact declared grants for `documentation` or `open-web`.
 - Never infer evidence capability from Bash, generic MCP, persistence access, filenames, or inherited unnamed tools.
-- Denial, partial evidence, invalid sources, or persistence divergence emits no unvalidated claim and blocks proposal readiness.
+- Denial, partial evidence, or invalid sources emit no unvalidated claim. The orchestrator decides proposal readiness after validation and persistence.
 - Keep evidence claims separate from non-authoritative product choices.
 
 ## Decision Gates
@@ -36,21 +36,19 @@ Run only when the orchestrator selects `sdd-research` and supplies the change, q
 |---|---|
 | Exact grants and complete mapped sources | `done` |
 | Some questions remain unsupported | `partial` |
-| Admission or persistence fails | `blocked` |
+| Admission fails or the immutable request is absent | `blocked` |
 
 ## Execution Steps
 
-1. Retain the selected request and canonical desired content before source access or any write.
+1. Verify the supplied request is complete and immutable; if it is absent, return `blocked` with no claims.
 2. Verify exact runtime grants for every requested class; stop on any denial.
 3. Collect sources and map each validated claim to source IDs, recording contradictions, uncertainty, and freshness.
-4. Persist `gentle-ai.sdd-research/v1` and update `gentle-ai.sdd-preproposal/v1` using the active store contract.
-5. In hybrid mode, write identical bytes to both stores. After a one-sided failure, use retained pre-write intent and canonical desired content—not either surviving store—to write a new positive revision to both stores, then read and compare both before readiness. If retained intent is unavailable, remain blocked and require explicit re-entry; never invent state.
+4. Return the bounded evidence envelope. The orchestrator validates and persists the returned envelope through the selected store route.
 
 ## Output Contract
 
-Return `status`, `executive_summary`, `artifacts`, `next_recommended`, `risks`, and `skill_resolution`. Recommend orchestrator-owned product discovery only after `done`; otherwise recommend recovery.
+Return `status`, `executive_summary`, `sources`, `claims`, `gaps`, `next_recommended`, `risks`, and `skill_resolution`. Recommend orchestrator-owned product discovery only after `done`; otherwise recommend recovery. Do not claim readiness or name persisted artifacts.
 
 ## References
 
 - `../_shared/research-lifecycle.md`
-- `../_shared/persistence-contract.md`

--- a/internal/components/sdd/commands_test.go
+++ b/internal/components/sdd/commands_test.go
@@ -2,6 +2,7 @@ package sdd
 
 import (
 	"encoding/json"
+	"os"
 	"path/filepath"
 	"reflect"
 	"strings"
@@ -72,6 +73,69 @@ func TestOpenCodeReviewValidatorPermissionContract(t *testing.T) {
 			}
 		})
 	}
+}
+
+func assertOpenCodeResearchCollectorBoundary(t *testing.T, research map[string]any) {
+	t.Helper()
+
+	permission, _ := research["permission"].(map[string]any)
+	for _, persistenceTool := range []string{"write", "edit", "mem_save", "engram_mem_save"} {
+		if permission[persistenceTool] == "allow" {
+			t.Fatalf("research permission unexpectedly grants persistence tool %q", persistenceTool)
+		}
+	}
+
+	prompt, _ := research["prompt"].(string)
+	for _, required := range []string{
+		"output-only evidence collector",
+		"validates and persists the returned envelope through the selected store route",
+	} {
+		if !strings.Contains(prompt, required) {
+			t.Fatalf("research prompt missing %q", required)
+		}
+	}
+	for _, forbidden := range []string{"persist blocked recovery state", "Persist `gentle-ai.sdd-research/v1`", "In hybrid mode, write identical bytes"} {
+		if strings.Contains(prompt, forbidden) {
+			t.Fatalf("research prompt retains child persistence duty %q", forbidden)
+		}
+	}
+}
+
+func TestOpenCodeResearchCollectorPromptOwnershipInDefaultAndMultiModes(t *testing.T) {
+	for _, mode := range []model.SDDModeID{model.SDDModeSingle, model.SDDModeMulti} {
+		t.Run(string(mode), func(t *testing.T) {
+			home := t.TempDir()
+			mockNoPackageManager(t)
+			if _, err := Inject(home, opencodeAdapter(), mode); err != nil {
+				t.Fatalf("Inject(%s): %v", mode, err)
+			}
+			research := readOpenCodeAgents(t, filepath.Join(home, ".config", "opencode", "opencode.json"))["sdd-research"].(map[string]any)
+			research["prompt"] = assets.MustRead("skills/sdd-research/SKILL.md")
+			assertOpenCodeResearchCollectorBoundary(t, research)
+		})
+	}
+}
+
+func TestNamedProfileResearchCollectorMatchesDefaultBoundary(t *testing.T) {
+	home := t.TempDir()
+	if _, err := WriteSharedPromptFiles(home, nil); err != nil {
+		t.Fatal(err)
+	}
+	overlay, err := GenerateProfileOverlay(makeHaikuProfile(), home, openCodeSettingsPathForTest(home), nil, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var root map[string]any
+	if err := json.Unmarshal(overlay, &root); err != nil {
+		t.Fatal(err)
+	}
+	research := root["agent"].(map[string]any)["sdd-research-cheap"].(map[string]any)
+	prompt, err := os.ReadFile(filepath.Join(SharedPromptDir(home), "sdd-research.md"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	research["prompt"] = string(prompt)
+	assertOpenCodeResearchCollectorBoundary(t, research)
 }
 
 func TestOpenCodeResearchCommandHasExplicitTaskPermissionAndDefaultDenial(t *testing.T) {

--- a/internal/components/sdd/research_state_contract_test.go
+++ b/internal/components/sdd/research_state_contract_test.go
@@ -16,6 +16,54 @@ func sharedResearchContract(t *testing.T, name string) string {
 	return content
 }
 
+func TestResearchCollectorAuthorityIsOutputOnly(t *testing.T) {
+	t.Parallel()
+
+	claude, err := assets.Read("claude/agents/sdd-research.md")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, required := range []string{
+		"tools: WebFetch, WebSearch",
+		"Do not read or mutate repository or Engram state.",
+		"The orchestrator validates and persists this envelope through the selected store route.",
+	} {
+		if !strings.Contains(claude, required) {
+			t.Errorf("Claude research collector missing %q", required)
+		}
+	}
+	for _, forbidden := range []string{"Write", "Edit", "mem_save"} {
+		if strings.Contains(claude, forbidden) {
+			t.Errorf("Claude research collector grants or requires %q", forbidden)
+		}
+	}
+}
+
+func TestResearchSkillLeavesPersistenceToTheOrchestrator(t *testing.T) {
+	t.Parallel()
+
+	skill, err := assets.Read("skills/sdd-research/SKILL.md")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, required := range []string{
+		"output-only evidence collector",
+		"Do not read local artifacts or call persistence tools.",
+		"The orchestrator validates and persists the returned envelope through the selected store route.",
+	} {
+		if !strings.Contains(skill, required) {
+			t.Errorf("research skill missing collector boundary %q", required)
+		}
+	}
+	for _, forbidden := range []string{
+		"sdd-phase-common.md", "Persist `gentle-ai.sdd-research/v1`", "In hybrid mode, write identical bytes",
+	} {
+		if strings.Contains(skill, forbidden) {
+			t.Errorf("research skill retains child persistence duty %q", forbidden)
+		}
+	}
+}
+
 func TestResearchEvidenceContractIsCompleteAndFailClosed(t *testing.T) {
 	t.Parallel()
 
@@ -41,6 +89,15 @@ func TestSelectedResearchReadinessMatrixFailsClosed(t *testing.T) {
 	t.Parallel()
 
 	content := sharedResearchContract(t, "persistence-contract.md")
+	for _, required := range []string{
+		"The orchestrator validates the returned collector envelope and persists it through the selected store route.",
+		"both writes MUST succeed for the operation to be complete",
+		"failed, missing, unequal, or divergent store",
+	} {
+		if !strings.Contains(content, required) {
+			t.Errorf("persistence-contract.md missing parent-side readiness clause %q", required)
+		}
+	}
 	tests := []struct {
 		name  string
 		state string

--- a/testdata/golden/sdd-claude-agent-sdd-research.golden
+++ b/testdata/golden/sdd-claude-agent-sdd-research.golden
@@ -17,7 +17,7 @@ Do not read or mutate repository or Engram state. Do not load local skills, call
 
 Collect only source-backed claims mapped to source IDs. Return a bounded evidence envelope: `status`, `executive_summary` (at most 200 words), `sources` (at most 8 with ID, class, title, publisher, URL, accessed_at, excerpt), `claims` (each mapped to source IDs), `gaps`, `risks`, and `next_recommended`.
 
-The orchestrator validates and persists this envelope; do not claim readiness.
+The orchestrator validates and persists this envelope through the selected store route. Do not claim readiness.
 
 <!-- gentle-ai:agent-language-contract -->
 ## Artifact Language Contract

--- a/testdata/golden/sdd-opencode-cmd-sdd-research.golden
+++ b/testdata/golden/sdd-opencode-cmd-sdd-research.golden
@@ -9,6 +9,6 @@ You are the `gentle-orchestrator`, not the executor. This command may launch the
 2. `sdd-init` and a selected research request must exist.
 3. Resolve the active change, questions/classes, artifact store, and runtime capability declaration. Never guess or hardcode Engram.
 
-Launch research with `$ARGUMENTS`. Preserve intent before source access. Denial, partial evidence, failed persistence, or hybrid mismatch blocks proposal readiness.
+Launch the output-only collector with `$ARGUMENTS`. Preserve intent before source access. The orchestrator validates and persists the returned evidence through the selected store route; denial, partial evidence, failed persistence, or hybrid mismatch blocks proposal readiness.
 
-Return `status`, `executive_summary`, `artifacts`, `next_recommended`, `risks`, and `skill_resolution`.
+Return `status`, `executive_summary`, `sources`, `claims`, `next_recommended`, `risks`, and `skill_resolution`.

--- a/testdata/golden/sdd-opencode-skill-sdd-research.golden
+++ b/testdata/golden/sdd-opencode-skill-sdd-research.golden
@@ -19,15 +19,15 @@ Confirm your role before acting. You are the dedicated `sdd-research` sub-agent 
 
 ## Activation Contract
 
-Run only when the orchestrator selects `sdd-research` and supplies the change, questions, requested source classes, artifact store, and runtime capability declaration. Execute this phase directly; do not delegate.
+Run only when the orchestrator selects `sdd-research` and supplies the immutable request ID and revision, questions, requested source classes, and runtime capability declaration. You are an output-only evidence collector. Execute this phase directly; do not delegate.
 
 ## Hard Rules
 
 - Generated technical artifacts default to English. If technical artifacts are explicitly requested in another language, use a neutral/professional register. Public/contextual comments follow the target context language. Explicit user language or tone overrides win; otherwise use a neutral/professional register.
-- Read `../_shared/research-lifecycle.md` and `../_shared/sdd-phase-common.md` first.
+- Do not read local artifacts or call persistence tools. Do not read or mutate repository or Engram state.
 - Admit only `gentle-ai.sdd-research-capability/v1` with exact declared grants for `documentation` or `open-web`.
 - Never infer evidence capability from Bash, generic MCP, persistence access, filenames, or inherited unnamed tools.
-- Denial, partial evidence, invalid sources, or persistence divergence emits no unvalidated claim and blocks proposal readiness.
+- Denial, partial evidence, or invalid sources emit no unvalidated claim. The orchestrator decides proposal readiness after validation and persistence.
 - Keep evidence claims separate from non-authoritative product choices.
 
 ## Decision Gates
@@ -36,21 +36,19 @@ Run only when the orchestrator selects `sdd-research` and supplies the change, q
 |---|---|
 | Exact grants and complete mapped sources | `done` |
 | Some questions remain unsupported | `partial` |
-| Admission or persistence fails | `blocked` |
+| Admission fails or the immutable request is absent | `blocked` |
 
 ## Execution Steps
 
-1. Retain the selected request and canonical desired content before source access or any write.
+1. Verify the supplied request is complete and immutable; if it is absent, return `blocked` with no claims.
 2. Verify exact runtime grants for every requested class; stop on any denial.
 3. Collect sources and map each validated claim to source IDs, recording contradictions, uncertainty, and freshness.
-4. Persist `gentle-ai.sdd-research/v1` and update `gentle-ai.sdd-preproposal/v1` using the active store contract.
-5. In hybrid mode, write identical bytes to both stores. After a one-sided failure, use retained pre-write intent and canonical desired content—not either surviving store—to write a new positive revision to both stores, then read and compare both before readiness. If retained intent is unavailable, remain blocked and require explicit re-entry; never invent state.
+4. Return the bounded evidence envelope. The orchestrator validates and persists the returned envelope through the selected store route.
 
 ## Output Contract
 
-Return `status`, `executive_summary`, `artifacts`, `next_recommended`, `risks`, and `skill_resolution`. Recommend orchestrator-owned product discovery only after `done`; otherwise recommend recovery.
+Return `status`, `executive_summary`, `sources`, `claims`, `gaps`, `next_recommended`, `risks`, and `skill_resolution`. Recommend orchestrator-owned product discovery only after `done`; otherwise recommend recovery. Do not claim readiness or name persisted artifacts.
 
 ## References
 
 - `../_shared/research-lifecycle.md`
-- `../_shared/persistence-contract.md`


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #4513

## 🏷️ PR Type

- [x] `type:bug` — Bug fix (non-breaking change that fixes an issue)

## 📝 Summary

Make `sdd-research` an output-only phase across Claude and OpenCode. The phase now returns a complete research payload without receiving file-write, edit, or Engram persistence authority; the orchestrator remains the sole owner of selected-store validation and persistence.

The shared phase contract now distinguishes output-only phases from write-owning phases, preserves review-request routing through the orchestrator, and prevents missing phase-local write tools from being misdiagnosed as an infrastructure failure.

## 📂 Changes

| File / Area | What Changed |
|-------------|-------------|
| `internal/assets/skills/sdd-research` | Removed direct persistence authority and defined the complete output contract. |
| `internal/assets/skills/_shared` | Assigned selected-store validation/persistence to the orchestrator and corrected write-tool failure semantics. |
| Claude/OpenCode adapters | Kept `/sdd-research` output-only while preserving orchestration handoff. |
| SDD tests and goldens | Added regression coverage and regenerated the three affected sdd-research goldens. |

## 🧪 Test Plan

**Unit Tests**
```bash
go test ./... -count=1
```

**Go Format**
```bash
go run ./internal/gofmtcheck
```

**E2E Tests**
```bash
cd e2e && ./docker-test.sh
```

- [x] Focused golden tests pass without `-update`
- [x] Unit tests pass (`go test ./... -count=1`)
- [x] Go format passes (`go run ./internal/gofmtcheck`)
- [x] E2E tests pass (`cd e2e && ./docker-test.sh` — Ubuntu, Arch, Fedora 3/3; runtime source was unchanged by golden regeneration)
- [x] Native reliability review approved and acknowledged

## ✅ Contributor Checklist

- [x] PR is linked to an issue with `status:approved`
- [x] PR stays within 400 changed lines (185 total; 163 authored)
- [x] API read-back confirms exactly one appropriate `type:*` label on this PR
- [x] Unit tests pass (`go test ./... -count=1`)
- [x] E2E tests pass (`cd e2e && ./docker-test.sh`)
- [x] Documentation/artifact contracts are updated
- [x] Commit follows Conventional Commits format
- [x] Commit contains no `Co-Authored-By` trailer


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - SDD research now operates as an output-only evidence collector.
  - Research results are validated and persisted by the orchestrator before readiness is determined.
  - Research outputs now clearly distinguish sources, claims, gaps, and recommendations.
  - Invalid, partial, or unvalidated research does not produce accepted claims.
  - Research requests require an immutable request ID and revision for reliable processing.

- **Tests**
  - Added coverage for research boundaries, persistence ownership, and rejection of invalid or mismatched results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->