### PR TITLE
fix(sdd): align research ownership across adapters

### DIFF
--- a/internal/assets/claude/commands/gentle-sdd-research.md
+++ b/internal/assets/claude/commands/gentle-sdd-research.md
@@ -2,10 +2,14 @@
 description: Collect source-backed evidence for a selected SDD research lane
 ---
 
-Use the native `sdd-research` sub-agent. If unavailable, read `~/.claude/skills/sdd-research/SKILL.md` and execute it inline without delegating.
+The command actor is the orchestrator. Use the native `sdd-research` sub-agent. If unavailable, read `~/.claude/skills/sdd-research/SKILL.md` and execute it inline without delegating.
 
-SDD Session Preflight and `sdd-init` must already be complete. Resolve the active change, selected research questions/classes, artifact store, and runtime capability declaration; if any is missing or ambiguous, ask and STOP.
+The collector is an output-only evidence collector. It may return a complete `blocked`, `partial`, or `done` record but must not retain intent, mutate repository state, save Engram state, select an artifact store, or persist research/preproposal. Do not let it read local artifacts or call persistence tools.
 
-Launch research with `$ARGUMENTS`. Preserve selected intent before source access. Exact grants and source-backed claims are mandatory; denial, partial evidence, failed persistence, or hybrid mismatch blocks proposal readiness.
+SDD Session Preflight and `sdd-init` must already be complete. Resolve the active change, selected research questions/classes, preflight-selected artifact store, and runtime capability declaration; if any is missing or ambiguous, ask and STOP.
+
+Launch research with `$ARGUMENTS`. Exact grants and source-backed claims are mandatory; denial, partial evidence, failed persistence, or hybrid mismatch blocks proposal readiness.
+
+The orchestrator validates and persists the returned envelope through the preflight-selected store route. Do this only after the collector returns.
 
 Return `status`, `executive_summary`, `artifacts`, `next_recommended`, `risks`, and `skill_resolution`.

--- a/internal/assets/cursor/agents/sdd-research.md
+++ b/internal/assets/cursor/agents/sdd-research.md
@@ -2,16 +2,18 @@
 name: sdd-research
 description: Record fail-closed outcomes for selected SDD research requests.
 model: inherit
-readonly: false
+readonly: true
 background: false
 ---
 
 You are the SDD **research** executor, not the orchestrator. Do this phase yourself. Do NOT delegate.
 
+You are an output-only evidence collector. You may return a complete `blocked`, `partial`, or `done` record but must not retain intent, mutate repository state, save Engram state, select an artifact store, or persist research/preproposal. Do not read local artifacts or call persistence tools.
+
 Evidence grants: documentation=[]; open-web=[].
 Persistence tools are not evidence grants.
-Unsupported or undeclared classes deny admission and emit no claims.
+Unsupported or undeclared classes deny admission and emit no claims. Because this runtime declares no evidence grants, return `blocked` with no claims.
 
-Read `~/.cursor/skills/sdd-research/SKILL.md` and the shared research and persistence contracts. Because this runtime declares no evidence grants, retain the selected request, persist a `blocked` outcome with no claims, and stop. On hybrid mismatch or write failure, never prefer one store; keep proposal readiness false for recovery.
+The orchestrator validates and persists the returned envelope through the preflight-selected store route.
 
 Return `status`, `executive_summary`, `artifacts`, `next_recommended`, `risks`, and `skill_resolution`.

--- a/internal/assets/kimi/agents/sdd-research.md
+++ b/internal/assets/kimi/agents/sdd-research.md
@@ -2,16 +2,18 @@
 name: sdd-research
 description: Record fail-closed outcomes for selected SDD research requests.
 model: inherit
-readonly: false
+readonly: true
 background: false
 ---
 
 You are the SDD **research** executor, not the orchestrator. Do this phase yourself. Do NOT delegate or call Task.
 
+You are an output-only evidence collector. You may return a complete `blocked`, `partial`, or `done` record but must not retain intent, mutate repository state, save Engram state, select an artifact store, or persist research/preproposal. Do not read local artifacts or call persistence tools.
+
 Evidence grants: documentation=[]; open-web=[].
 Persistence tools are not evidence grants.
-Unsupported or undeclared classes deny admission and emit no claims.
+Unsupported or undeclared classes deny admission and emit no claims. Because this runtime declares no evidence grants, return `blocked` with no claims.
 
-Read `~/.config/agents/skills/sdd-research/SKILL.md` and the shared research and persistence contracts. Because this runtime declares no evidence grants, retain the selected request, persist a `blocked` outcome with no claims, and stop. On hybrid mismatch or write failure, never prefer one store; keep proposal readiness false for recovery.
+The orchestrator validates and persists the returned envelope through the preflight-selected store route.
 
 Return `status`, `executive_summary`, `artifacts`, `next_recommended`, `risks`, and `skill_resolution`.

--- a/internal/assets/kiro/agents/sdd-research.md
+++ b/internal/assets/kiro/agents/sdd-research.md
@@ -1,19 +1,19 @@
 ---
 name: sdd-research
 description: Collect auditable documentation evidence for a selected SDD research lane.
-tools: ["@builtin", "@context7", "@engram"]
+tools: ["@context7"]
 model: {{KIRO_MODEL}}
 includeMcpJson: true
 ---
 
 You are the SDD **research** executor, not the orchestrator. Do this phase yourself. Do NOT delegate.
 
+You are an output-only evidence collector. You may return a complete `blocked`, `partial`, or `done` record but must not retain intent, mutate repository state, save Engram state, select an artifact store, or persist research/preproposal. Do not read local artifacts or call persistence tools.
+
 Evidence grants: documentation=[@context7]; open-web=[].
 Persistence tools are not evidence grants.
-Unsupported or undeclared classes deny admission and emit no claims.
+Unsupported or undeclared classes deny admission and emit no claims. Complete only documentation claims mapped to source IDs; an `open-web` request or unavailable documentation evidence returns `blocked` or `partial` with no unvalidated claims.
 
-Read the installed `sdd-research/SKILL.md`, `_shared/research-lifecycle.md`, and shared persistence conventions from the Kiro skills directory. Follow them exactly.
-
-Persist intent before source access. Complete only documentation claims mapped to source IDs. An `open-web` request, denial, partial evidence, failed write, or divergent hybrid revision/bytes must retain intent, persist `blocked` or `partial`, and stop without preferring a store.
+The orchestrator validates and persists the returned envelope through the preflight-selected store route.
 
 Return `status`, `executive_summary`, `artifacts`, `next_recommended`, `risks`, and `skill_resolution`.

--- a/internal/components/sdd/research_state_contract_test.go
+++ b/internal/components/sdd/research_state_contract_test.go
@@ -39,6 +39,84 @@ func TestResearchCollectorAuthorityIsOutputOnly(t *testing.T) {
 	}
 }
 
+func TestRuntimeResearchExecutorsAreOutputOnly(t *testing.T) {
+	t.Parallel()
+
+	const outputOnlyBoundary = "must not retain intent, mutate repository state, save Engram state, select an artifact store, or persist research/preproposal."
+	const orchestratorHandoff = "The orchestrator validates and persists the returned envelope through the preflight-selected store route."
+
+	for _, path := range []string{
+		"cursor/agents/sdd-research.md",
+		"kiro/agents/sdd-research.md",
+		"kimi/agents/sdd-research.md",
+		"claude/commands/gentle-sdd-research.md",
+	} {
+		path := path
+		t.Run(path, func(t *testing.T) {
+			t.Parallel()
+
+			content, err := assets.Read(path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			for _, required := range []string{"output-only evidence collector", outputOnlyBoundary, orchestratorHandoff} {
+				if !strings.Contains(content, required) {
+					t.Errorf("%s missing output-only boundary %q", path, required)
+				}
+			}
+			for _, stale := range []string{
+				"Persist intent before source access.",
+				"retain the selected request",
+				"persist a `blocked` outcome",
+				"shared research and persistence contracts",
+			} {
+				if strings.Contains(content, stale) {
+					t.Errorf("%s retains executor persistence instruction %q", path, stale)
+				}
+			}
+		})
+	}
+
+	for _, path := range []string{"cursor/agents/sdd-research.md", "kimi/agents/sdd-research.md"} {
+		content, err := assets.Read(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !strings.Contains(content, "readonly: true") {
+			t.Errorf("%s is not structurally read-only", path)
+		}
+	}
+
+	kiro, err := assets.Read("kiro/agents/sdd-research.md")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, required := range []string{`tools: ["@context7"]`, "documentation=[@context7]"} {
+		if !strings.Contains(kiro, required) {
+			t.Errorf("Kiro research executor missing narrow documentation capability %q", required)
+		}
+	}
+	for _, forbidden := range []string{"@builtin", "@engram"} {
+		if strings.Contains(kiro, forbidden) {
+			t.Errorf("Kiro research executor grants non-evidence capability %q", forbidden)
+		}
+	}
+
+	claudeCommand, err := assets.Read("claude/commands/gentle-sdd-research.md")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(claudeCommand, "The command actor is the orchestrator.") {
+		t.Error("Claude research command does not identify the command actor as the orchestrator")
+	}
+	if got := strings.Count(claudeCommand, "validates and persists the returned envelope through the preflight-selected store route."); got != 1 {
+		t.Errorf("Claude research command has %d validation/persistence handoffs, want 1", got)
+	}
+	if strings.Contains(claudeCommand, "After the collector returns, validate its envelope and persist it") {
+		t.Error("Claude research command duplicates the validation/persistence handoff")
+	}
+}
+
 func TestResearchSkillLeavesPersistenceToTheOrchestrator(t *testing.T) {
 	t.Parallel()
 

--- a/testdata/golden/sdd-claude-cmd-gentle-sdd-research.golden
+++ b/testdata/golden/sdd-claude-cmd-gentle-sdd-research.golden
@@ -2,10 +2,14 @@
 description: Collect source-backed evidence for a selected SDD research lane
 ---
 
-Use the native `sdd-research` sub-agent. If unavailable, read `~/.claude/skills/sdd-research/SKILL.md` and execute it inline without delegating.
+The command actor is the orchestrator. Use the native `sdd-research` sub-agent. If unavailable, read `~/.claude/skills/sdd-research/SKILL.md` and execute it inline without delegating.
 
-SDD Session Preflight and `sdd-init` must already be complete. Resolve the active change, selected research questions/classes, artifact store, and runtime capability declaration; if any is missing or ambiguous, ask and STOP.
+The collector is an output-only evidence collector. It may return a complete `blocked`, `partial`, or `done` record but must not retain intent, mutate repository state, save Engram state, select an artifact store, or persist research/preproposal. Do not let it read local artifacts or call persistence tools.
 
-Launch research with `$ARGUMENTS`. Preserve selected intent before source access. Exact grants and source-backed claims are mandatory; denial, partial evidence, failed persistence, or hybrid mismatch blocks proposal readiness.
+SDD Session Preflight and `sdd-init` must already be complete. Resolve the active change, selected research questions/classes, preflight-selected artifact store, and runtime capability declaration; if any is missing or ambiguous, ask and STOP.
+
+Launch research with `$ARGUMENTS`. Exact grants and source-backed claims are mandatory; denial, partial evidence, failed persistence, or hybrid mismatch blocks proposal readiness.
+
+The orchestrator validates and persists the returned envelope through the preflight-selected store route. Do this only after the collector returns.
 
 Return `status`, `executive_summary`, `artifacts`, `next_recommended`, `risks`, and `skill_resolution`.

--- a/testdata/golden/sdd-kiro-agent-sdd-research.golden
+++ b/testdata/golden/sdd-kiro-agent-sdd-research.golden
@@ -1,20 +1,20 @@
 ---
 name: sdd-research
 description: Collect auditable documentation evidence for a selected SDD research lane.
-tools: ["@builtin", "@context7", "@engram"]
+tools: ["@context7"]
 model: auto
 includeMcpJson: true
 ---
 
 You are the SDD **research** executor, not the orchestrator. Do this phase yourself. Do NOT delegate.
 
+You are an output-only evidence collector. You may return a complete `blocked`, `partial`, or `done` record but must not retain intent, mutate repository state, save Engram state, select an artifact store, or persist research/preproposal. Do not read local artifacts or call persistence tools.
+
 Evidence grants: documentation=[@context7]; open-web=[].
 Persistence tools are not evidence grants.
-Unsupported or undeclared classes deny admission and emit no claims.
+Unsupported or undeclared classes deny admission and emit no claims. Complete only documentation claims mapped to source IDs; an `open-web` request or unavailable documentation evidence returns `blocked` or `partial` with no unvalidated claims.
 
-Read the installed `sdd-research/SKILL.md`, `_shared/research-lifecycle.md`, and shared persistence conventions from the Kiro skills directory. Follow them exactly.
-
-Persist intent before source access. Complete only documentation claims mapped to source IDs. An `open-web` request, denial, partial evidence, failed write, or divergent hybrid revision/bytes must retain intent, persist `blocked` or `partial`, and stop without preferring a store.
+The orchestrator validates and persists the returned envelope through the preflight-selected store route.
 
 Return `status`, `executive_summary`, `artifacts`, `next_recommended`, `risks`, and `skill_resolution`.
 


### PR DESCRIPTION
## Summary

- make Cursor and Kimi research executors output-only
- narrow Kiro research tools and remove selected-store persistence instructions
- give the Claude fallback one explicit parent-orchestrator handoff
- add cross-adapter contract tests and regenerate affected goldens

## Verification

- focused SDD asset and contract tests
- `go run ./internal/gofmtcheck`
- `go test ./... -count=1`
- native reliability review approved and acknowledged

Closes #4513


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Research workflows now use read-only, output-only evidence collection across supported agent integrations.
  - Research results are validated and saved through the orchestrator’s selected storage route.
  - Research requests without available evidence return a blocked result without unsupported claims.

- **Bug Fixes**
  - Prevented research agents from modifying repository state or independently saving research and proposal data.
  - Restricted documentation research to the capabilities available at runtime.

- **Tests**
  - Added coverage to verify consistent output-only behavior and handoff rules across integrations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->